### PR TITLE
[libc] fix: crt0.S should count NULL in argv[] in finding envp[]

### DIFF
--- a/libc/crt0.S
+++ b/libc/crt0.S
@@ -24,6 +24,7 @@ _startup:
 	lea 4(%bp),%bx  // argv [0]
 	mov 2(%bp),%cx  // argc
 	mov %cx,%ax
+	inc %ax
 	shl $1,%ax
 	add %bx,%ax     // envp [0]
 	mov %ax,environ


### PR DESCRIPTION
`libc/crt0.S` should calculate `envp` as `&argv[argc + 1]`, not `&argv[argc]`.