### PR TITLE
LD scripts: set a.out's heap + stack size if `_total` defined

### DIFF
--- a/elks/elks-small.ld
+++ b/elks/elks-small.ld
@@ -12,13 +12,20 @@ SECTIONS {
 		LONG(SIZEOF (.data));
 		LONG (SIZEOF (.bss));
 		LONG (entry);    /* entry point */
-		LONG (0);        /* total memory allocated */
+		LONG (_total_adjusted); /* total memory allocated */
 		LONG (0);        /* symbol table size */
 		}
 	_begintext = ALIGN(0x20);
 	.text 0 : AT(_begintext) { *(.text*); . = ALIGN(0x10); }
 	_begindata = _begintext + .;
 	.data 0 : AT(_begindata) { *(.nildata*) *(.rodata*) *(.data*) }
-	.bss : { *(.bss) *(COMMON) }
+	.bss : {
+		*(.bss) *(COMMON)
+		ASSERT (. + 0x100 <= 0x10000,
+		    "Error: too large for a small-model ELKS a.out file.");
+	}
+	PROVIDE (_total = 0);
+	_total_adjusted = _total == 0 ? 0
+			  : MIN (0x10000, MAX (. + 0x100, _total));
 	/DISCARD/ : { *(.comment) }
 }

--- a/elks/elks-tiny.ld
+++ b/elks/elks-tiny.ld
@@ -12,11 +12,18 @@ SECTIONS {
 		LONG (0);        /* .data section size */
 		LONG (0);        /* .bss section size */
 		LONG (entry);    /* entry point */
-		LONG (0);        /* total memory allocated */
+		LONG (_total_adjusted); /* total memory allocated */
 		LONG (0);        /* symbol table size */
 		}
 	_begintext = ALIGN(0x20);
 	.text 0 : AT(_begintext) { *(.text*) *(.rodata*) *(.data*) }
-	.bss : { *(.bss) *(COMMON) }
+	.bss : {
+		*(.bss) *(COMMON)
+		ASSERT (. + 0x100 <= 0x10000,
+		    "Error: too large for a tiny-model ELKS a.out file.");
+	}
+	PROVIDE (_total = 0);
+	_total_adjusted = _total == 0 ? 0
+			  : MIN (0x10000, MAX (. + 0x100, _total));
 	/DISCARD/ : { *(.comment) }
 }


### PR DESCRIPTION
Partly addresses https://github.com/jbruchon/elks/issues/241 .

With this patch, if a user links an ELKS program with `-Wl,--defsym=_total=`_t_, the resulting a.out header will ask for _t_ bytes to be allocated for the whole data segment --- i.e. static data, heap, and stack.

The linker scripts will check and adjust _t_ to a sane offset value, in much the same way as `dev86`'s `ld86` (see https://github.com/jbruchon/dev86/blob/master/ld/writex86.c).