### PR TITLE
Enable pseudo ttys. Fix issue #88

### DIFF
--- a/elks/arch/i86/drivers/char/init.c
+++ b/elks/arch/i86/drivers/char/init.c
@@ -34,4 +34,7 @@ void chr_dev_init(void)
     eth_init ();
 #endif
 
+#ifdef CONFIG_PSEUDO_TTY    
+    pty_init();    
+#endif
 }

--- a/elks/include/linuxmt/ntty.h
+++ b/elks/include/linuxmt/ntty.h
@@ -17,21 +17,26 @@
 
 #ifdef CONFIG_PSEUDO_TTY
 #define NR_PTYS		4
+/*need MAX_TTYS 12 even if no serial devs */
+#define MAX_TTYS	12
 #else
 #define NR_PTYS		0
 #endif
 
 #ifdef CONFIG_CHAR_DEV_RS
- #ifdef CONFIG_PSEUDO_TTY
- #define NR_SERIAL	4
- #else
- #define NR_SERIAL	2
- #endif
+#define NR_SERIAL	4
+#ifndef CONFIG_PSEUDO_TTY
+#define MAX_TTYS	8
+#endif
 #else
 #define NR_SERIAL	0
 #endif
 
-#define NUM_TTYS	4+NR_SERIAL+NR_PTYS
+#ifndef CONFIG_PSEUDO_TTY
+#ifndef CONFIG_CHAR_DEV_RS
+#define MAX_TTYS 4
+#endif
+#endif
 
 #define DCGET_GRAPH	(('D'<<8)+0x01)
 #define DCREL_GRAPH	(('D'<<8)+0x02)

--- a/elkscmd/Makefile
+++ b/elkscmd/Makefile
@@ -21,7 +21,7 @@ include $(BASEDIR)/Make.defs
 
 DIRS		= sys_utils misc_utils disk_utils file_utils levee \
 		  minix1 minix2 minix3 ash bc mtools sash sh_utils \
-		  inet ktcp prems test/eth test/socket/echo
+		  inet ktcp prems test/eth test/socket/echo test/pty
 
 DONTUSE 	= debug_utils lib prn-utils rc tools xvi
 

--- a/elkscmd/rootfs_template/dev/MAKEDEV
+++ b/elkscmd/rootfs_template/dev/MAKEDEV
@@ -49,7 +49,14 @@ fi
 	$LINK  ram1	ramdisk
 
 ##############################################################################
-# Pseudo-TTY master devices. These are not yet supported by the ELKS kernel.
+# Pseudo-TTY master devices. 
+
+	$MKDEV ptyp0 c 2 8
+	$MKDEV ptyp1 c 2 9
+	$MKDEV ptyp2 c 2 10
+	$MKDEV ptyp3 c 2 11
+
+# These are not yet supported by the ELKS kernel.
 
 #	$MKSET   0 15 $MKDEV ptyp x 2
 #	$MKSET  16 15 $MKDEV ptyq x 2
@@ -77,8 +84,14 @@ fi
 #	$MKSET   0 3  $MKDEV fd b 2	# Ought to be.
 
 ##############################################################################
-# Pseudo-TTY master devices. These are not yet supported by the ELKS kernel.
+# Pseudo-TTY slave devices. 
 
+	$MKDEV ttyp0 c 4 8
+	$MKDEV ttyp1 c 4 9
+	$MKDEV ttyp2 c 4 10
+	$MKDEV ttyp3 c 4 11
+
+# These are not yet supported by the ELKS kernel.
 #	$MKSET   0 15 $MKDEV ttyp x 3
 #	$MKSET  16 15 $MKDEV ttyq x 3
 #	$MKSET  32 15 $MKDEV ttyr x 3

--- a/elkscmd/test/pty/Makefile
+++ b/elkscmd/test/pty/Makefile
@@ -1,0 +1,38 @@
+# Makefile for pseudo tty test
+
+BASEDIR=../..
+
+include $(BASEDIR)/Make.defs
+
+
+CFILES		= ptyshell.c
+
+OBJS		= $(CFILES:.c=.o)
+
+include $(BASEDIR)/Make.rules
+
+
+all:	ptyshell
+
+eth:	$(OBJS)
+
+
+smin_rfs: install
+
+min_rfs: install
+
+rfs: install
+
+max_rfs: install
+
+net_rfs: install
+
+
+install: all
+	cp -p ptyshell $(TARGET_MNT)/bin
+
+clean: 
+	rm -f *.o ptyshell
+
+dep:
+	makedepend $(CFILES)

--- a/elkscmd/test/pty/ptyshell.c
+++ b/elkscmd/test/pty/ptyshell.c
@@ -1,0 +1,141 @@
+/*
+ * ptyshell - demo program for ELKS pseudo tty support
+ * 
+ * This program opens a master pseudo tty and then forks a child process. 
+ * This child process opens a slave tty and starts a shell in it.
+ * The master process read user input from stdin (could be a network connection too)
+ * and writes it to the master pseudo tty. This sends this to the slave tty which gets
+ * input and output from the shell started by the child process. The output from the
+ * shell process is written by the slave tty to the master tty and read from the master
+ * process. Here, it will write that to stdout but it could be a network connection too.
+ * Signal handling does not work yet. The input is line oriented.
+ * If the message "cannot fork" appears, there is insufficient memory available. Disable
+ * some drivers to free memory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <signal.h>
+#include <termios.h>
+
+#define MAX_INPUT 250
+
+static int tfd, tfs;
+pid_t pid;
+
+int term_init();
+
+int main(int argc, char ** argv)
+{
+  	int rc;
+	char input[MAX_INPUT];
+	
+	printf("# "); /*simulate prompt */
+	fflush(stdout);
+	
+	if (term_init() < 0) exit(1);
+
+	while (1) {
+	      rc = read(0, input, sizeof(input));
+	      
+	      if (rc > 0)
+              {
+                  write(tfd, input, rc);
+                  // Get the child's answer through the PTY
+                  rc = read(tfd, input, MAX_INPUT-1); 
+                  if (rc > 0)
+                  {
+                    input[rc] = '\0'; // make NUL terminated
+                    if (strcmp(input,"exitshell\n")==0) {
+		       fprintf(stderr, "Terminating processes and ptyshell\n");
+		       kill(pid, SIGKILL);
+		       return 0; 
+		    }
+                    fprintf(stderr, "read from child:%s", input);
+repeat:		  	
+		    /* read output from shell */
+		    rc = read(tfd, input, sizeof(input));
+		    input[rc] = '\0';
+		    if (rc < 2) continue;
+		    
+                    fprintf(stderr, "%s", input);		      
+		    if (rc>0) goto repeat;
+                  } else {
+		    if (errno == EAGAIN){
+		      fprintf(stderr, "errno == EAGAIN\n");
+		      continue;
+		    }
+		    fprintf(stderr, "no input read\n");
+		  }
+	      }
+	} //while
+} //main
+
+char * nargv[2] = {"/bin/sh", NULL};
+
+void sigchild(int signo)
+{
+	fprintf(stderr, "Signal received:%d", signo);
+	exit(0);
+}
+
+int term_init()
+{
+	char pty_name[12];
+	int n = 0;
+	int rc;
+	
+	struct termios slave_orig_term_settings; // Saved terminal settings
+	struct termios new_term_settings; // Current terminal settings
+
+again:
+	sprintf(pty_name, "/dev/ptyp%d", n);
+	if ((tfd = open(pty_name, O_RDWR | O_NONBLOCK)) < 0) {
+		if ((errno == EBUSY) && (n < 3)) {
+			n++;
+			goto again;
+		}
+		fprintf(stderr, "Can't create pty %s\n", pty_name);
+		return -1;
+	}
+	signal(SIGCHLD, sigchild);
+	signal(SIGINT, sigchild);
+	
+	if ((pid = fork()) == -1) {
+		fprintf(stderr, "No processes\n");
+		return -1;
+	}
+	if (pid>0) {
+		// Save the default parameters of the slave side of the PTY - unused yet
+		rc = tcgetattr(tfs, &slave_orig_term_settings);
+		new_term_settings = slave_orig_term_settings;
+		// Set raw mode on the slave side of the PTY - not line oriented
+		//cfmakeraw (&new_term_settings);
+		//new_term_settings.c_lflag &= ~ECHO;
+		tcsetattr (tfs, TCSANOW, &new_term_settings);
+		
+		close(STDIN_FILENO);
+		close(STDOUT_FILENO);
+		close(STDERR_FILENO);
+		close(tfd);
+		
+		setsid();
+		pty_name[5] = 't'; /* results in: /dev/ttyp%d */
+		if ((tfs = open(pty_name, O_RDWR)) < 0) {
+			fprintf(stderr, "Child: Can't open pty %s\n", pty_name);
+			exit(1);
+		}
+	
+		dup2(tfs, STDIN_FILENO);
+		dup2(tfs, STDOUT_FILENO);
+		dup2(tfs, STDERR_FILENO);
+		execv(nargv[0], nargv);
+		perror("execv");
+		exit(1);
+	}
+	return 0;
+}
+	


### PR DESCRIPTION
Enable pseudo ttys and provide ptyshell test program in elkscmd/test/pty. Added master and slave ptyp/ttyp in MAKEDEV.

Fix regression problems in char/pty.c introduced in commit 5dc0534 on 1st of Jul 2016. Got ptyshell program working that way. EAGAIN did not clear.