### PR TITLE
[ash] Fix SIGINT handler registration

### DIFF
--- a/elkscmd/ash/trap.c
+++ b/elkscmd/ash/trap.c
@@ -145,7 +145,7 @@ clear_traps() {
 int
 setsignal(signo) {
 	int action;
-	sig_t sigact;
+	__sighandler_t sigact;
 	register char *t;
 	extern void onsig();
 

--- a/elkscmd/test/Makefile
+++ b/elkscmd/test/Makefile
@@ -6,6 +6,7 @@ SUBDIRS =  \
 	pty    \
 	socket \
 	select \
+	signal \
 	# EOL
 
 .PHONY: $(SUBDIRS)

--- a/elkscmd/test/signal/.gitignore
+++ b/elkscmd/test/signal/.gitignore
@@ -1,0 +1,1 @@
+test_signal

--- a/elkscmd/test/signal/Makefile
+++ b/elkscmd/test/signal/Makefile
@@ -1,0 +1,24 @@
+# Makefile for signal test
+
+BASEDIR=../..
+
+include $(BASEDIR)/Make.defs
+
+PGM = test_signal
+
+SRCS = $(PGM).c
+
+OBJS = $(SRCS:.c=.o)
+
+
+include $(BASEDIR)/Make.rules
+
+all: $(PGM)
+
+$(PGM): $(OBJS)
+
+install: $(PGM)
+	sudo install $(PGM) $(TARGET_MNT)/bin
+
+clean: 
+	rm -f $(OBJS) $(PGM)

--- a/elkscmd/test/signal/test_signal.c
+++ b/elkscmd/test/signal/test_signal.c
@@ -1,0 +1,29 @@
+
+#include <unistd.h>
+#include <signal.h>
+
+static int _signo = 0;
+
+void sigint (int signo)
+{
+	_signo = signo;
+}
+
+extern __sighandler_t __sigtable [15];
+
+int main (int argc, char ** argv)
+{
+	sig_t sigold;
+
+	puts ("before signal()");
+	printf ("SIGINT=%u\n", __sigtable [1]);
+
+	sigold = signal (SIGINT, sigint);
+	puts ("after signal()");
+	printf ("SIGINT=%u\n", __sigtable [1]);
+	printf ("sigint=%u\n", sigint);
+
+	while (!_signo) sleep (1);
+	printf ("exiting:signo=%u\n", _signo);
+	return 0;
+}


### PR DESCRIPTION
The `onsig()` handler address was badly converted to a byte because of the wrong type `sig_t` used for the intermediate variable `sigact`.

Also added a unit test for `signal()`.

Fixes #125 
