### PR TITLE
Portability fixes for MSDOS filesystem; Minix floppy boot fixup; ctype.h for tolower()

### DIFF
--- a/elks/arch/i86/drivers/block/directhd.c
+++ b/elks/arch/i86/drivers/block/directhd.c
@@ -13,6 +13,7 @@
 #include <linuxmt/directhd.h>
 #include <linuxmt/debug.h>
 
+#include <arch/io.h>
 #include <arch/segment.h>
 
 #ifdef CONFIG_BLK_DEV_HD

--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -87,8 +87,10 @@ uni16_to_x8(unsigned char *ascii, register unsigned char *uni)
 /* Read a complete directory entry for a (specified) file,
  * submit a message to the callback function,
  * return a value of 0 or an error code.
+ *
+ * Notice the optimization level - GCC IA16 optimizes out most of the function code at the moment with -Os.
  */
-int msdos_readdir(
+int __attribute__((optimize("O1"))) msdos_readdir(
 	struct inode *inode,
 	register struct file *filp,
 	char *dirent,

--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -31,7 +31,7 @@ static int msdos_readdir(struct inode *inode,
 
 /*@-type@*/
 
-static struct file_operations msdos_dir_operations = {
+static struct file_operations msdos_dir_operations1 = {
 	NULL,			/* lseek - default */
 	msdos_dir_read,		/* read */
 	NULL,			/* write - bad */
@@ -49,7 +49,7 @@ static struct file_operations msdos_dir_operations = {
  * directories can handle most operations...
  */
 struct inode_operations msdos_dir_inode_operations = {
-	&msdos_dir_operations,	/* default directory file-ops */
+	&msdos_dir_operations1,	/* default directory file-ops */
 	msdos_create,		/* create */
 	msdos_lookup,		/* lookup */
 	NULL,			/* link */
@@ -91,7 +91,7 @@ uni16_to_x8(unsigned char *ascii, register unsigned char *uni)
 int msdos_readdir(
 	struct inode *inode,
 	register struct file *filp,
-	void *dirent,
+	char *dirent,
 	filldir_t filldir)
 {
 	ino_t ino;
@@ -172,8 +172,8 @@ int msdos_readdir(
 			if (is_long) {
 				unsigned char sum;
 				for (sum = 0, i = 0; i < 11; i++) {
-					//sum = (((sum&1)<<7)|((sum&0xfe)>>1));
-					asm("rorb [bp-111], 1");    /* Note the offset */
+					sum = (((sum&1)<<7)|((sum&0xfe)>>1));
+//					asm("rorb [bp-111], 1");    /* Note the offset */
 					sum += de->name[i];
 				}
 

--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -31,7 +31,7 @@ static int msdos_readdir(struct inode *inode,
 
 /*@-type@*/
 
-static struct file_operations msdos_dir_operations1 = {
+static struct file_operations msdos_dir_operations = {
 	NULL,			/* lseek - default */
 	msdos_dir_read,		/* read */
 	NULL,			/* write - bad */
@@ -49,7 +49,7 @@ static struct file_operations msdos_dir_operations1 = {
  * directories can handle most operations...
  */
 struct inode_operations msdos_dir_inode_operations = {
-	&msdos_dir_operations1,	/* default directory file-ops */
+	&msdos_dir_operations,	/* default directory file-ops */
 	msdos_create,		/* create */
 	msdos_lookup,		/* lookup */
 	NULL,			/* link */

--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -90,7 +90,9 @@ uni16_to_x8(unsigned char *ascii, register unsigned char *uni)
  *
  * Notice the optimization level - GCC IA16 optimizes out most of the function code at the moment with -Os.
  */
-int __attribute__((optimize("O1"))) msdos_readdir(
+#pragma GCC push_options
+#pragma GCC optimize ("O1")
+int msdos_readdir(
 	struct inode *inode,
 	register struct file *filp,
 	char *dirent,
@@ -236,3 +238,4 @@ int __attribute__((optimize("O1"))) msdos_readdir(
 		unmap_brelse(bh);
 	return 0;
 }
+#pragma GCC pop_options

--- a/elks/fs/msdos/file.c
+++ b/elks/fs/msdos/file.c
@@ -25,7 +25,7 @@ static int msdos_file_write(struct inode *inode,struct file *filp,char *buf,
     size_t count);
 
 
-static struct file_operations msdos_file_operations1 = {
+static struct file_operations msdos_file_operations = {
 	NULL,			/* lseek - default */
 	msdos_file_read,	/* read */
 	msdos_file_write,	/* write */
@@ -39,7 +39,7 @@ static struct file_operations msdos_file_operations1 = {
 /* No getblk for MS-DOS FS' that don't align data at kByte boundaries. */
 
 struct inode_operations msdos_file_inode_operations_no_bmap = {
-	&msdos_file_operations1,	/* default file operations */
+	&msdos_file_operations,	/* default file operations */
 	NULL,			/* create */
 	NULL,			/* lookup */
 	NULL,			/* link */

--- a/elks/fs/msdos/file.c
+++ b/elks/fs/msdos/file.c
@@ -25,7 +25,7 @@ static int msdos_file_write(struct inode *inode,struct file *filp,char *buf,
     size_t count);
 
 
-static struct file_operations msdos_file_operations = {
+static struct file_operations msdos_file_operations1 = {
 	NULL,			/* lseek - default */
 	msdos_file_read,	/* read */
 	msdos_file_write,	/* write */
@@ -39,7 +39,7 @@ static struct file_operations msdos_file_operations = {
 /* No getblk for MS-DOS FS' that don't align data at kByte boundaries. */
 
 struct inode_operations msdos_file_inode_operations_no_bmap = {
-	&msdos_file_operations,	/* default file operations */
+	&msdos_file_operations1,	/* default file operations */
 	NULL,			/* create */
 	NULL,			/* lookup */
 	NULL,			/* link */
@@ -85,7 +85,7 @@ static int msdos_file_read(register struct inode *inode,register struct file *fi
 			break;
 		offset = (short)filp->f_pos & (SECTOR_SIZE-1);
 		if (!(bh = msdos_sread(inode->i_dev,sector,&data))) break;
-		filp->f_pos += (size = min(SECTOR_SIZE-offset,left));
+		filp->f_pos += (size = MIN(SECTOR_SIZE-offset,left));
 			memcpy_tofs(buf,(char *)data+offset,size);
 			buf += size;
 		unmap_brelse(bh);
@@ -125,7 +125,7 @@ static int msdos_file_write(register struct inode *inode,register struct file *f
 			if ((error = msdos_add_cluster(inode)) < 0) break;
 		if (error) break;
 		offset = (short)filp->f_pos & (SECTOR_SIZE-1);
-		size = min(SECTOR_SIZE-offset,count);
+		size = MIN(SECTOR_SIZE-offset,count);
 		if (!(bh = msdos_sread(inode->i_dev,sector,&data))) {
 			error = -EIO;
 			break;

--- a/elks/include/arch/io.h
+++ b/elks/include/arch/io.h
@@ -4,6 +4,7 @@
 extern void bell(void);
 
 #ifdef __BCC__
+//#error BCC
 extern void outb(unsigned char, void *);
 extern void outb_p(unsigned char, void *);
 extern void outw(unsigned short int, void *);
@@ -17,6 +18,8 @@ extern unsigned short int inw_p(void *);
 #endif
 
 #ifdef __ia16__
+//#error __IA16
+
 #define outb(value,port) \
 __asm__ ("outb %%al,%%dx"::"Ral" ((unsigned char)(value)),"d" (port))
 

--- a/elks/include/linuxmt/ctype.h
+++ b/elks/include/linuxmt/ctype.h
@@ -1,0 +1,41 @@
+/*
+ *	ctype.h		Character classification and conversion
+ */
+
+#ifndef __CTYPE_H
+#define __CTYPE_H
+
+extern	unsigned char	__ctype[];
+
+#define	__CT_d	0x01		/* numeric digit */
+#define	__CT_u	0x02		/* upper case */
+#define	__CT_l	0x04		/* lower case */
+#define	__CT_c	0x08		/* control character */
+#define	__CT_s	0x10		/* whitespace */
+#define	__CT_p	0x20		/* punctuation */
+#define	__CT_x	0x40		/* hexadecimal */
+
+/* Define these as simple old style ascii versions */
+#define	toupper(c)	(((c)>='a'&&(c)<='z') ? (c)^0x20 : (c))
+#define	tolower(c)	(((c)>='A'&&(c)<='Z') ? (c)^0x20 : (c))
+#define	_toupper(c)	((c)^0x20)
+#define	_tolower(c)	((c)^0x20)
+#define	toascii(c)	((c)&0x7F)
+
+#define __CT(c) (__ctype[1+(unsigned char)c])
+
+/* Note the '!!' is a cast to 'bool' and even BCC deletes it in an if()  */
+#define	isalnum(c)	(!!(__CT(c)&(__CT_u|__CT_l|__CT_d)))
+#define	isalpha(c)	(!!(__CT(c)&(__CT_u|__CT_l)))
+#define	isascii(c)	(!((c)&~0x7F))
+#define	iscntrl(c)	(!!(__CT(c)&__CT_c))
+#define	isdigit(c)	(!!(__CT(c)&__CT_d))
+#define	isgraph(c)	(!(__CT(c)&(__CT_c|__CT_s)))
+#define	islower(c)	(!!(__CT(c)&__CT_l))
+#define	isprint(c)	(!(__CT(c)&__CT_c))
+#define	ispunct(c)	(!!(__CT(c)&__CT_p))
+#define	isspace(c)	(!!(__CT(c)&__CT_s))
+#define	isupper(c)	(!!(__CT(c)&__CT_u))
+#define	isxdigit(c)	(!!(__CT(c)&__CT_x))
+
+#endif /* __CTYPE_H */

--- a/elks/include/linuxmt/msdos_fs.h
+++ b/elks/include/linuxmt/msdos_fs.h
@@ -6,9 +6,14 @@
  */
 
 #include <linuxmt/fs.h>
+#include <linuxmt/ctype.h>
 
+#ifndef toupper
 extern char toupper(char c);
+#endif
+#ifndef tolower
 extern char tolower(char c);
+#endif
 
 #define MSDOS_ROOT_INO  1 /* == MINIX_ROOT_INO */
 #define SECTOR_SIZE     512 /* sector size (bytes) */
@@ -131,7 +136,7 @@ extern void date_unix2dos(long unix_date,unsigned short *time,
 extern ino_t msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head **bh,
     struct msdos_dir_entry **de);
 extern int msdos_scan(struct inode *dir,char *name,struct buffer_head **res_bh,
-    struct msdos_dir_entry **res_de,int *ino);
+    struct msdos_dir_entry **res_de,ino_t *ino);
 extern ino_t msdos_parent_ino(struct inode *dir,int locked);
 
 /* fat.c */
@@ -162,7 +167,7 @@ extern int msdos_rename(struct inode *old_dir,const char *old_name,int old_len,
 
 extern void msdos_put_inode(struct inode *inode);
 extern void msdos_put_super(struct super_block *sb);
-extern struct super_block *msdos_read_super(struct super_block *s,void *data);
+extern struct super_block *msdos_read_super(register struct super_block *s,char *data, int silent);
 extern void msdos_statfs(struct super_block *sb,struct statfs *buf);
 extern long msdos_bmap(struct inode *inode,long block);
 extern void msdos_read_inode(struct inode *inode);

--- a/elks/include/linuxmt/msdos_fs.h
+++ b/elks/include/linuxmt/msdos_fs.h
@@ -176,12 +176,12 @@ extern int init_msdos_fs(void);
 
 /* dir.c */
 
-extern struct file_operations msdos_dir_operations;
+//extern struct file_operations msdos_dir_operations;
 extern struct inode_operations msdos_dir_inode_operations;
 
 /* file.c */
 
-extern struct file_operations msdos_file_operations;
+//extern struct file_operations msdos_file_operations;
 extern struct inode_operations msdos_file_inode_operations;
 extern struct inode_operations msdos_file_inode_operations_no_bmap;
 

--- a/elkscmd/bootblocks/minix_first.S
+++ b/elkscmd/bootblocks/minix_first.S
@@ -245,14 +245,17 @@ sect_max:
 #ifdef CONFIG_IMG_FD1440
 	.word 18
 #endif
+#ifdef CONFIG_IMG_FD720
+	.word 9
+#endif
 
 head_max:
-#ifdef CONFIG_IMG_FD1440
+#if defined(CONFIG_IMG_FD1440) || defined(CONFIG_IMG_FD720)
 	.word 2
 #endif
 
 track_max:
-#ifdef CONFIG_IMG_FD1440
+#if defined(CONFIG_IMG_FD1440) || defined(CONFIG_IMG_FD720)
 	.word 80
 #endif
 

--- a/elkscmd/bootblocks/minix_first.S
+++ b/elkscmd/bootblocks/minix_first.S
@@ -255,9 +255,15 @@ sect_max:
 #ifdef CONFIG_IMG_FD720
 	.word 9
 #endif
+#if defined(CONFIG_IMG_FD1200)
+	.word 15
+#endif
+#if defined(CONFIG_IMG_FD1680)
+	.word 21
+#endif
 
 head_max:
-#if defined(CONFIG_IMG_FD1440) || defined(CONFIG_IMG_FD720)
+#if defined(CONFIG_IMG_FD1440) || defined(CONFIG_IMG_FD720) || defined(CONFIG_IMG_FD360) || defined(CONFIG_IMG_FD1200) || defined(CONFIG_IMG_FD1680)
 	.word 2
 #endif
 
@@ -265,6 +271,11 @@ track_max:
 #if defined(CONFIG_IMG_FD1440) || defined(CONFIG_IMG_FD720)
 	.word 80
 #endif
+
+#if defined(CONFIG_IMG_FD360)
+	.word 40
+#endif
+
 
 //------------------------------------------------------------------------------
 

--- a/elkscmd/bootblocks/minix_first.S
+++ b/elkscmd/bootblocks/minix_first.S
@@ -65,12 +65,19 @@ _next1:
 
 	// Load the second sector of the boot block
 
+	xor %dl,%dl
+	xor %ah,%ah
+	int $0x13          // reset floppy
+
+
+loopy:
 	mov $0x0201,%ax    // read 1 sector
 	mov $sector_2,%bx  // destination
 	mov $2,%cx         // track 0 - from sector 2 (base 1)
 	xor %dx,%dx        // drive 0 - head 0
 	int $0x13          // BIOS disk services
-	jnc _next2
+	jc loopy
+	jmp _next2
 
 	mov $msg_load,%bx
 	call _puts


### PR DESCRIPTION
I had to fix certain minor things while tried to build the system for Poisk-1 soviet XT clone.
All issues are related to MSDOS code.
Not quite sure about ctype.h and io.h (were #error pragmas added intentionally?)