### PR TITLE
Fixed support for vi editor (levee) to use termcap.

### DIFF
--- a/elkscmd/levee/display.c
+++ b/elkscmd/levee/display.c
@@ -39,7 +39,9 @@ PROC
 mvcur(y,x)
 int y,x;
 {
+#if ANSI
     static char gt[30];
+#endif
    
     if (y == -1)
 	y = curpos.y;
@@ -77,8 +79,7 @@ int y,x;
 #endif
 
 #if TERMCAP
-    tgoto(gt,y,x);
-    strput(gt);
+    strput(tgoto(CM,x,y));
 #endif
 }
 

--- a/elkscmd/levee/extern.h
+++ b/elkscmd/levee/extern.h
@@ -85,15 +85,20 @@ extern int LINES, COLS;
 #endif
 #if TERMCAP
 extern bool CA, canUPSCROLL;
+#if RMX
 extern char FkL,
 	    CurRT,
 	    CurLT,
 	    CurDN,
 	    CurUP;
+#else
+extern char *functionkeys[];
+#endif /*RMX*/
 #endif /*TERMCAP*/
 extern char *TERMNAME,
 	    *HO,
 	    *UP,
+	    *BC,
 	    *CE,
 	    *CL,
 	    *OL,

--- a/elkscmd/levee/globals.c
+++ b/elkscmd/levee/globals.c
@@ -154,11 +154,16 @@ char *TERMNAME = "hardwired vt52",
 
 #if TERMCAP
 bool CA, canUPSCROLL;
+#if RMX
 char FkL, CurRT, CurLT, CurUP, CurDN;
+#else
+char *functionkeys[5];
+#endif
 
 char *TERMNAME,		/* will be set in termcap handling */
      *HO,
      *UP,
+     *BC,
      *CE,
      *CL,
      *OL,

--- a/elkscmd/levee/levee.h
+++ b/elkscmd/levee/levee.h
@@ -58,8 +58,8 @@
 /* #define SYS5	1 */
 
 /* what sort of terminal are you emulating? */
-#define VT52	1		/* this must be nonzero for the Atari ST */
-#define TERMCAP	0
+#define VT52	0		/* this must be nonzero for the Atari ST */
+#define TERMCAP	1
 #define ZTERM	0
 #define ANSI	0
 

--- a/elkscmd/levee/unixcall.c
+++ b/elkscmd/levee/unixcall.c
@@ -105,8 +105,56 @@ fixcon()
 
 getKey()
 {
+    static char functioncode[] = {
+	'l', 'h', 'k', 'j',
+    };
+    static char buffer[6], *cp;
+    static int npc = 0;
     unsigned char c;
+    unsigned char *p, *q;
+    int i;
 
-    read(0,&c,1);
+    if(npc) {
+	c = *cp++;
+	if(*cp == '\000')
+	    npc = 0;
+	return c;
+    }
+    read(0, &c, 1);
+    if(c == '\033') {	/* (single character) function key lead-in */
+	cp = buffer;
+	*cp++ = c;
+	*cp = '\000';
+	for(i = 0; functionkeys[i] != NULL; i++) {
+	    p = buffer;
+	    q = functionkeys[i];
+	    c = *p;
+	    while(*q != '\000') {
+		if(c == '\000') {
+		    read(0, cp, 1);
+		    c = *cp++;
+		    *cp = '\000';
+		}
+		if(c != *q)
+		    break;
+		c = *(++p);
+		q++;
+	    }
+	    if(*q == '\000')
+		break;
+	}
+	if(*q == '\000') {
+	    if(c != '\000') {
+		npc = 1;
+		cp = p;
+	    }
+	    c = functioncode[i];
+	}
+	else {
+	    npc = 1;
+	    cp = buffer;
+	    c = *cp++;
+	}
+    }
     return c;
 }

--- a/elkscmd/rootfs_template/etc/termcap
+++ b/elkscmd/rootfs_template/etc/termcap
@@ -1,7 +1,7 @@
 elks|vt52|vt-52|ELKS VT-52 console:\
-	:am:bs:co#80:it#8:li#25:\
+	:al=\EL:am:bs:co#80:it#8:li#25:\
 	:ce=\EK:cl=\EH\EJ:cm=\EY%+ %+ :do=\EB:ho=\EH:\
-	:le=\ED:nd=\EC:ta=^I:up=\EA:
+	:le=\ED:nd=\EC:sr=\EM:ta=^I:up=\EA:
 
 ansi|vt100|vt-100|ELKS ANSI (VT-100) console:\
 	:am:bs:co#80:it#8:li#25:\


### PR DESCRIPTION
BCC libc already provides support for termcap.

The termcap support under levee did not work for ELKS.
To make vi work, was originally compiled with fixed VT52 support.
The TERM environment points to an ansi term.

Anyway, the current kernel ansi/vt52 emulator does not provide
all functions needed by vi. It provides a small subset of ansi and vt52
at the same time.

With the fix of this pull request, will be possible to modify the console
driver to provide complete support to vi with the ansi emulator and reduce
code size by removing vt52 emulation, at the same time.

Let me know if there are more programs in elkscmd requiring VT52
