### PR TITLE
Reduction of kernel stack size: second part.

### DIFF
--- a/elks/arch/i86/kernel/asm-offsets.c
+++ b/elks/arch/i86/kernel/asm-offsets.c
@@ -12,7 +12,7 @@
 #endif
 
 extern int TASK_KRNL_SP, TASK_USER_DS, TASK_USER_AX, TASK_USER_SS;
-extern int TASK_USER_SP, TASK_USER_BX, TASK_USER_FL, TASK_USER_SI;
+extern int TASK_USER_BX, TASK_USER_SI, TASK_USER_DI;
 
 void asm_offsets(void)
 {
@@ -20,9 +20,8 @@ void asm_offsets(void)
     TASK_USER_DS = offsetof(struct task_struct, t_regs.ds);
     TASK_USER_AX = offsetof(struct task_struct, t_regs.ax);
     TASK_USER_SS = offsetof(struct task_struct, t_regs.ss);
-    TASK_USER_SP = offsetof(struct task_struct, t_regs.sp);
     TASK_USER_BX = offsetof(struct task_struct, t_regs.bx);
-    TASK_USER_FL = offsetof(struct task_struct, t_xregs.flags);
     TASK_USER_SI = offsetof(struct task_struct, t_regs.si);
+    TASK_USER_DI = offsetof(struct task_struct, t_regs.di);
 }
 

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -290,6 +290,10 @@ _algn:
 	jmp	_irqit
 
 #endif
+_syscall_int:
+	push	ax
+	mov	ax,#0x80
+	jmp	_irqit
 !
 !	On entry CS:IP is all we can trust
 !
@@ -301,7 +305,7 @@ _algn:
 !		Running on a kernel process stack anyway.
 !
 !	SS = current->t_regs.ss
-!		Interrupted user mode code
+!		Interrupted user mode code or syscall
 !		Switch to kernel stack for process (will be free)
 !		Task switch allowed
 !
@@ -336,79 +340,127 @@ _irq0:
 	xor	ax,ax
 _irqit:
 !
-!	Save all registers
+!	Make room
 !
 	push	ds
-	push	es
-	push	bx
-	push	cx
-	push	dx
 	push	si
 	push	di
-	push	bp
 !
 !	Recover data segment
 !
 #ifdef CONFIG_ROMCODE
 	mov	si,#CONFIG_ROM_IRQ_DATA
 	mov	ds,si
-	mov	si,stashed_ds
+	mov	ds,stashed_ds
 #else
 	seg	cs
-	mov	si,stashed_ds
+	mov	ds,stashed_ds
 #endif
-	mov	ds,si
-	mov	es,si
-
 !
-!	Set up task switch controller
-!
-	xor	ch,ch		! Assume we are not allowed to switch
-!
-!       See where we were (DX holds the SS on entry)
+!	See where we were
 !
 	mov	di,ss		! Get current SS
-	cmp	di,si		! SS = kernel SS ?
+	cmp	di,_kernel_ds	! SS = kernel SS ?
 	je	ktask		! Kernel - no work
 !
 !	User or BIOS etc
 !
-	mov	ss,si		! Set SS: right
 	mov	si,_current
-	cmp	di,TASK_USER_SS[si] ! entry ss = current->t_regs.ss?
+	cmp	di,TASK_USER_SS[si] ! entry SS = current->t_regs.ss?
 	jne	btask		! Switch to interrupt stack
 !
-!	User task. Extract kernel SP. (BX already holds current)
-!	At this point, the kernel stack is empty. Thus, we can load
-!       the kernel stack pointer without accesing memory
+!	User mode case - switch to kernel stack
 !
-	mov	TASK_USER_SP[si],sp
-	lea	sp,TASK_USER_AX[si] ! switch to kernel stack ptr
-	lea	bp,TASK_USER_SP[si]
-	inc	ch		! Switch allowable
-        j       updct
+	add	si,#TASK_USER_DI
+	j	save_regs
 !
 !	Bios etc - switch to interrupt stack
 !
 btask:
-	mov	sp,#_intstack
+	mov	si,#(_intstack-12)
+	j	save_regs
 !
-!	In ktask state we have a suitable stack. It might be
-!	better to use the intstack..
+!	Kernel mode case - keep using kernel stack
 !
 ktask:
+	mov	si,sp
+	sub	si,#6
 !
-!	Put the old SS;SP on the top of the stack. We can't
-!	leave them in stashed_ss/sp as we could re-enter the
-!	routine on a reschedule.
+!	Save segment, index, BP and SP registers
 !
-	mov	si,sp		! Get current SP
-	push	di		! push entry SS
-	push	si		! push entry SP
+save_regs:
+	pop	[si]		! DI
+	pop	2[si]		! SI
+	pop	6[si]		! DS
+	pop	di		! Original AX
+	push	bp		! BP
+	mov	8[si],sp	! SP
+	mov	10[si],ss	! SS
+	mov	4[si],es	! ES
 !
-!	The registers are now stored. Remember where
+!	Load new segment and SP registers
 !
-	mov	bp,sp
+	mov	sp,si
+	mov	si,ds
+	mov	ss,si
+	mov	es,si
+!
+!	Save remaining registers
+!
+	push	dx		! DX
+	push	cx		! CX
+	push	bx		! BX
+	push	di		! AX
+!
+!	AX has interrupt number
+!
+	cmp	ax,#0x80
+	jne	updct
+!
+!	----------PROCESS SYSCALL----------
+!
+	sti
+	call	_stack_check	! Check USER stack
+	pop	ax		! Get syscall function code
+#ifdef CONFIG_STRACE
+!
+!	strace(syscall#, params...)
+!
+	push	ax
+	call	_strace
+	pop	ax
+#endif
+!
+!	syscall(params...)
+!
+	call	_syscall
+	push	ax		! syscall returns a value in ax
+	call	_do_signal
+#ifdef CONFIG_STRACE
+!
+!	ret_strace(retval)
+!
+	pop	ax
+	push	ax
+	call	_ret_strace
+#endif
+!
+!	Restore registers
+!
+	cli
+	j	restore_regs
+!
+!	Done.
+!
+_ret_from_syscall:
+	mov	bx,_current	! Ensure we have the
+	lea	sp,TASK_USER_BX[bx] ! right kernel SP
+	xor	ax,ax		! Just in case we are starting a new task
+	push	ax
+	cli
+	j	restore_regs
+!
+!	----------PROCESS INTERRUPT----------
 !
 !	Update intr_count
 !
@@ -418,36 +470,35 @@ updct:
 !	Call the C code
 !
 	sti			! Reenable interrupts
-	push	cx		! Switch flag
+	mov	bx,sp		! Get pointer to pt_regs
 	push	ax		! IRQ for later
 
-	push	bp		! Register base
+	push	bx		! Register base
 	push	ax		! IRQ number
 	call	_do_IRQ		! Do the work
 	pop	ax		! Clean parameters
 	pop	bx
 
 	pop	ax		! Saved IRQ
-	pop	cx		! Recover switch allowed flag
 !
-!	Restore any chips
+!	Send EOI to interrupt controller
 !
-        cli                     ! Disable interrupts to avoid reentering ISR
+	cli			! Disable interrupts to avoid reentering ISR
 	cmp	ax,#16
 	jge	was_trap	! Traps need no reset
 	or	ax,ax		! Is int #0?
 	jnz	a4
 !
-!        IRQ 0 (timer) has to go on to the bios for some systems
+!	IRQ 0 (timer) has to go on to the bios for some systems
 !
-        dec     _bios_call_cnt_l ! Will call bios int?
-        jne     a4
-        mov     _bios_call_cnt_l,#5
-        pushf
-        callf   [_stashed_irq0_l]
+	dec	_bios_call_cnt_l ! Will call bios int?
+	jne	a4
+	mov	_bios_call_cnt_l,#5
+	pushf
+	callf	[_stashed_irq0_l]
 	jmp	was_trap	! EOI already sent by bios int
 a4:
-        cmp     ax,#8
+	cmp	ax,#8
 	movb	al,#0x20	! EOI
 	jb	a6		! IRQ on low chip
 !
@@ -470,51 +521,33 @@ was_trap:
 !
 !	Now look at rescheduling
 !
-	orb	ch,ch			! Schedule allowed ?
-	je	nosched			! No
-!	mov	bx,_need_resched	! Schedule needed
-!	cmp	bx,#0			!
-!	je	nosched			! No
+	mov	bx,_current	! Schedule allowed ?
+	add	bx,#TASK_USER_AX
+	cmp	bx,sp
+	jne	restore_regs	! No
+!	cmp	_need_resched,#0 ! Schedule needed ?
+!	je	restore_regs	! No
 !
 ! This path will return directly to user space
 !
-	call	_schedule		! Task switch
-	mov	bx,_current
-	mov	TASK_USER_FL[bx],#1
-	call	_do_signal		! Check signals
-!
-!	At this point, the kernel stack is empty. Thus, there is no
-!       need to save the kernel stack pointer.
-!
-	mov	bx,_current
-	mov	sp,TASK_USER_SP[bx]
-	mov	ss,TASK_USER_SS[bx]	! user ds
-#ifdef CONFIG_ADVANCED_MM
-	mov	bp,sp
-	mov	12[bp],ss		! change the es in the stack
-	mov	14[bp],ss		! change the ds in the stack
-#endif
-	j	noschedpop
-!
-!	Now we have to rescue our stack pointer/segment.
-!
-nosched:
-	pop	cx	! SP
-	pop	ss	! SS
-	mov	sp,cx
+	call	_schedule	! Task switch
+	call	_do_signal	! Check signals
 !
 !	Restore registers and return
 !
-noschedpop:
-	pop	bp
-	pop 	di
-	pop	si
-	pop	dx
-	pop	cx
+restore_regs:
+	pop	ax
 	pop	bx
+	pop	cx
+	pop	dx
+	pop	di
+	pop	si
 	pop	es
 	pop	ds
-	pop	ax
+	pop	bp
+	pop	ss
+	mov	sp,bp
+	pop	bp
 !
 !	Iret restores CS:IP and F (thus including the interrupt bit)
 !
@@ -524,19 +557,18 @@ noschedpop:
  *	tswitch();
  *
  *	This function can only be called with SS=DS=ES=kernel DS and
- *	CS=kernel CS. SS:SP is the relevant kernel stack (IRQ's are
- *	taken on 'current' kernel stack). Thus we don't need to arse about
- *	with segment registers. The kernel isn't relocating.
+ *	CS=kernel CS. SS:SP is the relevant kernel stack. Thus we don't need
+ *	to arse about with segment registers. The kernel isn't relocating.
  *
  *	tswitch() saves the "previous" task registers and state. It in effect
  *	freezes a copy of the caller context. Then restores the "current"
  *	context and returns running the current task.
  */
 
-	.globl _tswitch
+	.globl	_tswitch
 
 _tswitch:
-	push	bp	! /* schedule()'s bp */
+	push	bp		! schedule()'s bp
 	pushf
 	push	di
 	push	si
@@ -547,127 +579,14 @@ _tswitch:
 	pop	si
 	pop	di
 	popf
-	pop	bp	! BP of schedule()
-	xor	ax,ax	! Set ax=0, as this may be fork() return from child
-	ret		! thus to caller of schedule()
-
+	pop	bp		! BP of schedule()
+	ret
 !
-!	System Call Vector
-!
-!	On entry we are on the wrong stack, DS, ES are wrong
-!
-!	System calls enter here with ax as function and bx,cx,dx,di and si
-!	as parameters.
-!	syscall returns a value in ax
-!
-
-_syscall_int:
-!
-!	We know the process DS, we can discard it (indeed may change it)
-!
-!	Save si and free an index register
-!
-	push	si
-!
-!	Load kernel data segment
-!
-#ifdef CONFIG_ROMCODE
-	mov	si,#CONFIG_ROM_IRQ_DATA
-	mov	ds,si
-#else
-	seg	cs
-#endif
-	mov	ds,stashed_ds		! the org DS of kernel
-!
-!	At this point, the kernel stack is empty. Thus, we can push
-!	data into the kernel stack by writing directly to memory
-!
-	mov	si,_current
-	add	si,#TASK_USER_SI	! pops SI from user stack and pushes
-	pop	[si]			! it directly into kernel stack
-	push	bp			! Save BP in the user stack
-!
-!	Stash user mode stack - needed for stack checking!
-!
-	mov	6[si],sp		! Save user SP
-!
-!	load kernel stack pointer
-!
-	mov	sp,si			! Load kernel SP
-!
-!	Finish switching to the right things
-!
-	mov	si,ds			! ds=es=ss
-	mov	es,si
-	mov	ss,si
-	cld
-!
-!	Stack is now right, we can take interrupts OK
-!
-	sti				! SI already on top of stack
-	push	di
-	push	dx
-	push	cx
-	push	bx
-
-#ifdef CONFIG_STRACE
-!
-!	strace(syscall#, params...)
-!
-	push	ax
-	call	_strace
-	pop	ax
-#endif
-!
-!	syscall(params...)
-!
-	push	ax
-	call	_stack_check
-	pop	ax
-	call	_syscall
-	push	ax
-	mov	bx,_current
-	mov	TASK_USER_FL[bx],#0
-	call	_do_signal
-	pop	ax
-_ret_from_syscall:
-	mov	bx,_current		! Ensure we have the
-	lea	sp,TASK_USER_BX[bx]	! right kernel SP
-#ifdef CONFIG_STRACE
-!
-!	ret_strace(retval)
-!
-	push	ax
-	call	_ret_strace
-	pop	ax
-#endif
-!
-!	Restore registers
-!
-	cli
-	pop	bx
-	pop	cx
-	pop	dx
-	pop	di
-	pop	si
-	pop	es
-	pop	ds
-	pop	bp			! Restore user SS:SP
-	pop	ss
-	mov	sp,bp
-	pop	bp			! Restore user BP
-!
-!	return with error info.
-!
-	iret
-!
-!	Done.
-!
-
 	.data
 	.globl	_intr_count
 	.extern	_current
 	.extern	_previous
+	.extern	_kernel_ds
 
 	.even
 

--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -118,20 +118,17 @@ void arch_setup_kernel_stack(register struct task_struct *t)
 void arch_setup_sighandler_stack(register struct task_struct *t,
 				 __sighandler_t addr,unsigned signr)
 {
-    register char *i;
-
-    for (i = 0; (int)i < (t->t_xregs.flags ? 18 : 2); i += 2)
-	put_ustack(t, (int)i-4, (int)get_ustack(t,(int)i));
-    debug4("Stack %x was %x %x %x\n", addr, get_ustack(t,(int)i), get_ustack(t,(int)i+2),
-	   get_ustack(t,(int)i+4));
-    put_ustack(t, (int)i-4, (int)addr);
-    put_ustack(t, (int)i-2, (int)get_ustack(t,(int)i+2));
-    put_ustack(t, (int)i+2, (int)get_ustack(t,(int)i));
-    put_ustack(t, (int)i, (int)get_ustack(t,(int)i+4));
-    put_ustack(t, (int)i+4, (int)signr);
+    debug5("Stack %x was %x %x %x %x\n", addr, get_ustack(t,0), get_ustack(t,2),
+	   get_ustack(t,4), get_ustack(t,6));
+    put_ustack(t, -4, (int)get_ustack(t,0));
+    put_ustack(t, -2, (int)addr);
+    put_ustack(t, 0, (int)get_ustack(t,4));
+    put_ustack(t, 4, (int)get_ustack(t,2));
+    put_ustack(t, 2, (int)get_ustack(t,6));
+    put_ustack(t, 6, (int)signr);
     t->t_regs.sp -= 4;
-    debug5("Stack is %x %x %x %x %x\n", get_ustack(t,(int)i), get_ustack(t,(int)i+2),
-	   get_ustack(t,(int)i+4),get_ustack(t,(int)i+6), get_ustack(t,(int)i+8));
+    debug6("Stack is %x %x %x %x %x %x\n", get_ustack(t,0), get_ustack(t,2),
+	   get_ustack(t,4), get_ustack(t,6), get_ustack(t,8), get_ustack(t,10));
 }
 
 /*

--- a/elks/include/arch/types.h
+++ b/elks/include/arch/types.h
@@ -31,12 +31,12 @@ struct _registers {
 typedef struct _registers		__registers,	*__pregisters;
 
 struct xregs {
-    __u16	cs, ksp, flags;
+    __u16	cs, ksp;
 };
 
 struct pt_regs {
-    __u16	bp, di, si, dx, cx, bx,
-		es, ds, ax, ip, cs, flags;
+    __u16	ax, bx, cx, dx, di, si,
+		es, ds, sp, ss;
 };
 
 /* Changed to unsigned short int as that is what it is here.


### PR DESCRIPTION
Syscalls and interrupts now have the same stack layout.
Also share the code to save/restore registers.
Code size reduced by 64 bytes and BSS reduced in 32 bytes.