### PR TITLE
Initialize register ES from the begining.

### DIFF
--- a/elks/arch/i86/kernel/printreg.S
+++ b/elks/arch/i86/kernel/printreg.S
@@ -44,9 +44,12 @@ _print_regs:
 	.globl _printsp
 
 _printsp:
-	push sp
+	mov ax,sp
+	add ax,#2
+	push ax
 	push ss
-	push #msg
+	mov ax,#msg
+	push ax
 	call _printk
 	pop ax
 	pop ax

--- a/elks/arch/i86/kernel/signal.c
+++ b/elks/arch/i86/kernel/signal.c
@@ -75,7 +75,7 @@ int do_signal(void)
 		do_exit((int) signr);
 	    }
 	}
-	debug1("Setting up return stack for sig handler %x.\n", sa->sa_handler);
+	debug1("Setting up return stack for sig handler %x.\n", (unsigned)(*sah));
 	debug1("Stack at %x\n", currentp->t_regs.sp);
 	arch_setup_sighandler_stack(currentp, *sah, signr);
 	debug1("Stack at %x\n", currentp->t_regs.sp);

--- a/elks/arch/i86/kernel/strace.c
+++ b/elks/arch/i86/kernel/strace.c
@@ -47,7 +47,7 @@ void print_syscall(register struct syscall_params *p, int retval)
 #endif
 
 	i = 0;
-	tmpa = s->s_params;
+	tmpa = (s->s_params >> 4);
 	goto pscl;
 	while (tmpa >>= 4) {
 	    printk(", ");

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -445,9 +445,8 @@ int sys_brk(__pptr len)
             panic("Relocated shared hole");
         }
 
-        currentp->mm.dseg = h->page_base;
-        currentp->t_regs.ds = h->page_base;
-        currentp->t_regs.ss = h->page_base;
+	currentp->t_regs.ds = currentp->t_regs.es\
+		= currentp->t_regs.ss = currentp->mm.dseg = h->page_base;
         currentp->t_endseg = len;
     }
 #endif
@@ -621,8 +620,7 @@ static int swap_in(seg_t base, int chint)
 	}
 	if (c && !t->mm.flags) {
 	    t->t_regs.cs = t->mm.cseg;
-	    t->t_regs.ds = t->mm.dseg;
-	    t->t_regs.ss = t->mm.dseg;
+	    t->t_regs.ds = t->t_regs.es = t->t_regs.ss = t->mm.dseg;
 
 	    put_ustack(t, 2, t->t_regs.cs);
 	}

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -274,7 +274,7 @@ int sys_execve(char *filename, char *sptr, size_t slen)
     debug("EXEC: old binary flushed.\n");
 
     tregs->cs = currentp->mm.cseg = cseg;
-    tregs->ss = tregs->ds = currentp->mm.dseg = dseg;
+    tregs->ds = tregs->es = tregs->ss = currentp->mm.dseg = dseg;
 
     currentp->t_begstack = ((__pptr) ptr);	/* Just below the arguments */
     tregs->sp = (__u16)(currentp->t_begstack);

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -64,10 +64,10 @@ struct task_struct *find_empty_process(void)
 pid_t do_fork(int virtual)
 {
     register struct task_struct *t;
-    pid_t j;
+    int j;
     struct file *filp;
     register __ptask currentp = current;
-    int sc[4];
+    int sc[5];
 
     if ((t = find_empty_process()) == NULL)
         return -EAGAIN;
@@ -92,7 +92,7 @@ pid_t do_fork(int virtual)
 	    return -ENOMEM;
 	}
 
-	t->t_regs.ds = t->t_regs.ss = t->mm.dseg;
+	t->t_regs.ds = t->t_regs.es = t->t_regs.ss = t->mm.dseg;
     }
 
     /* Increase the reference count to all open files */
@@ -135,7 +135,7 @@ pid_t do_fork(int virtual)
 	 * first few bytes at the top of the user stack. Save those
 	 * bytes in the parent's kernel stack.
 	 */
-	fmemcpy(kernel_ds, sc, currentp->t_regs.ss, currentp->t_regs.sp, 8);
+	fmemcpy(kernel_ds, sc, currentp->t_regs.ss, currentp->t_regs.sp, 10);
 	/*
 	 * Let the child go on first.
 	 */
@@ -144,7 +144,7 @@ pid_t do_fork(int virtual)
 	 * By now, the child should have its own user stack. Restore
 	 * the parent's user stack.
 	 */
-	fmemcpy(currentp->t_regs.ss, currentp->t_regs.sp, kernel_ds, sc, 8);
+	fmemcpy(currentp->t_regs.ss, currentp->t_regs.sp, kernel_ds, sc, 10);
     }
     /*
      *      Return the created task.


### PR DESCRIPTION
Do not assume a 80186 processor or higher in  function printsp().
Fix minor bug in strace.c.
Other minor fixes.
