### PR TITLE
Fix waste of kernel data space in struct super_block.

### DIFF
--- a/elks/fs/minix/bitmap.c
+++ b/elks/fs/minix/bitmap.c
@@ -105,14 +105,14 @@ block_t minix_new_block(register struct super_block *sb)
 
   repeat:
     j = 8192;
-    for (i = 0; i < 8; i++)
+    for (i = 0; i < MINIX_Z_MAP_SLOTS; i++)
 	if ((bh = sb->u.minix_sb.s_zmap[i]) != NULL) {
 	    map_buffer(bh);
 	    j = (block_t) find_first_zero_bit((void *)(bh->b_data), 8192);
 	    if (j < 8192) break;
 	    unmap_buffer(bh);
 	}
-    if (i >= 8) return 0;
+    if (i >= MINIX_Z_MAP_SLOTS) return 0;
     if (set_bit(j, bh->b_data)) {
 	panic("mnb: already set %d %d\n", j, bh->b_data);
 	unmap_buffer(bh);
@@ -184,7 +184,7 @@ struct inode *minix_new_inode(struct inode *dir, __u16 mode)
 
     minix_set_ops(inode);
     j = 8192;
-    for (i = 0; i < 8; i++)
+    for (i = 0; i < MINIX_I_MAP_SLOTS; i++)
 	if ((bh = inode->i_sb->u.minix_sb.s_imap[i]) != NULL) {
 	    map_buffer(bh);
 	    j = (block_t) find_first_zero_bit((void *)(bh->b_data), 8192);

--- a/elks/include/linuxmt/minix_fs.h
+++ b/elks/include/linuxmt/minix_fs.h
@@ -14,8 +14,14 @@
 /* Not the same as the bogus LINK_MAX in <linux/limits.h>. Oh well. */
 #define MINIX_LINK_MAX	250
 
+#ifdef CONFIG_MINIX_V2
 #define MINIX_I_MAP_SLOTS	8
 #define MINIX_Z_MAP_SLOTS	64
+#else
+#define MINIX_I_MAP_SLOTS	4
+#define MINIX_Z_MAP_SLOTS	8
+#endif
+
 #define MINIX_SUPER_MAGIC	0x137F	/* original minix fs */
 #define MINIX_SUPER_MAGIC2	0x138F	/* minix fs, 30 char names */
 #define MINIX2_SUPER_MAGIC	0x2468	/* minix V2 fs */

--- a/elks/include/linuxmt/minix_fs_sb.h
+++ b/elks/include/linuxmt/minix_fs_sb.h
@@ -4,6 +4,7 @@
 /*
  * minix super-block data in memory
  */
+#include <linuxmt/minix_fs.h>
 
 struct minix_sb_info {
     unsigned short		s_ninodes;
@@ -13,8 +14,8 @@ struct minix_sb_info {
     unsigned short		s_firstdatazone;
     unsigned short		s_log_zone_size;
     unsigned long		s_max_size;
-    struct buffer_head *	s_imap[8];
-    struct buffer_head *	s_zmap[64];
+    struct buffer_head *	s_imap[MINIX_I_MAP_SLOTS];
+    struct buffer_head *	s_zmap[MINIX_Z_MAP_SLOTS];
     unsigned short		s_dirsize;
     unsigned short		s_namelen;
     struct buffer_head *	s_sbh;


### PR DESCRIPTION
Allocation of space for inode and zone bitmaps
was for minix-V2 needs. But we only support
minix-V1, so now allocate space for current needs.
Data space reduced by 480 bytes. Unexpectedly, there
is also a code size reduction of 48 bytes, because
offsets in indexed addressing instructions are smaller.
Compiled with BCC. Tested with Qemu.