### PR TITLE
fix to issue #29, rm command does not work

### DIFF
--- a/elks/fs/namei.c
+++ b/elks/fs/namei.c
@@ -504,13 +504,16 @@ int __do_rmthing(char *pathname, int opnum)
 	    error = -ENOENT;
 	else {
 	    dirp = dir;
-	    if (!iop || !(op = (opnum) ? iop->unlink : iop->rmdir)) {
-		error = -EPERM;
-	    } else {
-/*		dirp->i_count++;
-		down(&dirp->i_sem);*/
-		return op(dirp, basename, namelen);
-/*		up(&dirp->i_sem);*/
+	    if ((error = permission(dirp, MAY_WRITE | MAY_EXEC)) == 0) {
+		iop = dirp->i_op;
+		if (!iop || !(op = (opnum) ? iop->unlink : iop->rmdir)) {
+		    error = -EPERM;
+		} else {
+/*			dirp->i_count++;
+		    down(&dirp->i_sem);*/
+		    return op(dirp, basename, namelen);
+/*			up(&dirp->i_sem);*/
+		}
 	    }
 	}
 	iput(dirp);


### PR DESCRIPTION
Caused by an error in the kernel, in file fs/namei.c. Some lines accidentally removed by me on commit d9d6ece 3 month ago.
