### PR TITLE
Enable to compile Microwindows as a client/server application.

### DIFF
--- a/nano-X/Readme-ELKS
+++ b/nano-X/Readme-ELKS
@@ -40,9 +40,26 @@ with the name nano_hdd in the elkscmd directory and copy all demo files to it.
 To run the modified full3 image, run the "qemu.sh" script in the "src" directory,
 to run the hard disk image, run the "qemu_hdd.sh" script in the "src" directory.
 
+Microwindows will also allow to compile the package to a separate graphics server
+that the applications will use via Unix domain sockets. Therefore enable Unix
+domain sockets for that in menuconfig. To save space disable the ne2k driver.
+Then change the parameter in line 30 of the Makefile to "xLINK_APP_INTO_SERVER=1". 
+This undefines this parameter and will get Microwindows to compile a separate server.
+
+If you start "nano-X &" on the command line to run the server in the background it
+will switch the screen into graphics mode and clear it to black. Then you cannot
+enter the name of the demo to run in text mode. So you have to start both on the 
+command line e.g.: "nano-X &; demo2". There is also a demo.sh script which will
+start the nano-X server plus the demo application. Please try the landmine game
+right after booting ELKS. If you get the message "no space left on device" please 
+reload qemu and try again.
+
+You do not have to enable the nano sockets with ELKS for that, it will use the 
+Unix domain sockets which ELKS now supports.
+
 The original package and further information about Microwindows can be downloaded
 from this site: www.microwindows.org.
 
-18th of March 2017 Georg Potthast
+25th of March 2017 Georg Potthast
 
 

--- a/nano-X/src/Makefile
+++ b/nano-X/src/Makefile
@@ -27,7 +27,7 @@ NANOX=1
 # uncomment the following line to link the nano-X application
 # with the server.  This is required for ELKS, if no network is present,
 # or for speed or debugging.  This affects the nano-X server only.
-xLINK_APP_INTO_SERVER=1
+LINK_APP_INTO_SERVER=1
 
 # Window move algorithms, change for tradeoff between cpu speed and looks
 # UPDATEREGIONS paints in update clipping region only for better look and feel
@@ -45,7 +45,7 @@ TOPDIR := $(shell pwd)
 
 ifdef ELKS
 CC = bcc -0 -ansi -Dconst= -Dvolatile=
-INC = -I$(TOPDIR) -I/usr/bcc/include -I/home/georg/elks-dev/OS-build/elks/include
+INC = -I$(TOPDIR) -I/usr/bcc/include -I../../elks/include
 CFLAGS = -DELKS=1 -DUNIX=1 -DDEBUG=1 $(INC) -O
 MATHLIB =
 xSERMOUSE=1

--- a/nano-X/src/Makefile
+++ b/nano-X/src/Makefile
@@ -27,7 +27,7 @@ NANOX=1
 # uncomment the following line to link the nano-X application
 # with the server.  This is required for ELKS, if no network is present,
 # or for speed or debugging.  This affects the nano-X server only.
-LINK_APP_INTO_SERVER=1
+xLINK_APP_INTO_SERVER=1
 
 # Window move algorithms, change for tradeoff between cpu speed and looks
 # UPDATEREGIONS paints in update clipping region only for better look and feel
@@ -45,7 +45,7 @@ TOPDIR := $(shell pwd)
 
 ifdef ELKS
 CC = bcc -0 -ansi -Dconst= -Dvolatile=
-INC = -I$(TOPDIR) -I/usr/bcc/include -I../../elks/include
+INC = -I$(TOPDIR) -I/usr/bcc/include -I/home/georg/elks-dev/OS-build/elks/include
 CFLAGS = -DELKS=1 -DUNIX=1 -DDEBUG=1 $(INC) -O
 MATHLIB =
 xSERMOUSE=1
@@ -77,9 +77,10 @@ xNANOXFILES += $(NANOXDEMO) $(STUBFILES)
 NANOXFILES += $(STUBFILES)
 ALL += nano-X
 else
+xNANOXDEMO =demos/nanox/demo2.o
 NANOXFILES += $(NETFILES)
 DEMOLIBS += libnano-X.a
-ALL += libnano-X.a nano-X demo
+ALL += libnano-X.a nano-Xd demo
 endif
 
 endif
@@ -144,5 +145,17 @@ nano-X: $(SERVFILES) $(NANOXFILES) $(NANOXDEMO)
 	$(CC) $(CFLAGS) $(NANOXFILES) demos/nanox/world.o $(SERVFILES) $(NANOLIBS) $(LIBS) -o bin/world $(MATHLIB)
 	cp demos/nanox/world.map bin/world.map
 
+nano-Xd: $(SERVFILES) $(NANOXFILES)
+	$(CC) $(CFLAGS) $(NANOXFILES) $(SERVFILES) $(NANOLIBS) $(LIBS) -o bin/nano-X $(MATHLIB)
+
+#only a few demos work in client/server mode	
 demo: $(NANOXDEMO) libnano-X.a
-	$(CC) $(CFLAGS) $(NANOXDEMO) $(DEMOLIBS) -o demo
+#	$(CC) $(CFLAGS) $(NANOXDEMO) $(DEMOLIBS) -o bin/demo
+	$(CC) $(CFLAGS) demos/nanox/demo.o $(DEMOLIBS) -o bin/demo $(MATHLIB)
+	$(CC) $(CFLAGS) demos/nanox/landmine.o $(DEMOLIBS) -o bin/landmine $(MATHLIB)
+#	$(CC) $(CFLAGS) demos/nanox/nterm.o $(DEMOLIBS) -o bin/nterm $(MATHLIB)	
+#	$(CC) $(CFLAGS) demos/nanox/nclock.o $(DEMOLIBS) -o bin/nclock $(MATHLIB)	
+	$(CC) $(CFLAGS) demos/nanox/demo2.o $(DEMOLIBS) -o bin/demo2 $(MATHLIB)
+#	$(CC) $(CFLAGS) demos/nanox/world.o $(DEMOLIBS) -o bin/world $(MATHLIB)
+#	cp demos/nanox/world.map bin/world.map
+	cp demos/demo.sh bin/demo.sh	

--- a/nano-X/src/add_to_full3.sh
+++ b/nano-X/src/add_to_full3.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set +x
  
 echo "Adding nano-X demos to ELKS full3 image"

--- a/nano-X/src/demos/demo.sh
+++ b/nano-X/src/demos/demo.sh
@@ -1,0 +1,2 @@
+nano-X & 
+demo

--- a/nano-X/src/demos/nanox/demo2.c
+++ b/nano-X/src/demos/nanox/demo2.c
@@ -1,3 +1,5 @@
+#include <stdio.h>
+#include <stdlib.h>
 #include "nano-X.h"
 
 int main()
@@ -5,8 +7,13 @@ int main()
 	GR_WINDOW_ID 	window;
 	GR_EVENT 	event;
 
-	GrOpen();
+	if (GrOpen() < 0) {
+		fprintf(stderr, "cannot open graphics\n");
+		exit(1);
+	}
+
 	window = GrNewWindow(GR_ROOT_WINDOW_ID, 20, 20, 100, 60, 4, WHITE, BLUE);
+
 	GrMapWindow(window);
 
 	while(1)

--- a/nano-X/src/drivers/scr_bios.c
+++ b/nano-X/src/drivers/scr_bios.c
@@ -90,8 +90,7 @@ VGA_open(PSD psd)
 
 #if ELKS
 	/* disallow console switching while in graphics mode*/
-	if(ioctl(0, DCGET_GRAPH) != 0)
-		return -1;
+	ioctl(0, DCGET_GRAPH); /*continue if failed*/
 #endif
 
 #if HWINIT

--- a/nano-X/src/nano-X.h
+++ b/nano-X/src/nano-X.h
@@ -37,7 +37,7 @@ typedef unsigned short GR_FUNC;	/* function codes */
 typedef int GR_ERROR;		/* error value */
 typedef short GR_EVENT_TYPE;	/* event types */
 typedef unsigned long GR_EVENT_MASK;	/* event masks */
-typedef char GR_FUNC_NAME[20];	/* function name */
+typedef char GR_FUNC_NAME[21];	/* function name */
 typedef void (*GR_ERROR_FUNC)();	/* error function */
 
 /* Pixel packings within words. */

--- a/nano-X/src/nanox/serv.h
+++ b/nano-X/src/nanox/serv.h
@@ -336,7 +336,7 @@ extern	GR_FONT_INFO	curfont;		/* current font information */
  * The filename to use for the named socket. If we ever support multiple
  * servers on one machine, the last digit will be that of the FB used for it.
  */
-#define GR_NAMED_SOCKET "/var/nanox"
+#define GR_NAMED_SOCKET "/var/uds"
 
 /*
  * The network interface version number. Increment this if you make a change

--- a/nano-X/src/nanox/srvnet.c
+++ b/nano-X/src/nanox/srvnet.c
@@ -15,9 +15,14 @@
 #include <unistd.h>
 #include <errno.h>
 #include <string.h>
-#include <sys/stat.h>
+#ifndef __linux__ 
+#include <linuxmt/socket.h>
+#include <linuxmt/un.h>
+#else
 #include <sys/socket.h>
 #include <sys/un.h>
+#endif
+#include <sys/stat.h>
 #include "serv.h"
 
 extern	int		un_sock;
@@ -1275,7 +1280,7 @@ void GsMoveCursorWrapper(void)
 }
 
 /*
- * This is an array containting pointers to all of the above wrappers, in the same order as
+ * This is an array containing pointers to all of the above wrappers, in the same order as
  * the GrNum* #defines in nano-X.h. All the parser has to do is range check the function
  * number it gets from the client, and then call the relevant array member. The wrappers
  * do the work of reading the arguments and parsing them into the correct types and structures,
@@ -1442,9 +1447,9 @@ int GsRead(int fd, void *buf, int c)
 	n = 0;
 
 	while(n < c) {
-		e = read(fd, (buf + n), (c - n));
+		e = read(fd, ((char *)buf + n), (c - n));
 		if(e <= 0) {
-printf("GsRead: read failed %d %x %d: %d\r\n", e, buf+n, c-n, errno);
+printf("GsRead: read failed %d %x %d: %d\r\n", e, ((char *)buf +n), c-n, errno);
 			GsClose();
 			return -1;
 		}


### PR DESCRIPTION
This will use the Unix domain sockets to communicate between the graphics server and the application.

Plus add the line `#!/bin/bash` to the `add_to_full3.sh` script to get it to run on additional platforms.