### PR TITLE
[libc] indicate variadic syscall routines in syscall.{dat, awk}

### DIFF
--- a/elks/arch/i86/kernel/syscall.dat
+++ b/elks/arch/i86/kernel/syscall.dat
@@ -9,6 +9,7 @@
 #	'-' = Obsolete/not required
 #	'@' = May be required later
 #	'=' = Depends on stated config variable
+#	'!' = Last argument is optional in libc routine (i.e. variadic routine)
 #
 #	An initial plus on the call number specifies that this call is
 #	implemented in the kernel.
@@ -22,7 +23,7 @@ exit		+1	1	* c exit does stdio, _exit in crt0
 fork		+2	0	 
 read		+3	3	 
 write		+4	3	 
-open		+5	3	 
+open		+5	3	!
 close		+6	1	 
 wait4		+7	4
 creat		8	0	- Not needed alias for open
@@ -67,11 +68,11 @@ setgid		+46	1
 getgid		47	1	* this gets both gid and egid
 signal		+48	2	* have put the despatch table in user space.
 getinfo		49	1	@ possible? gets pid,ppid,uid,euid etc
-fcntl		+50	3	 
+fcntl		+50	3	!
 acct		51	1	@ Accounting to named file (off if null)
 phys		52	3	- Replaced by mmap()
 lock		53	1	@ Prevent swapping for this proc if flg!=0
-ioctl		+54	3	. make this and fcntl the same ?
+ioctl		+54	3	! make this and fcntl the same ?
 reboot		+55	3	. the magic number is 0xfee1,0xdead,...
 mpx		56	2	- Replaced by fifos and select.
 lstat		+57	2

--- a/libc/system/syscall.awk
+++ b/libc/system/syscall.awk
@@ -6,6 +6,7 @@ BEGIN {
 	print "\t.extern _syscall_0";
 	print "\t.extern _syscall_1";
 	print "\t.extern _syscall_2";
+	print "\t.extern _syscall_2p";
 	print "\t.extern _syscall_3";
 	print "\t.extern _syscall_4";
 	print "\t.extern _syscall_5\n";
@@ -29,7 +30,8 @@ BEGIN {
 	printf ("\t.global %s\n\n", funcname);
 	printf ("%s:\n", funcname);
 	printf ("\tmov $%d,%%ax\n", callno);
-	printf ("\tjmp _syscall_%d\n\n", $3);
+	if ($4 != "!" || $3 < 1) printf ("\tjmp _syscall_%d\n\n", $3);
+	else printf ("\tjmp _syscall_%dp\n\n", $3 - 1);
 }
 END {
 	for (i = 0; i <= max_call; i++)

--- a/libc/system/syscall0.s
+++ b/libc/system/syscall0.s
@@ -8,6 +8,7 @@
 	.global _syscall_0
 	.global _syscall_1
 	.global _syscall_2
+	.global _syscall_2p
 	.global _syscall_3
 	.global _syscall_4
 	.global _syscall_5
@@ -37,6 +38,7 @@ _syscall_2:
 	jmp    _syscall_0
 
 _syscall_3:
+_syscall_2p:
 	mov    %sp,%bx
 	mov    6(%bx),%dx
 	mov    4(%bx),%cx


### PR DESCRIPTION
This is part of my re-attempt to add support for non-`cdecl` function calling conventions in userland to `elks-libc`.

Since my previous attempt (https://github.com/jbruchon/elks/pull/257) was not very successful, I am now trying to add this support in stages, rather than all in one go (as before).

Thank you!

Partly for https://github.com/jbruchon/elks/issues/252 .

This change will come in useful when adding support for non-cdecl calling conventions (e.g. stdcall) in userland.