### PR TITLE
[libc] [elkscmd] Simplify linking of programs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,14 +32,14 @@ CFG_SHELL	:= $(shell \
 
 all: .config
 	$(MAKE) -C libc all
-	$(MAKE) -C libc PREFIX='$(TOPDIR)/cross' install
+	$(MAKE) -C libc DESTDIR='$(TOPDIR)/cross' install
 	$(MAKE) -C elks all
 	$(MAKE) -C elkscmd all
 	$(MAKE) -C image all
 
 clean:
 	$(MAKE) -C libc clean
-	$(MAKE) -C libc PREFIX='$(TOPDIR)/cross' uninstall
+	$(MAKE) -C libc DESTDIR='$(TOPDIR)/cross' uninstall
 	$(MAKE) -C elks clean
 	$(MAKE) -C elkscmd clean
 	$(MAKE) -C image clean

--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,14 @@ CFG_SHELL	:= $(shell \
 
 all: .config
 	$(MAKE) -C libc all
+	$(MAKE) -C libc PREFIX='$(TOPDIR)/cross' install
 	$(MAKE) -C elks all
 	$(MAKE) -C elkscmd all
 	$(MAKE) -C image all
 
 clean:
 	$(MAKE) -C libc clean
+	$(MAKE) -C libc PREFIX='$(TOPDIR)/cross' uninstall
 	$(MAKE) -C elks clean
 	$(MAKE) -C elkscmd clean
 	$(MAKE) -C image clean

--- a/elkscmd/Make.defs
+++ b/elkscmd/Make.defs
@@ -73,11 +73,9 @@ ELKS_VSN=$(shell printf '%s.%s.%s-pre%s' $(E_V) | sed 's/-pre$$//')
 
 ifeq ($(PLATFORM),i86-ELKS)
 	CC=ia16-elf-gcc
-	CFLBASE=-ffreestanding -fno-inline -melks -mcmodel=small -mno-segment-relocation-stuff -mtune=i8086 -Wall -Os
-	LD=ia16-elf-ld
-	LDFLAGS=-T $(TOPDIR)/elks/elks-small.ld $(TOPDIR)/libc/crt0.o
-# TODO: move crt0 to begin of object files
-	LDLIBS='-(' $(TOPDIR)/libc/libc.a '-)'
+	CFLBASE=-fno-inline -melks-libc -mcmodel=small -mno-segment-relocation-stuff -mtune=i8086 -Wall -Os
+	LD=ia16-elf-gcc
+	LDFLAGS=$(CFLBASE)
 	CHECK=gcc -c -o .null.o -Wall -pedantic
 	AS=ia16-elf-as
 	ASFLAGS=-mtune=i8086

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -63,9 +63,9 @@ SUBDIRS = \
 #     separate -melks-libc multilibs.
 #
 # For the first case, arrange to build elks-libc for the available
-# -melks-libc multilib settings.  Furthermore, if $(PREFIX) is defined, add
+# -melks-libc multilib settings.  Furthermore, if $(DESTDIR) is defined, add
 # an `install' makefile rule which will install the elks-libc files under
-# $(PREFIX), such that they can be used from outside the ELKS source tree;
+# $(DESTDIR), such that they can be used from outside the ELKS source tree;
 # and also add an `uninstall' rule to allow elks-libc to be cleaned away.
 #
 # For the second case, arrange to build elks-libc only for default compiler
@@ -87,7 +87,7 @@ MAINMULTI:=$(filter %;@melks-libc,$(ELKSLIBCMULTIS))
 else
 MAINMULTI:=$(filter .;,$(ALLMULTIS))
 BUILDMULTIS:=$(MAINMULTI)
-override PREFIX=
+override DESTDIR=
 endif
 
 MAINMULTISUBDIR=$(firstword $(subst ;, ,$(MAINMULTI)))
@@ -135,17 +135,17 @@ $(SUBDIRS):
 
 # Install one particular multilib variant of libc.a, crt0.o, and include files.
 # TODO: tidy up the include file installation?
-ifneq "" "$(PREFIX)"
+ifneq "" "$(DESTDIR)"
 INSTALL_DATA = install -c -m 644
-MULTIINCDIR = $(PREFIX)/ia16-elf/lib/$(MULTISUBDIR)/include
+MULTIINCDIR = $(DESTDIR)/ia16-elf/lib/$(MULTISUBDIR)/include
 .PHONY: install
 install: $(LIBC)
-	mkdir -p $(PREFIX)/ia16-elf/lib/$(MULTISUBDIR) \
+	mkdir -p $(DESTDIR)/ia16-elf/lib/$(MULTISUBDIR) \
 		 $(MULTIINCDIR)/asm $(MULTIINCDIR)/sys \
 		 $(MULTIINCDIR)/arch $(MULTIINCDIR)/linuxmt/arpa
 	$(INSTALL_DATA) $(LIBC) $(CRT0) \
 	    $(TOPDIR)/elks/elks-small.ld $(TOPDIR)/elks/elks-tiny.ld \
-	    $(PREFIX)/ia16-elf/lib/$(MULTISUBDIR)
+	    $(DESTDIR)/ia16-elf/lib/$(MULTISUBDIR)
 	$(INSTALL_DATA) include/*.h $(TOPDIR)/include/autoconf.h $(MULTIINCDIR)
 	$(INSTALL_DATA) include/asm/*.h $(MULTIINCDIR)/asm
 	$(INSTALL_DATA) include/sys/*.h $(MULTIINCDIR)/sys
@@ -155,10 +155,10 @@ install: $(LIBC)
 	$(INSTALL_DATA) $(TOPDIR)/elks/include/linuxmt/arpa/*.h \
 	    $(MULTIINCDIR)/linuxmt/arpa
 uninstall:
-	$(RM) $(PREFIX)/ia16-elf/lib/$(MULTISUBDIR)/$(notdir $(LIBC)) \
-	      $(PREFIX)/ia16-elf/lib/$(MULTISUBDIR)/$(notdir $(CRT0)) \
-	      $(PREFIX)/ia16-elf/lib/$(MULTISUBDIR)/elks-small.ld \
-	      $(PREFIX)/ia16-elf/lib/$(MULTISUBDIR)/elks-tiny.ld \
+	$(RM) $(DESTDIR)/ia16-elf/lib/$(MULTISUBDIR)/$(notdir $(LIBC)) \
+	      $(DESTDIR)/ia16-elf/lib/$(MULTISUBDIR)/$(notdir $(CRT0)) \
+	      $(DESTDIR)/ia16-elf/lib/$(MULTISUBDIR)/elks-small.ld \
+	      $(DESTDIR)/ia16-elf/lib/$(MULTISUBDIR)/elks-tiny.ld \
 	      $(MULTIINCDIR)/autoconf.h \
 	      $(patsubst include/%,$(MULTIINCDIR)/%, \
 		  $(wildcard include/*.h include/asm/*.h include/sys/*.h)) \
@@ -188,7 +188,7 @@ $(LIBC):
 	cp -u build-ml/$(MAINMULTISUBDIR)/crt0.o $(CRT0) || \
 	    cp build-ml/$(MAINMULTISUBDIR)/crt0.o $(CRT0)
 
-ifneq "" "$(PREFIX)"
+ifneq "" "$(DESTDIR)"
 .PHONY: install uninstall
 install uninstall:
 	set -e \

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -65,7 +65,8 @@ SUBDIRS = \
 # For the first case, arrange to build elks-libc for the available
 # -melks-libc multilib settings.  Furthermore, if $(PREFIX) is defined, add
 # an `install' makefile rule which will install the elks-libc files under
-# $(PREFIX), such that they can be used from outside the ELKS source tree.
+# $(PREFIX), such that they can be used from outside the ELKS source tree;
+# and also add an `uninstall' rule to allow elks-libc to be cleaned away.
 #
 # For the second case, arrange to build elks-libc only for default compiler
 # settings.  Installing the libraries outside the ELKS tree is not supported
@@ -153,11 +154,21 @@ install: $(LIBC)
 	    $(MULTIINCDIR)/linuxmt
 	$(INSTALL_DATA) $(TOPDIR)/elks/include/linuxmt/arpa/*.h \
 	    $(MULTIINCDIR)/linuxmt/arpa
+uninstall:
+	$(RM) $(PREFIX)/ia16-elf/lib/$(MULTISUBDIR)/$(notdir $(LIBC)) \
+	      $(PREFIX)/ia16-elf/lib/$(MULTISUBDIR)/$(notdir $(CRT0)) \
+	      $(PREFIX)/ia16-elf/lib/$(MULTISUBDIR)/elks-small.ld \
+	      $(PREFIX)/ia16-elf/lib/$(MULTISUBDIR)/elks-tiny.ld \
+	      $(MULTIINCDIR)/autoconf.h \
+	      $(patsubst include/%,$(MULTIINCDIR)/%, \
+		  $(wildcard include/*.h include/asm/*.h include/sys/*.h)) \
+	      $(patsubst $(TOPDIR)/elks/include/%,$(MULTIINCDIR)/%, \
+		  $(wildcard $(TOPDIR)/elks/include/arch/*.h \
+			     $(TOPDIR)/elks/include/linuxmt/*.h \
+			     $(TOPDIR)/elks/include/linuxmt/arpa/*.h))
 endif
 
 else
-
-.PHONY: install $(LIBC)
 
 # $(MULTISUBDIR) is undefined.  Build all multilibs that we can build; then
 # copy the library files for "default" settings into this directory.
@@ -178,14 +189,14 @@ $(LIBC):
 	    cp build-ml/$(MAINMULTISUBDIR)/crt0.o $(CRT0)
 
 ifneq "" "$(PREFIX)"
-.PHONY: install
-install:
+.PHONY: install uninstall
+install uninstall:
 	set -e \
 	$(foreach ml,$(BUILDMULTIS), ; \
 		export MULTISUBDIR='$(firstword $(subst ;, ,$(ml)))'; \
 		export MULTILIB='$(strip $(subst @, -, \
 		    $(lastword $(subst ;, ,$(ml)))))'; \
-		$(MAKE) install)
+		$(MAKE) $@)
 endif
 
 endif

--- a/libc/gcc/Makefile
+++ b/libc/gcc/Makefile
@@ -2,7 +2,10 @@
 
 include $(TOPDIR)/libc/Makefile.inc
 
-SRCS = divmodsi3.s ldivmod.s ashlsi3.s
+# It is feasible to now link programs with the real libgcc, so this libgcc
+# module is not really needed any more.  -- tkchia 20190603
+# SRCS = divmodsi3.s ldivmod.s ashlsi3.s
+SRCS =
 OBJS = $(SRCS:.s=.o)
 
 all: out.a

--- a/libc/include/stdint.h
+++ b/libc/include/stdint.h
@@ -1,0 +1,1 @@
+#include <stdint-gcc.h>

--- a/libc/stdio/Makefile
+++ b/libc/stdio/Makefile
@@ -2,7 +2,7 @@
 
 include $(TOPDIR)/libc/Makefile.inc
 
-SRCS = stdio.c printf.c scanf.c
+SRCS = stdio.c printf.c scanf.c putchar.c
 OBJS = $(SRCS:.c=.o)
 
 $(OBJS): $(SRCS)

--- a/libc/stdio/putchar.c
+++ b/libc/stdio/putchar.c
@@ -1,0 +1,19 @@
+/* Copyright (C) 2019 TK Chia
+ * This file is part of the Linux-8086 C library and is distributed
+ * under the GNU Library General Public License.
+ */
+
+/* Function implementation of putchar.  putchar is defined as a macro in
+ * <stdio.h>, but GCC sometimes rewrites calls to printf as putchar (or puts)
+ * calls, which will appear as actual function calls.
+ */
+
+#include <stdio.h>
+
+#undef putchar
+
+int
+putchar(int c)
+{
+   return putc(c, stdout);
+}

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -39,7 +39,7 @@ all:: .binutils.build
 
 # GCC for IA16
 
-GCC_VER=a28317104e1888e54057a03afbc1602386ad736b
+GCC_VER=2dd73a5500dce4be8f0f7d4bab02f5ed6bf849b0
 GCC_DIST=gcc-ia16-$(GCC_VER)
 
 $(DISTDIR)/$(GCC_DIST).zip:


### PR DESCRIPTION
Hello all,

This series of patches simplifies the procedure for building ELKS userland programs (https://github.com/jbruchon/elks/issues/252).  The main changes are as follows:

  * The top-level `Makefile` now arranges to "install" `elks-libc` into the cross toolchain directory (under `cross/ia16-elf/lib/`).
  * The makefile rules for the ELKS userland utilities (`elkscmd/Make.defs`) can then link userland programs simply by saying `ia16-elf-gcc` ... `-melks-libc`, rather than having to manually pass `crt0.o`, `libc.a`, etc. to the linker.  This is because `ia16-elf-gcc` can now find the C library and include files at the expected places.

I further modified `make clean` at the top level so that it cleans away any "installed" `elks-libc` files in the cross toolchain directory.

To get everything to build (especially the `bc` utility), I also had to

  * add a simple `<stdint.h>` to the C library --- it just hands over to `libgcc`'s version;
  * add a function implementation of `<stdio.h>`'s `putchar( )`;
  * disable the `libgcc` routines in `elks-libc` (`libc/gcc/`) for now --- `ia16-elf-gcc` can now link programs with the actual `libgcc`, and having two versions of the `libgcc` functions sometimes causes linker errors.

Thank you!