### PR TITLE
[libc] fix: `make install' forgot to install autoconf.h

### DIFF
--- a/libc/Makefile
+++ b/libc/Makefile
@@ -145,7 +145,7 @@ install: $(LIBC)
 	$(INSTALL_DATA) $(LIBC) $(CRT0) \
 	    $(TOPDIR)/elks/elks-small.ld $(TOPDIR)/elks/elks-tiny.ld \
 	    $(PREFIX)/ia16-elf/lib/$(MULTISUBDIR)
-	$(INSTALL_DATA) include/*.h $(MULTIINCDIR)
+	$(INSTALL_DATA) include/*.h $(TOPDIR)/include/autoconf.h $(MULTIINCDIR)
 	$(INSTALL_DATA) include/asm/*.h $(MULTIINCDIR)/asm
 	$(INSTALL_DATA) include/sys/*.h $(MULTIINCDIR)/sys
 	$(INSTALL_DATA) $(TOPDIR)/elks/include/arch/*.h $(MULTIINCDIR)/arch


### PR DESCRIPTION
This patch fixes a bug in the `install` rule I added to `libc/Makefile` to allow copying the `elks-libc` files into a `gcc-ia16` installation (part of https://github.com/jbruchon/elks/issues/252).

I found that `make install` forgot to install the `include/autoconf.h` file produced by `config/Configure` and friends, and the other `elks-libc` include files required `<autoconf.h>` to be present to work properly.

Thank you!