### PR TITLE
Replace select() queues hash by table

### DIFF
--- a/elks/arch/i86/drivers/net/ne2k-main.c
+++ b/elks/arch/i86/drivers/net/ne2k-main.c
@@ -57,7 +57,7 @@ static size_t ne2k_read (struct inode * inode, struct file * filp,
 				{
 				// Interrupted by signal
 
-				res = -ERESTARTSYS;
+				res = -EINTR;
 				break;
 				}
 
@@ -116,7 +116,7 @@ static size_t ne2k_write (struct inode * inode, struct file * file,
 				{
 				// Interrupted by signal
 
-				res = -ERESTARTSYS;
+				res = -EINTR;
 				break;
 				}
 
@@ -258,6 +258,8 @@ static int ne2k_open (struct inode * inode, struct file * file)
 
 		err = ne2k_start ();
 		if (err) break;
+
+		ne2k_inuse = 1;
 
 		err = 0;
 		break;

--- a/elks/include/arch/limits.h
+++ b/elks/include/arch/limits.h
@@ -2,7 +2,7 @@
 #ifndef ARCH_LIMITS_H
 #define ARCH_LIMITS_H
 
-// Coming from Ethernet NE2K driver
+/* Coming from Ethernet NE2K driver */
 #define MAX_PACKET_ETH (6 * 256 - 4)
 
 #endif /* !ARCH_LIMITS_H */

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -344,7 +344,7 @@ struct file_operations {
     size_t			(*read)(struct inode *,struct file *,char *,size_t);
     size_t			(*write)(struct inode *,struct file *,char *,size_t);
     int 			(*readdir) ();
-    int 			(*select) ();
+    int 			(*select) (struct inode *,struct file *, int flag);
     int 			(*ioctl) ();
     int 			(*open) ();
     void			(*release) ();

--- a/elks/include/linuxmt/limits.h
+++ b/elks/include/linuxmt/limits.h
@@ -4,4 +4,7 @@
 
 #include <arch/limits.h>
 
+/* Maximum number of polled queues per process */
+#define POLL_MAX 4
+
 #endif /* !LINUXMT_LIMITS_H */

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -8,6 +8,7 @@
 
 #include <linuxmt/config.h>
 #include <linuxmt/types.h>
+#include <linuxmt/limits.h>
 #include <linuxmt/fs.h>
 #include <linuxmt/time.h>
 #include <linuxmt/signal.h>
@@ -68,7 +69,7 @@ struct task_struct {
     __s16			state;
     __u32			timeout;	/* for select() */
     struct wait_queue		*waitpt;	/* Wait pointer */
-    __u16			pollhash;
+    struct wait_queue       *poll [POLL_MAX];  /* polled queues */
     struct task_struct		*next_run;
     struct task_struct		*prev_run;
     struct file_struct		files;		/* File system structure */
@@ -165,7 +166,7 @@ extern void put_ustack(register struct task_struct *,int,int);
 
 extern void tswitch(void);
 
-/* This should be an inline function !!! */
-extern void select_wait(struct wait_queue *);
+void select_wait(struct wait_queue *);
+int select_poll(struct task_struct *, struct wait_queue *);
 
 #endif

--- a/elks/include/linuxmt/wait.h
+++ b/elks/include/linuxmt/wait.h
@@ -11,24 +11,7 @@ struct wait_queue {
     char pad;
 };
 
-#ifdef __KERNEL__
-
-struct select_table_entry {
-    struct wait_queue wait;
-    struct wait_queue *wait_address;
-};
-
-typedef struct select_table_struct {
-    int nr;
-    struct select_table_entry *entry;
-} select_table;
-
-/*@-namechecks@*/
-
-#define __MAX_SELECT_TABLE_ENTRIES 32
-
-/*@+namechecks@*/
-
-#endif
+/* The special queue for selecting / polling */
+extern struct wait_queue select_queue;
 
 #endif

--- a/elks/kernel/sleepwake.c
+++ b/elks/kernel/sleepwake.c
@@ -92,15 +92,10 @@ void wake_up_process(register struct task_struct *p)
 void _wake_up(register struct wait_queue *q, unsigned short int it)
 {
     register struct task_struct *p;
-    unsigned short int phash;
-
-    extern struct wait_queue select_poll;
-
-    phash = ((unsigned short int)1) << (((unsigned short int)q >> 8) & 0x0F);
 
     for_each_task(p) {
 	if ((p->waitpt == q)
-	    || ((p->waitpt == &select_poll) && (p->pollhash & phash))
+	    || ((p->waitpt == &select_queue) && select_poll (p, q))
 	    )
 	    if (p->state == TASK_INTERRUPTIBLE ||
 		(it && p->state == TASK_UNINTERRUPTIBLE)) {

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -309,7 +309,7 @@ static int inet_write(register struct socket *sock, char *ubuf, int size,
 
 
 static int inet_select(register struct socket *sock,
-		       int sel_type, select_table * wait)
+		       int sel_type)
 {
     debug("inet_select\n");
     if (sel_type == SEL_IN) {

--- a/elks/net/socket.c
+++ b/elks/net/socket.c
@@ -201,7 +201,7 @@ static size_t sock_write(struct inode *inode, struct file *file,
 }
 
 static int sock_select(struct inode *inode,
-		       struct file *file, int sel_type, select_table * wait)
+		       struct file *file, int sel_type)
 {
     register struct socket *sock;
     register struct proto_ops *ops;
@@ -211,7 +211,7 @@ static int sock_select(struct inode *inode,
 
     ops = sock->ops;
     if (ops && ops->select)
-	return ops->select(sock, sel_type, wait);
+	return ops->select(sock, sel_type);
 
     return 0;
 }

--- a/elks/net/unix/af_unix.c
+++ b/elks/net/unix/af_unix.c
@@ -476,7 +476,7 @@ static int unix_write(struct socket *sock, char *ubuf, int size, int nonblock)
     return (size - todo);
 }
 
-static int unix_select(struct socket *sock, int sel_type, select_table * wait)
+static int unix_select(struct socket *sock, int sel_type)
 {
     struct unix_proto_data *upd, *peerupd;
 
@@ -490,11 +490,11 @@ static int unix_select(struct socket *sock, int sel_type, select_table * wait)
 	    if (sock->iconn)
 		return 1;
 
-	    select_wait(sock->wait, wait);
+	    select_wait(sock->wait);
 
 	    return (sock->iconn ? 1 : 0);
 	}
-	select_wait(sock->wait, wait);
+	select_wait(sock->wait);
 
 	return 0;
     }
@@ -508,7 +508,7 @@ static int unix_select(struct socket *sock, int sel_type, select_table * wait)
 	else if (sock->state != SS_CONNECTED)
 	    return 1;
 
-	select_wait(sock->wait, wait);
+	select_wait(sock->wait);
 
 	return 0;
     }
@@ -523,7 +523,7 @@ static int unix_select(struct socket *sock, int sel_type, select_table * wait)
 	if (UN_BUF_SPACE(peerupd) > 0)
 	    return 1;
 
-	select_wait(sock->wait, wait);
+	select_wait(sock->wait);
 
 	return 0;
     }


### PR DESCRIPTION
Result of the hash function used in select() was the same for two queues
within the same 256 bytes address range, and was unsafe for other queues
scattered over the kernel data segment.

The hash is replaced by a table of the polled queues. This design is the
safest, at the cost of some extra bytes in the task structure (+8).

Also fixes a missing update of the `ne2k_inuse` flag, reported by @Mellvik in #133.

Fixes #208