### PR TITLE
Claim 61Kb of unused memory for user processes.

### DIFF
--- a/elks/arch/i86/boot/crt0.S
+++ b/elks/arch/i86/boot/crt0.S
@@ -30,6 +30,76 @@ _main:
 	pop	dx
 #endif
 
+#ifdef REL_SYS
+! Relocate kernel code and data to lower memory
+! First set the stack next to the kernel data segment
+
+	mov	ax,si
+	add	ax,dx
+	rcr	ax,#1
+	shr	ax,#1
+	shr	ax,#1
+	shr	ax,#1
+	add	ax,cx
+	mov	ss,ax
+	mov	sp,#768
+	push	dx		! Save registers
+	push	si
+	push	cx
+	push	bx
+
+! Relocate setup data
+
+	mov	ax,#DEF_INITSEG
+	mov	ds,ax
+	mov	ax,#REL_SETUPSEG
+	mov	es,ax
+	xor	si,si
+	xor	di,di
+	mov	cx,#256
+	cld
+	rep
+	movsw
+
+! Relocate 1Kb of kernel code segment
+
+	mov	dx,cs		! Make sure this code
+	mov	ds,dx		! gets relocated
+	mov	ax,#REL_SYSSEG
+	mov	es,ax
+	sub	dx,ax
+	xor	si,si
+	xor	di,di
+	mov	cx,#512
+	rep
+	movsw
+	jmpi	cont,REL_SYSSEG
+
+! Relocate the remaining kernel code
+
+cont:	pop	bx		! Don't worry if copy
+	mov	cx,bx		! overlaps
+	sub	cx,#1024
+	rep
+	movsb
+
+! Relocate the kernel data segment
+
+	pop	ax
+	mov	ds,ax
+	sub	ax,dx
+	mov	es,ax		! New kernel DS
+	xor	si,si
+	xor	di,di
+	pop	ax
+	mov	cx,ax
+	rep
+	movsb
+	mov	si,ax
+	mov	cx,es
+	mov	ds,cx
+	pop	dx
+#endif
 ! Setup.S already initialized DS and ES (but not SS)
 ! In addition, registers contain:
 !   BX, Text size

--- a/elks/arch/i86/drivers/block/doshd.c
+++ b/elks/arch/i86/drivers/block/doshd.c
@@ -50,7 +50,11 @@
 
 /* #define MULT_SECT_RQ */
 
+#ifdef REL_SYS
+#define BUFSEG 0x60
+#else
 #define BUFSEG 0x800
+#endif
 
 static int bioshd_ioctl(struct inode *, struct file *,
 	unsigned int, unsigned int);
@@ -513,7 +517,7 @@ static struct file_operations bioshd_fops = {
 int init_bioshd(void)
 {
     register struct gendisk *ptr;
-    int count = 0;
+    int count;
 
 #ifndef CONFIG_SMALL_KERNEL
     printk("hd Driver Copyright (C) 1994 Yggdrasil Computing, Inc.\n"

--- a/elks/arch/i86/lib/setupb.S
+++ b/elks/arch/i86/lib/setupb.S
@@ -12,7 +12,11 @@ _setupb:
 	pop	dx
 
 #ifndef CONFIG_ROMCODE
+#ifndef REL_SYS
   INITSEG = DEF_INITSEG
+#else
+  INITSEG = REL_SETUPSEG
+#endif
 #else
   INITSEG = CONFIG_ROM_SETUP_DATA
 #endif

--- a/elks/arch/i86/lib/setupw.S
+++ b/elks/arch/i86/lib/setupw.S
@@ -12,7 +12,11 @@ _setupw:
 	pop	dx
 
 #ifndef CONFIG_ROMCODE
+#ifndef REL_SYS
   INITSEG = DEF_INITSEG
+#else
+  INITSEG = REL_SETUPSEG
+#endif
 #else
   INITSEG = CONFIG_ROM_SETUP_DATA
 #endif

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -63,6 +63,18 @@
 #define DEF_SETUPSEG	DEF_INITSEG + 0x20
 #define DEF_SYSSIZE	0x2F00
 
+#if !defined(CONFIG_286PMODE) && !defined(CONFIG_ROMCODE) && !defined(CONFIG_ARCH_SIBO)
+#define REL_SYS 1
+#endif
+
+#ifdef CONFIG_BLK_DEV_BIOS
+#define REL_SYSSEG	0xA0
+#define REL_SETUPSEG	0x80
+#else
+#define REL_SYSSEG	0x80
+#define REL_SETUPSEG	0x60
+#endif
+
 /* internal svga startup constants */
 #define VGA_NORMAL	0xffff	/* 80x25 mode */
 #define VGA_EXTENDED	0xfffe	/* 80x50 mode */


### PR DESCRIPTION
Done by relocating the kernel code and data segments to the lowest possible location.
Tested with the new telnetd daemon and a standard linux telnet client.
The vi editor now start on the client side, but complains of 'no TERM'.
Code size increased by 96 bytes.
The increase in usable memory was determined running the meminfo command before
and after the modification.