### PR TITLE
Restore compilability using IA16-GCC compiler.

### DIFF
--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -180,11 +180,11 @@ endif
 
 ifeq ($(MK_CPU), 8086)
 ifeq ($(USEIA16), y)
-    CPU_AS	= -0
+    CPU_AS	= -0 -O
     CPU_CC	= -mtune=i8086 -fno-inline -fdata-sections -ffunction-sections -mseparate-code-segment -Wl,--gc-sections
     CPU_LD	= -0
 else
-    CPU_AS	= -0
+    CPU_AS	= -0 -O
     CPU_CC	= -0
     CPU_LD	= -0
 endif
@@ -192,11 +192,11 @@ endif
 
 ifeq ($(MK_CPU), 80186)
 ifeq ($(USEIA16), y)
-    CPU_AS	= -1
+    CPU_AS	= -1 -O
     CPU_CC	= -mtune=i80186 -fno-inline -fdata-sections -ffunction-sections -mseparate-code-segment -Wl,--gc-sections
     CPU_LD	= -0
 else
-    CPU_AS	= -1
+    CPU_AS	= -1 -O
     CPU_CC	= -0
     CPU_LD	= -0
 endif
@@ -204,11 +204,11 @@ endif
 
 ifeq ($(MK_CPU), 80286)
 ifeq ($(USEIA16), y)
-    CPU_AS	= -2
+    CPU_AS	= -2 -O
     CPU_CC	= -mtune=i80286 -fno-inline -fdata-sections -ffunction-sections -mseparate-code-segment -Wl,--gc-sections
     CPU_LD	= -0
 else
-    CPU_AS	= -2
+    CPU_AS	= -2 -O
     CPU_CC	= -0
     CPU_LD	= -0
 endif
@@ -216,11 +216,11 @@ endif
 
 ifeq ($(MK_CPU), 80386)
 ifeq ($(USEIA16), y)
-    CPU_AS	= -3
+    CPU_AS	= -3 -O
     CPU_CC	= -3
     CPU_LD	= -3
 else
-    CPU_AS	= -3
+    CPU_AS	= -3 -O
     CPU_CC	= -3
     CPU_LD	= -3
 endif
@@ -228,11 +228,11 @@ endif
 
 ifeq ($(MK_CPU), 80486)
 ifeq ($(USEIA16), y)
-    CPU_AS	= -3
+    CPU_AS	= -3 -O
     CPU_CC	= -3
     CPU_LD	= -3
 else
-    CPU_AS	= -3
+    CPU_AS	= -3 -O
     CPU_CC	= -3
     CPU_LD	= -3
 endif

--- a/elks/arch/i86/drivers/char/lp.c
+++ b/elks/arch/i86/drivers/char/lp.c
@@ -29,7 +29,7 @@ struct lp_info {
 #ifdef BIOS_PORTS
 
 /* We'll get port info from BIOS. There are 4 ports max. */
-static struct lp_info ports[LP_PORTS] = { 0, 0, 0, 0 };
+static struct lp_info ports[LP_PORTS];
 
 #else
 
@@ -51,6 +51,11 @@ static int port_order[LP_PORTS] = { 0, };
 
 #endif
 
+/*
+#define USE_LP_RESET
+*/
+
+#ifdef USE_LP_RESET
 static int lp_reset(int target)
 {
     register struct lp_info *lpp;
@@ -70,6 +75,7 @@ static int lp_reset(int target)
 
     return LP_STATUS(lpp);
 }
+#endif
 
 static int lp_char_polled(char c, unsigned int target)
 {
@@ -157,7 +163,7 @@ static size_t lp_write(struct inode *inode, struct file *file, char *buf, int co
 {
     register char *chrsp;
 
-#if 0
+#ifdef USE_LP_RESET
 
     /* initialize printer */
     lp_reset(MINOR(inode->i_rdev));

--- a/elks/arch/i86/drivers/char/serial.c
+++ b/elks/arch/i86/drivers/char/serial.c
@@ -164,7 +164,7 @@ static void update_port(register struct serial_info *port)
     /* set baud rate divisor, first lower, then higher byte */
     cflags = port->tty->termios.c_cflag & CBAUD;
     if (cflags & CBAUDEX)
-	cflags = B38400 + cflags & 03;
+	cflags = B38400 + (cflags & 03);
     divisor = divisors[cflags];
 
     clr_irq();

--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -9,8 +9,8 @@
 #include <arch/segment.h>
 
 static char *args[] = {
-    0x01,	/* argc     */
-    0x08,	/* &argv[0] */
+(char *)0x01,	/* argc     */
+(char *)0x08,	/* &argv[0] */
     NULL,	/* end argv */
     NULL,	/* envp     */
     NULL,	/* argv[0]     */

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -383,8 +383,8 @@ struct malloc_hole *mm_resize(register struct malloc_hole *m, segext_t pages)
     if (next->flags == HOLE_FREE && next->extent >= ext){
         m->extent += ext;
         next->page_base += ext;
-        if ((next->extent -= ext) == 0){
-            next->flags == HOLE_SPARE;
+        if ((next->extent -= ext) == 0) {
+            next->flags = HOLE_SPARE;
             m->next = next->next;
         }
         return m;

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -450,7 +450,7 @@ void map_buffer(register struct buffer_head *bh)
 		goto do_map_buffer;
 	    }
 	  init_while:
-	    if ((char *)(++pi) >= NR_MAPBUFS) pi = (char *)0;
+	    if ((int)(++pi) >= NR_MAPBUFS) pi = (char *)0;
 	} while ((int)pi != lastumap);
 
 	/* previous loop failed */

--- a/elks/fs/namei.c
+++ b/elks/fs/namei.c
@@ -408,7 +408,7 @@ int open_namei(char *pathname, int flag, int mode,
     return error;
 }
 
-int do_mknod(char *pathname, size_t offst, int mode, dev_t dev)
+int do_mknod(char *pathname, int offst, int mode, dev_t dev)
 {
 #ifndef CONFIG_FS_RO
     register struct inode *dirp;
@@ -432,7 +432,7 @@ int do_mknod(char *pathname, size_t offst, int mode, dev_t dev)
 	else {
 	    dirp->i_count++;
 	    down(&dirp->i_sem);
-	    error = (offst != offsetof(struct inode_operations,mknod)
+	    error = (offst != (int)offsetof(struct inode_operations,mknod)
 			? op(dirp, basename, namelen, mode)
 			: op(dirp, basename, namelen, mode, dev)
 		    );

--- a/elks/include/arch/irq.h
+++ b/elks/include/arch/irq.h
@@ -55,9 +55,15 @@ extern void restore_flags(flag_t);
 
 #ifdef __ia16__
 #define save_flags(x) \
-__asm__ __volatile__("pushfw ; popw %0":"=r" (x): /* no input */ :"memory")
+__asm__ __volatile__("pushfw\n" \
+          "        popw %0\n" \
+          :"=r" (x): /* no input */ :"memory")
+
 #define restore_flags(x) \
-__asm__ __volatile__("pushw %0 ; popfw": /* no output */ :"r" (x):"memory")
+__asm__ __volatile__("pushw %0\n" \
+          "        popfw\n" \
+          : /* no output */ :"r" (x):"memory")
+
 #define clr_irq()	asm("cli")
 #define set_irq()	asm("sti")
 #endif

--- a/elks/include/linuxmt/chqueue.h
+++ b/elks/include/linuxmt/chqueue.h
@@ -12,7 +12,7 @@ struct ch_queue {
 extern void chq_init(register struct ch_queue *,unsigned char *,int);
 /*extern void chq_erase(register struct ch_queue *);*/
 extern int chq_wait_wr(register struct ch_queue *,int);
-extern int chq_addch(register struct ch_queue *,unsigned char);
+extern void chq_addch(register struct ch_queue *,unsigned char);
 extern int chq_delch(register struct ch_queue *);
 /*extern int chq_peekch(register struct ch_queue *);*/
 /*extern int chq_full(register struct ch_queue *);*/

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -135,7 +135,7 @@ pid_t do_fork(int virtual)
 	 * first few bytes at the top of the user stack. Save those
 	 * bytes in the parent's kernel stack.
 	 */
-	memcpy_fromfs(sc, currentp->t_regs.sp, sizeof(sc));
+	memcpy_fromfs(sc, (void *)currentp->t_regs.sp, sizeof(sc));
 	/*
 	 * Let the child go on first.
 	 */
@@ -144,7 +144,7 @@ pid_t do_fork(int virtual)
 	 * By now, the child should have its own user stack. Restore
 	 * the parent's user stack.
 	 */
-	memcpy_tofs(currentp->t_regs.sp, sc, sizeof(sc));
+	memcpy_tofs((void *)currentp->t_regs.sp, sc, sizeof(sc));
     }
     /*
      *      Return the created task.

--- a/elks/kernel/signal.c
+++ b/elks/kernel/signal.c
@@ -23,8 +23,8 @@ static void generate(int sig, register struct task_struct *p)
 
     sa = p->sig.action[--sig].sa_handler;
     msksig = (((sigset_t)1) << sig);
-    if ((sa == SIG_IGN) || (sa == SIG_DFL) && (msksig &
-	    (SM_SIGCONT | SM_SIGCHLD | SM_SIGWINCH | SM_SIGURG)))
+    if ((sa == SIG_IGN) || ((sa == SIG_DFL) && (msksig &
+	    (SM_SIGCONT | SM_SIGCHLD | SM_SIGWINCH | SM_SIGURG))))
 	return;
     debug1("SIGNAL: Generating sig %d.\n", sig);
     p->signal |= msksig;

--- a/elks/lib/chqueue.c
+++ b/elks/lib/chqueue.c
@@ -56,8 +56,8 @@ int chq_wait_wr(register struct ch_queue *q, int nonblock)
     return (int)pi;
 }
 
-/* Adds character c, waiting if wait=1 (or otherwise throws out new char) */
-int chq_addch(register struct ch_queue *q, unsigned char c)
+/* Adds character c if there is room (or otherwise throws out new char) */
+void chq_addch(register struct ch_queue *q, unsigned char c)
 {
     debug5("CHQ: chq_addch(%d, %c, %d) q->len=%d q->start=%d\n", q, c, 0,
 	   q->len, q->start);


### PR DESCRIPTION
Also uncovered a bug in malloc.c and
an unused function in lp driver. Removed
several warnings.
Compiled with BCC has a code size reduction
of 96 bytes. Binary obtained with BCC was
tested under Qemu an PCE.