### PR TITLE
Restore compilability using ia16-elf-gcc compiler

### DIFF
--- a/elks/Makefile
+++ b/elks/Makefile
@@ -56,7 +56,7 @@ endif
 #########################################################################
 # What do we need this time?
 
-ARCHIVES=kernel/kernel.a fs/fs.a lib/lib.a net/net.a
+ARCHIVES=fs/fs.a kernel/kernel.a lib/lib.a net/net.a
 
 #########################################################################
 # Check what filesystems to include

--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -268,7 +268,8 @@ ifeq ($(USEIA16), y)
 
 AS		= as86
 ASFLAGS 	= $(CPU_AS) $(ARCH_AS)
-CC		= ia16-elf-gcc
+#CC		= ia16-elf-gcc
+CC		= ia16-unknown-elks-gcc
 CFLAGS		= $(CPU_CC) $(ARCH_CC) -Os $(CFLBASE) -Wall
 LD		= ld86
 LDFLAGS 	= $(CPU_LD) -s

--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -181,7 +181,7 @@ endif
 ifeq ($(MK_CPU), 8086)
 ifeq ($(USEIA16), y)
     CPU_AS	= -0 -O
-    CPU_CC	= -mtune=i8086 -fno-inline -fdata-sections -ffunction-sections -mseparate-code-segment -Wl,--gc-sections
+    CPU_CC	= -mtune=i8086 -fno-inline -fdata-sections -ffunction-sections -fleading-underscore -mseparate-code-segment -Wl,--gc-sections
     CPU_LD	= -0
 else
     CPU_AS	= -0 -O
@@ -193,7 +193,7 @@ endif
 ifeq ($(MK_CPU), 80186)
 ifeq ($(USEIA16), y)
     CPU_AS	= -1 -O
-    CPU_CC	= -mtune=i80186 -fno-inline -fdata-sections -ffunction-sections -mseparate-code-segment -Wl,--gc-sections
+    CPU_CC	= -mtune=i80186 -fno-inline -fdata-sections -ffunction-sections -fleading-underscore -mseparate-code-segment -Wl,--gc-sections
     CPU_LD	= -0
 else
     CPU_AS	= -1 -O
@@ -205,7 +205,7 @@ endif
 ifeq ($(MK_CPU), 80286)
 ifeq ($(USEIA16), y)
     CPU_AS	= -2 -O
-    CPU_CC	= -mtune=i80286 -fno-inline -fdata-sections -ffunction-sections -mseparate-code-segment -Wl,--gc-sections
+    CPU_CC	= -mtune=i80286 -fno-inline -fdata-sections -ffunction-sections -fleading-underscore -mseparate-code-segment -Wl,--gc-sections
     CPU_LD	= -0
 else
     CPU_AS	= -2 -O
@@ -268,7 +268,7 @@ ifeq ($(USEIA16), y)
 
 AS		= as86
 ASFLAGS 	= $(CPU_AS) $(ARCH_AS)
-CC		= ia16-unknown-elks-gcc
+CC		= ia16-elf-gcc
 CFLAGS		= $(CPU_CC) $(ARCH_CC) -Os $(CFLBASE) -Wall
 LD		= ld86
 LDFLAGS 	= $(CPU_LD) -s

--- a/elks/arch/i86/lib/Makefile
+++ b/elks/arch/i86/lib/Makefile
@@ -32,7 +32,7 @@ include $(BASEDIR)/Makefile-rules
 ifeq ($(USEIA16), y)
 OBJS		=peekb.o peekw.o pokew.o bitops.o \
 		 string.o fmemsetb.o border.o setupw.o \
-		 ldivmod.o divmodsi3.o
+		 fmemcpyb.o ldivmod.o divmodsi3.o
 else
 OBJS		= $(IOBJS) $(JOBJS) $(LLOBJS) $(LXOBJS)
 endif

--- a/elks/fs/Makefile
+++ b/elks/fs/Makefile
@@ -35,9 +35,9 @@ include $(BASEDIR)/Makefile-rules
 #########################################################################
 # Objects to be compiled.
 
-OBJS  = super.o bufops.o devices.o fcntl.o stat.o inode.o file_table.o \
+OBJS  = buffer.o super.o bufops.o devices.o fcntl.o stat.o inode.o file_table.o \
 	block_dev.o namei.o ioctl.o filesystems.o open.o read_write.o \
-	readdir.o exec.o select.o pipe.o buffer.o
+	readdir.o exec.o select.o pipe.o
 
 #########################################################################
 # Commands.

--- a/elks/include/linuxmt/minix_fs.h
+++ b/elks/include/linuxmt/minix_fs.h
@@ -35,6 +35,8 @@
 #define MINIX_V1		0x0001	/* original minix fs */
 #define MINIX_V2		0x0002	/* minix V2 fs */
 
+struct super_block;
+
 /* inode in-kernel data */
 
 struct minix_inode_info {

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -30,6 +30,12 @@
 #include <linuxmt/mm.h>
 #include <stdarg.h>
 
+#ifdef __BCC__
+#define REGISTER register
+#else
+#define REGISTER
+#endif
+
 /*
  *	Just to make it work for now
  */
@@ -77,14 +83,14 @@ static void numout(__u32 v, int width, int base, int useSign,
     int c, vch;
     register char *i;
 
-    i = 10;
+    i = (char *)10;
     dvr = 0x3B9ACA00L;
     if (base > 10) {
-	i = 8;
+	i = (char *)8;
 	dvr = 0x10000000L;
     }
     if (base < 10) {
-	i = 11;
+	i = (char *)11;
 	dvr = 0x40000000L;
     }
 
@@ -195,7 +201,7 @@ static void vprintk(register char *fmt, va_list p)
 
 void printk(char *fmt, ...)
 {
-    register va_list p;
+    REGISTER va_list p;
 
     va_start(p, fmt);
     vprintk(fmt, p);


### PR DESCRIPTION
Includes modification in Makefiles-rules to use ia16-elf-gcc instead of ia16-unknown-elks-gcc.
The kernel image is successfully built, fails to mount the root filesystem.
