### PR TITLE
Fix problem when assembling files with CONFIG_ROMCODE option

### DIFF
--- a/elks/arch/i86/kernel/bios16.S
+++ b/elks/arch/i86/kernel/bios16.S
@@ -25,7 +25,7 @@
  */
 
 #ifdef CONFIG_ROMCODE
- #define stashed_ds	[0]
+#define stashed_ds	[0]
 #else 
 	.extern stashed_ds
 #endif	

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -20,7 +20,7 @@
  *  The segmentaddress is given by CONFIG_ROM_IRQ_DATA,
  *  the offset is constant per #define
  */
-   #define stashed_ds       [0]
+#define stashed_ds       [0]
 
 #else
 /*


### PR DESCRIPTION
Fix for issue #26. The C preprocessor don't want spaces before #defines's.
