### PR TITLE
Fix to access to inodes in FAT16 FS, issue #123.

### DIFF
--- a/elks/fs/Config.in
+++ b/elks/fs/Config.in
@@ -8,11 +8,16 @@ mainmenu_option next_comment
 	bool 'All file systems are READ-ONLY'  CONFIG_FS_RO               n
 	bool 'Minix file system'               CONFIG_MINIX_FS            y
 	bool 'ROM file system'                 CONFIG_ROMFS_FS            n
-	bool 'MS-DOS file system'              CONFIG_MSDOS_FS            y
+	bool 'MS-DOS file system'              CONFIG_MSDOS_FS            n
 
 	comment 'General filesystem settings'
 
-	bool 'Full VFS support'                CONFIG_FULL_VFS            n
+	if [ "$CONFIG_MSDOS_FS" != "y" ]; then
+	    bool 'Full VFS support'            CONFIG_FULL_VFS            n
+	else
+	    define_bool                        CONFIG_FULL_VFS            y
+	    define_bool                        CONFIG_32BIT_INODES        y
+	fi
 	bool 'Extra external buffer cache'     CONFIG_FS_EXTERNAL_BUFFER  y
 	bool 'Pipe support'                    CONFIG_PIPE                y
 

--- a/elks/fs/inode.c
+++ b/elks/fs/inode.c
@@ -161,7 +161,11 @@ static void list_inode_status(void)
     register struct inode *inode = first_inode;
 
     do {
+#ifdef CONFIG_32BIT_INODES
+        printk("[#%u: c=%u d=%x nr=%lu]", ((int)(pi++)),
+#else
         printk("[#%u: c=%u d=%x nr=%u]", ((int)(pi++)),
+#endif
 		inode->i_count, inode->i_dev, inode->i_ino);
     } while ((inode = inode->i_prev) != first_inode);
 }
@@ -218,7 +222,11 @@ void iput(register struct inode *inode)
 	wait_on_inode(inode);
 	if (!inode->i_count) {
 	    printk("VFS: iput: trying to free free inode\n"
+#ifdef CONFIG_32BIT_INODES
+		    "VFS: device %s, inode %lu, mode=0%06o\n",
+#else
 		    "VFS: device %s, inode %u, mode=0%06o\n",
+#endif
 		   kdevname(inode->i_rdev), inode->i_ino, inode->i_mode);
 	    return;
 	}
@@ -319,7 +327,11 @@ struct inode *__iget(struct super_block *sb,
     register struct inode *inode;
     register struct inode *n_ino;
 
-    debug3("iget called(%x, %d, %d)\n", sb, inr, 0 /* crossmntp */ );
+#ifdef CONFIG_32BIT_INODES
+    debug3("iget called(%x, %lu, %d)\n", sb, inr, 0 /* crossmntp */ );
+#else
+    debug3("iget called(%x, %u, %d)\n", sb, inr, 0 /* crossmntp */ );
+#endif
     if (!sb)
 	panic("VFS: iget with sb==NULL");
 

--- a/elks/fs/minix/bitmap.c
+++ b/elks/fs/minix/bitmap.c
@@ -153,14 +153,14 @@ void minix_free_inode(register struct inode *inode)
 	s = "nlink=%d\n";
     }
     else if (!inode->i_sb) s = "no sb\n";
-    else if (inode->i_ino < 1) s = "inode 0\n";
-    else if (inode->i_ino > inode->i_sb->u.minix_sb.s_ninodes)
+    else if ((unsigned int)inode->i_ino < 1) s = "inode 0\n";
+    else if ((unsigned int)inode->i_ino > inode->i_sb->u.minix_sb.s_ninodes)
 	s = "nonexistent inode\n";
-    else if (!(bh = inode->i_sb->u.minix_sb.s_imap[inode->i_ino >> 13]))
+    else if (!(bh = inode->i_sb->u.minix_sb.s_imap[(unsigned int)inode->i_ino >> 13]))
 	s = "nonexistent imap\n";
     else {
 	map_buffer(bh);
-	if (!clear_bit((unsigned int) (inode->i_ino & 8191), bh->b_data)) {
+	if (!clear_bit((unsigned int) ((unsigned int)inode->i_ino & 8191), bh->b_data)) {
 	    debug1("%s: bit %ld already cleared.\n",ino);
 	}
 	clear_inode(inode);
@@ -203,7 +203,7 @@ struct inode *minix_new_inode(struct inode *dir, __u16 mode)
     j += i * 8192;
     if (!j || j > inode->i_sb->u.minix_sb.s_ninodes) goto iputfail;
     unmap_buffer(bh);
-    inode->i_ino = j;
+    inode->i_ino = (ino_t)j;
     inode->i_dirt = 1;
 
 #ifdef BLOAT_FS

--- a/elks/fs/minix/namei.c
+++ b/elks/fs/minix/namei.c
@@ -214,7 +214,7 @@ static int minix_add_entry(register struct inode *dir,
 	    dir->i_version = ++event;
 #endif
 
-	    de->inode = ino;
+	    de->inode = (__u16)ino;
 	    mark_buffer_dirty(bh, 1);
 	    unmap_brelse(bh);
 	    break;

--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -122,7 +122,7 @@ int fat_readdirx(
 	bh = NULL;
 	is_long = 0;
 	ino = msdos_get_entry(inode,&filp->f_pos,&bh,&de);
-	while (ino != -1) {
+	while (ino != (ino_t)(-1L)) {
 		/* Check for long filename entry */
 		if (de->name[0] == (__s8) DELETED_FLAG) {
 			is_long = 0;

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -190,7 +190,7 @@ void msdos_read_inode(register struct inode *inode)
 	register struct msdos_dir_entry *raw_entry;
 	long this,nr;
 
-/* printk("read inode %d\r\n",inode->i_ino); */
+/* printk("read inode %lu\n",inode->i_ino); */
 	inode->u.msdos_i.i_busy = 0;
 	inode->i_uid = current->uid;
 	inode->i_gid = current->gid;

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -279,7 +279,7 @@ int msdos_scan(struct inode *dir,char *name,struct buffer_head **res_bh,
 				iput(inode);
 			}
 	}
-	if (*ino == -1) {
+	if (*ino == (ino_t)(-1L)) {
 		if (*res_bh) unmap_brelse(*res_bh);
 		*res_bh = NULL;
 		return name ? -ENOENT : -ENOSPC;

--- a/elks/fs/stat.c
+++ b/elks/fs/stat.c
@@ -22,7 +22,7 @@ static int cp_stat(register struct inode *inode, struct stat *statbuf)
     memset(&tmp, 0, sizeof(tmp));
 
     tmp.st_dev		= kdev_t_to_nr(inode->i_dev);
-    tmp.st_ino		= inode->i_ino;
+    tmp.st_ino		= (__u16)inode->i_ino;
     tmp.st_mode 	= inode->i_mode;
     tmp.st_nlink	= inode->i_nlink;
     tmp.st_uid		= inode->i_uid;

--- a/elks/fs/vfat/namei.c
+++ b/elks/fs/vfat/namei.c
@@ -243,7 +243,7 @@ static loff_t vfat_find_free_slots(register struct inode *dir,int slots)
 	ino = msdos_get_entry(dir,&curr,&bh,&de);
 
 	for (added = 0; added < 2; added++) {
-		while (ino != -1) {
+		while (ino != (ino_t)(-1L)) {
 			done = IS_FREE(de->name);
 			if (done) {
 				inode = iget(dir->i_sb,ino);

--- a/elks/include/arch/stat.h
+++ b/elks/include/arch/stat.h
@@ -5,7 +5,11 @@
 
 struct stat {
     dev_t	st_dev;
+#ifdef CONFIG_32BIT_INODES
+    __u16	st_ino;
+#else
     ino_t	st_ino;
+#endif
     mode_t	st_mode;
     nlink_t	st_nlink;
     uid_t	st_uid;

--- a/elks/include/linuxmt/romfs_fs.h
+++ b/elks/include/linuxmt/romfs_fs.h
@@ -56,7 +56,7 @@ struct romfs_inode {
 
 #define ROMFH_SIZE 16
 #define ROMFH_PAD (ROMFH_SIZE-1)
-#define ROMFH_MASK (~ROMFH_PAD)
+#define ROMFH_MASK (~((__u32)ROMFH_PAD))
 
 #ifdef __KERNEL__
 

--- a/elks/include/linuxmt/types.h
+++ b/elks/include/linuxmt/types.h
@@ -2,6 +2,7 @@
 #define LX86_LINUXMT_TYPES_H
 
 #include <arch/types.h>
+#include <linuxmt/config.h>
 
 
 typedef __u8            byte_t;
@@ -25,7 +26,11 @@ typedef __u32			block32_t;
 typedef __u16			dev_t;
 typedef __u16			flag_t;
 typedef __u16			gid_t;
+#ifdef CONFIG_32BIT_INODES
+typedef __u32			ino_t;
+#else
 typedef __u16			ino_t;
+#endif
 typedef __u32			ino32_t;
 typedef __u16			mode_t;
 typedef __u16			nlink_t;


### PR DESCRIPTION
Tested only with Mellvik's dos286.img.
Uses 32 bit inode numbers when msdos-fs is enabled,
otherwise, uses 16 bit inode numbers.
There is an increase in code size of 480 bytes when msdos-fs enabled.
Also modified configuration to enable Full VFS when msdos-fs enabled,
without need to ask.