### PR TITLE
Changed -lncurses search depth for Ubuntu multiarch

### DIFF
--- a/elks/scripts/lxdialog/Makefile
+++ b/elks/scripts/lxdialog/Makefile
@@ -85,7 +85,7 @@ local-curses.h:
 # Check that ncurses is available.
 
 ncurses: local-curses.h
-	@x=`find /lib/ /usr/lib/ /usr/local/lib/ -maxdepth 1 -name 'libncurses.*'` ;\
+	@x=`find /lib/ /usr/lib/ /usr/local/lib/ -maxdepth 2 -name 'libncurses.*'` ;\
 	if [ ! "$$x" ]; then \
 		echo -e "\007" ;\
 		echo ">> Unable to find the Ncurses libraries." ;\


### PR DESCRIPTION
I changed the search depth on the 'find' call for finding libncurses.so/libncurses.a to 2; Ubuntu (and possibly others) use /usr/lib/gnu-build-tuple/ instead of /usr/lib directly and the current check fails as a result. 
