### PR TITLE
Saving buffer space when not using serial devs.

### DIFF
--- a/elks/arch/i86/drivers/block/doshd.c
+++ b/elks/arch/i86/drivers/block/doshd.c
@@ -520,29 +520,31 @@ int init_bioshd(void)
 	   "Extended and modified for Linux 8086 by Alan Cox.\n");
 #endif /* CONFIG_SMALL_KERNEL */
 
-    printk("doshd: ");
-
 #ifdef CONFIG_BLK_DEV_BFD
     _fd_count = bioshd_getfdinfo();
-    printk("%d floppy drive%s",
-	   _fd_count, _fd_count == 1 ? "" : "s");
-    count += _fd_count;
 #endif
-
 #ifdef CONFIG_BLK_DEV_BHD
-#ifdef CONFIG_BLK_DEV_BFD
-    printk(" and ");
-#endif
     _hd_count = bioshd_gethdinfo();
-    printk("%d hard drive%s",
-       _hd_count, _hd_count == 1 ? "" : "s");
     bioshd_gendisk.nr_real = _hd_count;
-    count += _hd_count;
 #endif /* CONFIG_BLK_DEV_BHD */
 
-    printk("\n");
+#ifdef CONFIG_BLK_DEV_BFD
+#ifdef CONFIG_BLK_DEV_BHD
+    printk("doshd: %d floppy drive%s and %d hard drive%s\n",
+	   _fd_count, _fd_count == 1 ? "" : "s",
+	   _hd_count, _hd_count == 1 ? "" : "s");
+#else
+    printk("doshd: %d floppy drive%s\n",
+	   _fd_count, _fd_count == 1 ? "" : "s");
+#endif
+#else
+#ifdef CONFIG_BLK_DEV_BHD
+    printk("doshd: %d hard drive%s\n",
+	   _hd_count, _hd_count == 1 ? "" : "s");
+#endif
+#endif
 
-    if (!count) return 0;
+    if (!(_fd_count + _hd_count)) return 0;
 
 #ifdef TEMP_PRINT_DRIVES_MAX
     {

--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -375,20 +375,20 @@ void tty_init(void)
 
 #ifdef CONFIG_CHAR_DEV_RS
 
-    ttyp = &ttys[4]; /*put serial entries into ttys[4]-ttys[7] */
-    for (pi = (char *)4; ((int)pi) < 4+NR_SERIAL; pi++) {
+    /* put serial entries after console entries */
+    for (pi = 0; ((int)pi) < NR_SERIAL; pi++) {
 	ttyp->ops = &rs_ops;
-	(ttyp++)->minor = ((int)pi) +60; /* ttyS0 = 64 */
+	(ttyp++)->minor = ((int)pi) + 64; /* ttyS0 = 64 */
     }
 
 #endif
 
 #ifdef CONFIG_PSEUDO_TTY
-    /* start at 8 fixed to match pty entries in MAKEDEV */
-    ttyp = &ttys[8]; /*put slave pseudo tty entries into ttys[8]-ttys[11] */
-    for (pi = 8; ((int)pi) < 12; pi++) {
+    /* start at minor = 8 fixed to match pty entries in MAKEDEV */
+    /* put slave pseudo tty entries after serial entries */
+    for (pi = 0; ((int)pi) < NR_PTYS; pi++) {
 	ttyp->ops = &ttyp_ops;
-	(ttyp++)->minor = (int)pi;
+	(ttyp++)->minor = (int)pi + 8;
     }
 #endif
 

--- a/elks/include/linuxmt/ntty.h
+++ b/elks/include/linuxmt/ntty.h
@@ -17,26 +17,17 @@
 
 #ifdef CONFIG_PSEUDO_TTY
 #define NR_PTYS		4
-/*need MAX_TTYS 12 even if no serial devs */
-#define MAX_TTYS	12
 #else
 #define NR_PTYS		0
 #endif
 
 #ifdef CONFIG_CHAR_DEV_RS
 #define NR_SERIAL	4
-#ifndef CONFIG_PSEUDO_TTY
-#define MAX_TTYS	8
-#endif
 #else
 #define NR_SERIAL	0
 #endif
 
-#ifndef CONFIG_PSEUDO_TTY
-#ifndef CONFIG_CHAR_DEV_RS
-#define MAX_TTYS 4
-#endif
-#endif
+#define MAX_TTYS (4+NR_SERIAL+NR_PTYS)
 
 #define DCGET_GRAPH	(('D'<<8)+0x01)
 #define DCREL_GRAPH	(('D'<<8)+0x02)


### PR DESCRIPTION
Saved 2568 bytes in BSS when omitting serial devices.This is besides savings in code and data space.This is besides savings in code and data space.
Tested with the new ELKS telnet server and telnet linux client.
Not enough memory savings to run vi with telnet.