### PR TITLE
[boot] shrink bootblocks code via various tricks

### DIFF
--- a/elkscmd/bootblocks/Makefile
+++ b/elkscmd/bootblocks/Makefile
@@ -1,6 +1,6 @@
 
 CC = ia16-elf-gcc
-CROSS_CFLAGS = -fno-inline -mcmodel=tiny -mno-segment-relocation-stuff -ffreestanding -mtune=i8086
+CROSS_CFLAGS = -mregparmcall -fno-inline -mcmodel=tiny -mno-segment-relocation-stuff -ffreestanding -mtune=i8086
 INCLUDES = -I $(TOPDIR)/include
 CFLAGS = -Wall -Os $(CROSS_CFLAGS) $(INCLUDES)
 

--- a/elkscmd/bootblocks/boot_minix.c
+++ b/elkscmd/bootblocks/boot_minix.c
@@ -54,6 +54,14 @@ void run_prog ();
 
 //------------------------------------------------------------------------------
 
+// FIXME: this is a lot of source code just to get at the data segment value
+// from %ss.  Perhaps there should be a built-in function in gcc-ia16 for this.
+
+#define _FP_SEG(fp)	((int) ((long) (void __far *) (fp) >> 16))
+#define seg_data()	_FP_SEG (&i_now)
+
+//------------------------------------------------------------------------------
+
 static int strcmp (const char * s, const char * d)
 {
 	const char * p1 = s;

--- a/elkscmd/bootblocks/boot_minix.c
+++ b/elkscmd/bootblocks/boot_minix.c
@@ -41,7 +41,7 @@ static byte_t d_dir [BLOCK_SIZE];  // latest in program segment
 
 // Helpers from boot sector
 
-void except (int code);
+void except (char code);
 
 void puts (const char * s);
 

--- a/elkscmd/bootblocks/boot_sect.S
+++ b/elkscmd/bootblocks/boot_sect.S
@@ -218,54 +218,6 @@ puts_exit:
 
 //------------------------------------------------------------------------------
 
-/*
-_half_hex:
-
-	and $0x0F,%al
-	add $'0',%al
-	cmp $'9',%al
-	jle hh_next
-	add $('A'-'9'),%al
-
-hh_next:
-	jmp _putc
-
-_byte_hex:
-
-	mov %al,%dl
-
-	mov $4,%cl
-	shr %cl,%al
-	call _half_hex
-
-	mov %dl,%al
-	call _half_hex
-
-	ret
-
-_word_hex:
-
-	push %ax
-	mov %ah,%al
-	call _byte_hex
-	pop %ax
-	call _byte_hex
-	ret
-
-// void word_hex (word_t w)
-
-	.global word_hex
-
-word_hex:
-
-	mov %sp,%bx
-	mov 2(%bx),%ax
-	call _word_hex
-	ret
-*/
-
-//------------------------------------------------------------------------------
-
 // int drive_reset (int drive)
 /*
 	.global drive_reset

--- a/elkscmd/bootblocks/boot_sect.S
+++ b/elkscmd/bootblocks/boot_sect.S
@@ -158,12 +158,8 @@ _next2:
 	.global except
 
 except:
-
-	mov %sp,%bp
-	mov 2(%bp),%ax  // exception code
-
 _except:
-
+	// AX = exception code
 	xor %sp,%sp
 	add $'0',%al  // first version with single digit
 	call _putc
@@ -194,6 +190,12 @@ _putc:
 	int $0x10     // BIOS video services
 	ret
 
+	.global puts
+
+puts:
+	xchg %ax,%bx
+	// fall through
+
 	.global _puts
 
 _puts:
@@ -208,26 +210,56 @@ _puts:
 	inc %bx
 	jmp _puts
 
-// void puts (const char * s)
-
-	.global puts
-
-puts:
-
-	mov %sp,%bx
-	mov 2(%bx),%bx
-	jmp _puts
+puts_exit:
+	ret
 
 //------------------------------------------------------------------------------
 
-// int seg_data ()
+/*
+_half_hex:
 
-	.global seg_data
+	and $0x0F,%al
+	add $'0',%al
+	cmp $'9',%al
+	jle hh_next
+	add $('A'-'9'),%al
 
-seg_data:
+hh_next:
+	jmp _putc
 
-	mov %ds,%ax
+_byte_hex:
+
+	mov %al,%dl
+
+	mov $4,%cl
+	shr %cl,%al
+	call _half_hex
+
+	mov %dl,%al
+	call _half_hex
+
 	ret
+
+_word_hex:
+
+	push %ax
+	mov %ah,%al
+	call _byte_hex
+	pop %ax
+	call _byte_hex
+	ret
+
+// void word_hex (word_t w)
+
+	.global word_hex
+
+word_hex:
+
+	mov %sp,%bx
+	mov 2(%bx),%ax
+	call _word_hex
+	ret
+*/
 
 //------------------------------------------------------------------------------
 
@@ -253,10 +285,15 @@ drive_reset:
 
 disk_read:
 
+	push %cx
+	push %dx
 	push %bp
 	mov %sp,%bp
 	sub $8,%sp
 
+// 8(%bp) = segment
+// 4(%bp) = offset
+// 2(%bp) = logical count
 // -2(%bp) = relative sector
 // -4(%bp) = relative head
 // -6(%bp) = relative track
@@ -264,7 +301,7 @@ disk_read:
 
 	// Compute the CHS from absolute sector
 
-	mov 4(%bp),%ax   // absolute sector
+	// AX = absolute sector
 	xor %dx,%dx
 	divw sect_max
 	mov %dx,-2(%bp)
@@ -280,10 +317,10 @@ dr_loop:
 	// Compute remaining sectors in current track
 
 	mov -2(%bp),%ax
-	add 6(%bp),%ax    // absolute count
+	add 2(%bp),%ax    // absolute count
 	cmp sect_max,%ax
 	ja dr_over
-	mov 6(%bp),%ax
+	mov 2(%bp),%ax
 	jmp dr_next1
 
 dr_over:
@@ -302,8 +339,8 @@ dr_next1:
 	mov -6(%bp),%ch  // cylinder number
 
 	push %es
-	mov 8(%bp),%bx
-	mov 10(%bp),%es
+	mov 4(%bp),%bx
+	mov 8(%bp),%es
 	mov $0x02,%ah    // BIOS read disk
 	int $0x13
 	pop %es
@@ -337,7 +374,7 @@ dr_cont:
 	// Update absolute count
 
 	mov -8(%bp),%ax
-	sub %ax,6(%bp)
+	sub %ax,2(%bp)
 	jz dr_exit
 
 	// Move to next head
@@ -365,7 +402,7 @@ dr_next2:
 	mov -8(%bp),%ax
 	mov $9,%cl
 	shl %cl,%ax
-	add %ax,8(%bp)
+	add %ax,4(%bp)
 
 	jmp dr_loop
 
@@ -373,7 +410,9 @@ dr_exit:
 
 	mov %bp,%sp
 	pop %bp
-	ret
+	pop %dx
+	pop %cx
+	ret $2
 
 //------------------------------------------------------------------------------
 

--- a/elkscmd/bootblocks/boot_sect.S
+++ b/elkscmd/bootblocks/boot_sect.S
@@ -26,6 +26,11 @@
 
 entry:
 
+// Allow the new BIOS floppy parameter table to clobber the first few bytes
+// of the boot block after we are done with them
+
+floppy_table:
+
 	// Get the memory size
 	// TODO: optional BIOS INT 12h
 
@@ -42,10 +47,9 @@ entry:
 	and $0xF000,%ax
 	mov %ax,%es
 
-	xor %ax,%ax
-	mov %ax,%ds
-	mov $BOOTADDR,%si
 	xor %di,%di
+	mov %di,%ds
+	mov $BOOTADDR,%si
 	mov $256,%cx  // 256 words = 512 B
 	cld
 	rep
@@ -56,17 +60,21 @@ entry:
 
 	mov $0x78,%bx  // 0:78h (INT vector 1Eh)
 	lds (%bx),%si  // ds:si = BIOS original table
+.if floppy_table == sector_1
+	xor %di,%di
+.else
 	mov $floppy_table,%di
-	mov $6,%cx     // 12 bytes (actually 11 in the table)
+.endif
+	push %di
+	mov $6,%cl     // 12 bytes (actually 11 in the table); and, ch = 0
 	//cld
 	rep
 	movsw
 
 	// Change BIOS table pointer to our copy
 
-	mov %ax,%ds
-	mov $floppy_table,%di
-	mov %di,(%bx)
+	mov %cx,%ds    // cx = 0
+	popw (%bx)
 	mov %es,2(%bx)
 
 	// Rebase CS DS ES SS to work in the 64K segment
@@ -94,15 +102,8 @@ _next1:
 
 	// Set sector count in floppy parameter table
 
-	mov $floppy_table,%bx
 	mov sect_max,%al
-	mov %al,4(%bx)
-
-	// Reset the floppy drive
-
-	//mov drive_num,%dl
-	xor %ah,%ah
-	int $0x13
+	mov %al,floppy_table+4
 
 	// Load the second sector of the boot block
 
@@ -113,11 +114,13 @@ _next1:
 
 _loop1:
 
+	xor %ah,%ah        // reset the floppy drive
+	int $0x13
 	mov $0x0201,%ax    // read 1 sector
 	mov $payload,%bx  // destination (ES already set)
 	mov $2,%cx         // track 0 - from sector 2 (base 1)
-	xor %dh,%dh        // head 0
-	mov drive_num,%dl  // boot driver
+	cwtd               // head 0 (dh = 0)
+	mov drive_num,%dl  // boot drive
 	int $0x13          // BIOS disk services
 	jnc _next2
 
@@ -146,20 +149,20 @@ _next2:
 
 	call load_prog
 	mov $ERR_NO_SYSTEM,%al
-	jmp _except
+	// fall through to _except
 
 //------------------------------------------------------------------------------
 
 // We use an exception-like basic mechanism
 // to save the space required by error returning
 
-// void except (int code)
+// void except (char code)
 
 	.global except
 
 except:
 _except:
-	// AX = exception code
+	// AL = exception code
 	xor %sp,%sp
 	add $'0',%al  // first version with single digit
 	call _putc
@@ -564,11 +567,6 @@ msg_reboot:
 
 drive_num:
 	.byte 0
-
-// Local copy of BIOS floppy parameter table
-
-floppy_table:
-	.word 0,0,0,0,0,0
 
 // Disk geometry (CHS)
 


### PR DESCRIPTION
These two commits reduce the size of the boot blocks' code, from `0x1ee` bytes in the first sector and `0x1de` bytes in the second sector, down to `0x1cc` bytes and `0x19e` bytes respectively, without reducing functionality.

The main things I did were
  * using the `regparmcall` parameter passing convention (which I had recently introduced into `gcc-ia16`) when interfacing with the C code, instead of the default stack-based `cdecl`;
  * making the diskette drive parameter table overlap unneeded parts of the boot code; and
  * reimplementing `seg_data ()` as an inline macro, so that it mostly compiles into just a 1-byte `push %ss`.

Thank you!