### PR TITLE
[libc] build up libc.a from separate dirs. in more reliable way

### DIFF
--- a/libc/Makefile
+++ b/libc/Makefile
@@ -32,21 +32,62 @@ SUBDIRS = \
 
 .PHONY: all $(SUBDIRS)
 
-all: $(LIBC) crt0.o
+ifdef MULTISUBDIR
 
-$(LIBC):: $(SUBDIRS)
+# Build one particular multilib variant of libc.a.  $(MULTISUBDIR) gives the
+# multilib variant to build for, and $(MULTILIB) gives the C compiler flags
+# to pass to GCC.
+all: $(LIBC) build-ml/$(MULTISUBDIR)/crt0.o
+
+SUBDIRS_IN_MULTILIB = $(SUBDIRS:%=build-ml/$(MULTISUBDIR)/%)
+
+$(LIBC): $(SUBDIRS_IN_MULTILIB)
+	mkdir -p $(@D)
+	set -e; \
+	( \
+		echo CREATE $(LIBC).tmp; \
+		for s in $^; \
+			do echo ADDLIB "$$s"/out.a; done; \
+		echo SAVE \
+	) | $(AR) -M
+	mv $(LIBC).tmp $(LIBC)
+
+build-ml/$(MULTISUBDIR)/crt0.o: crt0.S
+
+build-ml/$(MULTISUBDIR)/%: %
+	mkdir -p $@
+	$(MAKE) -C $@ VPATH=$(abspath $<) -f $(abspath $<)/Makefile all
 
 $(SUBDIRS):
-	$(MAKE) -C $@ all
-ifeq ($(shell uname),Darwin)
-#	sleep 1
-endif
 
-#crt0.s: crt0.S
-crt0.o: crt0.S
+else
+
+# This currently just builds the default multilib.
+# TODO: if $(MULTISUBDIR) is undefined, then build all libc.a multilibs.
+
+.PHONY: $(LIBC)
+
+all: $(LIBC)
+
+$(LIBC):
+	set -e; \
+	save_ifs="$$IFS"; \
+	$(CC) -print-multi-lib | fgrep -x '.;' | \
+	while read -r line; do \
+		IFS=';'; \
+		set -- $$line; \
+		dir="$$1"; \
+		flags="$$2"; \
+		IFS="$$save_ifs"; \
+		flags="`echo "$$flags" | sed 's,@, -,g'`"; \
+		$(MAKE) MULTISUBDIR="$$dir" MULTILIB="$$flags" all; \
+	done
+	cp -u build-ml/libc_elks.a $(LIBC)
+
+endif
 
 .PHONY: clean
 
 clean:
 	for DIR in $(SUBDIRS); do $(MAKE) -C $$DIR clean || exit 1; done
-	rm -f *.o libc.a
+	rm -rf build-ml *.o libc.a

--- a/libc/Makefile.inc
+++ b/libc/Makefile.inc
@@ -14,11 +14,18 @@ AS=ia16-elf-as
 AR=ia16-elf-ar
 LD=ia16-elf-ld
 
-CFLAGS=$(ARCH) $(INCLUDES) $(CDEFS) -Wall -Os
+CFLAGS=$(ARCH) $(INCLUDES) $(CDEFS) -Wall -Os $(MULTILIB)
 ASFLAGS=-mtune=i8086
 LDFLAGS=-mtune=i8086
+# This is used in subdirectories to quickly create a library archive without
+# a symbol index
+ARFLAGS_SUB=cqS
 
+ifdef MULTISUBDIR
+LIBC=$(TOPDIR)/libc/build-ml/$(MULTISUBDIR)/libc_elks.a
+else
 LIBC=$(TOPDIR)/libc/libc.a
+endif
 LIB_CPU=i86
 LIB_OS=ELKS
 
@@ -28,6 +35,13 @@ LIB_OS=ELKS
 	gcc -E -traditional $(INCS) $(SDEFS) -o $*.tmp $<
 	$(AS) $(ASFLAGS) -o $*.o $*.tmp
 	rm -f $*.tmp
+
+ifdef MULTISUBDIR
+build-ml/$(MULTISUBDIR)/%.o: %.S
+	gcc -E -traditional $(INCS) $(SDEFS) -o $@.tmp $<
+	$(AS) $(ASFLAGS) -o $@ $@.tmp
+	rm -f $@.tmp
+endif
 
 .s.o:
 	$(AS) $(ASFLAGS) -o $*.o $<

--- a/libc/asm/Makefile
+++ b/libc/asm/Makefile
@@ -11,10 +11,11 @@ SRCS = \
 
 OBJS = $(SRCS:.s=.o)
 
-all: $(LIBC)
+all: out.a
 
-$(LIBC): $(OBJS)
-	$(AR) $(ARFLAGS) $@ $?
+out.a: $(OBJS)
+	$(RM) $@
+	$(AR) $(ARFLAGS_SUB) $@ $^
 
 clean:
-	rm -f *.o
+	rm -f *.[ao]

--- a/libc/error/Makefile
+++ b/libc/error/Makefile
@@ -5,12 +5,13 @@ include $(TOPDIR)/libc/Makefile.inc
 SRCS= __assert.c error.c perror.c
 OBJS= $(SRCS:.c=.o)
 
-all: $(LIBC)
-
 $(OBJS): $(SRCS)
 
-$(LIBC): $(OBJS)
-	$(AR) $(ARFLAGS) $@ $?
+all: out.a
+
+out.a: $(OBJS)
+	$(RM) $@
+	$(AR) $(ARFLAGS_SUB) $@ $^
 
 clean:
-	rm -f $(OBJS)
+	rm -f *.[ao]

--- a/libc/gcc/Makefile
+++ b/libc/gcc/Makefile
@@ -5,12 +5,13 @@ include $(TOPDIR)/libc/Makefile.inc
 SRCS = divmodsi3.s ldivmod.s ashlsi3.s
 OBJS = $(SRCS:.s=.o)
 
-all: $(LIBC) 
+all: out.a
 
-$(LIBC): $(OBJS)
-	$(AR) $(ARFLAGS) $@ $?
-
-$(OBJS): $(SRCS)
+out.a: $(OBJS)
+	$(RM) $@
+	$(AR) $(ARFLAGS_SUB) $@ $^
 
 clean:
-	rm -f *.o
+	rm -f *.[ao]
+
+$(OBJS): $(SRCS)

--- a/libc/getent/Makefile
+++ b/libc/getent/Makefile
@@ -5,12 +5,13 @@ include $(TOPDIR)/libc/Makefile.inc
 SRCS= utent.c pwent.c getpwuid.c getpwnam.c __getpwent.c getgrgid.c getgrnam.c __getgrent.c
 OBJS= $(SRCS:.c=.o)
 
-all: $(LIBC)
-
 $(OBJS): $(SRCS)
 
-$(LIBC): $(OBJS)
-	$(AR) $(ARFLAGS) $@ $?
+all: out.a
+
+out.a: $(OBJS)
+	$(RM) $@
+	$(AR) $(ARFLAGS_SUB) $@ $^
 
 clean:
-	rm -f *.o
+	rm -f *.[ao]

--- a/libc/malloc/Makefile
+++ b/libc/malloc/Makefile
@@ -11,12 +11,13 @@ OBJS = $(SRCS:.c=.o)
 
 .PHONY: all
 
-all: $(LIBC)
-
 $(OBJS): $(SRCS)
 
-$(LIBC): $(OBJS)
-	$(AR) $(ARFLAGS) $@ $?
+all: out.a
+
+out.a: $(OBJS)
+	$(RM) $@
+	$(AR) $(ARFLAGS_SUB) $@ $^
 
 clean:
-	rm -f *.o
+	rm -f *.[ao]

--- a/libc/misc/Makefile
+++ b/libc/misc/Makefile
@@ -24,12 +24,13 @@ SRCS= \
 	
 OBJS= $(SRCS:.c=.o)
 
-all: $(LIBC)
-
 $(OBJS): $(SRCS)
 
-$(LIBC): $(OBJS)
-	$(AR) $(ARFLAGS) $@ $?
+all: out.a
+
+out.a: $(OBJS)
+	$(RM) $@
+	$(AR) $(ARFLAGS_SUB) $@ $^
 
 clean:
-	rm -f *.o
+	rm -f *.[ao]

--- a/libc/regex/Makefile
+++ b/libc/regex/Makefile
@@ -5,12 +5,13 @@ include $(TOPDIR)/libc/Makefile.inc
 SRCS= regex.c
 OBJS= $(SRCS:.c=.o)
 
-all: $(LIBC)
-
 $(OBJS): $(SRCS)
 
-$(LIBC): $(OBJS)
-	$(AR) $(ARFLAGS) $@ $?
+all: out.a
+
+out.a: $(OBJS)
+	$(RM) $@
+	$(AR) $(ARFLAGS_SUB) $@ $^
 
 clean:
-	rm -f *.o
+	rm -f *.[ao]

--- a/libc/stdio/Makefile
+++ b/libc/stdio/Makefile
@@ -5,12 +5,13 @@ include $(TOPDIR)/libc/Makefile.inc
 SRCS = stdio.c printf.c scanf.c
 OBJS = $(SRCS:.c=.o)
 
-all: $(LIBC)
-
-$(LIBC): $(OBJS)
-	$(AR) $(ARFLAGS) $@ $?
-
 $(OBJS): $(SRCS)
 
+all: out.a
+
+out.a: $(OBJS)
+	$(RM) $@
+	$(AR) $(ARFLAGS_SUB) $@ $^
+
 clean:
-	rm -f *.o
+	rm -f *.[ao]

--- a/libc/string/Makefile
+++ b/libc/string/Makefile
@@ -22,12 +22,13 @@ OBJS = $(SRCS:.c=.o)
 
 .PHONY: all
 
-all: $(LIBC)
-
 $(OBJS): $(SRCS)
 
-$(LIBC): $(OBJS)
-	$(AR) $(ARFLAGS) $@ $?
+all: out.a
+
+out.a: $(OBJS)
+	$(RM) $@
+	$(AR) $(ARFLAGS_SUB) $@ $^
 
 clean:
-	rm -f *.o
+	rm -f *.[ao]

--- a/libc/system/Makefile
+++ b/libc/system/Makefile
@@ -6,14 +6,15 @@ SYSCALLDAT=${TOPDIR}/elks/arch/i86/kernel/syscall.dat
 
 OBJS = syscall0.o syscall1.o syslib.o signal.o exec.o dirent.o setjmp.o
 
-all: $(LIBC) 
+all: out.a
 
-$(LIBC): $(OBJS)
-	$(AR) $(ARFLAGS) $@ $?
+out.a: $(OBJS)
+	$(RM) $@
+	$(AR) $(ARFLAGS_SUB) $@ $^
 
 syscall1.s: syscall.awk $(SYSCALLDAT)
 	tr '[A-Z]' '[a-z]' < $(SYSCALLDAT) > syscall.dat
-	awk -f syscall.awk syscall.dat > syscall1.s
+	awk -f $< syscall.dat > syscall1.s
 
 syscall0.o: syscall0.s
 syscall1.o: syscall1.s
@@ -24,6 +25,6 @@ setjmp.o: setjmp.S
 #setjmp.s: setjmp.S
 
 clean:
-	rm -f *.o
+	rm -f *.[ao]
 	rm -f syscall.dat syscall1.s
 	rm -f call_tab.v defn_tab.v

--- a/libc/termcap/Makefile
+++ b/libc/termcap/Makefile
@@ -5,12 +5,13 @@ include $(TOPDIR)/libc/Makefile.inc
 SRCS= termcap.c tparam.c
 OBJS= $(SRCS:.c=.o)
 
-all: $(LIBC)
-
 $(OBJS): $(SRCS)
 
-$(LIBC): $(OBJS)
-	$(AR) $(ARFLAGS) $@ $?
+all: out.a
+
+out.a: $(OBJS)
+	$(RM) $@
+	$(AR) $(ARFLAGS_SUB) $@ $^
 
 clean:
-	rm -f *.o
+	rm -f *.[ao]

--- a/libc/termios/Makefile
+++ b/libc/termios/Makefile
@@ -5,12 +5,13 @@ include $(TOPDIR)/libc/Makefile.inc
 SRCS= termios.c ttyname.c
 OBJS= $(SRCS:.c=.o)
 
-all: $(LIBC)
-
 $(OBJS): $(SRCS)
 
-$(LIBC): $(OBJS)
-	$(AR) $(ARFLAGS) $@ $?
+all: out.a
+
+out.a: $(OBJS)
+	$(RM) $@
+	$(AR) $(ARFLAGS_SUB) $@ $^
 
 clean:
-	rm -f *.o
+	rm -f *.[ao]

--- a/libc/time/Makefile
+++ b/libc/time/Makefile
@@ -5,12 +5,13 @@ include $(TOPDIR)/libc/Makefile.inc
 SRCS= localtime.c ctime.c tm_conv.c asctime.c asc_conv.c
 OBJS= $(SRCS:.c=.o)
 
-all: $(LIBC)
-
 $(OBJS): $(SRCS)
 
-$(LIBC): $(OBJS)
-	$(AR) $(ARFLAGS) $@ $?
+all: out.a
+
+out.a: $(OBJS)
+	$(RM) $@
+	$(AR) $(ARFLAGS_SUB) $@ $^
 
 clean:
-	rm -f *.o
+	rm -f *.[ao]


### PR DESCRIPTION
With this patch, the `libc/` subtree now creates a separate `out.a` file for each of its subdirectories, then merges them all together into a single `libc.a` file using `ia16-elf-ar -M`.

I hope to add full support for multilibs once I have updated the assembly source files to work with the different calling conventions now supported by `ia16-elf-gcc` (`cdecl`, `stdcall`, and `regparmcall`).

Thank you!