### PR TITLE
Diverse improvements in fs/, fs/minix/ and doshd.c.

### DIFF
--- a/elks/arch/i86/drivers/block/doshd.c
+++ b/elks/arch/i86/drivers/block/doshd.c
@@ -446,9 +446,9 @@ static int bioshd_open(struct inode *inode, struct file *filp)
 	    *drivep = fd_types[drivep->fdtype];
 	    printk("fd: Floppy drive autoprobe failed!\n");
 	}
-	else
+	else	/* target already checked to be (2 <= target <= 3) */
 	    printk("fd: /dev/fd%d probably has %d sectors and %d cylinders\n",
-		   target & 3, drivep->sectors, drivep->cylinders);
+		   target, drivep->sectors, drivep->cylinders);
 
 #endif
 

--- a/elks/arch/i86/mm/segment.S
+++ b/elks/arch/i86/mm/segment.S
@@ -83,30 +83,32 @@ _fmemcpy:
 #endif
 	ret
 
-/* int strlen_fromfs(void *saddr); */
+/* int strnlen_fromfs(void *saddr, size_t maxlen); */
 
     /*  scasb uses es:di, not ds:si, so it is not necessary
      *  to save and restore ds
      */
-	.globl	_strlen_fromfs
+	.globl	_strnlen_fromfs
 
-_strlen_fromfs:
+_strnlen_fromfs:
 	mov	dx,di
 	mov	di,_current
+	mov	bx,sp
 	push	es
 	mov	es,TASK_USER_DS[di]
-	mov	bx,sp
 	mov	di,2[bx]
+	mov	cx,4[bx]
 	xor	al,al		! search for NULL byte
 	cld
-	mov	cx,#-1
 	repne
 	scasb
 	pop	es
 	mov	ax,di		! calc len +1
 	mov	di,dx
-	sub	ax,2[bx]
+	jnz	strnln1
 	dec	ax
+strnln1:
+	sub	ax,2[bx]
 	ret
 
 	.data

--- a/elks/fs/minix/inode.c
+++ b/elks/fs/minix/inode.c
@@ -295,24 +295,24 @@ static unsigned short map_izone(register struct inode *inode, block_t block,
     return *i_zone;
 }
 
-static unsigned short map_iblock(register struct inode *inode, block_t i,
+static unsigned short map_iblock(struct inode *inode, block_t i,
 				 block_t block, int create)
 {
     register struct buffer_head *bh;
+    register block_t *b_zone;
 
     if (!(bh = bread(inode->i_dev, i))) {
 	return 0;
     }
     map_buffer(bh);
-    i = ((block_t *) (bh->b_data))[block];
-    if (create && !i) {
-	if ((i = minix_new_block(inode->i_sb))) {
-	    ((block_t *) (bh->b_data))[block] = i;
+    b_zone = &(((block_t *) (bh->b_data))[block]);
+    if (create && !(*b_zone)) {
+	if ((*b_zone = minix_new_block(inode->i_sb))) {
 	    bh->b_dirty = 1;
 	}
     }
     unmap_brelse(bh);
-    return i;
+    return *b_zone;
 }
 
 unsigned short _minix_bmap(register struct inode *inode,

--- a/elks/fs/minix/symlink.c
+++ b/elks/fs/minix/symlink.c
@@ -75,8 +75,7 @@ static int minix_readlink(register struct inode *inode,
 	if (!bh) len = 0;
 	else {
 	    map_buffer(bh);
-	    if ((len = strlen(bh->b_data) + 1) > buflen) len = buflen;
-	    if (len > 1023) len = 1023;
+	    if ((len = strnlen(bh->b_data, 1023)) > buflen) len = buflen;
 	    memcpy_tofs(buffer, bh->b_data, len);
 	    unmap_brelse(bh);
 	}

--- a/elks/fs/super.c
+++ b/elks/fs/super.c
@@ -422,10 +422,11 @@ int sys_mount(char *dev_name, char *dir_name, char *type)
 #ifdef CONFIG_FULL_VFS
     debug("MOUNT: performing type check\n");
 
-    if ((retval = strlen_fromfs(type)) >= 16) {
+    retval = strnlen_fromfs(type, 15);
+/*    if ((retval = strlen_fromfs(type)) >= 16) {
 	debug("MOUNT: type size exceeds 16 characters, truncating\n");
 	retval = 15;
-    }
+    }*/
 
     verified_memcpy_fromfs(ltype, type, retval);
     ltype[retval] = '\0';	/* make asciiz again */

--- a/elks/include/linuxmt/mm.h
+++ b/elks/include/linuxmt/mm.h
@@ -25,7 +25,7 @@ extern unsigned long high_memory;
 extern void memcpy_fromfs(void *,void *,size_t);
 extern void memcpy_tofs(void *,void *,size_t);
 
-extern int strlen_fromfs(void *);
+extern int strnlen_fromfs(void *,size_t);
 
 /*@+namechecks@*/
 


### PR DESCRIPTION
Code size reduced in 48 bytes. Data size unchanged.
Compiled with BCC. Tested with Qemu.
Changed function strlen_fromfs() to strnlen_fromfs() because
it is safer. Also, makes unnecessary to check the result of
strlen_fromfs(), simplifying the code.