### PR TITLE
Allow `make install` for elks-libc (second try), and fix a bug in inb/outb/inb_p/outb_p

### DIFF
--- a/elks/include/arch/io.h
+++ b/elks/include/arch/io.h
@@ -18,17 +18,17 @@ extern unsigned short int inw_p(void *);
 
 #ifdef __ia16__
 #define outb(value,port) \
-__asm__ ("outb %%al,%%dx"::"a" (value),"d" (port))
+__asm__ ("outb %%al,%%dx"::"Ral" ((unsigned char)(value)),"d" (port))
 
 
 #define inb(port) ({ \
 unsigned char _v; \
-__asm__ volatile ("inb %%dx,%%al":"=a" (_v):"d" (port)); \
+__asm__ volatile ("inb %%dx,%%al":"=Ral" (_v):"d" (port)); \
 _v; \
 })
 
 #define outw(value,port) \
-__asm__ ("outw %%ax,%%dx"::"a" (value),"d" (port))
+__asm__ ("outw %%ax,%%dx"::"a" ((unsigned short)(value)),"d" (port))
 
 
 #define inw(port) ({ \
@@ -40,20 +40,20 @@ _v; \
 #define outb_p(value,port) \
 __asm__ volatile ("outb %%al,%%dx\n" \
         "outb %%al,$0x80\n" \
-        ::"a" (value),"d" (port))
+        ::"Ral" ((unsigned char)(value)),"d" (port))
 
 #define inb_p(port) ({ \
 unsigned char _v; \
 __asm__ volatile ("inb %%dx,%%al\n" \
         "outb %%al,$0x80\n" \
-        :"=a" (_v):"d" (port)); \
+        :"=Ral" (_v):"d" (port)); \
 _v; \
 })
 
 #define outw_p(value,port) \
 __asm__ volatile ("outw %%ax,%%dx\n" \
         "outb %%al,$0x80\n" \
-        ::"a" (value),"d" (port))
+        ::"a" ((unsigned short)(value)),"d" (port))
 
 #define inw_p(port) ({ \
 unsigned char _v; \

--- a/elks/include/arch/io.h
+++ b/elks/include/arch/io.h
@@ -32,7 +32,7 @@ __asm__ ("outw %%ax,%%dx"::"a" ((unsigned short)(value)),"d" (port))
 
 
 #define inw(port) ({ \
-unsigned char _v; \
+unsigned short _v; \
 __asm__ volatile ("inw %%dx,%%ax":"=a" (_v):"d" (port)); \
 _v; \
 })
@@ -56,7 +56,7 @@ __asm__ volatile ("outw %%ax,%%dx\n" \
         ::"a" ((unsigned short)(value)),"d" (port))
 
 #define inw_p(port) ({ \
-unsigned char _v; \
+unsigned short _v; \
 __asm__ volatile ("inw %%dx,%%ax\n" \
         "outb %%al,$0x80\n" \
         :"=a" (_v):"d" (port)); \

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -39,7 +39,7 @@ all:: .binutils.build
 
 # GCC for IA16
 
-GCC_VER=2aa70f8c292e4e67b980d7468a011206130bfd7d
+GCC_VER=a28317104e1888e54057a03afbc1602386ad736b
 GCC_DIST=gcc-ia16-$(GCC_VER)
 
 $(DISTDIR)/$(GCC_DIST).zip:


### PR DESCRIPTION
Hello @mfld-fr,

This is a follow-up to my previous pull request at https://github.com/jbruchon/elks/pull/267.  You had mentioned that, when you tried compiling ELKS with my newer `gcc-ia16` version (https://github.com/tkchia/gcc-ia16/commit/a28317104e1888e54057a03afbc1602386ad736b),

> Sanity test in default configuration is OK, but unfortunately, it looks like the new version of GCC-IA16 breaks something in the ELKS network stack, as the `telnet` test fails. The very first error is `[ne2k] IRQ 9 request error: -16` during the kernel boot.

I (finally) reproduced this problem, and found that this was happening:
  * `rs_probe( )` was erroneously getting the results of an `in %dx, %al` probe instructions from `%ah`rather than `%al`.  This caused `rs_probe( )` to erroneously "detect" the presence of a `com4` serial port --- with IRQ 2 --- when there was no `com4`.
  * This caused `rs_init( )` to request to handle IRQ 2, which was mapped to IRQ 9.
  * Thus when `eth_drv_init( )` later tried to grab IRQ 9, it was already taken (`-EBUSY`).

To fix this, I have modified the port I/O macros used by `rs_probe( )` to use the correct `asm` constraints.

(One peculiarity of `gcc-ia16`, as compared to GCC for i386 or x86-64, is that `"a"` for a byte operand can refer to either `%al` or `%ah`, since `gcc-ia16` can handle the two separately in register allocation.)

I have briefly tested the new patches with my new GCC-IA16 version, and they should work fine now.

Thank you!