### PR TITLE
Corrections to pty's. Simplify queue handling.

### DIFF
--- a/elks/arch/i86/drivers/char/bioscon.c
+++ b/elks/arch/i86/drivers/char/bioscon.c
@@ -111,7 +111,7 @@ static void AddQueue(unsigned char Key)
     register struct tty *ttyp = &ttys[Current_VCminor];
 
     if (!tty_intcheck(ttyp, Key))
-	chq_addch(&ttyp->inq, Key, 0);
+	chq_addch(&ttyp->inq, Key);
 }
 
 static void kbd_timer(int __data);
@@ -172,7 +172,7 @@ nhp:
 int wait_for_keypress(void)
 {
     set_irq();
-    return chq_getch(&ttys[0].inq, 1);
+    return chq_wait_rd(&ttys[0].inq, 0);
 }
 
 static void SetDisplayPage(unsigned int n)

--- a/elks/arch/i86/drivers/char/dircon.c
+++ b/elks/arch/i86/drivers/char/dircon.c
@@ -323,7 +323,6 @@ static void esc_YS(register Console * C, char c)
 	break;
     case 'Z':
 	C->fsm = std_char;
-	break;
     }
 }
 

--- a/elks/arch/i86/drivers/char/keyboard.c
+++ b/elks/arch/i86/drivers/char/keyboard.c
@@ -115,7 +115,7 @@ void AddQueue(unsigned char Key)
 {
     register struct tty *ttyp = &ttys[Current_VCminor];
 
-    chq_addch(&ttyp->inq, Key, 0);
+    chq_addch(&ttyp->inq, Key);
 }
 
 /*
@@ -124,7 +124,7 @@ void AddQueue(unsigned char Key)
 
 int wait_for_keypress(void)
 {
-    return chq_getch(&ttys[0].inq, 1);
+    return chq_wait_rd(&ttys[0].inq, 0);
 }
 
 #endif

--- a/elks/arch/i86/drivers/char/pty.c
+++ b/elks/arch/i86/drivers/char/pty.c
@@ -21,18 +21,18 @@
 int pty_open(struct inode *inode, struct file *file)
 {
     register struct tty *otty;
+    register char *pi;
 
-    debug1("PTY: open() %x ", otty);
-    if ((otty = determine_tty(inode->i_rdev))) {
-	if (otty->flags & TTY_OPEN) {
-	    debug("failed: BUSY\n");
-	    return -EBUSY;
-	}
-	debug("succeeded\n");
-	return 0;
+    pi = 0;
+    if((otty = determine_tty(inode->i_rdev))) {
+	debug("failed: NODEV\n");
+	pi = (char *)(-ENODEV);
     }
-    debug("failed: NODEV\n");
-    return -ENODEV;
+    else if(otty->flags & TTY_OPEN) {
+	debug("failed: BUSY\n");
+	pi = (char *)(-EBUSY);
+    }
+    return (int)pi;
 }
 
 void pty_release(struct inode *inode, struct file *file)
@@ -55,9 +55,9 @@ int pty_select(struct inode *inode, struct file *file, int sel_type)
 
     /* Since everything else was disabled... */
     if (sel_type == SEL_IN) {
-	if (chq_peekch(&tty->outq))
+	if (tty->outq.len != 0)
 	    return 1;
-	select_wait(&tty->outq.wq);
+	select_wait(&tty->outq.wait);
     }
     return 0;
 
@@ -66,18 +66,18 @@ int pty_select(struct inode *inode, struct file *file, int sel_type)
 
     switch (sel_type) {
     case SEL_IN:
-	if (chq_peekch(&tty->outq))
+	if (tty->outq.len != 0)
 	    ret = 1;
 	else
-	    select_wait(&tty->outq.wq);
+	    select_wait(&tty->outq.wait);
 	break;
     case SEL_OUT:
 
 #if 0
 
-	if (!chq_full(&tty->inq))
+	if (tty->inq.len != tty->inq.size)
 	    return 1;
-	select_wait(&tty->inq.wq);
+	select_wait(&tty->inq.wait);
     case SEL_EX:		/* fall thru! */
 
 #endif
@@ -101,14 +101,14 @@ size_t pty_read(struct inode *inode, struct file *file, char *data, int len)
     }
     pi = 0;
     while (((int)pi) < len) {
-	ch = chq_getch(&tty->outq, !(file->f_flags & O_NONBLOCK));
+	ch = chq_wait_rd(&tty->outq, file->f_flags & O_NONBLOCK);
 	if(ch < 0) {
 	    if((int)pi == 0)
 		pi = (char *)ch;
 	    break;
 	}
 	debug2(" rc[%u,%u]", (int)pi, len);
-	put_user_char(ch, (void *)(data++));
+	put_user_char(tty_outproc(tty), (void *)(data++));
 	pi++;
     }
     debug1("{%u}\n", (int)pi);
@@ -128,14 +128,13 @@ size_t pty_write(struct inode *inode, struct file *file, char *data, int len)
     }
     pi = 0;
     while(((int)pi) < len) {
-	s = chq_addch(&tty->inq,
-		      get_user_char((void *)(data++)),
-		      !(file->f_flags & O_NONBLOCK));
+	s = chq_wait_wr(&tty->inq, file->f_flags & O_NONBLOCK);
 	if(s < 0) {
 	    if((int)pi == 0)
 		pi = (char *)s;
 	    break;
 	}
+	chq_addch(&tty->inq, get_user_char((void *)(data++)));
 	pi++;
 	debug(" wc");
     }
@@ -146,7 +145,7 @@ size_t pty_write(struct inode *inode, struct file *file, char *data, int len)
 int ttyp_write(register struct tty *tty)
 {
     if (tty->outq.len == tty->outq.size)
-	interruptible_sleep_on(&tty->outq.wq);
+	interruptible_sleep_on(&tty->outq.wait);
     return 0;
 }
 

--- a/elks/arch/i86/drivers/char/serial.c
+++ b/elks/arch/i86/drivers/char/serial.c
@@ -206,10 +206,10 @@ static void receive_chars(register struct serial_info *sp)
     do {
 	ch = inb_p(sp->io + UART_RX);		/* Read received data */
 	if (!tty_intcheck(sp->tty, ch)) {
-	    chq_addch(q, ch, 0);		/* Save data in queue */
+	    chq_addch(q, ch);			/* Save data in queue */
 	}
     } while (inb_p(sp->io + UART_LSR) & UART_LSR_DR);
-    wake_up(&q->wq);
+    wake_up(&q->wait);
 }
 
 void rs_irq(int irq, struct pt_regs *regs, void *dev_id)

--- a/elks/arch/i86/drivers/char/sibo_key.c
+++ b/elks/arch/i86/drivers/char/sibo_key.c
@@ -128,7 +128,7 @@ void AddQueue(unsigned char Key)
 {
     register struct tty *ttyp = &ttys[Current_VCminor];
 
-    chq_addch(&ttyp->inq, Key, 0);
+    chq_addch(&ttyp->inq, Key);
 }
 
 /*
@@ -137,7 +137,7 @@ void AddQueue(unsigned char Key)
 
 int wait_for_keypress(void)
 {
-    return chq_getch(&ttys[0].inq, 1);
+    return chq_wait_rd(&ttys[0].inq, 0);
 }
 
 #endif

--- a/elks/arch/i86/drivers/char/xt_key.c
+++ b/elks/arch/i86/drivers/char/xt_key.c
@@ -106,7 +106,7 @@ void AddQueue(unsigned char Key)
     register struct tty *ttyp = &ttys[Current_VCminor];
 
     if (!tty_intcheck(ttyp, Key))
-	chq_addch(&ttyp->inq, Key, 0);
+	chq_addch(&ttyp->inq, Key);
 }
 
 /*************************************************************************
@@ -249,7 +249,7 @@ void keyboard_irq(int irq, struct pt_regs *regs, void *dev_id)
 int wait_for_keypress(void)
 {
     set_irq();
-    return chq_getch(&ttys[0].inq, 1);
+    return chq_wait_rd(&ttys[0].inq, 0);
 }
 
 #endif

--- a/elks/include/linuxmt/chqueue.h
+++ b/elks/include/linuxmt/chqueue.h
@@ -4,18 +4,20 @@
 #define LX86_LINUXMT_CHQ_H
 
 struct ch_queue {
-    char		*buf;
-    struct wait_queue	wq;
-    int 		size, tail, len;
+    char		*base;
+    struct wait_queue	wait;
+    int 		size, start, len;
 };
 
 extern void chq_init(register struct ch_queue *,unsigned char *,int);
 /*extern void chq_erase(register struct ch_queue *);*/
-extern int chq_addch(register struct ch_queue *,unsigned char,int);
+extern int chq_wait_wr(register struct ch_queue *,int);
+extern int chq_addch(register struct ch_queue *,unsigned char);
 extern int chq_delch(register struct ch_queue *);
-extern int chq_peekch(register struct ch_queue *);
-extern int chq_full(register struct ch_queue *);
+/*extern int chq_peekch(register struct ch_queue *);*/
+/*extern int chq_full(register struct ch_queue *);*/
 
-extern int chq_getch(register struct ch_queue *,int);
+extern int chq_wait_rd(register struct ch_queue *,int);
+extern int chq_getch(register struct ch_queue *);
 
 #endif

--- a/elks/include/linuxmt/pipe_fs_i.h
+++ b/elks/include/linuxmt/pipe_fs_i.h
@@ -1,11 +1,14 @@
 #ifndef LX86_LINUXMT_PIPE_FS_I_H
 #define LX86_LINUXMT_PIPE_FS_I_H
 
+#include <linuxmt/chqueue.h>
+
 struct pipe_inode_info {
+    struct ch_queue q;
+/*    char *base;
     struct wait_queue wait;
-    char *base;
-    unsigned int start;
-	  size_t len;
+    unsigned int size, start;
+	  size_t len;*/
     unsigned int lock;
     unsigned int rd_openers;
     unsigned int wr_openers;
@@ -16,19 +19,18 @@ struct pipe_inode_info {
 #define PAGE_SIZE 512
 #define PIPE_BUF 512
 
-#define PIPE_WAIT(inode)	((inode).u.pipe_i.wait)
-#define PIPE_BASE(inode)	((inode).u.pipe_i.base)
-#define PIPE_START(inode)	((inode).u.pipe_i.start)
-#define PIPE_LEN(inode)		((inode).u.pipe_i.len)
+#define PIPE_WAIT(inode)	((inode).u.pipe_i.q.wait)
+#define PIPE_BASE(inode)	((inode).u.pipe_i.q.base)
+#define PIPE_START(inode)	((inode).u.pipe_i.q.start)
+#define PIPE_LEN(inode)		((inode).u.pipe_i.q.len)
 #define PIPE_RD_OPENERS(inode)	((inode).u.pipe_i.rd_openers)
 #define PIPE_WR_OPENERS(inode)	((inode).u.pipe_i.wr_openers)
 #define PIPE_READERS(inode)	((inode).u.pipe_i.readers)
 #define PIPE_WRITERS(inode)	((inode).u.pipe_i.writers)
 #define PIPE_LOCK(inode)	((inode).u.pipe_i.lock)
-#define PIPE_SIZE(inode)	PIPE_LEN(inode)
 
-#define PIPE_EMPTY(inode)	(PIPE_SIZE(inode)==0)
-#define PIPE_FULL(inode)	(PIPE_SIZE(inode)==PIPE_BUF)
+#define PIPE_EMPTY(inode)	(PIPE_LEN(inode)==0)
+#define PIPE_FULL(inode)	(PIPE_LEN(inode)==PIPE_BUF)
 #define PIPE_FREE(inode)	(PIPE_BUF - PIPE_LEN(inode))
 #define PIPE_END(inode)		((PIPE_START(inode)+PIPE_LEN(inode))&\
 							   (PIPE_BUF-1))


### PR DESCRIPTION
Make struct member names in queues the same
as the queue in pipes.
Make queue members in pipes actually a
struct chq_queue.
Kernel tested under Qemu.
Code size reduced by 64 bytes.
