### PR TITLE
Fix warnings using IA16-GCC.

### DIFF
--- a/elks/.gitignore
+++ b/elks/.gitignore
@@ -18,6 +18,7 @@ arch/i86/kernel/entry.S
 arch/i86/kernel/irqtab.s
 arch/i86/kernel/printreg.s
 arch/i86/lib/setupw.s
+arch/i86/lib/string.s
 arch/i86/mm/segment.s
 arch/i86/tools/build
 arch/i86/tools/mkbootloader

--- a/elks/arch/i86/drivers/block/doshd.c
+++ b/elks/arch/i86/drivers/block/doshd.c
@@ -610,9 +610,8 @@ int init_bioshd(void)
 	bioshd_initialized = 1;
     } else {
 	printk("hd: unable to register\n");
-	return -1;
     }
-    return 0;
+    return count;
 }
 
 static int bioshd_ioctl(struct inode *inode,

--- a/elks/arch/i86/drivers/char/xt_key.c
+++ b/elks/arch/i86/drivers/char/xt_key.c
@@ -16,7 +16,7 @@
  * Georg Potthast 2017                                         *
  * ************************************************************/
 
-
+#include <linuxmt/kernel.h>
 #include <linuxmt/sched.h>
 #include <linuxmt/types.h>
 #include <linuxmt/errno.h>

--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -175,8 +175,8 @@ void arch_build_stack(struct task_struct *t, char *addr)
     register __u16 *tsp = ((__u16 *)(&(t->t_regs.ax))) - 1;
 
     if (addr == NULL)
-	addr = ret_from_syscall;
-    *tsp = addr;			/* Start execution address */
+	addr = (char *)ret_from_syscall;
+    *tsp = (__u16 *)addr;		/* Start execution address */
 #ifdef __ia16__
     *(tsp-2) = kernel_ds;		/* Initial value for ES register */
     t->t_xregs.ksp = (__u16)(tsp - 4);	/* Initial value for SP register */

--- a/elks/arch/i86/lib/string.S
+++ b/elks/arch/i86/lib/string.S
@@ -6,9 +6,6 @@
 	.globl _strcmp
 	.globl _memset
 	.text
-#ifdef USE_IA16
-	.extern _kernel_ds
-#endif
 	.even
 
 !
@@ -128,3 +125,8 @@ _memset:
 	mov	es,dx
 #endif
 	ret
+
+#ifdef USE_IA16
+	.data
+	.extern _kernel_ds
+#endif


### PR DESCRIPTION
Make buffer.c and inode.c more alike.
Reductions in code size. Kernels tested with Qemu
and PCE emulators. Compiled with BCC and IA16-GCC.
Code size reduced by 96 bytes.