### PR TITLE
Reorganize the irq code to reduce code size,

### DIFF
--- a/elks/arch/i86/drivers/block/doshd.c
+++ b/elks/arch/i86/drivers/block/doshd.c
@@ -40,6 +40,7 @@
 
 #include <arch/segment.h>
 #include <arch/system.h>
+#include <arch/irq.h>
 
 #ifdef CONFIG_BLK_DEV_BIOS
 
@@ -526,9 +527,17 @@ int init_bioshd(void)
 
 #ifdef CONFIG_BLK_DEV_BFD
     _fd_count = bioshd_getfdinfo();
+    enable_irq(6);		/* Floppy */
 #endif
 #ifdef CONFIG_BLK_DEV_BHD
     _hd_count = bioshd_gethdinfo();
+    if (arch_cpu > 5) {		/* PC-AT or greater */
+	enable_irq(HD_IRQ);	/* AT ST506 */
+	enable_irq(15);		/* AHA1542 */
+    }
+    else {
+	enable_irq(5);		/* XT ST506 */
+    }
     bioshd_gendisk.nr_real = _hd_count;
 #endif /* CONFIG_BLK_DEV_BHD */
 

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -30,29 +30,6 @@ stashed_ds:
 	.word	0
 #endif
 
-/*
- *	Low level IRQ control.
- */
-	.globl	___save_flags
-	.globl	_restore_flags
-
-___save_flags:
-	pushf
-	pop	ax
-	ret
-
-! this version is smaller than the functionally equivalent C version
-! at 7 bytes vs. 21 or thereabouts :-) --Alastair Bridgewater
-!
-! Further reduced to 5 bytes  --Juan Perez
-!
-
-_restore_flags:
-	pop	ax
-	popf
-	pushf
-	jmp	ax
-
 ; CS points to this kernel code segment
 ; DS points to page 0  (interrupt table)
 ; ES points to the kernel data segment
@@ -69,7 +46,6 @@ _irqtab_init:
         seg cs
 #endif
         mov stashed_ds,bx
-        mov es,bx
 
         xor ax,ax
         mov ds,ax      ;intr table
@@ -204,7 +180,7 @@ _irq15:
 !	Traps (we use IRQ 16->31 for these)
 !
 !	Currently not used so removed for space.
-#if 0
+#ifdef ENABLE_TRAPS
 _div0:
 	push	ax
 	mov	ax,#16

--- a/elks/arch/i86/lib/Makefile
+++ b/elks/arch/i86/lib/Makefile
@@ -31,7 +31,7 @@ include $(BASEDIR)/Makefile-rules
 
 ifeq ($(USEIA16), y)
 OBJS		=peekb.o peekw.o pokew.o bitops.o \
-		 memmove.o string.o fmemset.o border.o setupw.o \
+		 memmove.o blt_forth.o string.o fmemset.o border.o setupw.o \
 		 ldivmod.o divmodsi3.o
 else
 OBJS		= $(IOBJS) $(JOBJS) $(LLOBJS) $(LXOBJS)
@@ -43,9 +43,9 @@ IOBJS		=idiv.o idivu.o imod.o imodu.o imul.o isl.o isr.o isru.o
 
 # miscellaneous
 
-JOBJS		=inport.o inportb.o outport.o outportb.o \
+JOBJS		=inport.o inportb.o outport.o outportb.o irqflag.o\
 		 peekb.o peekw.o pokew.o bitops.o \
-		 memmove.o string.o fmemset.o border.o setupw.o
+		 memmove.o blt_forth.o string.o fmemset.o border.o setupw.o
 #		 ntohl.o ntohs.o
 
 # compiler support for long arithmetic on little-endian (normal) longs

--- a/elks/arch/i86/lib/blt_forth.s
+++ b/elks/arch/i86/lib/blt_forth.s
@@ -1,0 +1,22 @@
+!
+! blt_forth( soff, sseg, doff, dseg, bytes )
+! for to > from
+!
+	.globl _blt_forth
+
+_blt_forth:
+	mov	bx,sp
+	mov	ax,si
+	mov	dx,di
+	lds	si, 2[bx]
+	les	di, 6[bx]
+	mov	cx, 10[bx]
+	std
+	rep
+	movsb
+	mov	di,dx
+	mov	si,ax
+	mov	ax,ss
+	mov	ds,ax
+	mov	es,ax
+	ret

--- a/elks/arch/i86/lib/fmemset.s
+++ b/elks/arch/i86/lib/fmemset.s
@@ -1,21 +1,20 @@
 !
-! void farmemset(char *off, int seg, int value, size_t count)
+! void fmemset(char *off, int seg, int value, size_t count)
 !
 
-	.globl _fmemset
+	.globl	_fmemset
 	.text
 
 _fmemset:
-	push	bp
-	mov	bp,sp
+	mov	bx,sp
 	push	es
 	push	di
-	les	di,[bp+4]
-	mov	ax,[bp+8]
-	mov	cx,[bp+10]
+	les	di,2[bx]
+	mov	ax,6[bx]
+	mov	cx,8[bx]
 	cld
-	test cl,1
-	jz ___memset_words
+	test	cl,1
+	jz	___memset_words
 	stosb
 
 ___memset_words:
@@ -25,34 +24,4 @@ ___memset_words:
 	stosw
 	pop	di
 	pop	es
-	pop	bp
 	ret
-
-!
-! blt_forth( soff, sseg, doff, dseg, bytes )
-! for to > from
-!
-	.globl _blt_forth
-
-_blt_forth:
-	push	bp
-	mov	bp, sp
-	push	es
-	push	ds
-	push	si
-	push	di
-	pushf
-	lds	si, [bp+4]
-	les	di, [bp+8]
-	mov	cx, [bp+12]
-	std
-	rep
-	movsb
-	popf
-	pop	di
-	pop	si
-	pop	ds
-	pop	es
-	pop	bp
-	ret
-

--- a/elks/arch/i86/lib/irqflag.s
+++ b/elks/arch/i86/lib/irqflag.s
@@ -1,0 +1,27 @@
+!
+! int __save_flags(void)
+!
+! Low level IRQ control.
+
+	.globl	___save_flags
+	.text
+
+___save_flags:
+	pushf
+	pop	ax
+	ret
+
+! void restore_flags(unsigned int)
+!
+! this version is smaller than the functionally equivalent C version
+! at 7 bytes vs. 21 or thereabouts :-) --Alastair Bridgewater
+!
+! Further reduced to 5 bytes  --Juan Perez
+
+	.globl	_restore_flags
+
+_restore_flags:
+	pop	ax
+	popf
+	pushf
+	jmp	ax


### PR DESCRIPTION
and prepare to use ia16-gcc compiler.
Code size reduced by 48 bytes.
Tested with Qemu.