### PR TITLE
Make read and write for tty devices return the correct value.

### DIFF
--- a/elks/arch/i86/drivers/char/serial.c
+++ b/elks/arch/i86/drivers/char/serial.c
@@ -150,7 +150,7 @@ static int rs_probe(register struct serial_info *sp)
     /* clear RX register */
     scratch = (char *) MAX_RX_BUFFER_SIZE;
     do {
-	inb_p(sp->io + UART_RX);
+	inb_p(sp->io + UART_RX);		/* Flush input fifo */
     } while (--scratch && (inb_p(sp->io + UART_LSR) & UART_LSR_DR));
 
     return 0;
@@ -182,6 +182,22 @@ static void update_port(register struct serial_info *port)
     set_irq();
 }
 
+static int rs_write(struct tty *tty)
+{
+    register struct serial_info *port = &ports[tty->minor - RS_MINOR_OFFSET];
+    unsigned char ch;
+    register char *i;
+
+    i = 0;
+    while (chq_getch(&tty->outq, &ch, 0) >= 0) {
+	do {	/* Do nothing */	/* Wait until transmitter buffer empty */
+	} while(!(inb_p(port->io + UART_LSR) & UART_LSR_TEMT));
+	outb(ch, port->io + UART_TX);	/* Write data to transmitter buffer */
+	i++;
+    }
+    return (int)i;
+}
+
 static void receive_chars(register struct serial_info *sp)
 {
     register struct ch_queue *q;
@@ -191,11 +207,11 @@ static void receive_chars(register struct serial_info *sp)
     q = &sp->tty->inq;
     size = q->size - 1;
     do {
-	ch = inb_p(sp->io + UART_RX);
+	ch = inb_p(sp->io + UART_RX);		/* Read received data */
 	if (!tty_intcheck(sp->tty, ch)) {
-	    if (q->len == size)
+	    if (q->len == size)			/* Queue full? */
 		break;
-	    q->buf[(q->tail + q->len) & size] = (char) ch;
+	    q->buf[(q->tail + q->len) & size] = (char) ch; /* Save data in queue */
 	    q->len++;
 	}
     } while (inb_p(sp->io + UART_LSR) & UART_LSR_DR);
@@ -212,10 +228,10 @@ void rs_irq(int irq, struct pt_regs *regs, void *dev_id)
     sp = &ports[(int)irq_port[irq - 2]];
     do {
 	statusp = (char *)inb_p(sp->io + UART_LSR);
-	if ((int)statusp & UART_LSR_DR)
+	if ((int)statusp & UART_LSR_DR)		/* Receiver buffer full? */
 	    receive_chars(sp);
 #if 0
-	if (((int)statusp) & UART_LSR_THRE)
+	if (((int)statusp) & UART_LSR_THRE)	/* Transmitter buffer empty? */
 	    transmit_chars(sp);
 #endif
     } while (!(inb_p(sp->io + UART_IIR) & UART_IIR_NO_INT));
@@ -227,7 +243,7 @@ static void rs_release(struct tty *tty)
 
     debug("SERIAL: rs_release called\n");
     port->flags &= ~SERF_INUSE;
-    outb_p(0, port->io + UART_IER);
+    outb_p(0, port->io + UART_IER);	/* Disable all interrupts */
 }
 
 static int rs_open(struct tty *tty)
@@ -252,7 +268,7 @@ static int rs_open(struct tty *tty)
 
     countp = (char *) MAX_RX_BUFFER_SIZE;
     do
-	inb_p(port->io + UART_RX);
+	inb_p(port->io + UART_RX);		/* Flush input fifo */
     while (--countp && (inb_p(port->io + UART_LSR)) & UART_LSR_DR);
 
     inb_p(port->io + UART_IIR);
@@ -327,22 +343,6 @@ static int rs_ioctl(struct tty *tty, int cmd, char *arg)
     }
 
     return (int) retvalp;
-}
-
-static int rs_write(struct tty *tty)
-{
-    register struct serial_info *port = &ports[tty->minor - RS_MINOR_OFFSET];
-    unsigned char ch;
-    register char *i;
-
-    i = 0;
-    while (chq_getch(&tty->outq, &ch, 0) != -1) {
-	do {	/* Do nothing */
-	} while(!(inb_p(port->io + UART_LSR) & UART_LSR_TEMT));
-	outb(ch, port->io + UART_TX);
-	i++;
-    }
-    return (int)i;
 }
 
 int rs_init(void)

--- a/elks/arch/i86/kernel/irq.c
+++ b/elks/arch/i86/kernel/irq.c
@@ -117,11 +117,9 @@ void enable_irq(unsigned int irq)
 
 static int remap_irq(int irq)
 {
-    if (irq > 15)
+    if((irq > 15) || ((irq > 7) && (arch_cpu < 2)))
 	return -EINVAL;
-    if (irq > 7 && arch_cpu<2)
-	return -EINVAL;			/* AT interrupt line on an XT */
-    if (irq == 2 && arch_cpu>1)
+    if (irq == 2 && arch_cpu > 1)
 	irq = 9;			/* Map IRQ 9/2 over */
     return irq;
 }

--- a/elks/fs/pipe.c
+++ b/elks/fs/pipe.c
@@ -131,13 +131,11 @@ static size_t pipe_read(register struct inode *inode, struct file *filp,
     }
     (inode->u.pipe_i.lock)--;
     wake_up_interruptible(&(inode->u.pipe_i.wait));
-    if (read) {
+    if(read)
 	inode->i_atime = CURRENT_TIME;
-	return (int) read;
-    }
-    if ((inode->u.pipe_i.writers))
-	return -EAGAIN;
-    return 0;
+    else if((inode->u.pipe_i.writers))
+	read = (size_t)(-EAGAIN);
+    return read;
 }
 
 static size_t pipe_write(register struct inode *inode, struct file *filp,

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -128,11 +128,12 @@ pid_t do_fork(int virtual)
     if (virtual) {
 
 	/* Parent and child are sharing the user stack at this point.
-	 * The child will go first, returning from this function and
-	 * from the library code where the actual syscall was done
-	 * and then will issue an exec syscall, destroying the first
-	 * few bytes at the top of the user stack. Save those bytes
-	 * in the parent's kernel stack.
+	 * The child will go first, coming into life in the middle of
+	 * the tswitch() function, returning to user space, then will
+	 * return from the library code where the actual syscall was
+	 * done and then will issue an exec syscall, destroying the
+	 * first few bytes at the top of the user stack. Save those
+	 * bytes in the parent's kernel stack.
 	 */
 	fmemcpy(kernel_ds, sc, currentp->t_regs.ss, currentp->t_regs.sp, 8);
 	/*

--- a/elks/lib/chqueue.c
+++ b/elks/lib/chqueue.c
@@ -22,6 +22,7 @@
 #include <linuxmt/chqueue.h>
 #include <linuxmt/sched.h>
 #include <linuxmt/types.h>
+#include <linuxmt/errno.h>
 #include <linuxmt/debug.h>
 
 void chq_erase(register struct ch_queue *q)
@@ -43,16 +44,17 @@ int chq_addch(register struct ch_queue *q, unsigned char c, int wait)
     debug5("CHQ: chq_addch(%d, %c, %d) q->len=%d q->tail=%d\n", q, c, 0,
 	   q->len, q->tail);
 
-    if (q->len == q->size) {
-	if (wait) {
+    if(q->len == q->size) {
+	if(!wait)
+	    return -EAGAIN;
+	else {
 	    debug("CHQ: addch sleeping\n");
 	    interruptible_sleep_on(&q->wq);
 	    debug("CHQ: addch waken up\n");
 	}
+	if(q->len == q->size)
+	    return -EINTR;
     }
-
-    if (q->len == q->size)
-	return -1;
 
     q->buf[(unsigned int)((q->tail + q->len) & (q->size - 1))] = (char) c;
     q->len++;
@@ -81,17 +83,19 @@ int chq_getch(register struct ch_queue *q, register unsigned char *c, int wait)
     debug6("CHQ: chq_getch(%d, %d, %d) q->len=%d q->tail=%d q->size=%d\n",
 	   q, c, wait, q->len, q->tail, q->size);
 
-    if (q->len == 0) {
-	if (wait) {
+    if(q->len == 0) {
+	if(!wait)
+	    return -EAGAIN;
+	else {
 	    debug("CHQ: getch sleeping\n");
 	    interruptible_sleep_on(&q->wq);
 	    debug("CHQ: getch wokeup\n");
 	}
+	if(q->len == 0)
+	    return -EINTR;
     }
-    if (q->len == 0)
-	return -1;
 
-    retval = q->buf[q->tail];
+    retval = (int)(q->buf[q->tail]) & 0xFF;
     q->tail++;
     q->tail &= q->size - 1;
     q->len--;


### PR DESCRIPTION
Improve comments in serial.c and fork.c.
Simplifications in irq.c and pipe.c.
Compiled with BCC, tested with QEMU.
Code size reduced by 16 bytes.
