### PR TITLE
Last modifications required to fully build ELKS under OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # IDE local settings
 #
 .project
+.DS_Store
 
 #
 # Build ignores

--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -260,13 +260,13 @@ elks:
 
 doclean: $(CLEANDEP)
 	rm -fv *~ *.a *.bak *.lint *.map *.o *.tmp core $(CLEANME)
-	@for FILE in *.s ; do \
-		BASE=`basename "$$FILE" .s` ; \
-		if [ -f "$$BASE.c" -o -f "$$BASE.S" ]; then \
-			echo rm -fv "$$FILE" ; \
-			rm -fv "$$FILE" ; \
-		fi ; \
-	done
+#	@for FILE in *.s ; do \
+#		BASE=`basename "$$FILE" .s` ; \
+#		if [ -f "$$BASE.c" -o -f "$$BASE.S" ]; then \
+#			echo rm -fv "$$FILE" ; \
+#			rm -fv "$$FILE" ; \
+#		fi ; \
+#	done
 	@for DIR in */ ; do \
 		if [ -f "$$DIR/Makefile" ]; then \
 			${MAKE} -C "$$DIR" doclean ; \

--- a/elks/arch/i86/drivers/block/Makefile
+++ b/elks/arch/i86/drivers/block/Makefile
@@ -50,11 +50,7 @@ endif
 all:	blk_drv.a
 
 blk_drv.a: $(OBJS)
-	ar rcs blk_drv.a $(OBJS)
-
-ssd_asm.o: ssd_asm.s
-
-ssd_asm.s: ssd_asm.S
+	$(AR) rcs blk_drv.a $(OBJS)
 
 #########################################################################
 # Standard commands.

--- a/elks/arch/i86/drivers/char/Makefile
+++ b/elks/arch/i86/drivers/char/Makefile
@@ -55,23 +55,7 @@ endif # CONFIG_ARCH_SIBO
 all:	chr_drv.a
 
 chr_drv.a: $(OBJS)
-	ar rcs chr_drv.a $(OBJS)
-
-con_asm.s: con_asm.S
-
-con_asm.o: con_asm.s
-
-font.s: font.S
-
-font.o: font.s
-
-key_asm.s: key_asm.S
-
-key_asm.o: key_asm.s
-
-ser_asm.s: ser_asm.S
-
-ser_asm.o: ser_asm.s
+	$(AR) rcs chr_drv.a $(OBJS)
 
 KeyMaps/keymaps.h:
 	$(MAKE) -C KeyMaps keymaps.h

--- a/elks/arch/i86/drivers/net/Makefile
+++ b/elks/arch/i86/drivers/net/Makefile
@@ -35,7 +35,7 @@ endif
 all: net_drv.a
 
 net_drv.a: $(OBJS)
-	ar rcs net_drv.a $(OBJS)
+	$(AR) rcs net_drv.a $(OBJS)
 
 #########################################################################
 ### Dependencies:

--- a/elks/arch/i86/kernel/Makefile
+++ b/elks/arch/i86/kernel/Makefile
@@ -50,7 +50,7 @@ endif
 all:	akernel.a
 
 akernel.a: $(OBJS)
-	ar rcs akernel.a $(OBJS)
+	$(AR) rcs akernel.a $(OBJS)
 
 entry.S: syscall.dat mkentry.sh
 	sh mkentry.sh > entry.tmp

--- a/elks/arch/i86/mm/Makefile
+++ b/elks/arch/i86/mm/Makefile
@@ -43,7 +43,7 @@ OBJS  = init.o malloc.o user.o segment.o
 all:	mm.a
 
 mm.a: $(OBJS)
-	ar rcs mm.a $(OBJS)
+	$(AR) rcs mm.a $(OBJS)
 
 #########################################################################
 # Standard commands.

--- a/elks/arch/i86/tools/Makefile
+++ b/elks/arch/i86/tools/Makefile
@@ -50,8 +50,6 @@ endif
 
 wrt_disk.o: wrt_disk.c
 
-file.o: file.s
-
 wrt_disk.tmp: wrt_disk.o file.o
 	ld86 -0 -i -D $(DATA_SEG) -H $(HEAP_SEG) -o wrt_disk.tmp \
 		wrt_disk.o file.o \

--- a/elks/arch/i86/tools/build.c
+++ b/elks/arch/i86/tools/build.c
@@ -23,7 +23,9 @@
 
 #include <stdio.h>			/* fprintf */
 
+#if !defined(__APPLE__)
 #include <sys/sysmacros.h>		/* We NEED these macros */
+#endif
 #include <sys/stat.h>
 #include <sys/types.h>			/* unistd.h needs this */
 

--- a/elks/fs/Makefile
+++ b/elks/fs/Makefile
@@ -45,7 +45,7 @@ OBJS  = buffer.o super.o bufops.o devices.o fcntl.o stat.o inode.o file_table.o 
 all:	fs.a
 
 fs.a:	$(OBJS)
-	ar rcs fs.a $(OBJS)
+	$(AR) rcs fs.a $(OBJS)
 
 #########################################################################
 # Standard commands.

--- a/elks/fs/minix/Makefile
+++ b/elks/fs/minix/Makefile
@@ -43,7 +43,7 @@ OBJS  = bitmap.o dir.o file.o namei.o symlink.o truncate.o inode.o
 all:	minixfs.a
 
 minixfs.a: $(OBJS)
-	ar rcs minixfs.a $(OBJS)
+	$(AR) rcs minixfs.a $(OBJS)
 
 #########################################################################
 # Standard commands.

--- a/elks/fs/msdos/Makefile
+++ b/elks/fs/msdos/Makefile
@@ -46,7 +46,7 @@ OBJS  = namei.o inode.o file.o dir.o misc.o fat.o
 all:	msdos.a
 
 msdos.a: $(OBJS)
-	ar rcs msdos.a $(OBJS)
+	$(AR) rcs msdos.a $(OBJS)
 
 #########################################################################
 # Standard commands.

--- a/elks/fs/romfs/Makefile
+++ b/elks/fs/romfs/Makefile
@@ -43,7 +43,7 @@ OBJS  = romfs.o
 all:	romfs.a
 
 romfs.a: $(OBJS)
-	ar rcs romfs.a $(OBJS)
+	$(AR) rcs romfs.a $(OBJS)
 
 #########################################################################
 # Standard commands.

--- a/elks/kernel/Makefile
+++ b/elks/kernel/Makefile
@@ -44,7 +44,7 @@ OBJS  = sched.o printk.o sleepwake.o dma.o version.o sys.o fork.o \
 all:	kernel.a
 
 kernel.a: $(OBJS)
-	ar rcs kernel.a $(OBJS)
+	$(AR) rcs kernel.a $(OBJS)
 
 #########################################################################
 # Standard commands.

--- a/elkscmd/bootblocks/Makefile
+++ b/elkscmd/bootblocks/Makefile
@@ -17,16 +17,14 @@ all: minix.bin
 minix.bin: minix_first.o minix_second.o
 	$(LD) $(LDFLAGS) -o minix.bin minix_first.o minix_second.o
 
-minix_first.o: minix_first.s
-	$(AS) -o minix_first.o minix_first.s
-
-minix_first.s: minix_first.S
-	$(CC) $(INCLUDES) -E -o minix_first.s minix_first.S
+minix_first.o: minix_first.S
+	$(CC) $(INCLUDES) -E -o minix_first.tmp minix_first.S
+	$(AS) -o minix_first.o minix_first.tmp
+	rm -f minix_first.tmp
 
 minix_second.o: minix_second.c
 
 clean realclean:
-	rm -f minix_first.s
 	rm -f *.o *.bin
 
 # Boot blocks are not part of the target filesystem

--- a/elkscmd/lib/vga/Makefile
+++ b/elkscmd/lib/vga/Makefile
@@ -4,20 +4,23 @@
 
 BASEDIR 	= ../..
 
-include $(BASEDIR)/Make.rules
+include $(BASEDIR)/Make.defs
 
 ###############################################################################
 
-CC=bcc
+LOCALFLAGS=-DELKS=1
 
-LOCALFLAGS=-DELKS
+VGALIB = scr_bios.o elkplan4.o mempl4.o elksutilasm.o romfont.o
+HERCLIB = scr_herc.o elksutilasm.o romfont.o
 
-VGALIB = scr_bios.o elkplan4.o mempl4.o elksutil.o romfont.o
-
-all: demo
+#all: demo demo-herc
+all: demo-herc
 
 demo: $(VGALIB) demo.o
-	$(CC) $(LDFLAGS) -o demo demo.o $(VGALIB) 
+	$(CC) $(CFLAGS) $(LDFLAGS) -o demo demo.o $(VGALIB) 
+
+demo-herc: $(HERCLIB) demo-herc.o
+	$(CC) $(CFLAGS) $(LDFLAGS) -o demo-herc demo-herc.o $(HERCLIB) 
 
 clean:
 	rm -f core demo *.o

--- a/elkscmd/lib/vga/demo-herc.c
+++ b/elkscmd/lib/vga/demo-herc.c
@@ -1,0 +1,68 @@
+#include <sys/time.h>
+
+#include "vga_dev.h"
+
+MODE gr_mode;
+
+static void
+psleep(int num)
+{
+	struct timeval tv;
+
+	tv.tv_sec = 0;
+	tv.tv_usec = num * 100;
+
+	select(0, NULL, NULL, NULL, &tv);
+}
+
+main(
+	int argc,
+	char ** argv)
+{
+	struct _screendevice device;
+	SCREENINFO sinfo;
+	int i,j;
+
+	HERC_open(&device);
+	for (j = 0; j < 16; j++) {
+		for (i = 0; i < 320; i++) {
+			HERC_drawhline(&device, 0, 400, 20+i, j);
+		}
+		psleep(1);
+	}
+
+	for (j = 0; j < 16; j++) {
+		for (i = 0; i < 400; i++) {
+			HERC_drawvline(&device, 20+i, 150, 340, (j + 2) & 0xf);
+		}
+		psleep(1);
+	}
+
+#if 0
+	for (i = 0; i < 600; i++) {
+		for (j = 0; j < 200; j++) {
+			HERC_drawpixel(&device, i, j+100, HERC_readpixel(&device, i, j));
+		}
+	}
+
+	for (i = 0; i < 100; i++) {
+		for (j = 0; j < 100; j++) {
+			HERC_drawpixel(&device, i, j, i + j & 0xf);
+		}
+	}
+	/***for (i = 100; i < 600; i += 100) {
+		for (j = 100; j < 400; j += 100) {
+			herc_blit(&device, i, j, 100, 100, &device, 0, 0, 1);
+		}
+	}***/
+	psleep(10);
+#endif
+
+	HERC_getscreeninfo(&device, &sinfo);
+	
+	HERC_close(&device);
+
+	printf("[%d %d], %ld cols\n", sinfo.cols, sinfo.rows, sinfo.ncolors);
+}
+	
+	

--- a/elkscmd/lib/vga/elksutilasm.s
+++ b/elkscmd/lib/vga/elksutilasm.s
@@ -1,0 +1,211 @@
+// ELKS utility routines for Micro-Windows drivers
+// Copyright (c) 1999, 2019 Greg Haerr <greg@censoft.com>
+
+	.code16
+	.text
+
+//
+// Return the byte at far address
+//
+//unsigned char GETBYTE_FP(FARADDR addr)
+//
+	.global	GETBYTE_FP
+GETBYTE_FP:
+	push	%bp
+	mov		%sp,%bp
+	push	%ds
+
+	mov		4(%bp),%bx	// bx = lo addr
+	mov		6(%bp),%ax	// ds = hi addr
+	mov		%ax,%ds
+	mov		(%bx),%al	// get byte at ds:bx
+	xor		%ah,%ah
+
+	pop		%ds
+	pop		%bp
+	ret
+
+//
+// Put the byte at far address
+//
+//void PUTBYTE_FP(FARADDR addr,unsigned char val)
+//
+	.global	PUTBYTE_FP
+PUTBYTE_FP:
+	push	%bp
+	mov		%sp,%bp
+	push	%ds
+
+	mov		4(%bp),%bx	// bx = lo addr
+	mov		6(%bp),%ax	// ds = hi addr
+	mov		%ax,%ds
+	mov		8(%bp),%al	// al = val
+	mov		%al,(%bx)	// put type at ds:bx
+
+	pop		%ds
+	pop		%bp
+	ret
+
+//
+// Read-modify-write the byte at far address
+//
+//void RMW_FP(FARADDR addr)
+	.global	RMW_FP
+RMW_FP:
+	push	%bp
+	mov		%sp,%bp
+	push	%ds
+
+	mov		4(%bp),%bx	// bx = lo addr
+	mov		6(%bp),%ax	// ds = hi addr
+	mov		%ax,%ds
+	or		%al,(%bx)	// rmw byte at ds:bx, al value doesn't matter
+
+	pop		%ds
+	pop		%bp
+	ret
+
+//
+// Or the byte at far address
+//
+//void ORBYTE_FP(FARADDR addr,unsigned char val)
+	.global	ORBYTE_FP
+ORBYTE_FP:
+	push	%bp
+	mov		%sp,%bp
+	push	%ds
+
+	mov		4(%bp),%bx	// bx = lo addr
+	mov		6(%bp),%ax	// ds = hi addr
+	mov		%ax,%ds
+	mov		8(%bp),%al	// al = val
+	or		%al,(%bx)	// or byte at ds:bx
+
+	pop		%ds
+	pop		%bp
+	ret
+
+//
+// And the byte at far address
+//
+//void ANDBYTE_FP(FARADDR addr,unsigned char val)
+	.global	ANDBYTE_FP
+ANDBYTE_FP:
+	push	%bp
+	mov		%sp,%bp
+	push	%ds
+
+	mov		4(%bp),%bx	// bx = lo addr
+	mov		6(%bp),%ax	// ds = hi addr
+	mov		%ax,%ds
+	mov		8(%bp),%al	// al = val
+	and		%al,(%bx)	// and byte at ds:bx
+
+	pop		%ds
+	pop		%bp
+	ret
+
+//
+// Input byte from i/o port
+//
+//int inportb(int port)
+	.global	inportb
+inportb:
+	push	%bp
+	mov		%sp,%bp
+
+	mov		4(%bp),%dx	// dx = port
+	in		%dx,%al		// input byte
+	xor		%ah,%ah
+
+	pop		%bp
+	ret
+
+//
+// Output byte to i/o port
+//
+//void outportb(int port,unsigned char data)
+	.global	outportb
+outportb:
+	push	%bp
+	mov		%sp,%bp
+
+	mov		4(%bp),%dx	// dx = port
+	mov		6(%bp),%al	// al = data
+	out		%al,%dx
+
+	pop		%bp
+	ret
+
+//
+// Output word i/o port
+//
+//void outport(int port,int data)
+	.global	outport
+outport:
+	push	%bp
+	mov		%sp,%bp
+
+	mov		4(%bp),%dx	// dx = port
+	mov		6(%bp),%ax	// ax = data
+	out		%ax,%dx
+
+	pop		%bp
+	ret
+
+//
+// es:bp = int10(int ax,int bx)
+//  Call video bios using interrupt 10h
+//
+//FARADDR int10(int ax,int bx)
+	.global	int10
+int10:
+	push	%bp
+	mov		%sp,%bp
+	push	%es
+	push	%ds
+	push	%si
+	push	%di
+
+	mov		4(%bp),%ax	// get first arg
+	mov		6(%bp),%bx	// get second arg
+	int		$10
+	mov		%es,%dx		// return es:bp
+	mov		%bp,%ax
+
+	pop		%di
+	pop		%si
+	pop		%ds
+	pop		%es
+	pop		%bp
+	ret
+
+// poll the keyboard*/
+//int kbpoll(void)
+	.global	kbpoll
+kbpoll:
+	mov		$1,%ah		// read, no remove
+	int		$16
+	jz		nordy		// no chars ready
+	mov		$1,%ax		// chars ready
+	ret
+nordy:
+	xor		%ax,%ax		// no chars ready
+	ret
+
+// wait and read a kbd char when ready*/
+//int kbread(void)
+	.global	kbread
+kbread:
+	xor		%ah,%ah		// read and remove
+	int		$16			// return ax
+	ret
+
+// return kbd shift status*/
+//int kbflags(void)
+	.global	kbflags
+kbflags:
+	mov		$2,%ah		// get shift status
+	int		$16
+	mov		$0,%ah		// low bits only for now...
+	ret

--- a/elkscmd/lib/vga/scr_herc.c
+++ b/elkscmd/lib/vga/scr_herc.c
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 1999 Greg Haerr <greg@censoft.com>
+ * Based on code by Jakob Eriksson.
+ *
+ * Hercules Graphics Screen Driver, PC bios version
+ * 	This driver uses int10 bios to to get the address of the 
+ * 	ROM character font which is used for the character bitmaps.  
+ * 	All other access to the hardware is controlled through this driver.
+ *
+ * 	All text/font drawing code is based on the above routines and
+ * 	the included entry points for getting the ROM bitmap data.  Compiled
+ * 	in fonts aren't supported for size reasons.  scr_bogl supports them.
+ *
+ *	The environment variable CHARHEIGHT if set will set the assumed rom
+ *	font character height, which defaults to 14.
+ */
+#if ELKS
+#include <linuxmt/ntty.h>
+#endif
+#include <stdio.h>
+#include "vga_dev.h"
+#include "vgaplan4.h"
+#include "romfont.h"
+
+/* assumptions for speed: NOTE: psd is ignored in these routines*/
+#define SCREENADDR(offset) 	MK_FP(0xb000, (offset))
+
+#define SCREEN_ON 		8
+#define BLINKER_ON 		0x20
+
+/* HERC driver entry points*/
+int  HERC_open(PSD psd);
+void HERC_close(PSD psd);
+void HERC_getscreeninfo(PSD psd,PSCREENINFO psi);;
+void HERC_setpalette(PSD psd,int first,int count,RGBENTRY *pal);
+void HERC_drawpixel(PSD psd,COORD x, COORD y, PIXELVAL c);
+PIXELVAL HERC_readpixel(PSD psd,COORD x, COORD y);
+void HERC_drawhline(PSD psd,COORD x1, COORD x2, COORD y, PIXELVAL c);
+void HERC_drawvline(PSD psd,COORD x, COORD y1, COORD y2, PIXELVAL c);
+void HERC_fillrect(PSD psd,COORD x1,COORD y1,COORD x2,COORD y2,
+		PIXELVAL c);
+void HERC_blit(PSD dstpsd,COORD destx,COORD desty,COORD w,COORD h,
+		PSD srcpsd,COORD srcx,COORD srcy,int op);
+
+
+SCREENDEVICE	scrdev = {
+	0, 0, 0, 0, 0, 0, 0, 0, 0, NULL,
+	HERC_open,
+	HERC_close,
+	HERC_getscreeninfo,
+	HERC_setpalette,
+	HERC_drawpixel,
+	HERC_readpixel,
+	HERC_drawhline,
+	HERC_drawvline,
+	HERC_fillrect,
+	pcrom_getfontinfo,
+	pcrom_gettextsize,
+	pcrom_gettextbits,
+	HERC_blit
+};
+
+int
+HERC_open(PSD psd)
+{
+#if LINUX
+	/* get permission to write to the hercules ports*/
+	if(ioperm(0x3b4, 0x0d, 1))
+		return -1;
+#endif
+#if ELKS
+	/* disallow console switching while in graphics mode*/
+	if(ioctl(0, DCGET_GRAPH) != 0)
+		return -1;
+#endif
+
+	/* enter graphics mode*/
+	outportb(0x3bf, 1+2);
+	outportb(0x3b8, 0);
+	outport(0x3b4, 0x3500);
+	outport(0x3b4, 0x2d01);
+	outport(0x3b4, 0x2e02); /* Linesync at 46th character */
+	outport(0x3b4, 0x0703); /* linesync width 7 chrclock ticks */
+	outport(0x3b4, 0x5b04); /* height 92 chars (368 lines) */
+	outport(0x3b4, 0x0205); /* height adjust */
+	outport(0x3b4, 0x5706); /* lines / picture (348 lines)  */
+	outport(0x3b4, 0x5707); /* picturesync: after 87 character lines */
+	outport(0x3b4, 0x0309); /* character height: 4 lines / char */
+	outportb(0x3b8, 2+8); 	/* Allow graphics mode and video on */
+
+	/* init driver variables*/
+	psd->xres = 720;
+	psd->yres = 350;
+	psd->planes = 1;
+	psd->bpp = 1;
+	psd->ncolors = 2;
+	psd->pixtype = PF_PALETTE;
+	psd->flags = PSF_SCREEN;
+	psd->addr = SCREENADDR(0);
+	psd->linelen = 90;
+
+	/* init pc rom font routines*/
+	pcrom_init(psd);
+
+	return 1;
+}
+
+void
+HERC_close(PSD psd)
+{
+	int			i;
+	volatile FARADDR	dst;
+	static char 		herc_txt_tbl[12]= {
+		0x61,0x50,0x52,0x0f,0x19,6,0x19,0x19,2,0x0d,0x0b,0x0c
+	};
+
+#if ELKS
+	/* allow console switching again*/
+	ioctl(0, DCREL_GRAPH);
+#endif
+
+	/* switch back to text mode*/
+	outportb(0x3bf, 0);
+	outportb(0x3b8, 0);
+
+	for(i = 0; i < 12; ++i) {
+		outportb(0x3b4, i);
+		outportb(0x3b5, herc_txt_tbl[i]);
+	}
+
+	/* blank screen*/
+	dst = SCREENADDR(0);
+	for(i = 0; i <= 0x3fff; ++i) {
+		PUTBYTE_FP(dst++, 0x00);
+		PUTBYTE_FP(dst++, 0x07);
+	}
+	outportb(0x3b8, BLINKER_ON | SCREEN_ON);
+}
+
+void
+HERC_getscreeninfo(PSD psd,PSCREENINFO psi)
+{
+	psi->rows = psd->yres;
+	psi->cols = psd->xres;
+	psi->planes = psd->planes;
+	psi->bpp = psd->bpp;
+	psi->ncolors = psd->ncolors;
+	psi->pixtype = psd->pixtype;
+	psi->fonts = NUMBER_FONTS;
+	psi->xdpcm = 30;		/* assumes screen width of 24 cm*/
+	psi->ydpcm = 19;		/* assumes screen height of 18 cm*/
+}
+
+void
+HERC_setpalette(PSD psd,int first,int count,RGBENTRY *pal)
+{
+	/* no palette available*/
+}
+
+void
+HERC_drawpixel(PSD psd,COORD x, COORD y, PIXELVAL c)
+{
+	unsigned int 		offset;
+	unsigned char 		mask = 128;
+	volatile FARADDR	dst;
+
+	offset = 0x2000 * (y&3);
+	offset += 90*(y/4) + x/8;
+	dst = SCREENADDR(offset);
+	mask >>= x & 7;
+	if(c)
+		ORBYTE_FP(dst, mask);
+	else ANDBYTE_FP(dst, ~mask);
+}
+
+PIXELVAL
+HERC_readpixel(PSD psd,COORD x, COORD y)
+{
+	unsigned int 		offset;
+	unsigned char 		mask = 128;
+	volatile FARADDR	dst;
+
+	offset = 0x2000 * (y&3);
+	offset += 90*(y/4) + x/8;
+	dst = SCREENADDR(offset);
+	mask >>= x & 7;
+	return GETBYTE_FP(dst) & mask? 1: 0;
+}
+
+void
+HERC_drawhline(PSD psd,COORD x1, COORD x2, COORD y, PIXELVAL c)
+{
+	/*Optimized HERC_drawhline() by thomas_d_stewart@hotmail.com*/
+	unsigned int rowoffset, x1yoffset, x2yoffset;
+	unsigned int startbyte, endbyte;
+	volatile FARADDR dst;
+
+	/*offset of the row */
+	rowoffset = 8192 * (y % 4) + (y / 4) * 90;
+	
+	/*offset of first byte in line */
+	x1yoffset = rowoffset + (x1 / 8);
+	
+	/*ofset of the last byte in line */
+	x2yoffset = rowoffset + (x2 / 8);
+
+
+	/*shift "11111111" > buy (x1%8) to fill with 0's*/
+	startbyte = 0xff >> (x1 % 8);
+	/*same but in < dir*
+	endbyte = 0xff << (x2 % 8);
+
+	/* convert x1yoffset to a screen address */
+	dst = SCREENADDR(x1yoffset);
+
+	if(c)
+		ORBYTE_FP(dst, startbyte);    /* output byte to mem */
+	else ANDBYTE_FP(dst, ~startbyte);
+
+	x1yoffset++; /* increment so we are writing to the next byte */
+	while(x1yoffset < x2yoffset) {
+	       	dst = SCREENADDR(x1yoffset); /*convert x1yoffset to a scr address */
+		if(c)
+			ORBYTE_FP(dst, 0xff); /*ouput bytes */
+		else ANDBYTE_FP(dst, ~0xff);
+		x1yoffset++;
+		}
+
+	dst = SCREENADDR(x2yoffset); /* convert x2yoffset to a screen address */
+	if(c)
+		ORBYTE_FP(dst, endbyte); /* output byte to mem */
+	else ANDBYTE_FP(dst, ~endbyte);
+
+
+
+	/*NON Optimized version left in case my one goes wroung */
+	/*while(x1 <= x2)
+	  HERC_drawpixel(psd, x1++, y, c);*/
+}
+
+void
+HERC_drawvline(PSD psd,COORD x, COORD y1, COORD y2, PIXELVAL c)
+{
+	/* fixme write optimized vline*/
+	/*
+	 * Driver doesn't support vline yet
+	 */
+	while(y1 <= y2)
+		HERC_drawpixel(psd, x, y1++, c);
+}
+
+void
+HERC_fillrect(PSD psd,COORD x1, COORD y1, COORD x2, COORD y2, PIXELVAL c)
+{
+	while(y1 <= y2)
+		HERC_drawhline(psd, x1, x2, y1++, c);
+}
+
+void
+HERC_blit(PSD dstpsd,COORD destx,COORD desty,COORD w,COORD h,
+	PSD srcpsd,COORD srcx,COORD srcy,int op)
+{
+	/* FIXME*/
+}

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -38,6 +38,9 @@ $(LIBC):: $(SUBDIRS)
 
 $(SUBDIRS):
 	$(MAKE) -C $@ all
+ifeq ($(shell uname),Darwin)
+#	sleep 1
+endif
 
 #crt0.s: crt0.S
 crt0.o: crt0.S

--- a/nano-X/src/Makefile
+++ b/nano-X/src/Makefile
@@ -49,8 +49,7 @@ NANOXDEMO += demos/nanox/world.o
 NANOXDEMO += demos/nanox/nclock.o
 # works if pseudo tty enabled in ELKS menuconfig
 NANOXDEMO += demos/nanox/nterm.o
-# demo outtable[] is too large
-#NANOXDEMO += demos/nanox/demo.o
+NANOXDEMO += demos/nanox/demo.o
 NANOXDEMO += demos/nanox/demo2.o
 #NANOXDEMO += demos/nanox/info.o
 
@@ -81,9 +80,9 @@ endif
 
 ## mouse driver
 # serial mouse
-#SERVFILES += drivers/mou_ser.o
+SERVFILES += drivers/mou_ser.o
 # qemu mouse
-SERVFILES += drivers/mou_ser_qemu.o
+#SERVFILES += drivers/mou_ser_qemu.o
 # no mouse
 #SERVFILES += drivers/mou_null.o
 
@@ -107,11 +106,12 @@ nano-X: $(SERVFILES) $(NANOXFILES) $(NANOXDEMO)
 ifdef GCC
 	$(LD) $(LDFLAGS) $(NANOXFILES) demos/nanox/nterm.o $(SERVFILES) $(NANOLIBS) $(LIBS) -o bin/nterm $(LDLIBS)
 	$(LD) $(LDFLAGS) $(NANOXFILES) demos/nanox/world.o $(SERVFILES) $(NANOLIBS) $(LIBS) -o bin/world $(LDLIBS)
+	$(LD) $(LDFLAGS) $(NANOXFILES) demos/nanox/demo.o $(SERVFILES) $(NANOLIBS) $(LIBS) -o bin/demo $(LDLIBS)
 	$(LD) $(LDFLAGS) $(NANOXFILES) demos/nanox/demo2.o $(SERVFILES) $(NANOLIBS) $(LIBS) -o bin/demo2 $(LDLIBS)
 # nclock missing gmtime
-#	$(LD) $(LDFLAGS) $(NANOXFILES) demos/nanox/nclock.o $(SERVFILES) $(NANOLIBS) $(LIBS) -o bin/nclock $(LDLIBS)
+	$(LD) $(LDFLAGS) $(NANOXFILES) demos/nanox/nclock.o $(SERVFILES) $(NANOLIBS) $(LIBS) -o bin/nclock $(LDLIBS)
 # landmine missing rand/srand
-#	$(LD) $(LDFLAGS) $(NANOXFILES) demos/nanox/landmine.o $(SERVFILES) $(NANOLIBS) $(LIBS) -o bin/landmine $(LDLIBS)
+	$(LD) $(LDFLAGS) $(NANOXFILES) demos/nanox/landmine.o $(SERVFILES) $(NANOLIBS) $(LIBS) -o bin/landmine $(LDLIBS)
 else
 	$(CC) $(CFLAGS) $(NANOXFILES) demos/nanox/landmine.o $(SERVFILES) $(NANOLIBS) $(LIBS) -o bin/landmine $(MATHLIB)
 	$(CC) $(CFLAGS) $(NANOXFILES) demos/nanox/nterm.o $(SERVFILES) $(NANOLIBS) $(LIBS) -o bin/nterm $(MATHLIB)	

--- a/nano-X/src/device.h
+++ b/nano-X/src/device.h
@@ -36,7 +36,7 @@
 typedef int		COORD;		/* device coordinates*/
 typedef int		MODE;		/* drawing mode*/
 typedef unsigned long	COLORVAL;	/* device-independent color value*/
-#ifdef __AS386_16__
+#if ELKS
 /* support up to 32 bit truecolor except on ELKS for size*/
 typedef unsigned char	PIXELVAL;	/* pixel color value*/
 #else

--- a/nano-X/src/drivers/mou_null.c
+++ b/nano-X/src/drivers/mou_null.c
@@ -4,7 +4,7 @@
  * NULL Mouse Driver
  */
 #include <stdio.h>
-#include "device.h"
+#include "../device.h"
 
 #define	SCALE		3	/* default scaling factor for acceleration */
 #define	THRESH		5	/* default threshhold for acceleration */
@@ -13,7 +13,7 @@ static int  	NUL_Open(MOUSEDEVICE *pmd);
 static void 	NUL_Close(void);
 static int  	NUL_GetButtonInfo(void);
 static void	NUL_GetDefaultAccel(int *pscale,int *pthresh);
-static int  	NUL_Read(MWCOORD *dx, MWCOORD *dy, MWCOORD *dz, int *bp);
+static int  	NUL_Read(COORD *dx, COORD *dy, COORD *dz, int *bp);
 static int  	NUL_Poll(void);
 
 MOUSEDEVICE mousedev = {

--- a/nano-X/src/drivers/mou_ser.c
+++ b/nano-X/src/drivers/mou_ser.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <string.h>
 #include <errno.h>
 #include <fcntl.h>
 #include "../device.h"

--- a/nano-X/src/nanox/srvmain.c
+++ b/nano-X/src/nanox/srvmain.c
@@ -206,7 +206,7 @@ GsSelect(void)
 
 	/* Set up the timeout for the main select(): */
 	to.tv_sec = 0L;
-	to.tv_usec = 10000L;
+	to.tv_usec = 100L;
 
 	/* Wait for some input on any of the fds in the set or a timeout: */
 	if((e = select(setsize, &rfds, NULL, NULL, &to)) > 0) {


### PR DESCRIPTION
This patch allows ELKS kernel and cmds to be built with gcc-ia16 on OS X.
The following changes are made:

1) ia16-elf-ar must be used for all archives, OS X ar is broken and ia16-elf-ld can't read some .o symbol entries in resulting .a files.

2) Remove .s deletion in "make clean".

3) Remove .s: .S  and .o: .s rules in Makefiles (all unnecessary anyways).

4) Add test graphics adapter code to lib/vga (currently unused) and fix nano-X demo hang on startup.

5) Kluge fix for continuing libc.a build problem where race results in not all .o files added to archive: "sleep 1" added if $(shell uname) == "Darwin".

