### PR TITLE
Fix to BIOS console driver.

### DIFF
--- a/elks/arch/i86/drivers/char/bioscon.c
+++ b/elks/arch/i86/drivers/char/bioscon.c
@@ -154,7 +154,7 @@ savekey:
     int		0x16
     push	ax
     call	_AddQueue
-    pop		ax
+    add		sp,#2
 nhp:
     mov		ah, #0x01
     int		0x16


### PR DESCRIPTION
This makes the bios console driver work under Qemu. With PCE emulator still don't work.
I cannot guess what will happen with real hardware.