### PR TITLE
Refactoring of inode.c and buffer.c

### DIFF
--- a/elks/fs/inode.c
+++ b/elks/fs/inode.c
@@ -56,7 +56,7 @@ static void put_last_lru(register struct inode *inode)
  * because they are not in the object as such
  */
 
-void clear_inode(register struct inode *inode)
+void clear_inode(register struct inode *inode) /* and put_first_lru() */
 {
     wait_on_inode(inode);
     remove_inode_free(inode);
@@ -143,6 +143,120 @@ static void write_inode(register struct inode *inode)
     }
 }
 
+void sync_inodes(kdev_t dev)
+{
+    register struct inode *inode = first_inode;
+
+    do {
+	if (dev && inode->i_dev != dev)
+	    continue;
+	wait_on_inode(inode);
+	if (inode->i_dirt)
+	    write_inode(inode);
+    } while ((inode = inode->i_prev) != first_inode);
+}
+
+static void list_inode_status(void)
+{
+    register char *pi = 0;
+    register struct inode *inode = first_inode;
+
+    do {
+        printk("[#%u: c=%u d=%x nr=%lu]",
+	       ((int)(pi++)), inode->i_count,
+	       inode->i_dev, inode->i_ino);
+    } while ((inode = inode->i_prev) != first_inode);
+}
+
+static struct inode *get_empty_inode(void)
+{
+    static ino_t ino = 0;
+    register struct inode *inode;
+
+    do {
+        inode = first_inode->i_next;
+        do {
+            if (!inode->i_count && !inode->i_dirt && !inode->i_lock) {
+                goto found_empty_inode;
+            }
+        } while ((inode = inode->i_next) != first_inode->i_next);
+        printk("VFS: No free inodes\n");
+        list_inode_status();
+        sleep_on(&inode_wait);
+    } while (1);
+  found_empty_inode:
+/* Here we are doing the same checks again. There cannot be a significant *
+ * race condition here - no time has passed */
+#if 0
+    if (inode->i_lock) {
+	wait_on_inode(inode);
+	goto repeat;
+    }
+    if (inode->i_dirt) {
+	write_inode(inode);
+	goto repeat;
+    }
+    if (inode->i_count)
+	goto repeat;
+#endif
+    clear_inode(inode);
+    inode->i_count = inode->i_nlink = 1;
+    inode->i_uid = current->euid;
+#ifdef BLOAT_FS
+    inode->i_version = ++event;
+#endif
+    inode->i_ino = ++ino;
+    nr_free_inodes--;
+    if (nr_free_inodes < 0) {
+	printk("VFS: get_empty_inode: bad free inode count.\n");
+	nr_free_inodes = 0;
+    }
+    return inode;
+}
+
+void iput(register struct inode *inode)
+{
+    register struct super_operations *sop;
+
+    if (inode) {
+	wait_on_inode(inode);
+	if (!inode->i_count) {
+	    printk("VFS: iput: trying to free free inode\n");
+	    printk("VFS: device %s, inode %lu, mode=0%07o\n",
+		   kdevname(inode->i_rdev), inode->i_ino, inode->i_mode);
+	    return;
+	}
+#ifdef NOT_YET
+	if ((inode->i_mode & S_IFMT) == S_IFIFO)
+	    wake_up_interruptible(&PIPE_WAIT(*inode));
+#endif
+	goto ini_loop;
+	do {
+	    write_inode(inode);	/* we can sleep - so do again */
+	    wait_on_inode(inode);
+      ini_loop:
+	    if (inode->i_count > 1) {
+		inode->i_count--;
+		return;
+	    }
+
+	    wake_up(&inode_wait);
+
+	    if (inode->i_sb) {
+		sop = inode->i_sb->s_op;
+		if (sop && sop->put_inode) {
+		    sop->put_inode(inode);
+		    if (!inode->i_nlink)
+			return;
+		}
+	    }
+
+	} while (inode->i_dirt);
+	inode->i_count--;
+	nr_free_inodes++;
+    }
+}
+
 static void set_ops(register struct inode *inode)
 {
     static unsigned char tabc[] = {
@@ -174,20 +288,92 @@ static void read_inode(register struct inode *inode)
     unlock_inode(inode);
 }
 
-void sync_inodes(kdev_t dev)
+struct inode *new_inode(register struct inode *dir, __u16 mode)
 {
-    register struct inode *inode = first_inode;
+    register struct inode *inode;
 
-    do {
-	if (dev && inode->i_dev != dev)
-	    continue;
-	wait_on_inode(inode);
-	if (inode->i_dirt)
-	    write_inode(inode);
-    } while ((inode = inode->i_prev) != first_inode);
+    if (!(inode = get_empty_inode()))
+	return inode;
+    inode->i_gid =(__u8) current->egid;
+    if (dir) {
+	inode->i_sb = dir->i_sb;
+	inode->i_dev = inode->i_sb->s_dev;
+	inode->i_flags = inode->i_sb->s_flags;
+	if (dir->i_mode & S_ISGID) {
+	    inode->i_gid = dir->i_gid;
+	    if (S_ISDIR(mode))
+		mode |= S_ISGID;
+	}
+    }
+
+    if (S_ISLNK(mode))
+	mode |= 0777;
+    else
+	mode &= ~(current->fs.umask & 0777);
+    inode->i_mode = mode;
+    inode->i_mtime = inode->i_atime = inode->i_ctime = CURRENT_TIME;
+
+#ifdef BLOAT_FS
+    inode->i_blocks = inode->i_blksize = 0;
+#endif
+
+    set_ops(inode);
+    return inode;
 }
 
-int fs_may_mount(kdev_t dev)
+struct inode *__iget(register struct super_block *sb,
+		     ino_t inr /*,int crossmntp */ )
+{
+    register struct inode *inode;
+
+    debug3("iget called(%x, %d, %d)\n", sb, inr, 0 /* crossmntp */ );
+    if (!sb)
+	panic("VFS: iget with sb==NULL");
+
+  repeat:
+    do {
+	inode = first_inode;
+	do {
+	    if (inode->i_dev == sb->s_dev && inode->i_ino == inr)
+		goto found_it;
+	} while ((inode = inode->i_prev) != first_inode);
+	debug("iget: getting an empty inode...\n");
+    } while (!(inode = get_empty_inode()));
+    debug1("iget: got one... (%x)!\n", empty);
+
+    inode->i_sb = sb;
+    inode->i_dev = sb->s_dev;
+    inode->i_flags = ((unsigned short int) sb->s_flags);
+    inode->i_ino = inr;
+    put_last_lru(inode);
+    debug("iget: Reading inode\n");
+    read_inode(inode);
+    debug("iget: Read it\n");
+    goto return_it;
+
+  found_it:
+    if (!inode->i_count)
+	nr_free_inodes--;
+    inode->i_count++;
+    wait_on_inode(inode);
+    if (inode->i_dev != sb->s_dev || inode->i_ino != inr) {
+	printk("Whee.. inode changed from under us. Tell _.\n");
+	iput(inode);
+	goto repeat;
+    }
+    if ( /* crossmntp && */ inode->i_mount) {
+	struct inode *tmp = inode->i_mount;
+	tmp->i_count++;
+	iput(inode);
+	inode = tmp;
+	wait_on_inode(inode);
+    }
+
+  return_it:
+    return inode;
+}
+
+int fs_may_mount(kdev_t dev)	/* and invalidate_inodes() */
 {
     register struct inode *next;
     register struct inode *inode = first_inode;
@@ -333,189 +519,3 @@ int notify_change(register struct inode *inode, register struct iattr *attr)
     return 0;
 }
 #endif
-
-static void list_inode_status(void)
-{
-    register char *pi = 0;
-    register struct inode *inode = first_inode;
-
-    do {
-        printk("[#%u: c=%u d=%x nr=%lu]",
-	       ((int)(pi++)), inode->i_count,
-	       inode->i_dev, inode->i_ino);
-    } while ((inode = inode->i_prev) != first_inode);
-}
-
-static struct inode *get_empty_inode(void)
-{
-    static ino_t ino = 0;
-    register struct inode *inode;
-
-    do {
-        inode = first_inode->i_next;
-        do {
-            if (!inode->i_count && !inode->i_dirt && !inode->i_lock) {
-                goto found_empty_inode;
-            }
-        } while ((inode = inode->i_next) != first_inode->i_next);
-        printk("VFS: No free inodes\n");
-        list_inode_status();
-        sleep_on(&inode_wait);
-    } while (1);
-  found_empty_inode:
-/* Here we are doing the same checks again. There cannot be a significant *
- * race condition here - no time has passed */
-#if 0
-    if (inode->i_lock) {
-	wait_on_inode(inode);
-	goto repeat;
-    }
-    if (inode->i_dirt) {
-	write_inode(inode);
-	goto repeat;
-    }
-    if (inode->i_count)
-	goto repeat;
-#endif
-    clear_inode(inode);
-    inode->i_count = inode->i_nlink = 1;
-    inode->i_uid = current->euid;
-#ifdef BLOAT_FS
-    inode->i_version = ++event;
-#endif
-    inode->i_ino = ++ino;
-    nr_free_inodes--;
-    if (nr_free_inodes < 0) {
-	printk("VFS: get_empty_inode: bad free inode count.\n");
-	nr_free_inodes = 0;
-    }
-    return inode;
-}
-
-void iput(register struct inode *inode)
-{
-    register struct super_operations *sop;
-
-    if (inode) {
-	wait_on_inode(inode);
-	if (!inode->i_count) {
-	    printk("VFS: iput: trying to free free inode\n");
-	    printk("VFS: device %s, inode %lu, mode=0%07o\n",
-		   kdevname(inode->i_rdev), inode->i_ino, inode->i_mode);
-	    return;
-	}
-#ifdef NOT_YET
-	if ((inode->i_mode & S_IFMT) == S_IFIFO)
-	    wake_up_interruptible(&PIPE_WAIT(*inode));
-#endif
-	goto ini_loop;
-	do {
-	    write_inode(inode);	/* we can sleep - so do again */
-	    wait_on_inode(inode);
-      ini_loop:
-	    if (inode->i_count > 1) {
-		inode->i_count--;
-		return;
-	    }
-
-	    wake_up(&inode_wait);
-
-	    if (inode->i_sb) {
-		sop = inode->i_sb->s_op;
-		if (sop && sop->put_inode) {
-		    sop->put_inode(inode);
-		    if (!inode->i_nlink)
-			return;
-		}
-	    }
-
-	} while (inode->i_dirt);
-	inode->i_count--;
-	nr_free_inodes++;
-    }
-}
-
-struct inode *new_inode(register struct inode *dir, __u16 mode)
-{
-    register struct inode *inode;
-
-    if (!(inode = get_empty_inode()))
-	return inode;
-    inode->i_gid =(__u8) current->egid;
-    if (dir) {
-	inode->i_sb = dir->i_sb;
-	inode->i_dev = inode->i_sb->s_dev;
-	inode->i_flags = inode->i_sb->s_flags;
-	if (dir->i_mode & S_ISGID) {
-	    inode->i_gid = dir->i_gid;
-	    if (S_ISDIR(mode))
-		mode |= S_ISGID;
-	}
-    }
-
-    if (S_ISLNK(mode))
-	mode |= 0777;
-    else
-	mode &= ~(current->fs.umask & 0777);
-    inode->i_mode = mode;
-    inode->i_mtime = inode->i_atime = inode->i_ctime = CURRENT_TIME;
-
-#ifdef BLOAT_FS
-    inode->i_blocks = inode->i_blksize = 0;
-#endif
-
-    set_ops(inode);
-    return inode;
-}
-
-struct inode *__iget(register struct super_block *sb,
-		     ino_t inr /*,int crossmntp */ )
-{
-    register struct inode *inode;
-
-    debug3("iget called(%x, %d, %d)\n", sb, inr, 0 /* crossmntp */ );
-    if (!sb)
-	panic("VFS: iget with sb==NULL");
-
-  repeat:
-    do {
-	inode = first_inode;
-	do {
-	    if (inode->i_dev == sb->s_dev && inode->i_ino == inr)
-		goto found_it;
-	} while ((inode = inode->i_prev) != first_inode);
-	debug("iget: getting an empty inode...\n");
-    } while (!(inode = get_empty_inode()));
-    debug1("iget: got one... (%x)!\n", empty);
-
-    inode->i_sb = sb;
-    inode->i_dev = sb->s_dev;
-    inode->i_flags = ((unsigned short int) sb->s_flags);
-    inode->i_ino = inr;
-    put_last_lru(inode);
-    debug("iget: Reading inode\n");
-    read_inode(inode);
-    debug("iget: Read it\n");
-    goto return_it;
-
-  found_it:
-    if (!inode->i_count)
-	nr_free_inodes--;
-    inode->i_count++;
-    wait_on_inode(inode);
-    if (inode->i_dev != sb->s_dev || inode->i_ino != inr) {
-	printk("Whee.. inode changed from under us. Tell _.\n");
-	iput(inode);
-	goto repeat;
-    }
-    if ( /* crossmntp && */ inode->i_mount) {
-	struct inode *tmp = inode->i_mount;
-	tmp->i_count++;
-	iput(inode);
-	inode = tmp;
-	wait_on_inode(inode);
-    }
-
-  return_it:
-    return inode;
-}


### PR DESCRIPTION
Fixed several small problems. The similarities in handling of inodes and buffers are now clear.
Code size reduced in 16 bytes. Compiled with bcc and tested with Qemu. Works.