### PR TITLE
[libc] fix: various things warned by gcc-ia16

### DIFF
--- a/libc/error/error.c
+++ b/libc/error/error.c
@@ -3,6 +3,9 @@
  * under the GNU Library General Public License.
  */
 #include <string.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
 
 char **__sys_errlist =0;
 int __sys_nerr = 0;
@@ -11,7 +14,7 @@ char *
 strerror(err)
 int err;
 {
-   int fd;
+   int fd = -1;
    static char retbuf[80];
    char inbuf[256];
    int cc;

--- a/libc/error/perror.c
+++ b/libc/error/perror.c
@@ -1,5 +1,6 @@
-
 #include <errno.h>
+#include <string.h>
+#include <unistd.h>
 
 void
 perror(str)

--- a/libc/getent/utent.c
+++ b/libc/getent/utent.c
@@ -137,7 +137,7 @@ pututline(const struct utmp * utmp_entry)
 
   /* Ignoring untrapped errors */
   errno=xerrno;
-  return utmp_entry;
+  return (struct utmp *) utmp_entry;
 }
 
 void

--- a/libc/include/stdlib.h
+++ b/libc/include/stdlib.h
@@ -55,6 +55,9 @@ void exit (int status);
 void * malloc (size_t size);
 void free (void * ptr);
 
+#ifndef __STRICT_ANSI__
 void breakpoint ();
+char *itoa __P ((int));
+#endif
 
 #endif /* __STDLIB_H */

--- a/libc/include/string.h
+++ b/libc/include/string.h
@@ -28,6 +28,9 @@ extern int memcmp __P ((__const void*, __const void*, size_t));
 
 extern void * memmove __P ((void*, void*, size_t));
 
+/* Error messages */
+extern char * strerror __P ((int));
+
 /* Minimal (very!) locale support */
 #define strcoll strcmp
 #define strxfrm strncpy

--- a/libc/malloc/heap.c
+++ b/libc/malloc/heap.c
@@ -8,6 +8,8 @@
 
 //-----------------------------------------------------------------------------
 
+int _sbrk (intptr_t, void **);
+
 void * sbrk (intptr_t increment)
 {
    void * new_brk;
@@ -20,6 +22,8 @@ void * sbrk (intptr_t increment)
 //-----------------------------------------------------------------------------
 
 // TODO: simplify
+
+int _brk (void *);
 
 int brk (void * addr)
 {

--- a/libc/malloc/malloc.c
+++ b/libc/malloc/malloc.c
@@ -148,7 +148,6 @@ void *ptr;
 #ifdef __MINI_MALLOC__
       if (__alloca_alloc == __mini_malloc && __freed_list)
       {
-         mem *prev, *curr;
 	 chk = __freed_list;
 	 __freed_list = m_next(__freed_list);
 	 goto try_this;


### PR DESCRIPTION
This fix addresses `gcc-ia16`'s warning messages for `libc/error/`{`error`, `perror`}`.c`, `libc/getent/utent.c`, and `libc/malloc/`{`heap`, `malloc`}`.c`.