### PR TITLE
Virtual consoles tuning

### DIFF
--- a/elks/arch/i86/drivers/char/bioscon.c
+++ b/elks/arch/i86/drivers/char/bioscon.c
@@ -504,6 +504,7 @@ static void std_char(register Console * C, char c)
 #endif
 
     default:
+	PositionCursor(C);
 	VideoWrite(C, c);
 	C->cx++;
       linewrap:
@@ -657,7 +658,9 @@ void init_console(void)
 
 #endif
 
-	ClearRange(C, 0, C->cy, MaxCol, MaxRow);
+	/* Do not erase early printk() */
+	/* ClearRange(C, 0, C->cy, MaxCol, MaxRow); */
+
 	C++;
     }
 

--- a/elks/arch/i86/drivers/char/dircon.c
+++ b/elks/arch/i86/drivers/char/dircon.c
@@ -577,9 +577,8 @@ void init_console(void)
 
 #endif
 
-	/* This hide the early printk
-	 * ClearRange(C, 0, C->cy, MaxCol, MaxRow);
-	 */
+	/* Do not erase early printk() */
+	/* ClearRange(C, 0, C->cy, MaxCol, MaxRow); */
 
 	C++;
     }

--- a/elks/config.in
+++ b/elks/config.in
@@ -14,10 +14,10 @@ mainmenu_option next_comment
 	if [ "$CONFIG_ARCH_IBMPC" = "y" ]; then
 
 		choice 'Select IBM-PC variant' \
-			"PC    CONFIG_PC_AUTO \
+			"Auto  CONFIG_PC_AUTO \
 			 PC-XT CONFIG_PC_XT   \
 			 PC-AT CONFIG_PC_AT   \
-			 MCA   CONFIG_PC_MCA" Auto
+			 PS-2  CONFIG_PC_MCA" Auto
 
 		choice 'Model of computer' \
 			"TrueClone CONFIG_IBMPC_CLONE \
@@ -29,10 +29,24 @@ mainmenu_option next_comment
 
 		comment 'Platform'
 
-		choice 'Processor' \
-			"8086   CONFIG_CPU_8086   \
-			 80186  CONFIG_CPU_80186  \
-			 80286  CONFIG_CPU_80286" 8086
+		if [ "$CONFIG_PC_XT" == "y" ]; then
+
+			comment '(IBM PC/XT has 8088)'
+			define_bool CONFIG_CPU_8086 y
+
+		elif [ "$CONFIG_PC_AT" == "y" ]; then
+
+			comment '(IBM PC/AT has 80286)'
+			define_bool CONFIG_CPU_80286 y
+
+		else
+
+			choice 'Processor' \
+				"8086   CONFIG_CPU_8086   \
+				 80186  CONFIG_CPU_80186  \
+				 80286  CONFIG_CPU_80286" 8086
+
+		fi
 
 		int 'Ticks for BogoMIPS (0 = check at boottime)' CONFIG_BOGOMIPS 140055
 

--- a/elks/include/linuxmt/kernel.h
+++ b/elks/include/linuxmt/kernel.h
@@ -22,6 +22,7 @@ extern int kill_sl(void);
 
 extern void panic(char *, ...);
 extern void printk(char *, ...);
+extern void early_printk (char *);
 
 extern int wait_for_keypress(void);
 

--- a/elkscmd/rootfs_template/etc/inittab
+++ b/elkscmd/rootfs_template/etc/inittab
@@ -11,7 +11,5 @@ si::sysinit:/etc/rc.d/rc.sysinit
 #ud::once:/sbin/update
 
 1:2345:respawn:/bin/getty /dev/tty1
-#2:2345:respawn:/bin/getty /dev/tty2
-#3:2345:respawn:/bin/getty /dev/tty3
-
-
+2:2345:respawn:/bin/getty /dev/tty2
+3:2345:respawn:/bin/getty /dev/tty3

--- a/qemu.sh
+++ b/qemu.sh
@@ -30,5 +30,5 @@ HOSTFWD="-net user"
 SERIAL="-chardev pty,id=chardev1 -device isa-serial,chardev=chardev1,id=serial1"
 
 $QEMU -nodefaults -name ELKS -monitor stdio -machine isapc -cpu 486 -m 1M \
-$KEYBOARD -display sdl -vga cirrus -rtc base=utc $SERIAL \
+$KEYBOARD -display sdl -vga std -rtc base=utc $SERIAL \
 -net nic,model=ne2k_isa $HOSTFWD $NETDUMP -fda $IMAGE $@


### PR DESCRIPTION
- fixes #124 : initial text not visible in virtual consoles 2 and 3 with BIOS driver
- consoles 2 and 3 activated in `/etc/inittab`
- (extra) automatic CPU model for IBM XT/AT configuration
