### PR TITLE
Tune ethernet packet min & max sizes

### DIFF
--- a/elks/arch/i86/drivers/net/ne2k-main.c
+++ b/elks/arch/i86/drivers/net/ne2k-main.c
@@ -75,11 +75,11 @@ static size_t ne2k_read (struct inode * inode, struct file * filp,
 			break;
 			}
 
-		// Client should request at least MAX_PACKET_ETH bytes
+		// Client should read packet once
 		// otherwise end of packet will be lost
 
 		size = *((word_t *) (recv_buf + 2));
-		len = len > size ? size : len;
+		if (len > size) len = size;
 		memcpy_tofs (data, recv_buf + 4, len);
 
 		res = len;
@@ -128,9 +128,10 @@ static size_t ne2k_write (struct inode * inode, struct file * file,
 		// Client should write packet once
 		// otherwise end of packet will be lost
 
-		len = len > MAX_PACKET_ETH ? MAX_PACKET_ETH : len;
+		if (len > MAX_PACKET_ETH) len = MAX_PACKET_ETH;
 		memcpy_fromfs (send_buf, data, len);
 
+		if (len < 64) len = 64;  /* issue #133 */
 		res = ne2k_pack_put (send_buf, len);
 		if (res)
 			{

--- a/elks/include/arch/limits.h
+++ b/elks/include/arch/limits.h
@@ -2,7 +2,9 @@
 #ifndef ARCH_LIMITS_H
 #define ARCH_LIMITS_H
 
-/* Coming from Ethernet NE2K driver */
-#define MAX_PACKET_ETH (6 * 256 - 4)
+/* Maximum packet size for NE2K interface */
+/* 6 blocks of 256 bytes = 1536 */
+
+#define MAX_PACKET_ETH 1536
 
 #endif /* !ARCH_LIMITS_H */

--- a/elkscmd/ktcp/arp.c
+++ b/elkscmd/ktcp/arp.c
@@ -120,12 +120,9 @@ void arp_reply(char *packet,int size)
     struct arp *arp_r;
   __u8 *addr;
 
-    arp_r = (struct arp *)packet;
+    arp_r = (struct arp *) packet;
 
     /* arp_print(arp_r); */
-
-    /* Cache remote MAC and IP addresses */
-    arp_cache_add (&arp_r->ip_src, arp_r->eth_src);
 
     /* swap ip addresses and mac addresses */
     apair.daddr = arp_r->ip_src;
@@ -143,7 +140,7 @@ void arp_reply(char *packet,int size)
     memcpy(arp_r->eth_dest, apair.eth_dest, 6);
     arp_r->ip_dest=apair.daddr;
 
-    deveth_send(packet, size);
+    deveth_send(packet, sizeof (struct arp));
 }
 
 int arp_request(ipaddr_t ipaddress)
@@ -172,7 +169,7 @@ int arp_request(ipaddr_t ipaddress)
     for (i=0;i<6;i++) arp_r->eth_dest[i]=0;
     arp_r->ip_dest=ipaddress;
 
-    deveth_send(&packet, sizeof(struct arp));
+    deveth_send(&packet, sizeof (struct arp));
 
     /* wait for reply */
 selectagain:
@@ -198,11 +195,12 @@ void arp_proc (char * packet, int size)
 
 	arp_r = (struct arp *) packet;
 	switch (arp_r->op) {
-	case ARP_REQUEST:  /* big endian */
+	case ARP_REQUEST:
+		arp_cache_add (arp_r->ip_src, arp_r->eth_src);
 		arp_reply (packet, size);
 		break;
 
-	case ARP_REPLY:  /* big endian */
+	case ARP_REPLY:
 		arp_cache_add (arp_r->ip_src, arp_r->eth_src);
 		break;
 	}


### PR DESCRIPTION
This patch fixes the root cause of the issue #133, where @Mellvik reported packet with size < 64 bytes are discarded on real PC and LAN.

This problem in `ktcp` was not detected in QEMU, because that emulator is less strict on the packet size. Padding of the ARP request was correct in the `/bin/eth` unit test (previously used to test on my real SBC).

It also fixes the maximum size of the packet to be more consistent with NE2K interface.
