### PR TITLE
Remove unnecessary copy of memory blocks.

### DIFF
--- a/elks/include/linuxmt/socket.h
+++ b/elks/include/linuxmt/socket.h
@@ -37,5 +37,6 @@ struct msghdr {
 
 struct proto_ops;
 extern int sock_register(int,struct proto_ops *);
+extern int move_addr_to_user(char *,size_t,char *,int *);
 
 #endif

--- a/elks/kernel/sched.c
+++ b/elks/kernel/sched.c
@@ -162,10 +162,10 @@ static int detach_timer(register struct timer_list *timer)
     int retval = 0;
 
     if ((tmr = timer->tl_next)) {
-        tmr->tl_prev = tmr;
+        tmr->tl_prev = timer->tl_prev;
     }
     if ((tmr = timer->tl_prev)) {
-        tmr->tl_next = tmr;
+        tmr->tl_next = timer->tl_next;
 	retval = 1;
     }
     init_timer(timer);

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -77,9 +77,7 @@ static int inet_release(struct socket *sock, struct socket *peer)
     cmd.cmd = TDC_RELEASE;
     cmd.sock = sock;
     ret = tcpdev_inetwrite(&cmd, sizeof(struct tdb_release));
-    if (ret >= 0)
-	ret = 0;
-    return ret;
+    return (ret >= 0 ? 0 : ret);
 }
 
 static int inet_bind(register struct socket *sock, struct sockaddr *addr,
@@ -96,7 +94,7 @@ static int inet_bind(register struct socket *sock, struct sockaddr *addr,
 
     cmd.cmd = TDC_BIND;
     cmd.sock = sock;
-    memcpy(&cmd.addr, addr, sockaddr_len);
+    memcpy_fromfs(&cmd.addr, addr, sockaddr_len);
 
     tcpdev_inetwrite(&cmd, sizeof(struct tdb_bind));
 
@@ -129,12 +127,12 @@ static int inet_connect(register struct socket *sock,
     if (sock->state == SS_CONNECTING)
         return -EINPROGRESS;
 
-    if (sock->state == SS_CONNECTED)
-        return -EISCONN;
+/*    if (sock->state == SS_CONNECTED)
+        return -EISCONN;*/	/*Already checked in socket.c*/
 
     cmd.cmd = TDC_CONNECT;
     cmd.sock = sock;
-    memcpy(&cmd.addr, uservaddr, sockaddr_len);
+    memcpy_fromfs(&cmd.addr, uservaddr, sockaddr_len);
 
     tcpdev_inetwrite(&cmd, sizeof(struct tdb_connect));
 


### PR DESCRIPTION
In some net syscalls, they used to copy potentially
large blocks of data (110 bytes) from userspace, to
a stack allocated array and later to a family defined
structure. Now, the copy is directly from userspace
to final destination. Also removed repeating checks
Compiled with BCC and tested with Qemu using the
ELKS telnet daemon. Code size reduced in 64 bytes.