### PR TITLE
Code size reduced in 1 Kbyte. Fix to "double free" bug. Fix to printk().

### DIFF
--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -50,9 +50,8 @@ static void print_minor_name(register struct gendisk *hd,
 
     printk(" %s%c", hd->major_name, 'a' + unit);
     if (part)
-	printk("%d:", part);
-    else
-	printk(":");
+	printk("%d", part);
+    printk(":");
 }
 
 static void add_partition(register struct gendisk *hd,

--- a/elks/arch/i86/drivers/char/lp.c
+++ b/elks/arch/i86/drivers/char/lp.c
@@ -175,7 +175,7 @@ size_t lp_write(struct inode *inode, struct file *file, char *buf, int count)
 
     chrsp = 0;
     while (((int)chrsp) < count) {
-	if (!lp_char_polled((int)get_user_char((void *)(buf + (int)chrsp)),
+	if (!lp_char_polled((int)get_user_char((void *)(buf++)),
 			    MINOR(inode->i_rdev)))
 	    break;
 	chrsp++;
@@ -303,8 +303,8 @@ void lp_init(void)
 	printk("lp%d at 0x%x, using polling driver\n", (int)ip, lp->io);
 	lp->flags = LP_EXIST;
 	lp++;
-	count++;
     }
+    count = (int)ip;
 
 #else
 

--- a/elks/arch/i86/drivers/char/mem.c
+++ b/elks/arch/i86/drivers/char/mem.c
@@ -48,7 +48,7 @@ int memory_lseek(struct inode *inode, register struct file *filp,
 	offset += filp->f_pos;
     case 0:
 	if(offset >= 0)
-	break;
+	    break;
     default:
 	return -EINVAL;
     }

--- a/elks/arch/i86/drivers/char/tcpdev.c
+++ b/elks/arch/i86/drivers/char/tcpdev.c
@@ -87,12 +87,8 @@ void tcpdev_clear_data_avail(void)
 static size_t tcpdev_write(struct inode *inode, struct file *filp,
 			char *data, size_t len)
 {
-    int ret;
-
     debug4("TCPDEV: write( %p, %p, %p, %u )\n",inode,filp,data,len);
-    if (!len)
-	ret = 0;
-    else {
+    if(len > 0) {
 	down(&bufin_sem);
 
 	tdin_tail = (unsigned) len;
@@ -100,11 +96,9 @@ static size_t tcpdev_write(struct inode *inode, struct file *filp,
 
 	/* Call the af_inet code to handle the data */
 	inet_process_tcpdev(tdin_buf, len);
-
-	ret = (int) len;
     }
-    debug1("TCPDEV: write() returning %d\n",ret);
-    return (size_t)ret;
+    debug1("TCPDEV: write() returning %u\n", len);
+    return len;
 }
 
 int tcpdev_select(struct inode *inode, struct file *filp, int sel_type)

--- a/elks/arch/i86/drivers/char/xt_key.c
+++ b/elks/arch/i86/drivers/char/xt_key.c
@@ -129,7 +129,7 @@ void keyboard_irq(int irq, struct pt_regs *regs, void *dev_id)
     static unsigned int ModeState = 0;
     static int E0Prefix = 0;
     int code, mode;
-    register char *keyp_E0 = (char *)0;
+    register char *keyp_E0 = (char *)0;	/*[char *keyp; int E0]*/
     register char *IsReleasep;
 
     code = inb_p((void *) KBD_IO);
@@ -148,7 +148,7 @@ void keyboard_irq(int irq, struct pt_regs *regs, void *dev_id)
 	return;
     }
     if (E0Prefix) {
-	keyp_E0 = (char *)1;
+	keyp_E0 = (char *)1;	/*[ E0 ]*/
 	E0Prefix = 0;
     }
     IsReleasep = (char *)(code & 0x80);
@@ -159,7 +159,7 @@ void keyboard_irq(int irq, struct pt_regs *regs, void *dev_id)
 
     if(!(mode & 0xC0)) {
 #if defined(CONFIG_KEYMAP_DE) || defined(CONFIG_KEYMAP_SE)
-	if((mode == ALT) && ((int)keyp_E0 != 0))
+	if((mode == ALT) && ((int)keyp_E0 != 0))	/*[ E0 ]*/
 	    mode = ALT_GR;
 #endif
 	IsReleasep ? (ModeState &= ~mode) : (ModeState |= mode);
@@ -186,7 +186,7 @@ void keyboard_irq(int irq, struct pt_regs *regs, void *dev_id)
 
     /* --------------Handle extended scancodes-------------- */
     case 0x80:
-	if((int)keyp_E0) {		/* Is extended scancode? */
+	if((int)keyp_E0) {		/* Is extended scancode? */	/*[ E0 ]*/
 	    mode &= 0x3F;
 	    if(mode)
 		AddQueue(ESC);
@@ -207,23 +207,23 @@ void keyboard_irq(int irq, struct pt_regs *regs, void *dev_id)
 	mode = state_code[mode];
 	if(!mode && (ModeState & ALT_GR))
 	    mode = 3;
-	keyp_E0 = (char *)(*(scan_tabs[mode] + code));
+	keyp_E0 = (char *)(*(scan_tabs[mode] + code));	/*[ keyp ]*/
 
 	if (ModeState & CTRL && code < 14 && !(ModeState & ALT))
-	    keyp_E0 = (char *) xtkb_scan_shifted[code];
+	    keyp_E0 = (char *) xtkb_scan_shifted[code];	/*[ keyp ]*/
 	if (code < 70 && ModeState & NUM)
-	    keyp_E0 = (char *) xtkb_scan_shifted[code];
+	    keyp_E0 = (char *) xtkb_scan_shifted[code];	/*[ keyp ]*/
     /*
      *      Apply special modifiers
      */
 	if (ModeState & ALT && !(ModeState & CTRL))	/* Changed to support CTRL-ALT */
-	    keyp_E0 = (char *)(((int) keyp_E0) | 0x80); /* META-.. */
-	if (!keyp_E0)			/* non meta-@ is 64 */
-	    keyp_E0 = (char *) '@';
+	    keyp_E0 = (char *)(((int) keyp_E0) | 0x80); /* META-.. */	/*[ keyp ]*/
+	if (!keyp_E0)			/* non meta-@ is 64 */	/*[ keyp ]*/
+	    keyp_E0 = (char *) '@';	/*[ keyp ]*/
 	if (ModeState & CTRL && !(ModeState & ALT))	/* Changed to support CTRL-ALT */
-	    keyp_E0 = (char *)(((int) keyp_E0) & 0x1F); /* CTRL-.. */
-	if (((int)keyp_E0) == '\r')
-	    keyp_E0 = (char *) '\n';
+	    keyp_E0 = (char *)(((int) keyp_E0) & 0x1F); /* CTRL-.. */	/*[ keyp ]*/
+	if (((int)keyp_E0) == '\r')	/*[ keyp ]*/
+	    keyp_E0 = (char *) '\n';	/*[ keyp ]*/
 	AddQueue((unsigned char) keyp_E0);
     }
 }

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -121,7 +121,7 @@ _irqtab_init:
 !	main code).
 !
 	.extern	_schedule
-	.extern	_sig_check
+	.extern	_do_signal
 	.extern	_do_IRQ
 
 _irq1:			;keyboard
@@ -158,7 +158,7 @@ _irq7:
 	br	_irqit
 !
 !	AT interrupts
-!	
+!
 _irq8:
 	push	ax
 	mov	ax,#8
@@ -465,7 +465,7 @@ was_trap:
 	call	_schedule		! Task switch
 	mov	bx,_current
 	mov	8[bx],#1
-	call	_sig_check		! Check signals
+	call	_do_signal		! Check signals
 !
 !	At this point, the kernel stack is empty. Thus, there is no
 !       need to save the kernel stack pointer.
@@ -623,7 +623,7 @@ _syscall_int:
 	push	ax
 	mov	bx,_current
 	mov	8[bx],#0
-	call	_sig_check
+	call	_do_signal
 	pop	ax
 	pop	bx
 	pop	cx

--- a/elks/arch/i86/kernel/system.c
+++ b/elks/arch/i86/kernel/system.c
@@ -12,7 +12,7 @@ int arch_cpu;			/* Processor type */
 extern long int basmem;
 #endif
 
-void setup_arch(register seg_t *start, seg_t *end)
+void setup_arch(seg_t *start, seg_t *end)
 {
 #ifdef CONFIG_COMPAQ_FAST
 
@@ -38,14 +38,12 @@ void setup_arch(register seg_t *start, seg_t *end)
 
     /* XXX plac: free root ram disk */
 
-    *start = kernel_ds;
-    *start += ((unsigned int) (_endbss+15)) >> 4;
+    *start = kernel_ds + (((unsigned int) (_endbss+15)) >> 4);
 
 #else
 
     *end = (basmem)<<6;
-    *start = kernel_ds;
-    *start += (unsigned int) 0x1000;
+    *start = kernel_ds + (unsigned int) 0x1000;
 
 #endif
 

--- a/elks/arch/i86/mm/init.c
+++ b/elks/arch/i86/mm/init.c
@@ -46,7 +46,7 @@ void setup_mm(seg_t start, seg_t end)
 
     printk("Psion Series 3a machine, %s CPU\n%uK base"
 	   ", CPUID `NEC V30'",
-	   proc_name, basemem, cpuid);
+	   proc_name, basemem);
 
 #else
 

--- a/elks/arch/i86/sibo/irqtab.c
+++ b/elks/arch/i86/sibo/irqtab.c
@@ -126,7 +126,7 @@ _irqtab_init:
 !	main code).
 !
 	.extern	_schedule
-	.extern	_sig_check
+	.extern	_do_signal
 	.extern	_do_IRQ
 
 _irq1:
@@ -287,7 +287,7 @@ _algn:
 !
 !	There are three possible cases to cope with
 !
-!	SS = kernel DS. 
+!	SS = kernel DS.
 !		Interrupted kernel mode code.
 !		No task switch allowed
 !		Running on a kernel process stack anyway.
@@ -435,7 +435,7 @@ updct:
 	call	_schedule		! Task switch
         mov     bx,_current
         mov     8[bx],#1
-        call    _sig_check              ! Check signals
+        call    _do_signal              ! Check signals
 !
 !	At this point, the kernel stack is empty. Thus, there in no
 !       need to save the kernel stack pointer.

--- a/elks/fs/devices.c
+++ b/elks/fs/devices.c
@@ -123,16 +123,18 @@ int check_disk_change(kdev_t dev)
  * Called every time a block special file is opened
  */
 
-int blkdev_open(struct inode *inode, register struct file *filp)
+int blkdev_open(struct inode *inode, struct file *filp)
 {
-    unsigned int i;
+    register struct file_operations *fop;
+    register char *pi;
 
-    i = MAJOR(inode->i_rdev);
-    if (i >= MAX_BLKDEV || !blkdevs[i].ds_fops)
+    pi = (char *)MAJOR(inode->i_rdev);
+    fop = blkdevs[(unsigned int)pi].ds_fops;
+    if ((unsigned int)pi >= MAX_BLKDEV || !fop)
 	return -ENODEV;
-    filp->f_op = blkdevs[i].ds_fops;
-    return (filp->f_op->open)
-	? filp->f_op->open(inode, filp)
+    filp->f_op = fop;
+    return (fop->open)
+	? fop->open(inode, filp)
 	: 0;
 }
 
@@ -177,17 +179,18 @@ struct inode_operations blkdev_inode_operations = {
  * Called every time a character special file is opened.
  */
 
-static int chrdev_open(struct inode *inode,
-			register struct file *filp)
+static int chrdev_open(struct inode *inode, struct file *filp)
 {
-    unsigned int i;
+    register struct file_operations *fop;
+    register char *pi;
 
-    i = MAJOR(inode->i_rdev);
-    if (i >= MAX_CHRDEV || !chrdevs[i].ds_fops)
+    pi = (char *)MAJOR(inode->i_rdev);
+    fop = chrdevs[(unsigned int)pi].ds_fops;
+    if ((unsigned int)pi >= MAX_CHRDEV || !fop)
 	return -ENODEV;
-    filp->f_op = chrdevs[i].ds_fops;
-    return (filp->f_op->open)
-	? filp->f_op->open(inode, filp)
+    filp->f_op = fop;
+    return (fop->open)
+	? fop->open(inode, filp)
 	: 0;
 }
 

--- a/elks/fs/file_table.c
+++ b/elks/fs/file_table.c
@@ -44,7 +44,7 @@ int open_filp(unsigned short flags, struct inode *inode, struct file **fp)
     f->f_flags = flags;
     f->f_mode = (mode_t) ((flags + 1) & O_ACCMODE);
     f->f_count = 1;
-    f->f_pos = 0;	/* FIXME - should call lseek */
+/*    f->f_pos = 0;*/	/* FIXME - should call lseek *//* Set to zero by memset() */
 #ifdef BLOAT_FS
     f->f_version = ++event;
 #endif
@@ -58,7 +58,7 @@ int open_filp(unsigned short flags, struct inode *inode, struct file **fp)
 #endif
 
 #ifdef BLOAT_FS
-    f->f_reada = 0;
+/*    f->f_reada = 0;*/ /* Set to zero by memset() */
 #endif
 
     if(inode->i_op)

--- a/elks/fs/minix/bitmap.c
+++ b/elks/fs/minix/bitmap.c
@@ -216,7 +216,7 @@ struct inode *minix_new_inode(struct inode *dir, __u16 mode)
 	}
     if (!bh || j >= 8192) {
 	printk("No new inodes found!\n");
-	goto iputfail;
+	goto iputfail1;
     }
     if (set_bit(j, bh->b_data)) {	/* shouldn't happen */
 	printk("mni: already set\n");
@@ -240,9 +240,10 @@ struct inode *minix_new_inode(struct inode *dir, __u16 mode)
     /*  Oh no! We have 'Return of Goto' in a double feature with
      *  'Mozilla v Internet Exploder' :) */
 
-  iputfail:
     printk("new_inode: iput fail\n");
+  iputfail:
     unmap_buffer(bh);
+  iputfail1:
     iput(inode);
     return NULL;
 }

--- a/elks/fs/minix/file.c
+++ b/elks/fs/minix/file.c
@@ -25,8 +25,8 @@
 static size_t minix_file_read(struct inode *inode, register struct file *filp,
 			    char *buf, size_t count);
 
-static size_t minix_file_write(register struct inode *inode, struct file *filp,
-			    char *buf, size_t count);
+static size_t minix_file_write(struct inode *inode,
+			    register struct file *filp, char *buf, size_t count);
 
 /*
  * We have mostly NULL's here: the current defaults are ok for

--- a/elks/fs/minix/inode.c
+++ b/elks/fs/minix/inode.c
@@ -246,8 +246,8 @@ struct super_block *minix_read_super(register struct super_block *s,
 	    return NULL;
 	}
     }
-    (void) set_bit(0, s->u.minix_sb.s_imap[0]->b_data);
-    (void) set_bit(0, s->u.minix_sb.s_zmap[0]->b_data);
+    set_bit(0, s->u.minix_sb.s_imap[0]->b_data);
+    set_bit(0, s->u.minix_sb.s_zmap[0]->b_data);
     unlock_super(s);
     /* set up enough so that it can read an inode */
     s->s_dev = dev;

--- a/elks/fs/minix/symlink.c
+++ b/elks/fs/minix/symlink.c
@@ -50,12 +50,12 @@ static int minix_follow_link(register struct inode *dir,
 	iput(dir);
 	return -ELOOP;
     }
-    if (!(bh = minix_bread(inode, 0, 0))) {
-	iput(inode);
+    bh = minix_bread(inode, 0, 0);
+    iput(inode);
+    if (!bh) {
 	iput(dir);
 	return -EIO;
     }
-    iput(inode);
     /* current-> */ link_count++;
     map_buffer(bh);
     pds = &current->t_regs.ds;

--- a/elks/fs/read_write.c
+++ b/elks/fs/read_write.c
@@ -106,14 +106,16 @@ int sys_read(unsigned int fd, char *buf, size_t count)
 
 int sys_write(unsigned int fd, char *buf, size_t count)
 {
+    register struct file_operations *fop;
     struct file *file;
     register struct inode *inode;
     int written;
 
     if (((written = fd_check(fd, buf, count, FMODE_WRITE, &file)) == 0)
-	&& (0 != count)) {
+	&& (count != 0)) {
 	written = -EINVAL;
-	if (file->f_op->write) {
+	fop = file->f_op;
+	if (fop->write) {
 	    inode = file->f_inode;
 
 	    /*
@@ -135,7 +137,7 @@ int sys_write(unsigned int fd, char *buf, size_t count)
 #endif
 
 	    }
-	    written = (int) file->f_op->write(inode, file, buf, count);
+	    written = (int) fop->write(inode, file, buf, count);
 	    schedule();
 	}
     }

--- a/elks/fs/stat.c
+++ b/elks/fs/stat.c
@@ -114,9 +114,10 @@ int sys_fstat(unsigned int fd, struct stat *statbuf)
     return (!error) ? 0 /* error */ : cp_stat(f->f_inode, statbuf);
 }
 
-int sys_readlink(char *path, register char *buf, size_t bufsiz)
+int sys_readlink(char *path, char *buf, size_t bufsiz)
 {
     struct inode *inode;
+    register struct inode *pinode;
     register struct inode_operations *iop;
     int error = -EINVAL;
 
@@ -124,10 +125,11 @@ int sys_readlink(char *path, register char *buf, size_t bufsiz)
 	&& !(error = verify_area(VERIFY_WRITE, buf, bufsiz))
 	&& !(error = lnamei(path, &inode))
 	) {
-	iop = inode->i_op;
+	pinode = inode;
+	iop = pinode->i_op;
 	error = (!iop || !iop->readlink)
-	    ? (iput(inode), -EINVAL)
-	    : iop->readlink(inode, buf, bufsiz);
+	    ? (iput(pinode), -EINVAL)
+	    : iop->readlink(pinode, buf, bufsiz);
     }
 
     return error;

--- a/elks/include/arch/posix_types.h
+++ b/elks/include/arch/posix_types.h
@@ -2,6 +2,7 @@
 #define LX86_ARCH_POSIX_TYPES_H
 
 #include <arch/irq.h>
+#include <arch/bitops.h>
 
 /*
  * This file is generally used by user-level software, so you need to
@@ -12,6 +13,7 @@
 /*@-namechecks@*/
 
 #undef	__FD_SET
+#if 0
 #define __FD_SET(fd,fdsetp) {				\
 		int mask, addr = ((int) fdsetp);	\
 							\
@@ -21,8 +23,12 @@
 		*(int*)addr |= mask;			\
 		set_irq();					\
 	}
+#else
+#define __FD_SET(fd,fdsetp) set_bit(fd, fdsetp)
+#endif
 
 #undef	__FD_CLR
+#if 0
 #define __FD_CLR(fd,fdsetp) {				\
 		int mask, addr = ((int) fdsetp);	\
 							\
@@ -32,6 +38,9 @@
 		*(int*)addr &= ~mask;			\
 		set_irq();					\
 	}
+#else
+#define __FD_CLR(fd,fdsetp) clear_bit(fd, fdsetp)
+#endif
 
 #undef	__FD_ISSET
 #define __FD_ISSET(fd,fdsetp)				\

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -451,7 +451,7 @@ extern void put_write_access(struct inode *);
 extern __s16 link_count;
 
 extern int open_namei(char *,int,int,struct inode **,struct inode *);
-extern int do_mknod(char *,int,dev_t);
+extern int do_mknod(char *,int,int,dev_t);
 extern void iput(struct inode *);
 
 extern struct inode *get_empty_inode(void);

--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -94,7 +94,7 @@ void do_exit(int status)
 #endif
 
     /* UN*X process take their children out with them...
-     * I'm not going to implement that for 0.0.51 becuase we don't 
+     * I'm not going to implement that for 0.0.51 because we don't
      * have signals and we don't need them *yet*. */
 
     /* Let the parent know */

--- a/elks/kernel/sleepwake.c
+++ b/elks/kernel/sleepwake.c
@@ -41,10 +41,8 @@ static void __sleep_on(register struct wait_queue *p, __s16 state)
 {
     register __ptask pcurrent = current;
 
-    if (pcurrent == &task[0]) {
-	printk("task[0] trying to sleep ");
-	panic("from %x", (int)p);
-    }
+    if (pcurrent == &task[0])
+	panic("task[0] trying to sleep from %x", (int)p);
     pcurrent->state = state;
     wait_set(p);
     schedule();
@@ -91,7 +89,7 @@ void wake_up_process(register struct task_struct *p)
  * a process. The process itself must remove the queue once it has woken.
  */
 
-void _wake_up(struct wait_queue *q, unsigned short int it)
+void _wake_up(register struct wait_queue *q, unsigned short int it)
 {
     register struct task_struct *p;
     unsigned short int phash;

--- a/elks/kernel/sys.c
+++ b/elks/kernel/sys.c
@@ -52,19 +52,18 @@ int sys_reboot(unsigned int magic, unsigned int magic_too, int flag)
     if ((magic == 0x1D1E) && (magic_too == 0xC0DE)) {
 	register int *pflag = (int *)flag;
 
-	if ((int)pflag == 0x0123) {
-	    hard_reset_now();
-	}
-
-	if ((int)pflag == 0x6789) {
-	    printk("System halted\n");
-	    sys_kill(-1, SIGKILL);
-	    do_exit(0);
-	}
-
-	if (((int)pflag == 0x4567) || !(int)pflag) {
-	    C_A_D = ((int)pflag ? 1 : 0);
-	    return 0;
+	switch((int)pflag) {
+	    case 0x4567:
+		pflag = (int *)1;
+	    case 0:
+		C_A_D = (int)pflag;
+		return 0;
+	    case 0x0123:
+		hard_reset_now();
+	    case 0x6789:
+		printk("System halted\n");
+		sys_kill(-1, SIGKILL);
+		do_exit(0);
 	}
     }
 

--- a/elks/net/unix/af_unix.c
+++ b/elks/net/unix/af_unix.c
@@ -164,7 +164,7 @@ static int unix_bind(struct socket *sock,
     old_ds = current->t_regs.ds;
     current->t_regs.ds = kernel_ds;
 
-    i = do_mknod(fname, S_IFSOCK | S_IRWXUGO, 0);
+    i = do_mknod(fname, 0, S_IFSOCK | S_IRWXUGO, 0);
 
     if (i == 0)
 	i = open_namei(fname, 0, S_IFSOCK, &upd->inode, NULL);


### PR DESCRIPTION
Code size reduced in 1 Kbytes without sacrificing any feature.
Fix to "double free" bug in malloc.c.
Fix to printk() with formatting "%04X".
