### PR TITLE
Tty output processing more compatible with posix

### DIFF
--- a/elks/arch/i86/drivers/char/console.c
+++ b/elks/arch/i86/drivers/char/console.c
@@ -216,7 +216,6 @@ int Console_write(register struct tty *tty)
 {
     Console *C;
     int cnt = 0;
-    unsigned char ch;
 
 #ifdef CONFIG_VIRTUAL_CONSOLE
     C = &Con[tty->minor];
@@ -224,9 +223,8 @@ int Console_write(register struct tty *tty)
     C = &Con[0];		/* use default console: This is probably wrong */
 #endif
 
-    while (tty->outq.len != 0) {
-	chq_getch(&tty->outq, &ch, 0);
-	WriteChar(C, (char) ch);
+    while(tty->outq.len > 0) {
+	WriteChar(C, (char)tty_outproc(tty));
 	cnt++;
     }
 

--- a/elks/arch/i86/drivers/char/dircon.c
+++ b/elks/arch/i86/drivers/char/dircon.c
@@ -504,11 +504,9 @@ static int Console_write(register struct tty *tty)
 {
     register Console *C = &Con[tty->minor];
     int cnt = 0;
-    unsigned char ch;
 
-    while (tty->outq.len != 0) {
-	chq_getch(&tty->outq, &ch, 0);
-	WriteChar(C, (char) ch);
+    while((tty->outq.len > 0) && !glock) {
+	WriteChar(C, (char)tty_outproc(tty));
 	cnt++;
     }
     if(C == Visible)

--- a/elks/arch/i86/drivers/char/keyboard.c
+++ b/elks/arch/i86/drivers/char/keyboard.c
@@ -103,9 +103,6 @@ void keyboard_irq(int irq, struct pt_regs *regs, void *data)
 	AddQueue(ESC);
 	AddQueue('D');
 	return;
-    case '\r':
-	AddQueue('\n');
-	return;
     default:
 	AddQueue(key);
 	return;
@@ -118,8 +115,7 @@ void AddQueue(unsigned char Key)
 {
     register struct tty *ttyp = &ttys[Current_VCminor];
 
-    if (ttyp->inq.size != 0)
-	chq_addch(&ttyp->inq, Key, 0);
+    chq_addch(&ttyp->inq, Key, 0);
 }
 
 /*
@@ -128,7 +124,7 @@ void AddQueue(unsigned char Key)
 
 int wait_for_keypress(void)
 {
-    return chq_getch(&ttys[0].inq, 0, 1);
+    return chq_getch(&ttys[0].inq, 1);
 }
 
 #endif

--- a/elks/arch/i86/drivers/char/sibo_con.c
+++ b/elks/arch/i86/drivers/char/sibo_con.c
@@ -267,7 +267,6 @@ int Console_write(register struct tty *tty)
 {
     Console *C;
     int cnt = 0;
-    unsigned char ch;
 
 #ifdef CONFIG_SIBO_VIRTUAL_CONSOLE
     C = &Con[tty->minor];
@@ -275,9 +274,8 @@ int Console_write(register struct tty *tty)
     C = &Con[0];		/* use default console: This is probably wrong */
 #endif
 
-    while (tty->outq.len != 0) {
-	chq_getch(&tty->outq, &ch, 0);
-	WriteChar(C, ch);
+    while(tty->outq.len > 0) {
+	WriteChar(C, (char)tty_outproc(tty));
 	cnt++;
     }
 

--- a/elks/arch/i86/drivers/char/sibo_key.c
+++ b/elks/arch/i86/drivers/char/sibo_key.c
@@ -128,8 +128,7 @@ void AddQueue(unsigned char Key)
 {
     register struct tty *ttyp = &ttys[Current_VCminor];
 
-    if (ttyp->inq.size != 0)
-	chq_addch(&ttyp->inq, Key, 0);
+    chq_addch(&ttyp->inq, Key, 0);
 }
 
 /*
@@ -138,7 +137,7 @@ void AddQueue(unsigned char Key)
 
 int wait_for_keypress(void)
 {
-    return chq_getch(&ttys[0].inq, 0, 1);
+    return chq_getch(&ttys[0].inq, 1);
 }
 
 #endif

--- a/elks/arch/i86/drivers/char/tcpdev.c
+++ b/elks/arch/i86/drivers/char/tcpdev.c
@@ -69,7 +69,8 @@ int tcpdev_inetwrite(char *data, unsigned int len)
     down(&bufout_sem);
 
     /* Copy the data to the buffer */
-    fmemcpy(kernel_ds, (__u16) tdout_buf, kernel_ds, (__u16) data, (__u16) len);
+/*    fmemcpy(kernel_ds, (__u16) tdout_buf, kernel_ds, (__u16) data, (__u16) len);*/
+    memcpy(tdout_buf, data, len);
     tdout_tail = len;
     wake_up(&tcpdevq);
     debug("TCPDEV: inetwrite() returning\n");

--- a/elks/arch/i86/drivers/char/xt_key.c
+++ b/elks/arch/i86/drivers/char/xt_key.c
@@ -61,7 +61,7 @@ int kraw = 0;
 #define SSC 0xC0
 
 static unsigned char tb_state[] = {
-    0x80, CTRL, SSC, SSC,			/*1C->1F*/
+    SSC, CTRL, SSC, SSC,			/*1C->1F*/
     SSC, SSC, SSC, SSC, SSC, SSC, SSC, SSC,	/*20->27*/
     SSC, SSC, LSHIFT, SSC, SSC, SSC, SSC, SSC,	/*28->2F*/
     SSC, SSC, SSC, SSC, SSC, SSC, RSHIFT, SSC,	/*30->37*/
@@ -105,7 +105,7 @@ void AddQueue(unsigned char Key)
 {
     register struct tty *ttyp = &ttys[Current_VCminor];
 
-    if (!tty_intcheck(ttyp, Key) && (ttyp->inq.size != 0))
+    if (!tty_intcheck(ttyp, Key))
 	chq_addch(&ttyp->inq, Key, 0);
 }
 
@@ -249,7 +249,7 @@ void keyboard_irq(int irq, struct pt_regs *regs, void *dev_id)
 int wait_for_keypress(void)
 {
     set_irq();
-    return chq_getch(&ttys[0].inq, 0, 1);
+    return chq_getch(&ttys[0].inq, 1);
 }
 
 #endif

--- a/elks/include/linuxmt/chqueue.h
+++ b/elks/include/linuxmt/chqueue.h
@@ -16,7 +16,6 @@ extern int chq_delch(register struct ch_queue *);
 extern int chq_peekch(register struct ch_queue *);
 extern int chq_full(register struct ch_queue *);
 
-extern int chq_getch(register struct ch_queue *,
-		     register unsigned char *,int);
+extern int chq_getch(register struct ch_queue *,int);
 
 #endif

--- a/elks/include/linuxmt/ntty.h
+++ b/elks/include/linuxmt/ntty.h
@@ -69,6 +69,7 @@ struct tty {
 
     struct ch_queue inq, outq;
     struct termios termios;
+    int ostate;
     pid_t pgrp;
 };
 
@@ -80,6 +81,9 @@ extern int tty_intcheck(struct tty *,unsigned char);
 
 extern int pipe_lseek(struct inode *,struct file *,off_t,int);
 		/* Empty function, returns -ESPIPE. useful */
+
+extern int tty_outproc(register struct tty *);
+		/* TTY postprocessing */
 
 extern struct termios def_vals;
 		/* global use of def_vals */

--- a/elks/lib/chqueue.c
+++ b/elks/lib/chqueue.c
@@ -76,7 +76,7 @@ int chq_delch(register struct ch_queue *q)
 #endif
 
 /* Gets tail character, waiting for one if wait != 0 */
-int chq_getch(register struct ch_queue *q, register unsigned char *c, int wait)
+int chq_getch(register struct ch_queue *q, int wait)
 {
     int retval;
 
@@ -101,8 +101,6 @@ int chq_getch(register struct ch_queue *q, register unsigned char *c, int wait)
     q->len--;
 
     wake_up(&q->wq);
-    if (c != 0)
-	*c = (unsigned char) retval;
 
     return retval;
 }


### PR DESCRIPTION
It is now placed between output buffer and tty device
Modified tty output devices to use new function.
Simplified chq_getch(). Translation from input CR into
NL now performed by tty layer. In keyboard drivers,
removed nonsense code checking that input buffer size
is greater than zero. In serial driver, fixed bug that
saved received data outside the input buffer.
Code size unchanged.
