### PR TITLE
[ktcp] Add MAC filtering for promiscuous mode

### DIFF
--- a/elks/Documentation/html/user/qemu.html
+++ b/elks/Documentation/html/user/qemu.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+
+<html>
+
+<head>
+<meta charset="utf-8">
+<title>ELKS in QEMU</title>
+</head>
+
+<body>
+
+<h1>Running ELKS in QEMU</h1>
+
+<p>Last QEMU version tested: 2.7.0</p>
+
+<p>QEMU is the prefered emulator to test ELKS, as it is mainstream, is able to
+emulate a pure ISA machine, and provides some useful debug facilities, like
+the guest network dump.</p>
+
+<p>Another emulator is <a href="https://github.com/jbruchon/dev86/tree/master/emu86">
+EMU86</a> (part of the DEV86 project), but is more intended
+for low level debugging for the ELKS developers.</p>
+
+<p>To run ELKS in QEMU, use the launcher script in:</p>
+<pre>
+cd .../elks
+./qemu.sh
+</pre>
+
+<p>Edit this script to customize your QEMU configuration. It contains some comments
+to explain the most useful options.<p>
+
+<h2>ELKS networking in QEMU</h2>
+
+<p>The simplest way to do networking in QEMU is the "user" mode. Outgoing
+connections work without additional configuration. For incoming connections,
+use the "host-to-guest" forwarding of the user VLAN. In the following example,
+we tell QEMU to listen on port 2323 on the host local address 127.0.0.1, and
+to redirect to port 23 on ELKS, so that we can telnet to ELKS:</p>
+
+<pre>
+qemu.sh: -net user,hostfwd=tcp:127.0.0.1:2323-10.0.2.15:23
+telnet 127.0.0.1 2323
+</pre>
+
+<p>To capture and dump the packets from the user VLAN, use the option:</p>
+<pre>
+qemu.sh: -net dump
+</pre>
+
+<p>Then use TcpDump or Wireshark to display the network trafic:</p>
+<pre>
+tcpdump -r qemu-vlan0.pcap
+</pre>
+
+</body>
+</html>

--- a/elks/Documentation/index.html
+++ b/elks/Documentation/index.html
@@ -4,17 +4,15 @@
 
 <head>
 <meta charset="utf-8">
-<title>ELKS Documentation Directory</title>
+<title>ELKS Documentation</title>
 </head>
 
 <body>
 
-<h1>Index of ELKS Documentation Directory</h1>
-
-<p>This is a brief list of all the files in /Documentation and what
-they contain. If you add a documentation file, please list it here.</p>
+<h1>Index of ELKS Documentation</h1>
 
 <h2>FAQs:</h2>
+
 <ul>
 <li><a href="html/faq/index.html">Index of FAQs</a></li>
 <li><a href="html/faq/FAQ-English.html">The ELKS-FAQ in English</a>, by <a href="mailto:ajr@ecs.soton.ac.uk">Alistair Riddoch</a></li>
@@ -26,7 +24,16 @@ they contain. If you add a documentation file, please list it here.</p>
 <li><a href="html/faq/FAQ-Portuguese.html">The ELKS-FAQ in Portuguese</a></li>
 </ul>
 
-<h2>Others:</h2>
+<h2>User guide</h2>
+
+<p>This section contains some HOWTOs to help using ELKS.<p>
+
+<ul>
+<li><a href="html/user/qemu.html">Running ELKS in QEMU</a></li>
+</ul>
+
+<h2>Technical reference</h2>
+
 <ul>
 <li><a href="text/8086.txt">notes on 8086 processor architecture.</a></li>
 <li><a href="Configure.help">text file that is used for help when you run "make config".</a></li>

--- a/elkscmd/ktcp/arp.c
+++ b/elkscmd/ktcp/arp.c
@@ -131,7 +131,7 @@ void arp_reply(char *packet,int size)
     apair.daddr = arp_r->ip_src;
     apair.saddr = arp_r->ip_dest;
     memcpy(apair.eth_dest, arp_r->eth_src, 6);
-    memcpy(apair.eth_src, local_mac, 6);
+    memcpy(apair.eth_src, eth_local_addr, 6);
 
     /* build arp reply */
     arp_r->op=0x200; /*response - big endian*/
@@ -159,7 +159,7 @@ int arp_request(ipaddr_t ipaddress)
     
     /* build arp request */
     for (i=0;i<6;i++) arp_r->ll_eth_dest[i]=0xFF; /*broadcast*/
-    memcpy(arp_r->ll_eth_src, local_mac, 6);
+    memcpy(arp_r->ll_eth_src, eth_local_addr, 6);
     /*specify below in big endian*/
     arp_r->ll_type_len=0x0608;
     arp_r->hard_type=0x0100;
@@ -167,7 +167,7 @@ int arp_request(ipaddr_t ipaddress)
     arp_r->hard_len=6;
     arp_r->proto_len=4;
     arp_r->op=0x0100; /*request - big endian*/
-    memcpy(arp_r->eth_src, local_mac, 6);
+    memcpy(arp_r->eth_src, eth_local_addr, 6);
     arp_r->ip_src=local_ip;
     for (i=0;i<6;i++) arp_r->eth_dest[i]=0; 
     arp_r->ip_dest=ipaddress;

--- a/elkscmd/ktcp/deveth.h
+++ b/elkscmd/ktcp/deveth.h
@@ -13,15 +13,16 @@
 
 typedef __u8 eth_addr_t [6];
 
-struct eth_head_s
-	{
-	__u8  eth_dst [6]; 	/* MAC destination address */
-	__u8  eth_src [6]; 	/* MAC source address */
+struct eth_head_s {
+	eth_addr_t eth_dst;  /* MAC destination address */
+	eth_addr_t eth_src;  /* MAC source address */
 
-	__u16 eth_type;     /* Ethernet II type */
+	__u16 eth_type;      /* Ethernet II type */
 	};
 
 typedef struct eth_head_s eth_head_t;
+
+extern eth_addr_t eth_local_addr;
 
 
 void deveth_printhex(char* packet, int len);

--- a/elkscmd/ktcp/ip.c
+++ b/elkscmd/ktcp/ip.c
@@ -180,6 +180,11 @@ void ip_sendpacket(char *packet,int len,struct addr_pair *apair)
     ipaddr_t ip_local_addr;
     eth_addr_t eth_addr;
 
+    /*
+    addr = (__u8 *) &apair->daddr;
+    printf ("daddr: %2X.%2X.%2X.%2X\n", addr [0], addr [1], addr [2], addr [3]);
+    */
+
     if (dev->type == 1) {  /* Ethernet */
         /* Is this the best place for the IP routing to happen ? */
         /* I think no, because actual sending interface is coming from the routing */
@@ -201,12 +206,7 @@ void ip_sendpacket(char *packet,int len,struct addr_pair *apair)
             /* MAC not in cache */
             /* Issue an ARP request to get it */
             /* Until issue jbruchon#67 fixed, we block until ARP reply */
-            arp_request (apair->daddr);
-
-/*    
-    addr = (__u8 *)&apair->daddr;
-    printf("daddr: %2X.%2X.%2X.%2X \n",addr[0],addr[1],addr[2],addr[3]);
-*/
+            arp_request (ip_local_addr);
 
     /*link layer*/
 
@@ -214,7 +214,7 @@ void ip_sendpacket(char *packet,int len,struct addr_pair *apair)
     /* So this part should be moved downward */
 
     memcpy(ipll->ll_eth_dest, eth_addr, 6);
-    memcpy(ipll->ll_eth_src,local_mac, 6);
+    memcpy(ipll->ll_eth_src,eth_local_addr, 6);
     ipll->ll_type_len=0x08; /*=0x0800 bigendian*/
     } //if (dev->type == 1)
     

--- a/elkscmd/ktcp/ip.c
+++ b/elkscmd/ktcp/ip.c
@@ -177,7 +177,7 @@ void ip_sendpacket(char *packet,int len,struct addr_pair *apair)
     char llbuf[15];    
     struct ip_ll *ipll = (struct ip_ll *)&llbuf;
 
-    ipaddr_t ip_local_addr;
+    ipaddr_t ip_addr;
     eth_addr_t eth_addr;
 
     /*
@@ -192,21 +192,21 @@ void ip_sendpacket(char *packet,int len,struct addr_pair *apair)
         if ((local_ip & netmask_ip) != (apair->daddr & netmask_ip))
             /* Not on the same local network */
             /* Route to the gateway as local destination */
-            ip_local_addr = gateway_ip;
+            ip_addr = gateway_ip;
         else
             /* On the same local network */
             /* Route to the local destination */
-            ip_local_addr = apair->daddr;
+            ip_addr = apair->daddr;
 
         /* The ARP transaction should occur before sending the IP packet */
         /* So this part should be moved upward in the IP protocol automaton */
         /* to avoid this dangerous unlimited try again loop */
 
-        while (arp_cache_get (ip_local_addr, eth_addr))
+        while (arp_cache_get (ip_addr, eth_addr))
             /* MAC not in cache */
             /* Issue an ARP request to get it */
             /* Until issue jbruchon#67 fixed, we block until ARP reply */
-            arp_request (ip_local_addr);
+            arp_request (ip_addr);
 
     /*link layer*/
 

--- a/elkscmd/ktcp/ip.h
+++ b/elkscmd/ktcp/ip.h
@@ -54,6 +54,4 @@ typedef struct ip_ll
 
 static int tcpdevfd;
 
-char local_mac [6];
-
 #endif

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -101,6 +101,8 @@ void ktcp_run(void)
 
 int main(int argc,char **argv)
 {
+    __u8 * addr;
+
     const char dname[9];
     sprintf(dname,"/dev/eth");
 	
@@ -123,6 +125,15 @@ int main(int argc,char **argv)
     } else { /* default */
       netmask_ip = in_aton("255.255.255.0");
     }
+
+    /*
+    addr = (__u8 *) &local_ip;
+    printf ("local_ip: %2X.%2X.%2X.%2X\n", addr [0], addr [1], addr [2], addr[3]);
+    addr = (__u8 *) &gateway_ip;
+    printf ("gateway_ip: %2X.%2X.%2X.%2X\n", addr [0], addr [1], addr [2], addr [3]);
+    addr = (__u8 *) &netmask_ip;
+    printf ("netmask_ip: %2X.%2X.%2X.%2X\n", addr [0], addr [1], addr [2], addr [3]);
+    */
 
     debug("\nKTCP: 2. init tcpdev\n");
     if ((tcpdevfd = tcpdev_init("/dev/tcpdev")) < 0)

--- a/elkscmd/rootfs_template/etc/rc.d/rc.sysinit
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sysinit
@@ -16,7 +16,7 @@ ttybaud=4800
 
 if test -f /bin/ktcp
 then
-	echo -n 'Starting kernel network facilities:'
+	echo -n 'Starting network process:'
 	if test "$interface" != "/dev/eth" 
 	then stty $ttybaud < $interface
 	echo -n ' stty slip'
@@ -27,9 +27,8 @@ then
 	ktcp $localip $interface &
 	echo ' ktcp'
 	
-	echo -n "Starting network daemons: "
-	for daemon in ftpd httpd 
-	#echoserver
+	echo -n "Starting network services: "
+	for daemon in telnetd ftpd httpd
 	do
 		if test -f /bin/$daemon 
 		then


### PR DESCRIPTION
To work with QEMU that implements badly the MAC unicast filtering, the Ethernet NE2K driver forces the promiscuous mode to bypass that filtering. This results in receiving all the packets from the network, that causes failure on a real one. So this commit adds a filter to retain only the packets of interest.

Tested with HTTP from the host, and with TELNET from the guest (yes, ELKS telnet client works !).