### PR TITLE
Optimizations to reduce kernel stack size.

### DIFF
--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -4,7 +4,7 @@
 #define MAX_TASKS 15
 #define NGROUPS	13		/* Supplementary groups */
 #define NOGROUP 0xFFFF
-#define KSTACK_BYTES 1014	/* Size of kernel stacks */
+#define KSTACK_BYTES 1008	/* Size of kernel stacks */
 
 #include <linuxmt/types.h>
 #include <linuxmt/fs.h>


### PR DESCRIPTION
Task kernel stack reduced by 7 bytes.
DATA + BSS reduced by 92 bytes. Code size
unchanged.
Basically rewrote function numout() from scratch to avoid using a buffer allocated in the stack, plus some optimizations to keep the code size unchanged.
The savings in the kernel stack are 7 bytes, but only reduced it by 6 bytes to keep an even size for the struct task.