### PR TITLE
fix waste of kernel data memory in inode array.

### DIFF
--- a/elks/fs/minix/truncate.c
+++ b/elks/fs/minix/truncate.c
@@ -42,7 +42,7 @@ static int V1_trunc_direct(register struct inode *inode)
 
   repeat:
     for (i = DIRECT_BLOCK; i < 7; i++) {
-	p = &inode->i_zone[i];
+	p = &inode->u.minix_i.i_zone[i];
 	if (!(tmp = *p)) continue;
 	bh = get_hash_table(inode->i_dev, (block_t) tmp);
 	if (i < DIRECT_BLOCK) {
@@ -176,8 +176,8 @@ void minix_truncate(register struct inode *inode)
 	  S_ISLNK(inode->i_mode))) return;
     while (1) {
 	retry = V1_trunc_direct(inode);
-	retry |= V1_trunc_indirect(inode, 7, &inode->i_zone[7]);
-	retry |= V1_trunc_dindirect(inode, 7 + 512, &inode->i_zone[8]);
+	retry |= V1_trunc_indirect(inode, 7, &inode->u.minix_i.i_zone[7]);
+	retry |= V1_trunc_dindirect(inode, 7 + 512, &inode->u.minix_i.i_zone[8]);
 	if (!retry) break;
 	schedule();
     }

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -10,6 +10,7 @@
 #include <linuxmt/vfs.h>
 #include <linuxmt/kdev_t.h>
 #include <linuxmt/ioctl.h>
+#include <linuxmt/minix_fs.h>
 #include <linuxmt/pipe_fs_i.h>
 #include <linuxmt/net.h>
 #include <linuxmt/config.h>
@@ -215,7 +216,6 @@ struct inode {
     __u32			i_mtime;
     __u8			i_gid;
     __u8			i_nlink;
-    __u16			i_zone[9];
 
     /* This stuff is just in-memory... */
     ino_t			i_ino;
@@ -248,6 +248,7 @@ struct inode {
 
     union {
 	struct pipe_inode_info	pipe_i;
+	struct minix_inode_info	minix_i;
 	struct romfs_inode_info	romfs_i;
 #ifdef CONFIG_MSDOS_FS	
 	struct msdos_inode_info msdos_i;

--- a/elks/include/linuxmt/minix_fs.h
+++ b/elks/include/linuxmt/minix_fs.h
@@ -35,6 +35,12 @@
 #define MINIX_V1		0x0001	/* original minix fs */
 #define MINIX_V2		0x0002	/* minix V2 fs */
 
+/* inode in-kernel data */
+
+struct minix_inode_info {
+    __u16	i_zone[9];
+};
+
 /*  This is the original minix inode layout on disk.
  *  Note the 8-bit gid and atime and ctime.
  */


### PR DESCRIPTION
Achieved moving the minix specific i_zone
array in the inode structure out of the
common part, to the filesystem specific
union u. Data size reduced in 1728 bytes.
Code size increased 32 bytes. Compiled with
BCC. Tested with Qemu.