### PR TITLE
[libc] read ( ) & write ( ) should return ssize_t, not size_t

### DIFF
--- a/libc/include/unistd.h
+++ b/libc/include/unistd.h
@@ -4,12 +4,15 @@
 #include <features.h>
 #include <sys/types.h>
 
+typedef int intptr_t;
+typedef intptr_t ssize_t;
+
 #define STDIN_FILENO 0
 #define STDOUT_FILENO 1
 #define STDERR_FILENO 2
 
-extern size_t read __P ((int __fd, char * __buf, size_t __nbytes));
-extern size_t write __P ((int __fd, __const char * __buf, size_t __n));
+extern ssize_t read __P ((int __fd, char * __buf, size_t __nbytes));
+extern ssize_t write __P ((int __fd, __const char * __buf, size_t __n));
 extern int pipe __P ((int __pipedes[2]));
 extern unsigned int alarm __P ((unsigned int __seconds));
 extern unsigned int sleep __P ((unsigned int __seconds));
@@ -30,10 +33,6 @@ extern char*    crypt __P((__const char *__key, __const char *__salt));
 #endif
 
 #define _POSIX_VDISABLE	'\0'
-
-// Types
-
-typedef int intptr_t;
 
 // Functions
 


### PR DESCRIPTION
This fixes a build error that occurred when compiling `gcc-ia16`'s stack protector (`libssp`) together with `elks-libc`.

I am not sure why `read ( )` and `write ( )` were declared to return `size_t` in the first place --- they need to be able to return a negative value (`-1`) in case of an error, and `size_t` is unsigned.

I have tested the change with a run of `qemu-system-i386`.

Thank you!