### PR TITLE
Refactor telnetd and PTY master side

### DIFF
--- a/elkscmd/rootfs_template/etc/inittab
+++ b/elkscmd/rootfs_template/etc/inittab
@@ -11,5 +11,5 @@ si::sysinit:/etc/rc.d/rc.sysinit
 #ud::once:/sbin/update
 
 1:2345:respawn:/bin/getty /dev/tty1
-2:2345:respawn:/bin/getty /dev/tty2
-3:2345:respawn:/bin/getty /dev/tty3
+#2:2345:respawn:/bin/getty /dev/tty2
+#3:2345:respawn:/bin/getty /dev/tty3


### PR DESCRIPTION
Cleanup of telnetd client loop.

Restore select for PTY master side.

Correct read / write behavior for PTY master side:
can return without blocking if less data available
in buffer than requested by the user.

Fixes #211