### PR TITLE
Update existing and add new documentation.

### DIFF
--- a/elks/Documentation/html/technical/kernel_mode_device_drivers.html
+++ b/elks/Documentation/html/technical/kernel_mode_device_drivers.html
@@ -1,0 +1,270 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<HTML>
+<HEAD>
+	<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=windows-1252">
+	<TITLE></TITLE>
+	<META NAME="GENERATOR" CONTENT="OpenOffice 4.1.2  (Win32)">
+	<META NAME="AUTHOR" CONTENT="Georg Potthast">
+	<META NAME="CREATED" CONTENT="20170105;19172240">
+	<META NAME="CHANGEDBY" CONTENT="Georg Potthast">
+	<META NAME="CHANGED" CONTENT="20170304;11433543">
+	<STYLE TYPE="text/css">
+	<!--
+		@page { margin: 2cm }
+		TD P { margin-bottom: 0cm }
+		P { margin-bottom: 0.21cm }
+		PRE.cjk { font-family: "NSimSun", monospace }
+		H2 { margin-bottom: 0.21cm }
+		H2.western { font-family: "Arial", sans-serif; font-size: 14pt; font-style: italic }
+		H2.cjk { font-family: "Microsoft YaHei"; font-size: 14pt; font-style: italic }
+		H2.ctl { font-family: "Lucida Sans"; font-size: 14pt; font-style: italic }
+		A:link { so-language: zxx }
+	-->
+	</STYLE>
+</HEAD>
+<BODY LANG="de-DE" DIR="LTR">
+<TABLE WIDTH=718 BORDER=0 CELLPADDING=4 CELLSPACING=0 STYLE="page-break-before: always">
+	<COL WIDTH=710>
+	<TR>
+		<TD WIDTH=710 VALIGN=TOP>
+			<H2 CLASS="western" STYLE="font-style: normal">Writing kernel mode
+			drivers for ELKS</H2>
+			<P STYLE="margin-bottom: 0.5cm"><FONT FACE="Arial, sans-serif">Like
+			most alternative operating systems, ELKS is missing drivers for
+			many peripherals. Therefore this text describes to write
+			additional drivers.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm"><FONT FACE="Arial, sans-serif">As
+			a proof of concept, the 'hellodev' driver will be implemented now:</FONT></P>
+			<PRE CLASS="western">/*
+ * hello driver for ELKS kernel
+ */
+
+#include &lt;linuxmt/kernel.h&gt; /* printk() */
+#include &lt;linuxmt/fs.h&gt;     /* file_operations struct */
+#include &lt;string.h&gt;
+
+#define HELLO_DEVICE_NAME       &quot;hellodev&quot;
+#define HELLO_MAJOR     9
+
+static char message[256];
+char *msgptr = message;
+
+static int hello_write(struct inode *inode, struct file *file, char* buf, int len)
+{
+    memcpy_fromfs(message,buf,len);
+    printk(&quot;hellodev: hello_write() called\n&quot;);
+    return 0;
+}
+
+static int hello_read(struct inode *inode, struct file *file, char* buf, int len)
+{
+    memcpy_tofs(buf, message, len);
+    printk(&quot;hellodev: hello_read() called\n&quot;);
+    return len;
+}
+
+static int hello_open(struct inode *inode, struct file *file)
+{
+    printk(&quot;hellodev: hello_open() called\n&quot;);
+    return 0;
+}
+
+static void hello_release(struct inode *inode, struct file *file)
+{
+    printk(&quot;hellodev: hello_release() called\n&quot;);
+    return;
+}
+
+static struct file_operations hello_fops = {
+    NULL,                       /* lseek */
+    hello_read,                 /* read */
+    hello_write,                /* write */
+    NULL,                       /* readdir */
+    NULL,                       /* select */
+    NULL,                       /* ioctl */
+    hello_open,                 /* open */
+    hello_release               /* release */
+    
+#ifdef BLOAT_FS
+        ,
+    NULL,                       /* fsync */
+    NULL,                       /* check_media_type */
+    NULL                        /* revalidate */
+#endif
+};
+
+void hello_init(void)
+{
+        printk(&quot;hellodev: hello_init() called\n&quot;);
+
+    /* register device */
+    if (register_chrdev(HELLO_MAJOR, HELLO_DEVICE_NAME, &amp;hello_fops))
+        printk(&quot;hellodev: unable to register\n&quot;);
+}</PRE><P STYLE="margin-bottom: 0.5cm">
+			<FONT FACE="Arial, sans-serif">This driver just implements the
+			functions hello_init(), hello_open(), hello_read(), hello_write()
+			and hello_release(). When these functions are called it outputs a
+			message using the printk() statement. This is the equivalent for
+			printf() in kernel code. Also the functions memcpy_fromfs() and
+			memcpy_tofs() are used. The kernel will for security reasons not
+			accept pointers from userspace which may be faulty. Therefore you
+			have to use these functions. For single chars there are equivalent
+			functions available called get_user_char() and put_user_char().
+			You will also not be able to use inportb() and outportb()
+			functions, use the inb() and inb_p() or out() and out_p()
+			functions instead. The &bdquo;_p&ldquo; versions insert a small
+			pause or delay before returning to support slower devices.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm"><FONT FACE="Arial, sans-serif">When
+			the driver is loaded the kernel will call hello_init() and the
+			hellodev driver will execute the register_chrdev() function. This
+			function contains the device name which will appear in the /dev
+			directory and a pointer to the file_operations structure called
+			hello_ops. In there the kernel will find the addresses of the
+			functions defined in the driver.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm"><FONT FACE="Arial, sans-serif">The
+			kernel identifies the driver by its unique the major number. In
+			our demo driver we have included these macros in the code: </FONT>
+			</P>
+			<PRE CLASS="western">#define HELLO_DEVICE_NAME       &quot;hellodev&quot;
+#define HELLO_MAJOR     9</PRE><P STYLE="margin-bottom: 0.5cm">
+			<FONT FACE="Arial, sans-serif">Usually in ELKS these are defined
+			in the elks/include/linuxmt/major.h file which the drivers
+			include. However, that file still needs to be changed. Increase
+			the maximum number of char devices to 10:</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm"><FONT FACE="Arial, sans-serif">#define
+			MAX_CHRDEV 10</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm"><FONT FACE="Arial, sans-serif">Put
+			the code above as the hellodev.c file into the
+			elks/arch/i86/drivers/char/ directory and add it to the Makefile
+			in this directory:</FONT></P>
+			<PRE CLASS="western">else
+OBJS  = bioscon.o common.o serial.o lp.o xt_key.o init.o dircon.o mem.o \
+        <B>hellodev.o </B>ntty.o meta.o tcpdev.o pty.o bell.o # clist.o tty.o</PRE><P STYLE="margin-bottom: 0.5cm">
+			<FONT FACE="Arial, sans-serif">Also edit the init.c file:</FONT></P>
+			<PRE CLASS="western">void chr_dev_init(void)
+{
+#if 1
+hello_init();
+#endif
+#ifdef CONFIG_CHAR_DEV_RS
+rs_init();</PRE><P STYLE="margin-bottom: 0.5cm">
+			<FONT FACE="Arial, sans-serif"><FONT SIZE=3>Normally, you would
+			define a macro in the elks/arch/i86/defconfig file which can be
+			modified with &bdquo;menuconfig&ldquo; and modify the files
+			elks/arch/i86/drivers/char/config.in plus
+			elks/Documentation/Configure.help.</FONT></FONT></P>
+			<P STYLE="margin-bottom: 0.5cm"><FONT FACE="Arial, sans-serif"><FONT SIZE=3>Further,
+			the hello_init() function has to be declared in the
+			elks/include/linuxmt/init.h file:</FONT></FONT></P>
+			<PRE CLASS="western">extern void xtk_init(void);
+extern void hello_init(void);
+
+extern void init_console(void);</PRE><P STYLE="margin-bottom: 0.5cm">
+			<FONT FACE="Arial, sans-serif"><FONT SIZE=3>To load the driver
+			simply add it after the tcpdev device in the
+			elkscmd/rootfs_template/dev/MAKEDEV script. In this script there
+			is a macro for the mknod() function called MAKEDEV:</FONT></FONT></P>
+			<PRE CLASS="western"># TCPDEV, used by ktcp
+
+        mknod tcpdev c 8 0
+        $MKDEV hellodev c 9 0</PRE><P STYLE="margin-bottom: 0.5cm">
+			<FONT FACE="Arial, sans-serif"><FONT SIZE=3>The letter &bdquo;c&ldquo;
+			stands for character driver while the number 9 is the major number
+			and zero the minor number. </FONT></FONT>
+			</P>
+			<P STYLE="margin-bottom: 0.5cm"><FONT FACE="Arial, sans-serif"><FONT SIZE=3>To
+			sum it up, you added hellodev.c into the
+			elks/arch/i86/drivers/char directory and modified init.c and the
+			Makefile in there. Also you modified major.h and init.h in the
+			elks/include/linuxmt directory and the file MAKEDEV in the
+			elkscmd/rootfs_template/dev directory.</FONT></FONT></P>
+			<P STYLE="margin-bottom: 0.5cm"><FONT FACE="Arial, sans-serif">Now
+			you can compile ELKS again and it will include the hellodev driver
+			and load it. If you enter &bdquo;ls /dev&ldquo; you will see a
+			device node called hellodev.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm"><FONT FACE="Arial, sans-serif">To
+			test this driver use this program which you may drvtest.c:</FONT></P>
+			<PRE CLASS="western">#include&lt;stdio.h&gt;
+#include&lt;stdlib.h&gt;
+#include&lt;errno.h&gt;
+#include&lt;fcntl.h&gt;
+ 
+#define BUFFER_LENGTH 256               
+static char receive[BUFFER_LENGTH];     
+ 
+int main(){
+   int ret, fd;
+   char stringToSend[BUFFER_LENGTH];
+
+   printf(&quot;Starting device test code example...\n&quot;);
+
+   fd = open(&quot;/dev/hellodev&quot;, O_RDWR);  
+
+   if (fd &lt; 0){
+      perror(&quot;Failed to open the device...&quot;);
+      return errno;
+   }
+
+   printf(&quot;Type in a short string to send to the kernel module:\n&quot;);
+   scanf(&quot;%s&quot;, stringToSend);                // Read in a string
+   printf(&quot;Writing message to the device [%s].\n&quot;, stringToSend);
+
+   ret = write(fd, stringToSend, strlen(stringToSend)); 
+   if (ret &lt; 0){
+      perror(&quot;Failed to write the message to the device.&quot;);
+      return errno;
+   }
+ 
+   printf(&quot;Now reading the string back from the device...\n&quot;);
+   ret = read(fd, &amp;receive[0], BUFFER_LENGTH);        
+   if (ret &lt; 0){
+      perror(&quot;Failed to read the message from the device.&quot;);
+      return errno;
+   }
+
+   printf(&quot;The received message is: [%s]\n&quot;, receive);
+
+   return 0;
+}</PRE><P STYLE="margin-bottom: 0.5cm">
+			<FONT FACE="Arial, sans-serif">To compile this program enter &bdquo;bcc
+			-ansi -o drvtest drvtest.c&ldquo; and e.g. copy the executable
+			drvtest to the full3 image file using a loop device.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm"><FONT FACE="Arial, sans-serif">Here
+			are some additional notes how ELKS drivers work describing the
+			concepts used above taken from the fs.txt file:<BR><BR>The
+			inode-&gt;i_op pointer is initialised in the function which reads
+			in an inode, e.g. V1_minix_read_inode, and its contents depend on
+			the type of file. If the node is a character or block device, i_op
+			points to chrdev_inode_operations or blkdev_inode_operations
+			respectively. These tables are declared in devices.c and contain
+			pointers just to the respective &quot;open&quot; functions,
+			chrdev_open and blkdev_open. <BR><BR>When the user opens one of
+			these inodes, the kernel calls the open function and passes in a
+			pointer to the relevant &quot;struct file&quot; record. The fops
+			pointer in this record is copied from chrdevs[major].fops or
+			blkdevs[major].fops, which was set up when the device was
+			initialised and registered itself.<BR><BR>So, in the case of the
+			console for example, the file record defined as dircon_ops (see
+			drivers/char/dircon.c) has pointers to the functions to perform
+			I/O to the console. <BR><BR>In the case of block devices, the
+			read() and write() functions *don't* point to device-specific read
+			and write functions; rather, they point to the generic functions
+			block_read() and block_write() in block_dev.c. These take care of
+			caching blocks, part-block reads and writes etc.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm"><BR><BR>
+			</P>
+			<P STYLE="margin-bottom: 0.5cm"><FONT FACE="Arial, sans-serif">Since
+			the ELKS kernel is almost 64k in size now, currently there is only
+			very limited space available for additional device drivers. User
+			mode device drivers should be considered as an alternative.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm"><FONT FACE="Arial, sans-serif">4<SUP>th</SUP>
+			of March 2017 Georg Potthast</FONT></P>
+			<P><BR>
+			</P>
+		</TD>
+	</TR>
+</TABLE>
+<P><BR><BR>
+</P>
+</BODY>
+</HTML>

--- a/elks/Documentation/html/user/setup_slip.html
+++ b/elks/Documentation/html/user/setup_slip.html
@@ -1,0 +1,199 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<HTML>
+<HEAD>
+	<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=windows-1252">
+	<TITLE></TITLE>
+	<META NAME="GENERATOR" CONTENT="OpenOffice 4.1.2  (Win32)">
+	<META NAME="AUTHOR" CONTENT="Georg Potthast">
+	<META NAME="CREATED" CONTENT="20170105;19172240">
+	<META NAME="CHANGEDBY" CONTENT="Georg Potthast">
+	<META NAME="CHANGED" CONTENT="20170304;11234607">
+	<STYLE TYPE="text/css">
+	<!--
+		@page { margin: 2cm }
+		TD P { margin-bottom: 0cm }
+		P { margin-bottom: 0.21cm }
+		PRE.cjk { font-family: "NSimSun", monospace }
+		H2 { margin-bottom: 0.21cm }
+		H2.western { font-family: "Arial", sans-serif; font-size: 14pt; font-style: italic }
+		H2.cjk { font-family: "Microsoft YaHei"; font-size: 14pt; font-style: italic }
+		H2.ctl { font-family: "Lucida Sans"; font-size: 14pt; font-style: italic }
+		A:link { so-language: zxx }
+	-->
+	</STYLE>
+</HEAD>
+<BODY LANG="de-DE" DIR="LTR">
+<TABLE WIDTH=718 BORDER=0 CELLPADDING=4 CELLSPACING=0 STYLE="page-break-before: always">
+	<COL WIDTH=710>
+	<TR>
+		<TD WIDTH=710 VALIGN=TOP>
+			<H2 CLASS="western"><SPAN STYLE="font-style: normal">Networking
+			with SLIP and Qemu</SPAN></H2>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">The
+			tcp/ip communication is implemented via serial lines using the
+			slip protocol. This works as long as there are serial ports
+			available with the PCs used. You can connect ELKS via a &bdquo;point
+			to point&ldquo; slip connection with a different Linux system and
+			configure that as a gateway for the ELKS PC. This way ELKS can
+			connect to the internet, provided the gateway itself is connected
+			to that. Since there is no name resolution implemented with ELKS
+			you need to know the IP address required.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">If
+			you do not want to use a cross-over cable between your ELKS PC and
+			a different Linux PC, you can run ELKS using Qemu on your host and
+			configure a serial connection with Qemu to that host. This way you
+			can connect your host and the ELKS system running within Qemu via
+			a SLIP connection.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">To
+			enable a serial connection from Qemu to your host, start Qemu with
+			these parameters:</FONT></P>
+			<PRE CLASS="western">qemu-system-i386 \
+      -chardev pty,id=chardev1 \
+      -device isa-serial,chardev=chardev1,id=serial1 \
+      -fda full3</PRE><P STYLE="margin-bottom: 0.5cm; font-weight: normal">
+			<FONT FACE="Arial, sans-serif">Qemu will report e.g. &quot;char
+			device redirected to /dev/pts/4 (label chardev1)&quot; after
+			loading. Make a note of this pty since you will need that for the
+			host configuration.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">You
+			could also simply specifiy the &bdquo;-serial pty&ldquo; parameter
+			but if you use &bdquo;-chardev pty&ldquo; instead you can specify
+			that this serial device (with the id=chardev1) will emulate an isa
+			bus serial card so you get the interrupt and i/o address required
+			for direct hardware access.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">After
+			ELKS has booted, login with &quot;root&quot; and check that ktcp
+			is running with the command &quot;ps&quot;. Then use vi to look at
+			the &quot;/etc/rc.d/rc.sysinit&quot; file and check the ttybaud
+			and localip entries in there.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">This
+			is my setting in the file rc.sysinit:</FONT></P>
+			<PRE CLASS="western">#
+# Network initialization
+#
+
+localip=192.168.1.10
+sliptty=/dev/ttyS0
+ttybaud=9600</PRE><P STYLE="margin-bottom: 0.5cm; font-weight: normal">
+			<FONT FACE="Arial, sans-serif">If you want to change these
+			settings, modify this file in &quot;elkscmd/rootfs_template/etc/rc.d&quot;
+			and compile ELKS again. Or modify the file in ELKS and enter the
+			&quot;reboot&quot; command. This is all that is required on the
+			ELKS side of the slip connection.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm"><A NAME="result_box"></A><FONT FACE="Arial, sans-serif"><SPAN STYLE="font-weight: normal">Now
+			on the host check the </SPAN></FONT><FONT FACE="Arial, sans-serif"><SPAN LANG="en">presence</SPAN></FONT>
+			<FONT FACE="Arial, sans-serif"><SPAN STYLE="font-weight: normal">of
+			the new PTY: &quot;ls -l /dev/pts&quot;.</SPAN></FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">Then
+			use the slattach command to start slip on your host. Slattach can
+			be used to put a normal terminal (&quot;serial&quot;) line into
+			one of several &quot;network&quot; modes, thus allowing you to </FONT>
+			</P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">use
+			it for point-to-point links to other computers.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">I
+			have made the following script to start the slip interface on the
+			host. Run this script with &bdquo;sudo&ldquo;. It takes the number
+			of the PTY generated by Qemu as a parameter (using $1 in the
+			script):</FONT></P>
+			<PRE CLASS="western">slattach -p slip -L -s 9600 /dev/pts/$1 &amp;
+ps
+ifconfig -a
+ifconfig sl0 192.168.1.9 pointopoint 192.168.1.10 netmask 255.255.255.0 mtu 296
+ifconfig -a
+route add 192.168.1.10 sl0
+route -n</PRE><P STYLE="margin-bottom: 0.5cm; font-weight: normal">
+			<FONT FACE="Arial, sans-serif">The first command is the mentioned
+			slattach command. Since this does not return you have to run that
+			in the background with &quot;&amp;&quot; or you cannot continue on
+			your command line.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">The
+			parameters used with slattach are: &quot;-p slip&quot; which
+			selects the slip protocol, &quot;-L&quot; enables 3 wire
+			operation, i.e. no hardware flow control, &quot;-s 9600&quot;
+			specifies the line speed of 9600 baud and finally the PTY
+			generated by Qemu is specified.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">Now
+			the script checks if slattach is running in the background:</FONT></P>
+			<PRE CLASS="western" STYLE="margin-bottom: 0.5cm">sudo ps</PRE><P STYLE="margin-bottom: 0.5cm; font-weight: normal">
+			<FONT FACE="Arial, sans-serif">and if the network interface has
+			been generated:</FONT></P>
+			<PRE CLASS="western" STYLE="margin-bottom: 0.5cm">ifconfig -a</PRE><P STYLE="margin-bottom: 0.5cm; font-weight: normal">
+			<FONT FACE="Arial, sans-serif">You will see a new interface called
+			&quot;sl0&quot;. The interface name is &quot;sl&quot; for serial
+			plus a zero.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">Now
+			we have to assign an IP address to this serial interface.</FONT></P>
+			<PRE CLASS="western" STYLE="margin-bottom: 0.5cm">ifconfig sl0 192.168.1.9 pointopoint 192.168.1.10 netmask 255.255.255.0 mtu 296</PRE><P STYLE="margin-bottom: 0.5cm; font-weight: normal">
+			<FONT FACE="Arial, sans-serif">Here 192.168.1.9 is the address we
+			will assign to the serial interface, next we establish a
+			pointopoint connection, 192.168.1.10 is the ip address of the ELKS
+			system within Qemu and ELKS uses an mtu of 296 for slip.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">Now
+			&bdquo;ifconfig -a&ldquo; will tell us that the sl0 interface got
+			the ip address 192.168.1.9 and</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">it
+			has a point to point connection to the ip address 192.168.1.10,
+			which is ip address for ELKS that we configured.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">Next
+			we have to tell the host that it can reach the address
+			192.168.1.10 via the address of the serial inferface. So we
+			configure a static route for this:</FONT></P>
+			<PRE CLASS="western" STYLE="margin-bottom: 0.5cm">route add 192.168.1.10 sl0</PRE><P STYLE="margin-bottom: 0.5cm">
+			&bdquo;<FONT FACE="Arial, sans-serif"><SPAN STYLE="font-weight: normal">route
+			-n&ldquo; shows this routing table:</SPAN></FONT></P>
+			<PRE CLASS="western">Destination     Gateway         Genmask       Flags Metric  Ref    Use Iface
+0.0.0.0         192.168.1.1     0.0.0.0         UG    0      0       0 eno1
+192.168.1.0     0.0.0.0         255.255.255.0   U     0      0       0 eno1
+192.168.1.0     0.0.0.0         255.255.255.0   U     0      0       0 sl0
+192.168.1.10    0.0.0.0         255.255.255.255 UH    0      0       0 sl0</PRE><P STYLE="margin-bottom: 0.5cm; font-weight: normal">
+			<FONT FACE="Arial, sans-serif">Now you have to disable or
+			configure the firewall on your host system so that it will not
+			drop the packets from ELKS for security reasons. Usually you will
+			have a firewall running and that will not accept data from ELKS.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">If
+			you then enter &quot;ping 192.168.1.10&quot; now, it will report a
+			response from the ELKS system.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">In
+			case you have to restart ELKS you can remove the slattach process
+			on the host with &bdquo;sudo pkill -f slattach&ldquo;. This
+			releases the PTY generated by Qemu.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">However,
+			in case ELKS does not respond to the ping request, this is what
+			you can do to debug the slip connection.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">First
+			check if you have a working serial connection to the host. For
+			that stop ktcp to have that release the serial port on ELKS.
+			Determine with the &bdquo;ps&ldquo; command the process number
+			assigned to ktcp and enter e.g. &bdquo;kill 5 &amp;&ldquo; if the
+			PID is 5. Then enter &bdquo;cat /dev/ttyS0&ldquo;. If you then
+			start &bdquo;ping 192.168.1.10&ldquo; on your host, you should see
+			the slip packets from the host on the screen.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">Then
+			you can check if you can send slip packets from ELKS to the host.
+			I use cutecom on the host and open the device &bdquo;/dev/pts/2&ldquo;
+			provided Qemu generated the PTY 2. If you then enter on ELKS
+			&bdquo;urlget http://192.168.1.7&ldquo;, provided the host has the
+			ip address 192.168.1.7, the slip packets from ELKS can be seen
+			with cutecom.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">If
+			this works, you can use &bdquo;tcpdump&ldquo; on the host to
+			monitor the tcp/ip traffic between the host and ELKS. Enter
+			&bdquo;tcpdump -n -i sl0&ldquo; to monitor the traffic via the
+			slip interface &bdquo;sl0&ldquo;.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">You
+			will see that the host sends icmp requests to ELKS and receives
+			them from there.</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-weight: normal"><FONT FACE="Arial, sans-serif">4<SUP>th</SUP>
+			of March 2017 Georg Potthast</FONT></P>
+			<P STYLE="margin-bottom: 0.5cm; font-style: normal"><BR><BR>
+			</P>
+			<P><BR>
+			</P>
+		</TD>
+	</TR>
+</TABLE>
+<P><BR><BR>
+</P>
+</BODY>
+</HTML>

--- a/elks/Documentation/index.html
+++ b/elks/Documentation/index.html
@@ -30,6 +30,7 @@
 
 <ul>
 <li><a href="html/user/qemu.html">Running ELKS in QEMU</a></li>
+<li><a href="html/user/setup_slip.html">Installing a slip connection.</a></li>
 </ul>
 
 <h2>Technical reference</h2>
@@ -50,6 +51,7 @@
 <li><a href="text/memory.txt">notes on memory gestion.</a></li>
 <li><a href="text/modules.txt">implementation of module code.</a></li>
 <li><a href="text/networking.txt">notes on networking code.</a></li>
+<li><a href="text/networking_guide.txt">using the networking code.</a></li>
 <li><a href="html/technical/process.html">ELKS processes.</a></li>
 <li><a href="text/ramdisk.txt">notes on RAMdisk driver.</a></li>
 <li><a href="text/rom_changes.txt">notes on ROM boot: changes.</a></li>
@@ -57,6 +59,7 @@
 <li><a href="text/rom_info_01.txt">notes on ROM boot: miscellaneous.</a></li>
 <li><a href="text/source.txt">notes on code himself.</a></li>
 <li><a href="text/minix_fs.txt">description of the minix file system.</a></li>
+<li><a href="html/technical/kernel_mode_device_drivers.html">writing kernel mode device drivers.</a></li>
 </ul>
 
 </body>

--- a/elks/Documentation/text/networking.txt
+++ b/elks/Documentation/text/networking.txt
@@ -74,10 +74,14 @@ function tcpdev_inetwrite() in our char/tcpdev driver which writes it into the
 "tdout_buf" buffer.
 
 This buffer is then copied to memory in the tcpdev_read() function for the ktcp
-user space driver to pick up and send. On the other hand, the char/tcpdev
-driver will use the tcpdev_write() function to copy received data to the kernel
-interface "af_inet.c" by calling the function inet_process_tcpdev() in that
-code.
+user space driver to pick up and send. The ktcp driver will use the select() 
+command to query if any data is available to send and call tcp_process() in "tcp.c" 
+which handles the tcp connection status and calls tcp_syn_sent() which again calls 
+tcp_output() in "tcp_output.c" which sends the data via ip_sendpacket() in "ip.c".
+
+On the other hand, the char/tcpdev driver will use the tcpdev_write() function 
+to copy received data to the kernel interface "af_inet.c" by calling the function 
+inet_process_tcpdev() in that code.
 
 There are two tcpdev.c files in the code. One, the "char/tcpdev", is linked as
 a kernel driver, and the other, "ktcp/tcpdev", handles the tcp part for the
@@ -98,6 +102,10 @@ again uses the function slip_send() in "slip.c".
 
 The loop in ktcp_run() also calls slip_process() in slip.c which handles the
 data received by calling ip_recvpacket() in "ip.c".
+
+If an icmp packet is received by ip_recvpacket() in "ip.c" it will call
+icmp_process() in "icmp.c". This function just supports icmp echo to allow
+ELKS to reply to a ping command on the remote host.
 
 
 2. Setup
@@ -147,4 +155,4 @@ purpose is to give users an idea of what is done and what to expect of
 the ELKS networking.
 
 
-Harry / Georg Potthass
+Harry / Georg Potthast

--- a/elks/Documentation/text/networking_guide.txt
+++ b/elks/Documentation/text/networking_guide.txt
@@ -11,6 +11,8 @@ ntohl() / htonl() in linuxmt/arpa/inet.h. Plus several small changes here and th
 
 As a result you can now use the ne2k driver for ethernet communication.
 
+If you run this using Qemu, please read the file "elks/Documentation/html/user/qemu.html" 
+for the parameters to use for the required network support.
 
 ----------------------
 Loading ne2k and ktcp
@@ -97,14 +99,16 @@ Using the echo server and client for testing
 
 You can also use an echo server on ELKS and access that with an echo client on the host
 or vice versa for testing. These programs are in the elkscmd/test/socket/echo directory. 
-Use the echoserver_in.c and echoclient_in.c code. 
+Use the echoserver.c and echoclient.c code. 
 
-The other versions are for unix domain sockets on ELKS. If you enable unix domain sockets 
-plus the ne2k driver the kernel will exceed 64k and cannot be compiled.
+You can also test the unix domain sockets on ELKS with these programs. If you enable 
+unix domain sockets plus the ne2k driver the kernel will exceed 64k and cannot be compiled. 
+To test the unix domain sockets, start both programs with the "-u" option. This is
+"echoserver -u &" and "echoclient -u".
 
-First copy echoclient_in to the host and compile it with gcc. Then start the server
-with "echoserver_in &" on ELKS. Check with "ps" it has been loaded successfully. If you 
-then run echoclient_in on the host, you can enter something on the keyboard and that will 
+First copy the echoclient to the host and compile it with gcc. Then start the server
+with "echoserver &" on ELKS. Check with "ps" if it has been loaded successfully. If you 
+then run the echoclient on the host, you can enter something on the keyboard and that will 
 be returned. Terminate the echoserver again with the kill command or loading Qemu again 
 with new parameters may fail.
 
@@ -113,10 +117,45 @@ Then change the qemu.sh file in the elks directory again to:
 # no forwarding, just ELKS to host
 hostfwd="-net user"
 
-Then copy echoserver_in to the host and compile it with gcc. Then start it with
-"./echoserver_in &" on the host. Run "qemu.sh" and enter "echoclient_in" in ELKS.
+Then copy the echoserver to the host and compile it with gcc. Then start it with
+"./echoserver &" on the host. Run "qemu.sh" and enter "echoclient" in ELKS.
 Again you can type anything on the keyboard and that will be returned by the server
 on the host.
 
+---------------------------------------------------
+Connect to the host with the telnet client on ELKS
+---------------------------------------------------
 
-26th February 2017 Georg Potthast
+There is a telnet client on ELKS called "telnet". To use that you first have to install
+the telnetd server on your host.
+
+The telnet server telnetd is part of xinetd on current Linux distributions. You can usually 
+configure xinetd from your system manager. This will only work if xinetd is running. So enter 
+"chkconfig xinetd on" on the command line and reboot your system. As a superuser you may by 
+able to start xinetd from the command line with "xinetd" or "xinetd start".
+
+After that the system manager will show the configured services with xinetd. Search the 
+telnetd line and try to enable that. This will usually cause that telnetd is downloaded and 
+installed. Then you set the status to "ON". You can also change the owner of "/usr/sbin/in.telnetd" 
+to your name and the group to "users". This will make your system unsecure so you should disable 
+telnet after you tested ELKS.
+
+Then set the qemu.sh file in the elks directory again to:
+
+# no forwarding, just ELKS to host
+hostfwd="-net user"
+
+and run the qemu.sh script to load ELKS. If you then log in and enter "telnet 192.168.1.5" on the 
+command line - provided your host has the ip-address 192.168.1.5. After a while you will get the 
+welcome message from the telnet server on your host.
+
+You can also configure your host manually. This is different on the available distros, so here are 
+some hints: 
+edit the /etc/xinetd.d/telnet file and change the line disabled = yes to disabled = no. Sometimes 
+there is no separate telnet file but a /etc/xinetd.conf file you have to edit. Instead of editing 
+that you may be able to enter "chkconfig telnetd on" on the command line to enable telnetd. 
+The command "chkconfig --list telnet" will display if telnetd is running. If you do not run telnetd
+as root, there will be no login prompt and you cannot log into the host.
+
+
+4th of March 2017 Georg Potthast


### PR DESCRIPTION
Move the readme file from the ktcp directory to Documentation/text giving it the new name networking_guide.txt. Extend the file networking.txt. Add new descriptions how to setup a slip connection and how to write kernel mode device drivers. Update index.html with the new files.