### PR TITLE
Simplifications to reduce code size.

### DIFF
--- a/elks/fs/minix/bitmap.c
+++ b/elks/fs/minix/bitmap.c
@@ -160,10 +160,10 @@ void minix_free_inode(register struct inode *inode)
 	s = "nonexistent imap\n";
     else {
 	map_buffer(bh);
-	clear_inode(inode);
 	if (!clear_bit((unsigned int) (inode->i_ino & 8191), bh->b_data)) {
 	    debug1("%s: bit %ld already cleared.\n",ino);
 	}
+	clear_inode(inode);
 	mark_buffer_dirty(bh, 1);
 	unmap_buffer(bh);
     }

--- a/elks/fs/namei.c
+++ b/elks/fs/namei.c
@@ -502,9 +502,9 @@ int __do_rmthing(char *pathname, size_t offst)
 	    if (!iop || !(op = (*(int (**)())((char *)iop + offst)))) {
 		error = -EPERM;
 	    } else {
-/*		dirp->i_count++;
-		down(&dirp->i_sem);*/
-		return op(dirp, basename, namelen);
+		dirp->i_count++;
+/*		down(&dirp->i_sem);*/
+		error = op(dirp, basename, namelen);
 /*		up(&dirp->i_sem);*/
 	    }
 	}

--- a/elks/net/unix/af_unix.c
+++ b/elks/net/unix/af_unix.c
@@ -20,6 +20,16 @@
 
 #ifdef CONFIG_UNIX
 
+#ifdef __WATCOMC__
+#define offsetof(__typ,__id) ((size_t)((char *)&(((__typ*)0)->__id) - (char *)0))
+#else
+#ifdef __ia16__
+#define offsetof(TYPE, MEMBER) __builtin_offsetof (TYPE, MEMBER)
+#else
+#define offsetof(s,m) ((size_t)&(((s *)0)->m))
+#endif
+#endif
+
 struct unix_proto_data unix_datas[NSOCKETS_UNIX];
 
 static struct unix_proto_data *unix_data_alloc(void)
@@ -165,7 +175,7 @@ static int unix_bind(struct socket *sock,
     old_ds = current->t_regs.ds;
     current->t_regs.ds = kernel_ds;
 
-    i = do_mknod(fname, 0, S_IFSOCK | S_IRWXUGO, 0);
+    i = do_mknod(fname, offsetof(struct inode_operations,mknod), S_IFSOCK | S_IRWXUGO, 0);
 
     if (i == 0)
 	i = open_namei(fname, 0, S_IFSOCK, &upd->inode, NULL);


### PR DESCRIPTION
Fix to problem when removing inodes.
Pending fix in unix domain sockets.
code size reduced by 32 bytes.
Tested with Qemu.
