### PR TITLE
Fixed problem for building ktcp

### DIFF
--- a/elks/include/arch/posix_types.h
+++ b/elks/include/arch/posix_types.h
@@ -13,30 +13,26 @@
 /*@-namechecks@*/
 
 #undef	__FD_SET
-#if 0
+#ifndef __KERNEL__
 #define __FD_SET(fd,fdsetp) {				\
 		int mask, addr = ((int) fdsetp);	\
 							\
 		addr += fd >> 4;			\
 		mask = 1 << (fd & 0xf); 		\
-		clr_irq();					\
 		*(int*)addr |= mask;			\
-		set_irq();					\
 	}
 #else
 #define __FD_SET(fd,fdsetp) set_bit(fd, fdsetp)
 #endif
 
 #undef	__FD_CLR
-#if 0
+#ifndef __KERNEL__
 #define __FD_CLR(fd,fdsetp) {				\
 		int mask, addr = ((int) fdsetp);	\
 							\
 		addr += fd >> 4;			\
 		mask = 1 << (fd & 0xf); 		\
-		clr_irq();					\
 		*(int*)addr &= ~mask;			\
-		set_irq();					\
 	}
 #else
 #define __FD_CLR(fd,fdsetp) clear_bit(fd, fdsetp)

--- a/elks/include/linuxmt/posix_types.h
+++ b/elks/include/linuxmt/posix_types.h
@@ -52,5 +52,6 @@ typedef __u32 __kernel_fd_set;
 /*@+namechecks@*/
 
 #include <arch/posix_types.h>
+#include <linuxmt/time.h>
 
 #endif

--- a/elks/include/linuxmt/types.h
+++ b/elks/include/linuxmt/types.h
@@ -29,7 +29,9 @@ typedef __u16			uid_t;
 typedef __u16			umode_t;
 
 typedef __u8			cc_t;
+#ifndef sig_t
 typedef __u8			sig_t;
+#endif
 
 /*@ignore@*/
 

--- a/elkscmd/elvis/Makefile
+++ b/elkscmd/elvis/Makefile
@@ -342,10 +342,8 @@ smin_rfs: all
 net_rfs:
 
 elvis: $(OBJS) $(EXTRA) $(EXTRA2)
-
-
-#	$(CC) -s $(CFLAGS) $(OF)elvis $(OBJS) $(EXTRA) $(EXTRA2) $(LIBS)
-#	$(CHMEM)
+	$(CC) -s $(CFLAGS) $(OF)elvis $(OBJS) $(EXTRA) $(EXTRA2) $(LIBS)
+	$(CHMEM)
 
 ctags: ctags.c
 	$(CC) $(CFLAGS) $(SORT) $(OF)ctags ctags.c

--- a/elkscmd/ktcp/Makefile
+++ b/elkscmd/ktcp/Makefile
@@ -9,7 +9,7 @@ CC		= bcc
 #BASE_CFLAGS	= -g
 BASE_CFLAGS	= -ansi -O -0
 
-LOCALFLAGS	= -D__KERNEL__
+LOCALFLAGS	= 
 
 CFLAGS		= $(BASE_CFLAGS) $(LOCALFLAGS) -I$(ELKS_DIR)/include
 

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -9,7 +9,7 @@
  *	2 of the License, or (at your option) any later version.
  */ 
 
-#include <linuxmt/time.h>
+#include <time.h>
 #include <sys/types.h>
 #include <unistd.h> 
 

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -9,6 +9,8 @@
  *	2 of the License, or (at your option) any later version.
  */
 
+#define __KERNEL__
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/elkscmd/ktcp/timer.c
+++ b/elkscmd/ktcp/timer.c
@@ -8,7 +8,7 @@
  *	2 of the License, or (at your option) any later version.
  */
 
-#include <linuxmt/time.h>
+#include <time.h>
 
 #include "timer.h"
 


### PR DESCRIPTION
This problem was reported by Derek Johansen in the mailing list.
Building ktcp required macro **KERNEL**, despite
that ktcp is a userspace program. This causes
wreak havoc because userspace and kernel space
have different library support.
Here the need for that macro was reduced to a minimum
and fixed 2 kernel headers
