### PR TITLE
[ktcp] Multi-line ARP cache

### DIFF
--- a/elkscmd/inet/nettools/.gitignore
+++ b/elkscmd/inet/nettools/.gitignore
@@ -1,0 +1,1 @@
+nslookup

--- a/elkscmd/ktcp/arp.c
+++ b/elkscmd/ktcp/arp.c
@@ -39,12 +39,14 @@ typedef struct arp_cache_s arp_cache_t;
 static arp_cache_t _arp_cache [ARP_CACHE_MAX];
 
 
-static int arp_cache_init () {
+static int arp_cache_init (void)
+{
 	memset (_arp_cache, 0, ARP_CACHE_MAX * sizeof (arp_cache_t));
-	}
+}
 
 
-int arp_cache_get (ipaddr_t ip_addr, eth_addr_t * eth_addr) {
+int arp_cache_get (ipaddr_t ip_addr, eth_addr_t * eth_addr)
+{
 	int err = -1;
 
 	/* First pair is the more recent */
@@ -57,16 +59,17 @@ int arp_cache_get (ipaddr_t ip_addr, eth_addr_t * eth_addr) {
 			memcpy (eth_addr, entry->eth_addr, sizeof (eth_addr_t));
 			err = 0;
 			break;
-			}
-
-		entry++;
 		}
 
-	return err;
+		entry++;
 	}
 
+	return err;
+}
 
-void arp_cache_add (ipaddr_t ip_addr, eth_addr_t * eth_addr) {
+
+void arp_cache_add (ipaddr_t ip_addr, eth_addr_t * eth_addr)
+{
 	if (arp_cache_get (ip_addr, eth_addr)) {
 		/* Shift the whole cache */
 
@@ -74,14 +77,14 @@ void arp_cache_add (ipaddr_t ip_addr, eth_addr_t * eth_addr) {
 		while (entry > _arp_cache) {
 			memcpy (entry, entry - 1, sizeof (arp_cache_t));
 			entry--;
-			}
+		}
 
 		/* Set the first pair as the more recent */
 
 		entry->ip_addr = ip_addr;
 		memcpy (entry->eth_addr, eth_addr, sizeof (eth_addr_t));
-		}
 	}
+}
 
 
 void arp_print(struct arp *arp_r)
@@ -105,11 +108,11 @@ void arp_print(struct arp *arp_r)
     printf("eth_dest: %2X.%2X.%2X.%2X.%2X.%2X \n",addr[0],addr[1],addr[2],addr[3],addr[4],addr[5]);
 }
 
-int arp_init ()
-	{
+int arp_init (void)
+{
 	arp_cache_init ();
 	return 0;
-	}
+}
 
 void arp_reply(char *packet,int size)
 {
@@ -190,19 +193,17 @@ selectagain:
 /* Process incoming ARP packets */
 
 void arp_proc (char * packet, int size)
-	{
+{
 	struct arp * arp_r;
 
 	arp_r = (struct arp *) packet;
-	switch (arp_r->op)
-		{
-		case ARP_REQUEST:  /* big endian */
-			arp_reply (packet, size);
-			break;
+	switch (arp_r->op) {
+	case ARP_REQUEST:  /* big endian */
+		arp_reply (packet, size);
+		break;
 
-		case ARP_REPLY:  /* big endian */
-			arp_cache_add (arp_r->ip_src, arp_r->eth_src);
-			break;
-
-		}
+	case ARP_REPLY:  /* big endian */
+		arp_cache_add (arp_r->ip_src, arp_r->eth_src);
+		break;
 	}
+}

--- a/elkscmd/ktcp/arp.c
+++ b/elkscmd/ktcp/arp.c
@@ -29,8 +29,7 @@
 
 #define ARP_CACHE_MAX 5
 
-struct arp_cache_s
-	{
+struct arp_cache_s {
 	ipaddr_t   ip_addr;   /* IPv4 address */
 	eth_addr_t eth_addr;  /* MAC address */
 	};
@@ -40,25 +39,21 @@ typedef struct arp_cache_s arp_cache_t;
 static arp_cache_t _arp_cache [ARP_CACHE_MAX];
 
 
-static int arp_cache_init ()
-	{
+static int arp_cache_init () {
 	memset (_arp_cache, 0, ARP_CACHE_MAX * sizeof (arp_cache_t));
 	}
 
 
-int arp_cache_get (ipaddr_t ip_addr, eth_addr_t * eth_addr)
-	{
+int arp_cache_get (ipaddr_t ip_addr, eth_addr_t * eth_addr) {
 	int err = -1;
 
 	/* First pair is the more recent */
 
 	arp_cache_t * entry = _arp_cache;
-	while (entry < _arp_cache + ARP_CACHE_MAX)
-		{
+	while (entry < _arp_cache + ARP_CACHE_MAX) {
 		if (!entry->ip_addr) break;
 
-		if (entry->ip_addr == ip_addr)
-			{
+		if (entry->ip_addr == ip_addr) {
 			memcpy (eth_addr, entry->eth_addr, sizeof (eth_addr_t));
 			err = 0;
 			break;
@@ -71,15 +66,12 @@ int arp_cache_get (ipaddr_t ip_addr, eth_addr_t * eth_addr)
 	}
 
 
-void arp_cache_add (ipaddr_t ip_addr, eth_addr_t * eth_addr)
-	{
-	if (arp_cache_get (ip_addr, eth_addr))
-		{
+void arp_cache_add (ipaddr_t ip_addr, eth_addr_t * eth_addr) {
+	if (arp_cache_get (ip_addr, eth_addr)) {
 		/* Shift the whole cache */
 
 		arp_cache_t * entry = _arp_cache + ARP_CACHE_MAX - 1;
-		while (entry > _arp_cache)
-			{
+		while (entry > _arp_cache) {
 			memcpy (entry, entry - 1, sizeof (arp_cache_t));
 			entry--;
 			}
@@ -116,7 +108,7 @@ void arp_print(struct arp *arp_r)
 int arp_init ()
 	{
 	arp_cache_init ();
-    return 0;
+	return 0;
 	}
 
 void arp_reply(char *packet,int size)

--- a/elkscmd/ktcp/arp.h
+++ b/elkscmd/ktcp/arp.h
@@ -29,8 +29,8 @@ typedef struct arp
 
 int arp_init ();
 
-void arp_cache_add (arp_cache_t * pair);
-int arp_cache_get (ipaddr_t * ip_addr, eth_addr_t * eth_addr);
+void arp_cache_add (ipaddr_t ip_addr, eth_addr_t * eth_addr);
+int arp_cache_get (ipaddr_t ip_addr, eth_addr_t * eth_addr);
 
 void arp_proc (char * packet, int size);
 

--- a/elkscmd/ktcp/arp.h
+++ b/elkscmd/ktcp/arp.h
@@ -3,11 +3,6 @@
 
 #include "ip.h"
 
-#define ARP_ETHER            1
-
-#define ARP_REQUEST          1
-#define ARP_REPLY            2
-
 
 typedef struct arp_addr {
 	ipaddr_t daddr;		/* IP destination address */
@@ -32,6 +27,10 @@ typedef struct arp
          __u32 ip_dest; 	/* IP destination address */
 };
 
+int arp_init ();
+
+void arp_cache_add (arp_cache_t * pair);
+int arp_cache_get (ipaddr_t * ip_addr, eth_addr_t * eth_addr);
 
 void arp_proc (char * packet, int size);
 

--- a/elkscmd/ktcp/arp.h
+++ b/elkscmd/ktcp/arp.h
@@ -27,7 +27,7 @@ typedef struct arp
          __u32 ip_dest; 	/* IP destination address */
 };
 
-int arp_init ();
+int arp_init (void);
 
 void arp_cache_add (ipaddr_t ip_addr, eth_addr_t * eth_addr);
 int arp_cache_get (ipaddr_t ip_addr, eth_addr_t * eth_addr);

--- a/elkscmd/ktcp/deveth.c
+++ b/elkscmd/ktcp/deveth.c
@@ -59,24 +59,15 @@ int deveth_init(char *fdev, int argc, char **argv)
     /* read mac of nic */
     if (ioctl (devfd, IOCTL_ETH_ADDR_GET, local_mac)<0) {
 	perror ("ioctl /dev/eth addr_get local_mac");
-	memcpy(local_mac,default_mac, 6);
+
+	/* MAC not available is a fatal error */
+	/* because it means the driver cannot work */
+
+	return -1;
     }    
     
     //printf("argc:%d,argv[2]:%s\n",argc,argv[2]);
-
-    arp_request(gateway_ip); /*updates ARP cache*/
-    memcpy(gateway_mac,acache.remotemac, 6);
-    /*clear cache again*/
-    for (i=0;i<6;i++) acache.remotemac[i]=0x00;
-    acache.ipaddr = 0;
     
-    arp_request(nameserver_ip); /*updates ARP cache*/
-    memcpy(nameserver_mac,acache.remotemac, 6);
-    /*clear cache again*/
-    for (i=0;i<6;i++) acache.remotemac[i]=0x00;
-    acache.ipaddr = 0;
-    if (strlen(nameserver_mac)==0)
-       memcpy(nameserver_mac,gateway_mac, 6); /*need to use gateway*/
 /*    
     addr = (__u8 *)&local_ip;
     printf("\nlocal_ip: %2X.%2X.%2X.%2X ",addr[0],addr[1],addr[2],addr[3]);    
@@ -84,12 +75,6 @@ int deveth_init(char *fdev, int argc, char **argv)
     printf("local_mac: %2X.%2X.%2X.%2X.%2X.%2X \n",addr[0],addr[1],addr[2],addr[3],addr[4],addr[5]);
     addr = (__u8 *)&gateway_ip;
     printf("\ngateway_ip: %2X.%2X.%2X.%2X ",addr[0],addr[1],addr[2],addr[3]);
-    addr = (__u8 *)&gateway_mac;
-    printf("gateway_mac: %2X.%2X.%2X.%2X.%2X.%2X \n",addr[0],addr[1],addr[2],addr[3],addr[4],addr[5]);
-    addr = (__u8 *)&nameserver_ip;
-    printf("nameserver_ip: %2X.%2X.%2X.%2X ",addr[0],addr[1],addr[2],addr[3]);
-    addr = (__u8 *)&nameserver_mac;
-    printf("nameserver_mac: %2X.%2X.%2X.%2X.%2X.%2X \n",addr[0],addr[1],addr[2],addr[3],addr[4],addr[5]);
 */    
     return devfd;
 }

--- a/elkscmd/ktcp/deveth.c
+++ b/elkscmd/ktcp/deveth.c
@@ -62,7 +62,6 @@ int deveth_init(char *fdev, int argc, char **argv)
 
 	/* MAC not available is a fatal error */
 	/* because it means the driver cannot work */
-
 	return -1;
     }    
     

--- a/elkscmd/ktcp/deveth.h
+++ b/elkscmd/ktcp/deveth.h
@@ -11,6 +11,8 @@
 
 /* Ethernet header (no VLAN tag) */
 
+typedef __u8 eth_addr_t [6];
+
 struct eth_head_s
 	{
 	__u8  eth_dst [6]; 	/* MAC destination address */

--- a/elkscmd/ktcp/ip.c
+++ b/elkscmd/ktcp/ip.c
@@ -184,29 +184,24 @@ void ip_sendpacket(char *packet,int len,struct addr_pair *apair)
         /* Is this the best place for the IP routing to happen ? */
         /* I think no, because actual sending interface is coming from the routing */
 
-        if ((local_ip & netmask_ip) != (apair->daddr & netmask_ip)) {
+        if ((local_ip & netmask_ip) != (apair->daddr & netmask_ip))
             /* Not on the same local network */
             /* Route to the gateway as local destination */
-
             ip_local_addr = gateway_ip;
-            } else {
+        else
             /* On the same local network */
             /* Route to the local destination */
-
             ip_local_addr = apair->daddr;
-            }
 
         /* The ARP transaction should occur before sending the IP packet */
         /* So this part should be moved upward in the IP protocol automaton */
         /* to avoid this dangerous unlimited try again loop */
 
-        while (arp_cache_get (ip_local_addr, eth_addr)) {
+        while (arp_cache_get (ip_local_addr, eth_addr))
             /* MAC not in cache */
             /* Issue an ARP request to get it */
             /* Until issue jbruchon#67 fixed, we block until ARP reply */
-
             arp_request (apair->daddr);
-            }
 
 /*    
     addr = (__u8 *)&apair->daddr;
@@ -234,7 +229,8 @@ void ip_sendpacket(char *packet,int len,struct addr_pair *apair)
     iph->frag_off 	= 0;
     iph->ttl		= 64;
     iph->protocol	= apair->protocol;
-    if (dev->type == 1){
+
+    if (dev->type == 1) {
       iph->daddr		= apair->daddr;
       iph->saddr		= local_ip;
     } else {
@@ -248,7 +244,7 @@ void ip_sendpacket(char *packet,int len,struct addr_pair *apair)
     //ip_print(iph);
     
     memcpy(&ipbuf[tlen], packet, len);    
-    if (dev->type == 1){ /*add link layer*/
+    if (dev->type == 1) { /*add link layer*/
       memmove(&ipbuf[14],&ipbuf, TCPDEV_BUFSIZE-14);
       memcpy(&ipbuf,&llbuf,14);
     }
@@ -257,9 +253,9 @@ void ip_sendpacket(char *packet,int len,struct addr_pair *apair)
     /* if (iph->daddr == local_ip && iph->daddr == 0x0100007f) { */
 	/* 127.0.0.1 */
 	/* TODO */
-	if (dev->type == 1){
-		deveth_send(&ipbuf, tlen + len +14); /*add link layer lenght*/
-        } else {
+
+	if (dev->type == 1)
+		deveth_send(&ipbuf, tlen + len + 14);  /* add link layer length */
+        else
 		slip_send(&ipbuf, tlen + len);  
-	} 
 }

--- a/elkscmd/ktcp/ip.c
+++ b/elkscmd/ktcp/ip.c
@@ -180,20 +180,16 @@ void ip_sendpacket(char *packet,int len,struct addr_pair *apair)
     ipaddr_t ip_local_addr;
     eth_addr_t eth_addr;
 
-    if (dev->type == 1)  /* Ethernet */
-        {
+    if (dev->type == 1) {  /* Ethernet */
         /* Is this the best place for the IP routing to happen ? */
         /* I think no, because actual sending interface is coming from the routing */
 
-        if ((local_ip & netmask_ip) != (apair->daddr & netmask_ip))
-            {
+        if ((local_ip & netmask_ip) != (apair->daddr & netmask_ip)) {
             /* Not on the same local network */
             /* Route to the gateway as local destination */
 
             ip_local_addr = gateway_ip;
-            }
-        else
-            {
+            } else {
             /* On the same local network */
             /* Route to the local destination */
 
@@ -202,9 +198,9 @@ void ip_sendpacket(char *packet,int len,struct addr_pair *apair)
 
         /* The ARP transaction should occur before sending the IP packet */
         /* So this part should be moved upward in the IP protocol automaton */
+        /* to avoid this dangerous unlimited try again loop */
 
-        if (!arp_cache_get (ip_local_addr, eth_addr))
-            {
+        while (arp_cache_get (ip_local_addr, eth_addr)) {
             /* MAC not in cache */
             /* Issue an ARP request to get it */
             /* Until issue jbruchon#67 fixed, we block until ARP reply */

--- a/elkscmd/ktcp/ip.h
+++ b/elkscmd/ktcp/ip.h
@@ -42,7 +42,7 @@ __u16 ip_calc_chksum(char *data, int len);
 ipaddr_t local_ip;
 ipaddr_t gateway_ip;
 ipaddr_t netmask_ip;
-ipaddr_t nameserver_ip;
+
 __u16	next_port;
 
 typedef struct ip_ll
@@ -52,19 +52,8 @@ typedef struct ip_ll
          __u16 ll_type_len;	/* 0x800 big endian for IP */
 };
 
-typedef struct arp_cache {
-	ipaddr_t ipaddr;	/* IP remote address */
-	__u8  remotemac[6]; 	/* MAC remote address */
-};
-
 static int tcpdevfd;
 
-struct arp_cache acache;
-static char default_mac [6] = {0x52, 0x54, 0x00, 0x12, 0x34, 0x56};  // QEMU default
-static char local_mac [6];
-char remote_mac [6];
-char gateway_mac [6];
-char netmask_mac [6];
-char nameserver_mac [6];
+char local_mac [6];
 
 #endif

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -105,7 +105,7 @@ int main(int argc,char **argv)
     sprintf(dname,"/dev/eth");
 	
     if (argc < 3) {
-	printf("Syntax :\n    %s local_ip [interface] [gateway] [netmask] [nameserver]\n",argv[0]);
+	printf("Syntax :\n    %s local_ip [interface] [gateway] [netmask]\n", argv[0]);
 	exit(3);
     }
 
@@ -124,12 +124,6 @@ int main(int argc,char **argv)
       netmask_ip = in_aton("255.255.255.0");
     }
 
-    if (argc>5) {
-      nameserver_ip = in_aton(argv[5]);
-    } else { /* default */
-      nameserver_ip = in_aton("8.8.8.8"); /*google*/
-    }
-    
     debug("\nKTCP: 2. init tcpdev\n");
     if ((tcpdevfd = tcpdev_init("/dev/tcpdev")) < 0)
 	exit(1);
@@ -146,6 +140,8 @@ int main(int argc,char **argv)
     	      if ((intfd = slip_init(argv[2])) < 0)
 	      exit(2);
 	}
+
+    arp_init ();
 
     debug("KTCP: 4. ip_init()\n");
     ip_init();

--- a/elkscmd/test/eth/Makefile
+++ b/elkscmd/test/eth/Makefile
@@ -1,4 +1,4 @@
-# Makefile for eth
+# Makefile for ethernet driver test
 
 BASEDIR=../..
 
@@ -16,18 +16,20 @@ all:	eth
 
 eth:	$(OBJS)
 
-min_rfs:
 
 smin_rfs:
 
-max_rfs: install
+min_rfs:
 
-rfs: install
+rfs:
 
-net_rfs: install
+max_rfs:
 
-install: eth
-	cp -p eth $(TARGET_MNT)/bin/eth
+net_rfs:
+
+
+install: all
+	cp -p eth $(TARGET_MNT)/bin
 
 clean: 
 	rm -f *.o eth

--- a/elkscmd/test/socket/echo/Makefile
+++ b/elkscmd/test/socket/echo/Makefile
@@ -33,19 +33,19 @@ include $(BASEDIR)/Make.rules
 
 PRGS=echoserver_un echoserver_in echoclient_un echoclient_in
 
-SPRGS=
-
 all: $(PRGS)
 
-max_rfs: install
 
-rfs:
-
-net_rfs: install
+smin_rfs:
 
 min_rfs:
 
-smin_rfs:
+rfs:
+
+max_rfs:
+
+net_rfs:
+
 
 install: all
 	cp -p $(PRGS) $(TARGET_MNT)/bin


### PR DESCRIPTION
**Jody: please wait for the end of the code review before merging this one.**

This commit replaces the single-line ARP cache by a multi-line one. This allows to simplify the code (no direct cache manipulation) and get a cleaner layering.

I also removed the unit tests from the default images, as discussed on the mailing list, plus some cosmetics.

I am asking for a code review, because a peer review is always a good thing, and in Github workflow, a pull request is a good place to discuss the proposed changes. And we do have time to discuss: this is an improvement, not a bug fix.