### PR TITLE
[libc] fix: syscall.awk now zots +'s when memoizing syscall nos.

### DIFF
--- a/libc/system/syscall.awk
+++ b/libc/system/syscall.awk
@@ -14,7 +14,7 @@ BEGIN {
 /^[	 ]*#/ { next; }
 /^[	 ]*$/ { next; }
 {
-	callno = $2;
+	callno = $2 + 0;
 	if (!(callno in calltab))
 		callwas [callno] = $1;
 


### PR DESCRIPTION
I stumbled upon this bug in the `elks-libc` build process while preparing packages for `elksemu` [on `launchpad.net`](https://launchpad.net/~tkchia/+archive/ubuntu/build-ia16).

It seems, given a line in `syscall.dat` like
```
read            +3      3
```
the `syscall.awk` script --- under certain `awk`'s (?) --- would remember that there is a syscall numbered `"+3"`.

But when looking up the syscall later, for producing the `call_tab.v` and `defn_tab.v` files, the script would look for `"3"` (sans `"+"`), and fail to find it.  Thus it would mistakenly believe that the syscall `"3"` was unimplemented (`sys_enosys`), and say so in `call_tab.v` and `defn_tab.v`.

This small patch fixes this problem, by forcing the `"+3"` to be interpreted as a numeric value.

Thank you!