### PR TITLE
Add elksemu (from dev86 project) into ELKS tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ all: .config
 	$(MAKE) -C elks all
 	$(MAKE) -C elkscmd all
 	$(MAKE) -C image all
-	$(MAKE) -C elksemu elksemu
+	-$(MAKE) -C elksemu PREFIX='$(TOPDIR)/cross' elksemu
 
 clean:
 	$(MAKE) -C libc clean

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ all: .config
 	$(MAKE) -C elks all
 	$(MAKE) -C elkscmd all
 	$(MAKE) -C image all
+	$(MAKE) -C elksemu elksemu
 
 clean:
 	$(MAKE) -C libc clean
@@ -43,6 +44,7 @@ clean:
 	$(MAKE) -C elks clean
 	$(MAKE) -C elkscmd clean
 	$(MAKE) -C image clean
+	$(MAKE) -C elksemu clean
 	@echo
 	@if [ ! -f .config ]; then \
 	    echo ' * This system is not configured. You need to run' ;\

--- a/elksemu/COPYING
+++ b/elksemu/COPYING
@@ -1,0 +1,339 @@
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+                          675 Mass Ave, Cambridge, MA 02139, USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Library General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+	Appendix: How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) 19yy  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) 19yy name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Library General
+Public License instead of this License.

--- a/elksemu/Kernel_patch
+++ b/elksemu/Kernel_patch
@@ -1,0 +1,22 @@
+This kernel patch allows you to run Linux-8086 executables transparently
+on a Linux-i386 (1.2.13) system.
+It requires V0.0.2 or better of elksemu in the file "/lib/elksemu".
+
+If you are using kernel 1.3.* or later try the module: binfmt_elks.o
+If you are using 2.0.36, 2.1.43 or 2.2.0  and later use binfmt_misc.
+
+--- orig-13/fs/exec.c	Sun Sep 24 13:22:37 1995
++++ linux/fs/exec.c	Sun Feb 11 20:11:47 1996
+@@ -615,6 +615,12 @@
+ 	set_fs(old_fs);
+ 	if (retval < 0)
+ 		goto exec_error2;
++#ifndef NO_ELKSEMU
++	/* What a horrible hack! :-) */
++	if ((bprm.buf[0] == 1)    && (bprm.buf[1] == 3) && 
++	    (bprm.buf[2] == 0x20 || bprm.buf[2] == 0x10) && (bprm.buf[3] == 4))
++		memcpy(bprm.buf, "#!/lib/elksemu\n", 16);
++#endif
+ 	if ((bprm.buf[0] == '#') && (bprm.buf[1] == '!') && (!sh_bang)) {
+ 		/*
+ 		 * This section does the #! interpretation.

--- a/elksemu/Makefile
+++ b/elksemu/Makefile
@@ -1,0 +1,67 @@
+#
+#	Makefile for elksemu.
+#
+
+# Use BCC to make a tiny static a.out version.
+ifeq ($(CC),bcc)
+CFLAGS=-Ml -ansi -s $(DEFS)
+endif
+ifeq ($(CC),ncc)
+CFLAGS=-Ml -ansi -s $(DEFS)
+endif
+
+# Default
+ifeq ($(CFLAGS),)
+CFLAGS=-O
+endif
+
+# Turn on elkemu's strace like facility.
+# DEFS=-DDEBUG
+
+# For gcc making a.out with a basically ELF compiler
+# CFLAGS=-O2 -fno-strength-reduce -b i486-linuxaout -N -s -static
+
+OBJ=elks.o elks_sys.o elks_signal.o minix.o
+
+elksemu:	$(OBJ)
+		$(CC) $(CFLAGS) -o $@ $^
+
+elks_sys.o:	call_tab.v efile.h
+$(OBJ):		elks.h
+
+call_tab.v:	dummy
+	-cp -p ../libc/syscall/call_tab.v . 2>/dev/null
+	-cp -p ../libc/syscall/defn_tab.v . 2>/dev/null
+
+efile.h: ../libc/error/liberror.txt
+	sh mkefile ../libc/error/liberror.txt
+
+dummy:
+
+# The kernel patch or module _requires_ this location but binfmt-misc is easy
+# to redirect.
+install: elksemu
+	install -d $(DIST)/lib
+	install -s -o root -g root -m 4555 elksemu $(DIST)/lib/elksemu
+
+clean realclean:
+	rm -f $(OBJ) binfmt_elks.o elksemu call_tab.v defn_tab.v efile.h
+
+module: binfmt_elks.o
+
+# HOW to compile the module...
+# BUT remember you don't need it for a recent 2.1.X; use binfmt_misc.
+
+# This matches my compile (2.0.x); yours may be different.
+MODCFLAGS=-D__KERNEL__ -Wall -Wstrict-prototypes -O2 -fomit-frame-pointer \
+          -fno-strength-reduce -pipe -m486 -DCPU=486 -DMODULE -DMODVERSIONS \
+	  -include /usr/include/linux/modversions.h
+
+binfmt_elks.o:	binfmt_elks.c
+	gcc -c $(MODCFLAGS) binfmt_elks.c
+
+# This is another option
+#MODCFLAGS=-O -fomit-frame-pointer -DCPU=386 -D__KERNEL__ -DMODULE
+# Or this ...
+#MODCFLAGS=-O -fomit-frame-pointer -D__KERNEL__ -DMODULE -DCONFIG_MODVERSIONS
+

--- a/elksemu/Makefile
+++ b/elksemu/Makefile
@@ -12,7 +12,7 @@ endif
 
 # Default
 ifeq ($(CFLAGS),)
-CFLAGS=-O
+CFLAGS=-O $(DEFS)
 endif
 
 # Turn on elkemu's strace like facility.
@@ -26,15 +26,18 @@ OBJ=elks.o elks_sys.o elks_signal.o minix.o
 elksemu:	$(OBJ)
 		$(CC) $(CFLAGS) -o $@ $^
 
-elks_sys.o:	call_tab.v efile.h
+elks_sys.o:	call_tab.v defn_tab.v efile.h
 $(OBJ):		elks.h
 
-call_tab.v:	dummy
-	-cp -p ../libc/syscall/call_tab.v . 2>/dev/null
-	-cp -p ../libc/syscall/defn_tab.v . 2>/dev/null
+ifneq "" "$(PREFIX)"
+call_tab.v:	$(PREFIX)/share/misc/elks/call_tab.v
+	cp $< $@
+defn_tab.v:	$(PREFIX)/share/misc/elks/defn_tab.v
+	cp $< $@
+endif
 
-efile.h: ../libc/error/liberror.txt
-	sh mkefile ../libc/error/liberror.txt
+efile.h: $(TOPDIR)/elkscmd/rootfs_template/lib/liberror.txt
+	sh mkefile $<
 
 dummy:
 

--- a/elksemu/README
+++ b/elksemu/README
@@ -1,0 +1,24 @@
+
+Elksemu is an emulator for the environment that elks will provide on a
+real ELKS machine. The emulator only runs on linux-i386 or similar.
+
+If you're using a 2.0.36, 2.1.43, 2.2.0 or later kernel then the
+binfmt_misc driver is in the stock kernel and all you need to do is
+add the following line into the relevent /etc/rc* file.
+
+echo ':i86-elks:M::\x01\x03\x20\x00:\xff\xff\xff\x83:/usr/bin/elksemu:' \
+     > /proc/sys/fs/binfmt_misc/register
+
+Note, however, if binfmt_misc is compiled as a module it will not auto
+load so you will have to do this manually. 
+
+If your kernel version is 1.2.13 then apply the patch in the Kernel_patch
+file. 
+
+If you're using one of the other 2.0.X series then the binfmt_elks.c module
+should be able to compile and install. BUT do note you need the modules
+and probably modversions options and you _may_ have to alter the compile
+command to match those seen when you compile modules that come with the
+kernel.
+
+Rob.

--- a/elksemu/Security
+++ b/elksemu/Security
@@ -1,0 +1,20 @@
+Is is possible to install /usr/bin/elksemu as a suid-root executable.
+This gives two additional facilities when running elks executables.
+
+1) It is now possible to run programs that are execute only, without
+   read permission, as the file is opened while we have superuser
+   access.
+
+2) If the ELKS executable has suid or sgid bits set these will be honoured.
+
+The user now needs execute access to run an executable, this is checked.
+
+If the executable does not have either suid/sgid bits set then all
+extra permissions will be dropped within the first few lines of the
+main() function. Because of this you need only check this tiny
+piece of code if you intend never to use suid.
+
+If you have any problem with elksemu being suid-root the program will
+run as before, with no complaints, if you remove the suid permission.
+
+Rob.

--- a/elksemu/binfmt_elks.c
+++ b/elksemu/binfmt_elks.c
@@ -1,0 +1,116 @@
+/*
+ *  linux/fs/binfmt_elks.c
+ *
+ *  Copyright (C) 1996  Martin von Löwis
+ *  original #!-checking implemented by tytso.
+ *  ELKS hack added by Chad Page...
+ *  Cleaned up some more by Robert de Bath 
+ */
+
+#include <linux/module.h>
+#ifndef LINUX_VERSION_CODE
+#include <linux/version.h>
+#endif
+#include <linux/string.h>
+#include <linux/stat.h>
+#include <linux/malloc.h>
+#include <linux/binfmts.h>
+
+static int do_load_elksaout(struct linux_binprm *bprm,struct pt_regs *regs)
+{
+	char *cp, *interp, *i_name, *i_arg;
+	int retval;
+
+	/* What a horrible hack! :-) */
+	if ((bprm->buf[0] != 1)   || (bprm->buf[1] != 3) || 
+	    (bprm->buf[2] != 0x20 && bprm->buf[2] != 0x10) ||
+	    (bprm->buf[3] != 4) || bprm->sh_bang)
+		return -ENOEXEC;
+
+	bprm->sh_bang++;
+	iput(bprm->inode);
+#if LINUX_VERSION_CODE >= 0x010300
+	bprm->dont_iput=1;
+#endif
+
+	interp = "/lib/elksemu";
+	i_name = interp;
+	i_arg = 0;
+
+	for (cp=i_name; *cp && (*cp != ' ') && (*cp != '\t'); cp++) {
+ 		if (*cp == '/')
+			i_name = cp+1;
+	}
+
+	/*
+	 * OK, we've parsed out the interpreter name and
+	 * (optional) argument.
+	 * Splice in (1) the interpreter's name for argv[0]
+	 *           (2) (optional) argument to interpreter
+	 *           (3) filename of shell script (replace argv[0])
+	 *
+	 * This is done in reverse order, because of how the
+	 * user environment and arguments are stored.
+	 */
+	remove_arg_zero(bprm);
+	bprm->p = copy_strings(1, &bprm->filename, bprm->page, bprm->p, 2);
+	bprm->argc++;
+	if (i_arg) {
+		bprm->p = copy_strings(1, &i_arg, bprm->page, bprm->p, 2);
+		bprm->argc++;
+	}
+	bprm->p = copy_strings(1, &i_name, bprm->page, bprm->p, 2);
+	bprm->argc++;
+	if (!bprm->p) 
+		return -E2BIG;
+	/*
+	 * OK, now restart the process with the interpreter's inode.
+	 * Note that we use open_namei() as the name is now in kernel
+	 * space, and we don't need to copy it.
+	 */
+	retval = open_namei(interp, 0, 0, &bprm->inode, NULL);
+	if (retval)
+		return retval;
+#if LINUX_VERSION_CODE >= 0x010300
+	bprm->dont_iput=0;
+#endif
+	retval=prepare_binprm(bprm);
+	if(retval<0)
+		return retval;
+	return search_binary_handler(bprm,regs);
+}
+
+static int load_elksaout(struct linux_binprm *bprm,struct pt_regs *regs)
+{
+	int retval;
+	MOD_INC_USE_COUNT;
+	retval = do_load_elksaout(bprm,regs);
+	MOD_DEC_USE_COUNT;
+	return retval;
+}
+
+struct linux_binfmt elksaout_format = {
+#ifndef MODULE
+	NULL, 0, load_elksaout, NULL, NULL
+#else
+	NULL, &mod_use_count_, load_elksaout, NULL, NULL
+#endif
+};
+
+int init_elksaout_binfmt(void) {
+	return register_binfmt(&elksaout_format);
+}
+
+#ifdef MODULE
+#if LINUX_VERSION_CODE < 0x010300
+char kernel_version[] = UTS_RELEASE;
+#endif
+int init_module(void)
+{
+	return init_elksaout_binfmt();
+}
+
+void cleanup_module( void) {
+	unregister_binfmt(&elksaout_format);
+}
+#endif

--- a/elksemu/elks.c
+++ b/elksemu/elks.c
@@ -1,0 +1,322 @@
+/*
+ *	ELKSEMU	An emulator for Linux8086 binaries.
+ *
+ *	VM86 is used to process all the 8086 mode code.
+ *	We trap up to 386 mode for system call emulation and naughties. 
+ */
+ 
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdarg.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <sys/vm86.h>
+#include <sys/mman.h>
+#include "elks.h" 
+
+#ifdef __BCC__
+#define OLD_LIBC_VERSION
+#endif
+
+volatile struct vm86_struct elks_cpu;
+unsigned char *elks_base;	/* Paragraph aligned */
+
+#ifdef DEBUG
+#define dbprintf(x) db_printf x
+#else
+#define dbprintf(x) 
+#endif
+
+static void elks_init()
+{
+	elks_cpu.screen_bitmap=0;
+	elks_cpu.cpu_type = CPU_286;
+	/*
+	 *	All INT xx calls are trapped.
+	 */
+	memset((void *)&elks_cpu.int_revectored,0xFF, sizeof(elks_cpu.int_revectored));
+}
+
+static void elks_take_interrupt(int arg)
+{
+#if 1
+	if(arg==0x20) { minix_syscall(); return; }
+#endif
+	if(arg!=0x80)
+	{
+		dbprintf(("Took an int %d\n", arg));
+		fflush(stderr);
+		kill(getpid(), SIGILL);
+		return;
+	}
+	
+	dbprintf(("syscall AX=%x BX=%x CX=%x DX=%x\n",
+		(unsigned short)elks_cpu.regs.eax,
+		(unsigned short)elks_cpu.regs.ebx,
+		(unsigned short)elks_cpu.regs.ecx,
+		(unsigned short)elks_cpu.regs.edx));
+		
+	elks_cpu.regs.eax = elks_syscall();
+	dbprintf(("elks syscall returned %d\n", elks_cpu.regs.eax));
+	/* Finally return to vm86 state */
+}
+
+
+static int load_elks(int fd)
+{
+	/* Load the elks binary image and set it up in a suitable VM86 segment. Load CS and DS/SS
+	   according to image type. chmem is ignored we always use 64K segments */
+	struct elks_exec_hdr mh;
+	unsigned char *dsp;
+	if(read(fd, &mh,sizeof(mh))!=sizeof(mh))
+		return -ENOEXEC;
+	if(mh.hlen!=EXEC_HEADER_SIZE)
+		return -ENOEXEC;
+	if(mh.type!=ELKS_COMBID&&mh.type!=ELKS_SPLITID)
+		return -ENOEXEC;
+#ifdef DEBUG
+	fprintf(stderr,"Linux-86 binary - %lX. tseg=%ld dseg=%ld bss=%ld\n",
+		mh.type,mh.tseg,mh.dseg,mh.bseg);
+#endif
+	if(read(fd,elks_base,mh.tseg)!=mh.tseg)
+		return -ENOEXEC;
+	if(mh.type==ELKS_COMBID)
+		dsp=elks_base+mh.tseg;
+	else
+		dsp=elks_base+65536;
+	if(read(fd,dsp,mh.dseg)!=mh.dseg)
+		return -ENOEXEC;
+	memset(dsp+mh.dseg,0, mh.bseg);
+	/*
+	 *	Load the VM86 registers
+	 */
+	 
+	if(mh.type==ELKS_COMBID)
+		dsp=elks_base;
+	elks_cpu.regs.ds=PARAGRAPH(dsp);
+	elks_cpu.regs.es=PARAGRAPH(dsp);
+	elks_cpu.regs.ss=PARAGRAPH(dsp);
+	elks_cpu.regs.esp=65536; 	/* Args stacked later */
+	elks_cpu.regs.cs=PARAGRAPH(elks_base);
+	elks_cpu.regs.eip=0;		/* Run from 0 */
+	
+	/*
+	 *	Loaded, check for sanity.
+	 */
+	if( dsp != ELKS_PTR(unsigned char, 0) )
+	{
+	   printf("Error VM86 problem %lx!=%lx (Is DS > 16 bits ?)\n",
+	           (long)dsp, (long)ELKS_PTR(char, 0));
+	   exit(0);
+	}
+
+	return 0;
+}
+
+#ifndef OLD_LIBC_VERSION
+  /*
+   *  recent versions of libc have changed the proto for vm86()
+   *  for now I'll just override ...
+   */
+#define OLD_SYS_vm86  113
+#define NEW_SYS_vm86  166
+
+static inline int vm86_mine(struct vm86_struct* v86)
+{
+	int __res;
+	__asm__ __volatile__("int $0x80\n"
+	:"=a" (__res):"a" ((int)OLD_SYS_vm86), "b" ((int)v86));
+	return __res;
+} 
+#endif
+
+void run_elks()
+{
+	/*
+	 *	Execute 8086 code for a while.
+	 */
+#ifndef OLD_LIBC_VERSION
+	int err=vm86_mine((struct vm86_struct*)&elks_cpu);
+#else
+	int err=vm86((struct vm86_struct*)&elks_cpu);
+#endif
+	switch(VM86_TYPE(err))
+	{
+		/*
+		 *	Signals are just re-starts of emulation (yes the
+		 *	handler might alter elks_cpu)
+		 */
+		case VM86_SIGNAL:
+			break;
+		case VM86_UNKNOWN:
+			fprintf(stderr, "VM86_UNKNOWN returned\n");
+			exit(1);
+		case VM86_INTx:
+			elks_take_interrupt(VM86_ARG(err));
+			break;
+		case VM86_STI:
+			fprintf(stderr, "VM86_STI returned\n");
+			break;	/* Shouldnt be seen */
+		default:
+			fprintf(stderr, "Unknown return value from vm86\n");
+			exit(1);
+	}
+}
+
+void build_stack(char ** argv, char ** envp)
+{
+	char **p;
+	int argv_len=0, argv_count=0;
+	int envp_len=0, envp_count=0;
+	int stack_bytes;
+	unsigned short * pip;
+	unsigned short pcp;
+
+	/* How much space for argv */
+	for(p=argv; *p; p++)
+	{
+	   argv_count++; argv_len += strlen(*p)+1;
+	}
+
+	/* How much space for envp */
+	for(p=envp; *p; p++)
+	{
+	   envp_count++; envp_len += strlen(*p)+1;
+	}
+
+	/* tot it all up */
+	stack_bytes = 2				/* argc */
+	            + argv_count * 2 + 2	/* argv */
+		    + argv_len
+		    + envp_count * 2 + 2	/* envp */
+		    + envp_len;
+
+	/* Allocate it */
+	elks_cpu.regs.esp -= stack_bytes;
+
+/* Sanity check 
+	printf("Argv = (%d,%d), Envp=(%d,%d), stack=%d\n",
+	        argv_count, argv_len, envp_count, envp_len, stack_bytes);
+*/
+
+	/* Now copy in the strings */
+	pip=ELKS_PTR(unsigned short, elks_cpu.regs.esp);
+	pcp=elks_cpu.regs.esp+2*(1+argv_count+1+envp_count+1);
+
+	*pip++ = argv_count;
+	for(p=argv; *p; p++)
+	{
+	   *pip++ = pcp;
+	   strcpy(ELKS_PTR(char, pcp), *p);
+	   pcp += strlen(*p)+1;
+	}
+	*pip++ = 0;
+
+	for(p=envp; *p; p++)
+	{
+	   *pip++ = pcp;
+	   strcpy(ELKS_PTR(char, pcp), *p);
+	   pcp += strlen(*p)+1;
+	}
+	*pip++ = 0;
+}
+
+int
+main(int argc, char *argv[], char *envp[])
+{
+	int fd;
+	struct stat st;
+	int ruid, euid, rgid, egid;
+
+	if(argc<=1)
+	{
+		fprintf(stderr,"elksemu cmd args.....\n");
+		exit(1);
+	}
+	/* This uses the _real_ user ID If the file is exec only that's */
+	/* ok cause the suid root will override.  */
+	/* BTW, be careful here, security problems are possible because of 
+	 * races if you change this. */
+
+	if( access(argv[1], X_OK) < 0
+	  || (fd=open(argv[1], O_RDONLY)) < 0
+	  || fstat(fd, &st) < 0
+	  )
+	{
+		perror(argv[1]);
+		exit(1);
+	}
+
+	/* Check the suid bits ... */
+	ruid = getuid(); rgid = getgid();
+	euid = ruid; egid = rgid;
+	if( st.st_mode & S_ISUID ) euid = st.st_uid;
+	if( st.st_mode & S_ISGID ) egid = st.st_gid;
+
+	/* Set the _real_ permissions, or revoke superuser priviliages */
+	setregid(rgid, egid);
+	setreuid(ruid, euid);
+
+	dbprintf(("ELKSEMU\n"));
+	elks_init();
+
+	/* The Linux vm will deal with not allocating the unused pages */
+#if __AOUT__
+#if __GNUC__
+	/* GNU malloc will align to 4k with large chunks */
+	elks_base = malloc(0x20000);
+#else
+	/* But others won't */
+	elks_base = malloc(0x20000+4096);
+	elks_base = (void*) (((int)elks_base+4095) & -4096);
+#endif
+#else
+	/* For ELF first 128M is unmapped, it needs to be mapped manually */
+	elks_base = mmap((void*)0x10000, 0x20000,
+	                  PROT_EXEC|PROT_READ|PROT_WRITE,
+			  MAP_ANON|MAP_PRIVATE|MAP_FIXED, 
+			  0, 0);
+#endif
+	if( (long)elks_base < 0 || (long)elks_base >= 0xE0000 )
+	{
+		fprintf(stderr, "Elks memory is at an illegal address\n");
+		exit(255);
+	}
+	
+	if(load_elks(fd) < 0)
+	{
+		fprintf(stderr,"Not a elks binary.\n");
+		exit(1);
+	}
+	
+	close(fd);
+
+	build_stack(argv+1, envp);
+
+	while(1)
+		run_elks();
+}
+
+#ifdef DEBUG
+void db_printf(const char * fmt, ...)
+{
+static FILE * db_fd = 0;
+  va_list ptr;
+  int rv;
+  if( db_fd == 0 )
+  {
+     db_fd = fopen("/tmp/ELKS_log", "a");
+     if( db_fd == 0 ) db_fd = stderr;
+     setbuf(db_fd, 0);
+  }
+  fprintf(db_fd, "%d: ", getpid());
+  va_start(ptr, fmt);
+  rv = vfprintf(db_fd,fmt,ptr);
+  va_end(ptr);
+}
+#endif

--- a/elksemu/elks.h
+++ b/elksemu/elks.h
@@ -1,0 +1,97 @@
+/*
+ *	Definitions for emulating ELKS
+ */
+ 
+#define ELKS_CS_OFFSET		0
+#define ELKS_DS_OFFSET		0		/* For split I/D */
+
+#define HZ			100
+
+#define ELKS_SIG_IGN		(-1)
+#define ELKS_SIG_DFL		0
+
+#define WRITE_USPACE		0
+#define READ_USPACE		1
+
+#if !__ELF__
+#define __AOUT__		1
+#endif
+
+/*
+ *	Minix view of stat(). We have to squash a bit here and give
+ *	wrong values with inode >65535 etc
+ */
+ 
+struct elks_stat
+{
+	unsigned short est_dev;
+	unsigned short est_inode;
+	unsigned short est_mode;
+	unsigned short est_nlink;
+	unsigned short est_uid;
+	unsigned short est_gid;
+	unsigned short est_rdev;
+	int est_size;
+	int est_atime;
+	int est_mtime;
+	int est_ctime;
+};
+
+
+/*
+ *	Minix ioctl list
+ */
+
+#define 	ELKS_TIOCGETP	(('t'<<8)|8)
+#define		ELKS_TIOCSETP	(('t'<<8)|9)
+#define		ELKS_TIOCGETC	(('t'<<8)|18)
+#define		ELKS_TIOCSETC	(('t'<<8)|17)
+#define 	ELKS_TIOCFLUSH	(('t'<<8)|16)
+
+/*
+ *	fcntl list
+ */
+ 
+#define ELKS_F_DUPFD	0
+#define ELKS_F_GETFD	1
+#define ELKS_F_SETFD	2
+#define ELKS_F_GETFL	3
+#define ELKS_F_SETFL	4
+#define ELKS_F_GETLK	5
+#define ELKS_F_SETLK	6
+#define ELKS_F_SETLKW	7
+
+/*
+ *	Elks binary formats
+ */
+ 
+#define EXEC_HEADER_SIZE	32
+
+struct elks_exec_hdr
+{
+	unsigned long type;
+#define ELKS_COMBID	0x04100301L
+#define ELKS_SPLITID	0x04200301L	
+	unsigned long hlen;
+	unsigned long tseg;
+	unsigned long dseg;
+	unsigned long bseg;
+	unsigned long unused;
+	unsigned long chmem;
+	unsigned long unused2; 
+};
+
+#define PARAGRAPH(x)	(((unsigned long)(x))>>4)
+#define ELKS_DSEG(x)	((unsigned char *)(((x)&0xFFFF)+(elks_cpu.regs.ds<<4)))
+
+#define ELKS_PTR(_t,x)	  ((_t *) ((elks_cpu.regs.ds<<4)+((x)&0xFFFF)) )
+#define ELKS_PEEK(_t,x)	(*((_t *) ((elks_cpu.regs.ds<<4)+((x)&0xFFFF)) ))
+#define ELKS_POKE(_t,x,_v)	\
+		(*((_t *) ((elks_cpu.regs.ds<<4)+((x)&0xFFFF)) ) = (_v))
+
+extern unsigned char * elks_base;
+extern volatile struct vm86_struct elks_cpu;
+
+void db_printf(const char *, ...);
+int elks_syscall(void);
+void minix_syscall(void);

--- a/elksemu/elks_signal.c
+++ b/elksemu/elks_signal.c
@@ -1,0 +1,39 @@
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <sys/vm86.h>
+#include "elks.h" 
+
+static int elks_sigtrap= -1;
+
+void sig_trap(int signo)
+{
+   elks_cpu.regs.esp -= 2;
+   ELKS_POKE(unsigned short, elks_cpu.regs.esp, signo);
+   elks_cpu.regs.esp -= 2;
+   ELKS_POKE(unsigned short, elks_cpu.regs.esp, elks_cpu.regs.eip);
+   elks_cpu.regs.eip = elks_sigtrap;
+}
+
+int elks_signal(int bx,int cx,int dx,int di,int si)
+{
+   void (*oldsig)(int) = 0;
+   if( bx < 0 || bx >= NSIG ) { errno = EINVAL; return -1; }
+   if( cx == 0 )      oldsig = signal(bx, SIG_DFL);
+   else if( cx == 1 ) oldsig = signal(bx, SIG_IGN);
+   else 
+   {
+      elks_sigtrap = cx;
+      oldsig = signal(bx, sig_trap);
+   }
+   if( oldsig == SIG_ERR) return -1;
+   if( oldsig == SIG_DFL) return 0;
+   if( oldsig == SIG_IGN) return 1;
+   return 2;
+}

--- a/elksemu/elks_signal.c
+++ b/elksemu/elks_signal.c
@@ -7,18 +7,17 @@
 #include <signal.h>
 #include <errno.h>
 #include <sys/stat.h>
-#include <sys/vm86.h>
 #include "elks.h" 
 
 static int elks_sigtrap= -1;
 
 void sig_trap(int signo)
 {
-   elks_cpu.regs.esp -= 2;
-   ELKS_POKE(unsigned short, elks_cpu.regs.esp, signo);
-   elks_cpu.regs.esp -= 2;
-   ELKS_POKE(unsigned short, elks_cpu.regs.esp, elks_cpu.regs.eip);
-   elks_cpu.regs.eip = elks_sigtrap;
+   elks_cpu.regs.xsp -= 2;
+   ELKS_POKE(unsigned short, elks_cpu.regs.xsp, signo);
+   elks_cpu.regs.xsp -= 2;
+   ELKS_POKE(unsigned short, elks_cpu.regs.xsp, elks_cpu.regs.xip);
+   elks_cpu.regs.xip = elks_sigtrap;
 }
 
 int elks_signal(int bx,int cx,int dx,int di,int si)

--- a/elksemu/elks_sys.c
+++ b/elksemu/elks_sys.c
@@ -1,0 +1,781 @@
+/*
+ * System calls are mostly pretty easy as the emulator is tightly bound to
+ * the elks task.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/vm86.h>
+#include <sys/times.h>
+#include <utime.h>
+#include <termios.h>
+#include <time.h>
+#include <signal.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/resource.h>
+#include <sys/wait.h>
+#include <sys/ioctl.h>
+#include <dirent.h>
+#include <sys/time.h>
+#include "elks.h" 
+
+#include "efile.h"
+
+#ifdef DEBUG
+#define dbprintf(x) db_printf x
+#else
+#define dbprintf(x)
+#endif
+
+#define sys_signal elks_signal
+extern int elks_signal(int bx,int cx,int dx,int di,int si);
+
+/* Forward refs */
+static int elks_termios(int bx,int cx,int dx,int di,int si);
+static int elks_enosys(int bx,int cx,int dx,int di,int si);
+
+#define DIRCOUNT 20
+DIR * dirtab[DIRCOUNT];
+int diropen = 0;
+static int elks_opendir(char * dname);
+static int elks_readdir(int bx,int cx,int dx,int di,int si);
+static int elks_closedir(int bx);
+
+/*
+ *	Compress a host stat into a elks one. Lose upper bits with wild
+ *	abandon. For SYS5.3 this isn't a problem, but machines with 32
+ *	bit inodes (BSD, SYS5 with veritas, newest SCO) you lose the top
+ *	bits which can confuse a few programs which use inode numbers 
+ *	(eg gnu tar).
+ */
+ 
+static void squash_stat(struct stat *s, int bx)
+{
+#if 1	/* Can't use elks_stat, shot in the foot by alignment */
+
+	ELKS_POKE(short, bx+0, s->st_dev);
+	ELKS_POKE(short, bx+2, s->st_ino ^ (s->st_ino>>16));
+	ELKS_POKE(short, bx+4, s->st_mode);
+	ELKS_POKE(short, bx+6, s->st_nlink);
+	ELKS_POKE(short, bx+8, s->st_uid);
+	ELKS_POKE(short, bx+10, s->st_gid);
+	ELKS_POKE(short, bx+12, s->st_rdev);
+	ELKS_POKE(long, bx+14, s->st_size);
+	ELKS_POKE(long, bx+18, s->st_atime);
+	ELKS_POKE(long, bx+22, s->st_mtime);
+	ELKS_POKE(long, bx+26, s->st_ctime);
+#else
+	struct elks_stat * ms = ELKS_PTR(struct elks_stat, bx);
+	ms->est_dev=s->st_dev;
+	ms->est_inode=(unsigned short)s->st_ino;	/* Bits lost */
+	ms->est_mode=s->st_mode;
+	ms->est_nlink=s->st_nlink;
+	ms->est_uid=s->st_uid;
+	ms->est_gid=s->st_gid;
+	ms->est_rdev=s->st_rdev;
+	ms->est_size=s->st_size;
+	ms->est_atime=s->st_atime;
+	ms->est_mtime=s->st_mtime;
+	ms->est_ctime=s->st_ctime;
+#endif
+}
+
+/*
+ *	Implementation of ELKS syscalls.
+ */
+ 
+ 
+#define sys_exit elks_exit
+static int elks_exit(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("exit(%d)\n",bx));
+	exit(bx);
+}
+
+#define sys_vfork elks_fork
+#define sys_fork elks_fork
+static int elks_fork(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("fork()\n"));
+	/* This is fun 8) - fork the emulator (its easier that way) */
+	return fork();
+}
+
+#define sys_read elks_read
+static int elks_read(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("read(%d, %d, %d)\n",
+		bx,cx,dx));
+	if( bx >= 10000 && bx < 10000+DIRCOUNT)
+		return elks_readdir(bx, cx, dx, di, si);
+	if( dx < 0 || dx > 1024 ) dx = 1024;
+	return read(bx, ELKS_PTR(void, cx), dx);
+}
+
+#define sys_write elks_write
+static int elks_write(int bx,int cx,int dx,int di,int si)
+{
+#ifdef TESTING
+	if( dx > 1024 || dx < 0 )
+	{
+	   dx = 1024;
+	   dbprintf(("write(%d, %d, >%d)\n",bx,cx,dx));
+	}
+	else 
+#endif
+	{
+	   dbprintf(("write(%d, %d, %d)\n",bx,cx,dx));
+	}
+	return write(bx,ELKS_PTR(void, cx),dx);
+}
+
+#define sys_open elks_open
+static int elks_open(int bx,int cx,int dx,int di,int si)
+{
+	struct stat s;
+
+	/* Assumes _all_ flags are the same */
+	char *dp=ELKS_PTR(char, bx);
+	dbprintf(("open(%s, %d, %d)\n",
+		dp,cx,dx));
+
+	/* Nasty hack so /lib/liberror.txt doesn't exist on the host.
+	 */
+	if (strcmp(dp, "/lib/liberror.txt") == 0 ) {
+	   int fd = open("/tmp/liberror.txt", O_CREAT|O_EXCL|O_RDWR, 0666);
+	   if (fd < 0) return fd;
+	   unlink("/tmp/liberror.txt");
+	   write(fd, efile, sizeof(efile));
+	   lseek(fd, 0L, 0);
+	   return fd;
+	}
+
+	if( cx == O_RDONLY )
+	{
+		if(stat(dp,&s)==-1)
+			return -1;
+		if( S_ISDIR(s.st_mode) )
+			return elks_opendir(dp);
+	}
+
+	return open(dp,cx,dx);
+}
+
+#define sys_close elks_close
+static int elks_close(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("close(%d)\n",bx));
+	if( bx >= 10000 && bx < 10000+DIRCOUNT)
+		return elks_closedir(bx);
+	return close(bx);
+}
+
+#define sys_wait4 elks_wait4
+static int elks_wait4(int bx,int cx,int dx,int di,int si)
+{
+	int status;
+	unsigned short *tp=ELKS_PTR(unsigned short, cx);
+	int r;
+	struct rusage use;
+
+	dbprintf(("wait4(%d, %d, %d, %d)\n", bx, cx, dx, di));
+	r=wait4((int)(short)bx, &status, dx, &use );
+
+	*tp=status;
+	if( di ) memcpy(ELKS_PTR(void, di), &use, sizeof(use));
+	return r;
+}
+
+#define sys_link elks_link
+static int elks_link(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("link(%s,%s)\n", ELKS_PTR(char, bx), ELKS_PTR(char, cx)));
+	return link(ELKS_PTR(char, bx),ELKS_PTR(char, cx));
+}
+
+#define sys_unlink elks_unlink
+static int elks_unlink(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("unlink(%s)\n",ELKS_PTR(char, bx)));
+	return unlink(ELKS_PTR(char, bx));
+}
+
+#define sys_chdir elks_chdir
+static int elks_chdir(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("chdir(%s)\n",ELKS_PTR(char, bx)));
+	return chdir(ELKS_PTR(char, bx));
+}
+
+#define sys_fchdir elks_fchdir
+static int elks_fchdir(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("fchdir(%s)\n",bx));
+	return fchdir(bx);
+}
+
+
+#define sys_mknod elks_mknod
+static int elks_mknod(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("mknod(%s,%d,%d)\n", ELKS_PTR(char, bx),cx,dx));
+	return mknod(ELKS_PTR(char, bx),cx,dx);
+}
+
+#define sys_chmod elks_chmod
+static int elks_chmod(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("chmod(%s,%d)\n", ELKS_PTR(char, bx),cx));
+	return chmod(ELKS_PTR(char, bx), cx);
+}
+
+#define sys_chown elks_chown
+static int elks_chown(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("chown(%s,%d,%d)\n", ELKS_PTR(char, bx),cx,dx));
+	return chown(ELKS_PTR(char, bx),cx,dx);
+}
+
+#define sys_brk elks_brk
+static int elks_brk(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("brk(%d)\n",bx));	
+	if(bx>=elks_cpu.regs.esp)
+	{
+		errno= 1;	/* Really return -1 */
+		return -1;
+	}
+	return 0;		/* Can't return bx, 0xBAD1 is an error */
+}
+
+#define sys_stat elks_stat
+static int elks_stat(int bx,int cx,int dx,int di,int si)
+{
+	struct stat s;
+	dbprintf(("stat(%s,%d)\n", ELKS_PTR(char, bx), cx));
+	if(stat(ELKS_PTR(char, bx),&s)==-1)
+		return -1;
+	squash_stat(&s,cx);
+	return 0;
+}
+
+#define sys_lstat elks_lstat
+static int elks_lstat(int bx,int cx,int dx,int di,int si)
+{
+	struct stat s;
+	dbprintf(("lstat(%s,%d)\n", ELKS_PTR(char, bx), cx));
+	if(lstat(ELKS_PTR(char, bx),&s)==-1)
+		return -1;
+	squash_stat(&s,cx);
+	return 0;
+}
+
+#define sys_lseek elks_lseek
+static int elks_lseek(int bx,int cx,int dx,int di,int si)
+{
+	long l=ELKS_PEEK(long, cx);
+	
+	dbprintf(("lseek(%d,%ld,%d)\n",bx,l,dx));
+	l = lseek(bx,l,dx);
+	if( l < 0 ) return -1;
+	ELKS_POKE(long, cx, l);
+	return 0;
+}
+
+#define sys_getpid elks_getpid
+static int elks_getpid(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("getpid/getppid()\n"));
+	ELKS_POKE(unsigned short, bx, getppid());
+	return getpid();
+}
+
+#define sys_setuid elks_setuid
+static int elks_setuid(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("setuid(%d)\n",bx));
+	return setuid(bx);
+}
+
+#define sys_getuid elks_getuid
+static int elks_getuid(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("get[e]uid()\n"));
+	ELKS_POKE(unsigned short, bx, geteuid());
+	return getuid();
+}
+
+#define sys_alarm elks_alarm
+static int elks_alarm(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("alarm(%d)\n",bx&0xFFFF));
+	return alarm(bx&0xFFFF);
+}
+
+#define sys_fstat elks_fstat
+static int elks_fstat(int bx,int cx,int dx,int di,int si)
+{
+	struct stat s;
+	int err;
+	dbprintf(("fstat(%d,%d)\n",bx,cx));
+	err=fstat(bx,&s);
+	squash_stat(&s,cx);
+	return err;
+}
+
+#define sys_pause elks_pause
+static int elks_pause(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("pause()\n"));
+	return pause();
+}
+
+#define sys_utime elks_utime
+static int elks_utime(int bx,int cx,int dx,int di,int si)
+{
+	unsigned long *up=ELKS_PTR(long, cx);
+	struct utimbuf u;
+	u.actime=*up++;
+	u.modtime=*up;
+	return utime(ELKS_PTR(char, bx), &u);
+}
+
+#define sys_access elks_access
+static int elks_access(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("access(%s,%d)\n",ELKS_PTR(char, bx),cx));
+	return access(ELKS_PTR(char, bx),cx);
+}
+
+#define sys_sync elks_sync
+static int elks_sync(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("sync()\n"));
+	sync();
+	return 0;
+}
+
+#define sys_kill elks_kill
+static int elks_kill(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("kill(%d,%d)\n",bx,cx));
+	return kill(bx,cx);
+}
+
+#define sys_pipe elks_pipe
+static int elks_pipe(int bx,int cx,int dx,int di,int si)
+{
+	unsigned short *dp=ELKS_PTR(unsigned short, bx);
+	int p[2];
+	int err=pipe(p);
+	if(err==-1)
+		return err;
+	*dp++=p[0];
+	*dp=p[1];
+	return 0;
+}
+
+#define sys_times elks_times
+static int elks_times(int bx,int cx,int dx,int di,int si)
+{
+	struct tms t;
+	long clock_ticks=times(&t);
+	long *tp=ELKS_PTR(long, bx);
+	long *clkt=ELKS_PTR(long, cx);
+	*tp++=t.tms_utime;
+	*tp++=t.tms_stime;
+	*tp++=t.tms_cutime;
+	*tp=t.tms_cstime;
+	*clkt = clock_ticks;
+	return 0;	/* Should be clock_ticks */
+}
+
+#define sys_setgid elks_setgid
+static int elks_setgid(int bx,int cx,int dx,int di,int si)
+{
+	return setgid(bx);
+}
+
+#define sys_getgid elks_getgid
+static int elks_getgid(int bx,int cx,int dx,int di,int si)
+{
+	ELKS_POKE(unsigned short, bx, getegid());
+	return getgid();
+}
+
+/*
+ * Exec is fun. The Minix user library builds a complete elks stack image.
+ * Great except that we need to unpack it all again and do a real exec. If
+ * its another elks image then our kernel side binary loader will load
+ * elksemu again and we'll take the Unix args and turn them back into a
+ * elks stack image.
+ * 
+ * For now we run elksemu ourselves and do token attempts at binary checking.
+ *
+ * Of course if the kernel misc module is confiured we could just run the exe.
+ */
+#define sys_execve elks_execve
+static int elks_execve(int bx,int cx,int dx,int di,int si)
+{
+	int fd;
+	int arg_ct,env_ct;
+	int ct;
+	char **argp, **envp;
+	unsigned short *bp;
+	unsigned char *base;
+	unsigned short *tmp;
+	struct elks_exec_hdr mh;
+	int is_elks = 1;
+	
+	dbprintf(("exec(%s,%d,%d)\n",ELKS_PTR(char, bx), cx, dx));
+
+	base=ELKS_PTR(unsigned char, cx);
+	bp=ELKS_PTR(unsigned short, cx+2);
+	tmp=bp;
+
+	fd=open(ELKS_PTR(char, bx),O_RDONLY);
+	if(fd==-1)
+	{ errno = ENOENT; return -1; }
+	if(read(fd, &mh, sizeof(mh))!=sizeof(mh))
+	{
+		close(fd);
+		errno = ENOEXEC;
+		return -1;
+	}
+	close(fd);
+	if(mh.hlen!=EXEC_HEADER_SIZE
+	   || (mh.type!=ELKS_COMBID && mh.type!=ELKS_SPLITID))
+	   is_elks = 0;
+
+	arg_ct = env_ct = 0;
+	while(*tmp++)
+		arg_ct++;
+	while(*tmp++)
+		env_ct++;
+	arg_ct+=2;	/* elksemu-path progname arg0...argn */
+	argp=malloc(sizeof(char *)*(arg_ct+1));
+	envp=malloc(sizeof(char *)*(env_ct+1));
+	if(!argp||!envp) { errno = ENOMEM; return -1; }
+	ct=0;
+	if( is_elks )
+	{
+	   argp[0]="/usr/bin/elksemu";
+	   /* argp[1]=ELKS_PTR(char, bx); */
+	   ct=1;
+	}
+	while(*bp)
+		argp[ct++]=ELKS_PTR(char, cx+ *bp++);
+	argp[ct]=0;
+	bp++;
+	ct=0;
+	while(*bp)
+		envp[ct++]=ELKS_PTR(char, cx+ *bp++);
+	envp[ct]=0;
+	if( is_elks )
+	{
+	   argp[1]=ELKS_PTR(char, bx);
+	   execve(argp[0],argp,envp);
+	}
+	else
+	   execve(ELKS_PTR(char, bx),argp,envp);
+	if( errno == ENOEXEC || errno == EACCES ) return -1;
+	perror("elksemu");
+	exit(1);
+}
+
+#define sys_umask elks_umask
+static int elks_umask(int bx,int cx,int dx,int di,int si)
+{
+	return umask(bx);
+}
+
+#define sys_chroot elks_chroot
+static int elks_chroot(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("chroot(%s)\n", ELKS_PTR(char, bx)));
+	return chroot(ELKS_PTR(char, bx));
+}
+
+
+#define sys_fcntl elks_fcntl
+static int elks_fcntl(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("fcntl(%d,%d,%d)\n", bx,cx,dx));
+	switch(cx)
+	{
+		case ELKS_F_GETFD:
+			return fcntl(bx,F_GETFD,0);
+		case ELKS_F_GETFL:
+			return fcntl(bx,F_GETFL,0);
+		case ELKS_F_DUPFD:
+			return fcntl(bx,F_DUPFD,dx);
+		case ELKS_F_SETFD:
+			return fcntl(bx,F_SETFD,dx);
+		case ELKS_F_SETFL:
+			return fcntl(bx,F_SETFL,dx);
+		/*
+		 *	Fixme: Unpack and process elks file locks 
+		 */
+		case ELKS_F_GETLK:
+		case ELKS_F_SETLK:
+		case ELKS_F_SETLKW:
+			errno = EINVAL;
+			return -1;
+	}
+	errno = EINVAL;
+	return -1;
+}
+
+#define sys_dup elks_dup
+static int elks_dup(int bx,int cx,int dx,int di,int si)
+{
+	return dup(bx);
+}
+
+#define sys_dup2 elks_dup2
+static int elks_dup2(int bx,int cx,int dx,int di,int si)
+{
+	return dup2(bx, cx);
+}
+
+#define sys_rename elks_rename
+static int elks_rename(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("rename(%s,%s)\n", ELKS_PTR(char, bx), ELKS_PTR(char, cx)));
+	return rename(ELKS_PTR(char, bx), ELKS_PTR(char, cx));
+}
+
+#define sys_mkdir elks_mkdir
+static int elks_mkdir(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("mkdir(%s,%d)\n", ELKS_PTR(char, bx),cx));
+	return mkdir(ELKS_PTR(char, bx),cx);
+}
+
+#define sys_rmdir elks_rmdir
+static int elks_rmdir(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("rmdir(%s)\n", ELKS_PTR(char, bx)));
+	return rmdir(ELKS_PTR(char, bx));
+}
+
+#define sys_gettimeofday elks_gettimeofday
+static int elks_gettimeofday(int bx,int cx,int dx,int di,int si)
+{
+	struct timeval tv;
+	struct timezone tz;
+	int ax;
+	dbprintf(("gettimeofday(%d,%d)\n",bx,cx));
+
+	ax = gettimeofday(&tv, &tz);
+
+	if( ax == 0 && bx )
+	{
+	   ELKS_POKE(long, bx, tv.tv_sec);
+	   ELKS_POKE(long, bx+4, tv.tv_usec);
+	}
+	if( ax == 0 && cx )
+	{
+	   ELKS_POKE(short, cx, tz.tz_minuteswest);
+	   ELKS_POKE(short, cx+2, tz.tz_dsttime);
+	}
+	return ax?-1:0;
+}
+
+#define sys_settimeofday elks_settimeofday
+static int elks_settimeofday(int bx,int cx,int dx,int di,int si)
+{
+	struct timeval tv, *pv = 0;
+	struct timezone tz, *pz = 0;
+	int ax;
+	dbprintf(("settimeofday(%d,%d)\n",bx,cx));
+
+	if( bx )
+	{
+	   pv = &tv;
+	   tv.tv_sec  = ELKS_PEEK(long, bx);
+	   tv.tv_usec = ELKS_PEEK(long, bx+4);
+	}
+	if( cx )
+	{
+	   pz = &tz;
+	   tz.tz_minuteswest = ELKS_PEEK(short, cx);
+	   tz.tz_dsttime =     ELKS_PEEK(short, cx+2);
+	}
+
+	ax = settimeofday(pv, pz);
+	return ax?-1:0;
+}
+
+#define sys_nice elks_nice
+static int elks_nice(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("nice(%d)\n",bx));
+	return nice(bx);
+}
+
+#define sys_symlink elks_symlink
+static int elks_symlink(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("symlink(%s,%s)\n", ELKS_PTR(char, bx), ELKS_PTR(char, cx)));
+	return symlink(ELKS_PTR(char, bx), ELKS_PTR(char, cx));
+}
+
+#define sys_readlink elks_readlink
+static int elks_readlink(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("readlink(%s,%s,%d)\n",
+		ELKS_PTR(char, bx),
+		ELKS_PTR(char, cx),
+		dx));
+	return readlink(ELKS_PTR(char, bx), ELKS_PTR(char, cx), dx);
+}
+
+#define sys_ioctl elks_ioctl
+static int elks_ioctl(int bx,int cx,int dx,int di,int si)
+{
+	dbprintf(("ioctl(%d,0x%04x,0x%04x)\n", bx,cx,dx));
+	switch((cx>>8)&0xFF)
+	{
+	case 'T': return elks_termios(bx,cx,dx,di,si);
+	default:  return elks_enosys(bx,cx,dx,di,si);
+	}
+}
+
+#define sys_reboot elks_reboot
+static int elks_reboot(int bx,int cx,int dx,int di,int si)
+{
+   errno = EINVAL;
+   if( bx != 0xfee1 || cx != 0xdead ) return -1;
+
+   switch(dx)
+   {
+   /* graceful shutdown, C-A-D off, kill -? 1 */
+   case 0:     return reboot(0xfee1dead, 672274793, 0);
+   /* Enable C-A-D */
+   case 0xCAD: return reboot(0xfee1dead, 672274793, 0x89abcdef);
+   /* Time to die! */
+   case 0xD1E: return reboot(0xfee1dead, 672274793, 0x1234567);
+   }
+   return -1;
+}
+
+/****************************************************************************/
+
+static int
+elks_opendir(char * dname)
+{
+	DIR * d;
+	int rv;
+	for(rv=0; rv<DIRCOUNT; rv++)
+		if( dirtab[rv] == 0 )
+			break;
+	if( rv >= DIRCOUNT ) { errno=ENOMEM; return -1; }
+	d = opendir(dname);
+	if( d == 0 ) return -1;
+	dirtab[rv] = d;
+	return 10000+rv;
+}
+
+#define sys_readdir elks_readdir
+static int elks_readdir(int bx,int cx,int dx,int di,int si)
+{
+	struct dirent * ent;
+
+	/* Only read _ONE_ _WHOLE_ dirent at a time */
+	if( dx != 266 && dx != 1 )
+	{
+		errno=EINVAL; return -1;
+	}
+	errno = 0;
+	ent = readdir(dirtab[bx-10000]);
+	if( ent == 0 ) { if( errno ) { return -1; } else return 0; }
+
+	memcpy(ELKS_PTR(char, cx+10), ent->d_name, ent->d_reclen+1);
+	ELKS_POKE(long, cx, ent->d_ino);
+	ELKS_POKE(short, cx+8, ent->d_reclen);
+	return dx;
+}
+
+static int
+elks_closedir(int bx)
+{
+	bx-=10000;
+	if( dirtab[bx] ) closedir(dirtab[bx]);
+	dirtab[bx] = 0;
+	return 0;
+}
+
+/****************************************************************************/
+
+static int elks_termios(int bx,int cx,int dx,int di,int si)
+{
+   int rv = 0;
+   switch(cx&0xFF)
+   {
+   case 0x01: rv = ioctl(bx, TCGETS, ELKS_PTR(void, dx)); break;
+   case 0x02: rv = ioctl(bx, TCSETS, ELKS_PTR(void, dx)); break;
+   case 0x03: rv = ioctl(bx, TCSETSW, ELKS_PTR(void, dx)); break;
+   case 0x04: rv = ioctl(bx, TCSETSF, ELKS_PTR(void, dx)); break;
+
+   case 0x09: rv = ioctl(bx, TCSBRK, dx); break;
+   case 0x0A: rv = ioctl(bx, TCXONC, dx); break;
+   case 0x0B: rv = ioctl(bx, TCFLSH, dx); break;
+
+   case 0x11: rv = ioctl(bx, TIOCOUTQ, ELKS_PTR(void, dx)); break;
+   case 0x1B: rv = ioctl(bx, TIOCINQ, ELKS_PTR(void, dx)); break;
+
+   default: rv = -1; errno = EINVAL; break;
+   }
+   return rv;
+}
+
+/****************************************************************************/
+/*                                                                          */
+/****************************************************************************/
+#define sys_enosys elks_enosys
+static int elks_enosys(int bx,int cx,int dx,int di,int si)
+{
+	fprintf(stderr, "Function number %d called (%d,%d,%d)\n",
+	                 (int)(0xFFFF&elks_cpu.regs.eax),
+			 bx, cx, dx);
+	errno = ENOSYS;
+	return -1;
+}
+
+#include "defn_tab.v"
+/* * */
+
+typedef int (*funcp)(int, int, int, int, int);
+
+static funcp jump_tbl[] = {
+#include "call_tab.v"
+   elks_enosys
+};
+ 
+int elks_syscall(void)
+{
+	int r, n;
+	int bx=elks_cpu.regs.ebx&0xFFFF;
+	int cx=elks_cpu.regs.ecx&0xFFFF;
+	int dx=elks_cpu.regs.edx&0xFFFF;
+	int di=elks_cpu.regs.edi&0xFFFF;
+	int si=elks_cpu.regs.esi&0xFFFF;
+	
+	errno=0;
+	n = (elks_cpu.regs.eax&0xFFFF);
+	if( n>= 0 && n< sizeof(jump_tbl)/sizeof(funcp) )
+	   r = (*(jump_tbl[n]))(bx, cx, dx, di, si);
+	else
+		return -ENOSYS;
+
+	if(r>=0)
+		return r;
+	else
+		return -errno;
+}

--- a/elksemu/minix.c
+++ b/elksemu/minix.c
@@ -1,0 +1,66 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/vm86.h>
+#include <sys/times.h>
+#include <utime.h>
+#include <termios.h>
+#include <time.h>
+#include <signal.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/resource.h>
+#include <sys/wait.h>
+#include <sys/ioctl.h>
+#include <dirent.h>
+#include "elks.h"
+
+#ifdef DEBUG
+#define dbprintf(x) db_printf x
+#else
+#define dbprintf(x)
+#endif
+
+static char * minix_names[] = {
+   "0", "EXIT", "FORK", "READ", "WRITE", "OPEN", "CLOSE", "WAIT",
+   "CREAT", "LINK", "UNLINK", "WAITPID", "CHDIR", "TIME", "MKNOD",
+   "CHMOD", "CHOWN", "BRK", "STAT", "LSEEK", "GETPID", "MOUNT",
+   "UMOUNT", "SETUID", "GETUID", "STIME", "PTRACE", "ALARM", "FSTAT",
+   "PAUSE", "UTIME", "31", "32", "ACCESS", "34", "35", "SYNC", "KILL",
+   "RENAME", "MKDIR", "RMDIR", "DUP", "PIPE", "TIMES", "44", "45",
+   "SETGID", "GETGID", "SIGNAL", "49", "50", "51", "52", "53", "IOCTL",
+   "FCNTL", "56", "57", "58", "EXEC", "UMASK", "CHROOT", "SETSID",
+   "GETPGRP", "KSIG", "UNPAUSE", "66", "REVIVE", "TASK_REPLY", "69",
+   "70", "SIGACTION", "SIGSUSPEND", "SIGPENDING", "SIGPROCMASK",
+   "SIGRETURN", "REBOOT", "77"
+
+   };
+
+void
+minix_syscall()
+{
+   static char *nm[4] = {"?", "send", "receive", "sendrec"};
+   char   tsks[10], syss[10];
+
+   int   sr  = (unsigned short) elks_cpu.regs.ecx;
+   int   tsk = (unsigned short) elks_cpu.regs.eax;
+   int   sys = ELKS_PEEK(short, (unsigned short) elks_cpu.regs.ebx + 2);
+
+   if (sr < 0 || sr > 3) sr = 0;
+   switch(tsk)
+   {
+   case 0:  strcpy(tsks, "MM"); break;
+   case 1:  strcpy(tsks, "FS"); break;
+   default: sprintf(tsks, "task(%d)", tsk);
+   }
+   if( sys > 0 && sys < 77 )
+      strcpy(syss, minix_names[sys]);
+   else
+      sprintf(syss, "%d", sys);
+
+   fprintf(stderr, "Minix syscall %s(%s,&{%d,%s,...})\n", nm[sr], tsks, getpid(), syss);
+   exit(99);
+}

--- a/elksemu/minix.c
+++ b/elksemu/minix.c
@@ -4,7 +4,6 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>
-#include <sys/vm86.h>
 #include <sys/times.h>
 #include <utime.h>
 #include <termios.h>
@@ -45,9 +44,9 @@ minix_syscall()
    static char *nm[4] = {"?", "send", "receive", "sendrec"};
    char   tsks[10], syss[10];
 
-   int   sr  = (unsigned short) elks_cpu.regs.ecx;
-   int   tsk = (unsigned short) elks_cpu.regs.eax;
-   int   sys = ELKS_PEEK(short, (unsigned short) elks_cpu.regs.ebx + 2);
+   int   sr  = (unsigned short) elks_cpu.regs.xcx;
+   int   tsk = (unsigned short) elks_cpu.regs.xax;
+   int   sys = ELKS_PEEK(short, (unsigned short) elks_cpu.regs.xbx + 2);
 
    if (sr < 0 || sr > 3) sr = 0;
    switch(tsk)

--- a/elksemu/mkefile
+++ b/elksemu/mkefile
@@ -1,0 +1,11 @@
+#!/bin/sh - 
+
+awk '
+BEGIN {
+   printf "char efile[] =\n"
+}
+{ printf "   \"%s\\n\"\n", $0 }
+END{
+   printf ";\n";
+}
+' < "$1" > efile.h

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -190,6 +190,9 @@ $(LIBC):
 
 ifneq "" "$(DESTDIR)"
 .PHONY: install uninstall
+# Besides installing library files and header files, also install the system
+# call tables call_tab.v and defn_tab.v in a reasonable place.  The elksemu
+# build process needs these.
 install uninstall:
 	set -e \
 	$(foreach ml,$(BUILDMULTIS), ; \
@@ -197,6 +200,17 @@ install uninstall:
 		export MULTILIB='$(strip $(subst @, -, \
 		    $(lastword $(subst ;, ,$(ml)))))'; \
 		$(MAKE) $@)
+	set -e; \
+	dest=$(DESTDIR)/share/misc/elks; \
+	case $@ in \
+	    install) \
+		mkdir -p "$$dest"; \
+		cp build-ml/$(MAINMULTISUBDIR)/system/call_tab.v \
+		   build-ml/$(MAINMULTISUBDIR)/system/defn_tab.v "$$dest";; \
+	    *) \
+		$(RM) "$$dest"/call_tab.v "$$dest"/defn_tab.v; \
+		rmdir -p "$$dest" || true;; \
+	esac
 endif
 
 endif


### PR DESCRIPTION
These commits

 * add in the code for `elksemu` from the `dev86` project, including my proposed patches to get `elksemu` working on Linux/x86-64 and not just Linux/x86-32 (https://github.com/jbruchon/dev86/pull/18);
  * modifies the `elks-libc` installation process to install `call_tab.v` and `defn_tab.v`, so that the `elksemu` build process can more easily find them;
  * and modifies the main ELKS makefile to build everything.

Thank you!