### PR TITLE
Fix missing GAS suffix in setup.S

### DIFF
--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -870,11 +870,11 @@ con_cp1:
 	mov	copro,%ax
 	cmp	$3,%ah
 	jne	nofpu
-	and	$0xff7f,copro
+	andw	$0xff7f,copro
 	fldcw	copro
 	fdisi
 	fstcw	copro
-	test	$0x0080,copro
+	testw	$0x0080,copro
 	jnz	is8087
 	finit		// 80287/387 test
 	fld1


### PR DESCRIPTION
This patch fixes following build error that occurred when assembling `boot/setup.o` with `CONFIG_HW_FPU` config option.

```text
gcc -E -traditional -I/home/donghyeon/elks/include -I/home/donghyeon/elks/elks/include -I/home/donghyeon/elks/libc/include -DELKS_VERSION_CODE=0x00030000 -DUTS_RELEASE=\"0.3.0\" -D__KERNEL__ -DUSE_IA16 -o boot/setup.tmp boot/setup.S
ia16-elf-as -mtune=i8086  -o boot/setup.o boot/setup.tmp
boot/setup.S: Assembler messages:
boot/setup.S:873: Error: no instruction mnemonic suffix given and no register operands; can't size instruction
boot/setup.S:877: Error: no instruction mnemonic suffix given and no register operands; can't size instruction
../../Makefile-rules:238: recipe for target 'boot/setup.o' failed
```