### PR TITLE
Code reduction by elimination of file fs/block_dev.c.

### DIFF
--- a/elks/fs/block_dev.c
+++ b/elks/fs/block_dev.c
@@ -18,6 +18,7 @@
 
 #include <arch/segment.h>
 #include <arch/system.h>
+#ifndef USE_GETBLK
 
 static int blk_rw(struct inode *inode, register struct file *filp,
 		  char *buf, size_t count, int wr)
@@ -95,4 +96,5 @@ size_t block_write(struct inode *inode, struct file *filp,
     return blk_rw(inode, filp, buf, count, BLOCK_WRITE);
 }
 
+#endif
 #endif

--- a/elks/fs/devices.c
+++ b/elks/fs/devices.c
@@ -119,8 +119,8 @@ int blkdev_open(struct inode *inode, struct file *filp)
     register char *pi;
 
     pi = (char *)MAJOR(inode->i_rdev);
-    fop = blkdevs[(unsigned int)pi].ds_fops;
-    if ((unsigned int)pi >= MAX_BLKDEV || !fop) return -ENODEV;
+    if ((unsigned int)pi >= MAX_BLKDEV
+		|| !(fop = blkdevs[(unsigned int)pi].ds_fops)) return -ENODEV;
     filp->f_op = fop;
     return (fop->open) ? fop->open(inode, filp) : 0;
 }
@@ -153,8 +153,8 @@ struct inode_operations blkdev_inode_operations = {
     NULL,			/* mknod */
     NULL,			/* readlink */
     NULL,			/* follow_link */
-#ifdef BLOAT_FS
-    NULL,			/* bmap */
+#ifdef USE_GETBLK
+    NULL,			/* getblk */
 #endif
     NULL,			/* truncate */
 #ifdef BLOAT_FS
@@ -172,8 +172,8 @@ static int chrdev_open(struct inode *inode, struct file *filp)
     register char *pi;
 
     pi = (char *)MAJOR(inode->i_rdev);
-    fop = chrdevs[(unsigned int)pi].ds_fops;
-    if ((unsigned int)pi >= MAX_CHRDEV || !fop) return -ENODEV;
+    if ((unsigned int)pi >= MAX_CHRDEV
+		|| !(fop = chrdevs[(unsigned int)pi].ds_fops)) return -ENODEV;
     filp->f_op = fop;
     return (fop->open) ? fop->open(inode, filp) : 0;
 }
@@ -207,8 +207,8 @@ struct inode_operations chrdev_inode_operations = {
     NULL,			/* mknod */
     NULL,			/* readlink */
     NULL,			/* follow_link */
-#ifdef BLOAT_FS
-    NULL,			/* bmap */
+#ifdef USE_GETBLK
+    NULL,			/* getblk */
 #endif
     NULL,			/* truncate */
 #ifdef BLOAT_FS

--- a/elks/fs/minix/dir.c
+++ b/elks/fs/minix/dir.c
@@ -56,8 +56,8 @@ struct inode_operations minix_dir_inode_operations = {
     minix_mknod,		/* mknod */
     NULL,			/* readlink */
     NULL,			/* follow_link */
-#ifdef BLOAT_FS
-    NULL,			/* bmap */
+#ifdef USE_GETBLK
+    NULL,			/* getblk */
 #endif
     minix_truncate,		/* truncate */
 #ifdef BLOAT_FS

--- a/elks/fs/minix/symlink.c
+++ b/elks/fs/minix/symlink.c
@@ -100,8 +100,8 @@ struct inode_operations minix_symlink_inode_operations = {
     NULL,			/* mknod */
     minix_readlink,		/* readlink */
     minix_follow_link,		/* follow_link */
-#ifdef BLOAT_FS
-    NULL,			/* bmap */
+#ifdef USE_GETBLK
+    NULL,			/* getblk */
 #endif
     NULL,			/* truncate */
 #ifdef BLOAT_FS

--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -60,8 +60,8 @@ struct inode_operations msdos_dir_inode_operations = {
 	NULL,			/* mknod */
 	NULL,			/* readlink */
 	NULL,			/* follow_link */
-#ifdef BLOAT_FS
-	NULL,			/* bmap */
+#ifdef USE_GETBLK
+	NULL,			/* getblk */
 #endif
 	NULL,			/* truncate */
 #ifdef BLOAT_FS

--- a/elks/fs/msdos/file.c
+++ b/elks/fs/msdos/file.c
@@ -36,7 +36,7 @@ static struct file_operations msdos_file_operations = {
 	NULL			/* release */
 };
 
-/* No bmap for MS-DOS FS' that don't align data at kByte boundaries. */
+/* No getblk for MS-DOS FS' that don't align data at kByte boundaries. */
 
 struct inode_operations msdos_file_inode_operations_no_bmap = {
 	&msdos_file_operations,	/* default file operations */
@@ -50,8 +50,8 @@ struct inode_operations msdos_file_inode_operations_no_bmap = {
 	NULL,			/* mknod */
 	NULL,			/* readlink */
 	NULL,			/* follow_link */
-#ifdef BLOAT_FS
-	NULL,			/* bmap */
+#ifdef USE_GETBLK
+	NULL,			/* getblk */
 #endif
 	msdos_truncate,		/* truncate */
 #ifdef BLOAT_FS

--- a/elks/fs/pipe.c
+++ b/elks/fs/pipe.c
@@ -324,16 +324,14 @@ struct inode_operations pipe_inode_operations = {
     NULL,			/* mknod */
     NULL,			/* readlink */
     NULL,			/* follow_link */
-#ifdef BLOAT_FS
-    NULL,			/* bmap */
+#ifdef USE_GETBLK
+    NULL,			/* getblk */
 #endif
     NULL,			/* truncate */
 #ifdef BLOAT_FS
     NULL			/* permission */
 #endif
 };
-
-/*@+type@*/
 
 static int do_pipe(register int *fd)
 {

--- a/elks/fs/romfs/inode.c
+++ b/elks/fs/romfs/inode.c
@@ -512,8 +512,8 @@ static struct inode_operations romfs_file_inode_operations = {
     NULL,			/* mknod */
     NULL,			/* readlink */
     NULL,			/* followlink */
-#ifdef BLOAT_FS
-    NULL,			/* bmap -- not really */
+#ifdef USE_GETBLK
+    NULL,			/* getblk -- not really */
 #endif
     NULL			/* truncate */
 #ifdef BLOAT_FS
@@ -555,8 +555,8 @@ static struct inode_operations romfs_dirlink_inode_operations = {
     NULL,			/* mknod */
     romfs_readlink,		/* readlink */
     NULL,			/* followlink */
-#ifdef BLOAT_FS
-    NULL,			/* bmap */
+#ifdef USE_GETBLK
+    NULL,			/* getblk */
 #endif
     NULL			/* truncate */
 #ifdef BLOAT_FS

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -22,6 +22,8 @@
 #include <linuxmt/msdos_fs_sb.h>
 #endif
 
+#define USE_GETBLK
+
 /*  It's silly to have NR_OPEN bigger than NR_FILE, but I'll fix that later.
  *  Anyway, now the file code is no longer dependent on bitmaps in unsigned
  *  longs, but uses the new fd_set structure..
@@ -349,8 +351,8 @@ struct inode_operations {
     int 			(*readlink) ();
     int 			(*follow_link) ();
 
-#ifdef BLOAT_FS
-    int 			(*bmap) ();
+#ifdef USE_GETBLK
+    struct buffer_head *	(*getblk) ();
 #endif
 
     void			(*truncate) ();

--- a/elks/net/socket.c
+++ b/elks/net/socket.c
@@ -407,8 +407,8 @@ struct inode_operations sock_inode_operations = {
     NULL,			/* mknod */
     NULL,			/* readlink */
     NULL,			/* follow_link */
-#ifdef BLOAT_FS
-    NULL,			/* bmap */
+#ifdef USE_GETBLK
+    NULL,			/* getblk */
 #endif
     NULL,			/* truncate */
 #ifdef BLOAT_FS


### PR DESCRIPTION
Operation of functions in that file and those of
fs/minix/file.c were almost identical, so merging
them was easy. Code size reduced by 272 bytes and
data size increased by 20 bytes. Compiled with BCC,
tested with Qemu.
Changes were indicated by conditional compilation using
the macro USE_GETBLK, so that changes can be easily
evaluated. If accepted, I will submit changes for the final
version.