### PR TITLE
working kernel compiled with IA16-GCC compiler.

### DIFF
--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -309,10 +309,10 @@ endif
 .s.o:
 	$(AS) $(ASFLAGS) -o $*.o $<
 
-.S.s:
-	gcc -E -traditional -I$(INCDIR) $(CCDEFS) -o $*.s $<
-
 ifeq ($(USEIA16), y)
+.S.s:
+	gcc -E -traditional -I$(INCDIR) -DUSE_IA16 $(CCDEFS) -o $*.s $<
+
 .c.o:
 	$(CC) $(CFLAGS) -S -o $*.s $<
 	att2as86 < $*.s > $*.asm
@@ -320,6 +320,9 @@ ifeq ($(USEIA16), y)
 	rm $*.s $*.asm
 
 else
+.S.s:
+	gcc -E -traditional -I$(INCDIR) $(CCDEFS) -o $*.s $<
+
 .c.o:
 	$(CC) $(CFLAGS) -c -o $*.o $<
 

--- a/elks/arch/i86/kernel/Makefile
+++ b/elks/arch/i86/kernel/Makefile
@@ -25,7 +25,7 @@ DEPEND  	=
 
 DISTFILES	= syscall.dat
 
-NOINDENT	= bios16.c irq.c irqtab.c printreg.c process.c strace.h \
+NOINDENT	= bios16.S irq.c irqtab.S printreg.S process.c strace.h \
 		  system.c timer.c
 
 #########################################################################
@@ -48,7 +48,7 @@ endif
 # Commands.
 
 irqtab.o: irqtab.s
- 
+
 bios16.o: bios16.s
 
 printreg.o: printreg.s

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -387,18 +387,16 @@ save_regs:
 !
 	call	_syscall
 	push	ax		! syscall returns a value in ax
-	call	_do_signal
 #ifdef CONFIG_STRACE
 !
 !	ret_strace(retval)
 !
-	pop	ax
-	push	ax
 	call	_ret_strace
 #endif
 !
 !	Restore registers
 !
+	call	_do_signal
 	cli
 	j	restore_regs
 !
@@ -522,7 +520,9 @@ restore_regs:
 
 _tswitch:
 	push	bp		! schedule()'s bp
-	pushf
+#ifdef USE_IA16
+	push	es
+#endif
 	push	di
 	push	si
 	mov	bx,_previous
@@ -531,7 +531,9 @@ _tswitch:
 	mov	sp,TASK_KRNL_SP[bx]
 	pop	si
 	pop	di
-	popf
+#ifdef USE_IA16
+	pop	es
+#endif
 	pop	bp		! BP of schedule()
 	ret
 !

--- a/elks/arch/i86/kernel/printreg.S
+++ b/elks/arch/i86/kernel/printreg.S
@@ -25,7 +25,8 @@ _print_regs:
 	push cx
 	push bx
 	push ax
-	push #fmtprg
+	mov  ax,#fmtprg
+	push ax
 	call _printk
 	pop ax
 	pop ax

--- a/elks/arch/i86/lib/Makefile
+++ b/elks/arch/i86/lib/Makefile
@@ -71,6 +71,8 @@ lib86.a: $(OBJS)
 
 setupw.s: setupw.S
 
+string.s: string.S
+
 #########################################################################
 # Standard commands.
 

--- a/elks/arch/i86/lib/blt_forth.s
+++ b/elks/arch/i86/lib/blt_forth.s
@@ -5,12 +5,13 @@
 	.globl _blt_forth
 
 _blt_forth:
-	mov	bx,sp
 	mov	ax,si
 	mov	dx,di
-	lds	si, 2[bx]
-	les	di, 6[bx]
-	mov	cx, 10[bx]
+	mov	si,sp
+	mov	bx,es
+	mov	cx, 10[si]
+	les	di, 6[si]
+	lds	si, 2[si]
 	std
 	rep
 	movsb
@@ -18,5 +19,5 @@ _blt_forth:
 	mov	si,ax
 	mov	ax,ss
 	mov	ds,ax
-	mov	es,ax
+	mov	es,bx
 	ret

--- a/elks/arch/i86/lib/string.S
+++ b/elks/arch/i86/lib/string.S
@@ -6,6 +6,9 @@
 	.globl _strcmp
 	.globl _memset
 	.text
+#ifdef USE_IA16
+	.extern _kernel_ds
+#endif
 	.even
 
 !
@@ -15,6 +18,10 @@
 !
 
 _strlen:			! needs more testing!
+#ifdef USE_IA16
+	mov	dx,es
+	mov	es,_kernel_ds
+#endif
 	mov	bx,sp
 	push	di
 	mov	di,2[bx]
@@ -27,6 +34,9 @@ _strlen:			! needs more testing!
 	sub	ax,2[bx]
 	dec	ax
 	pop	di
+#ifdef USE_IA16
+	mov	es,dx
+#endif
 	ret
 
 !
@@ -36,6 +46,10 @@ _strlen:			! needs more testing!
 !
 
 _strcpy:
+#ifdef USE_IA16
+	mov	dx,es
+	mov	es,_kernel_ds
+#endif
 	mov	bx,sp
 	push	di
 	push	si
@@ -50,6 +64,9 @@ copyon:	lodsb			! al = [ds:si++]
 	mov	ax,2[bx]	! _strcpy returns a pointer to the destination string
 	pop	si
 	pop	di
+#ifdef USE_IA16
+	mov	es,dx
+#endif
 	ret
 
 !
@@ -59,6 +76,10 @@ copyon:	lodsb			! al = [ds:si++]
 !
 
 _strcmp:
+#ifdef USE_IA16
+	mov	dx,es
+	mov	es,_kernel_ds
+#endif
 	mov	bx,sp
 	push	di
 	push	si
@@ -79,6 +100,9 @@ cmpend:	sbb	ax,ax		! strings differ
 
 cmpret:	pop	si
 	pop	di
+#ifdef USE_IA16
+	mov	es,dx
+#endif
 	ret
 
 !
@@ -86,6 +110,10 @@ cmpret:	pop	si
 !
 
 _memset:
+#ifdef USE_IA16
+	mov	dx,es
+	mov	es,_kernel_ds
+#endif
 	mov	bx,sp
 	push	di
 	mov	di,2[bx]	! address of the memory block
@@ -96,4 +124,7 @@ _memset:
 	stosb			! 	cx--, [es:di++] = al
 	mov	ax,2[bx]	! return value = start addr of block
 	pop	di
+#ifdef USE_IA16
+	mov	es,dx
+#endif
 	ret

--- a/elks/arch/i86/mm/segment.S
+++ b/elks/arch/i86/mm/segment.S
@@ -18,13 +18,20 @@ _memcpy_fromfs:
 	mov	cx,6[bx]
 	mov	bx,_current
 	mov	ds,TASK_USER_DS[bx]
+	mov	bx,ss
+#ifdef USE_IA16
+	push	es
+	mov	es,bx
+#endif
 	cld
 	rep
 	movsb
+#ifdef USE_IA16
+	pop	es
+#endif
+	mov	ds,bx
 	mov	di,dx
 	mov	si,ax
-	mov	ax,ss
-	mov	ds,ax
 	ret
 
 /* void memcpy_tofs(void *daddr, void *saddr, size_t len);*/
@@ -33,19 +40,19 @@ _memcpy_fromfs:
 _memcpy_tofs:
 	mov	ax,si
 	mov	dx,di
-	mov	bx,sp
-	mov	di,2[bx]
-	mov	si,4[bx]
-	mov	cx,6[bx]
-	mov	bx,_current
-	mov	es,TASK_USER_DS[bx]
+	mov	bx,es
+	mov	si,_current
+	mov	es,TASK_USER_DS[si]
+	mov	si,sp
+	mov	di,2[si]
+	mov	cx,6[si]
+	mov	si,4[si]
 	cld
 	rep
 	movsb
+	mov	es,bx
 	mov	di,dx
 	mov	si,ax
-	mov	ax,ss
-	mov	es,ax
 	ret
 
 /* void fmemcpy(dseg, dest, sseg, src, size); */
@@ -54,11 +61,14 @@ _memcpy_tofs:
 _fmemcpy:
 	mov	ax,si
 	mov	dx,di
-	mov	bx,sp
-	mov	es,2[bx]
-	mov	si,8[bx]
-	mov	cx,10[bx]
-	lds	di,4[bx]
+#ifdef USE_IA16
+	mov	bx,es
+#endif
+	mov	di,sp
+	mov	es,2[di]
+	mov	si,8[di]
+	mov	cx,10[di]
+	lds	di,4[di]
 	cld
 	rep
 	movsb
@@ -66,7 +76,11 @@ _fmemcpy:
 	mov	si,ax
 	mov	ax,ss
 	mov	ds,ax
+#ifdef USE_IA16
+	mov	es,bx
+#else
 	mov	es,ax
+#endif
 	ret
 
 /* int strlen_fromfs(void *saddr); */
@@ -77,9 +91,10 @@ _fmemcpy:
 	.globl	_strlen_fromfs
 
 _strlen_fromfs:
-	mov	bx,_current
-	mov	es,TASK_USER_DS[bx]
 	mov	dx,di
+	mov	di,_current
+	push	es
+	mov	es,TASK_USER_DS[di]
 	mov	bx,sp
 	mov	di,2[bx]
 	xor	al,al		! search for NULL byte
@@ -87,8 +102,7 @@ _strlen_fromfs:
 	mov	cx,#-1
 	repne
 	scasb
-	mov	ax,ss
-	mov	es,ax
+	pop	es
 	mov	ax,di		! calc len +1
 	mov	di,dx
 	sub	ax,2[bx]


### PR DESCRIPTION
Kernel tested with Qemu using BCC and IA16-GCC.
Code size under BCC not changed. Under IA16-GCC
there is a reduction of 1264 bytes.
Also tested with the PCE emulator.
