### PR TITLE
[boot] (take 2) put boot_minix.c's entry point at sector start

### DIFF
--- a/elkscmd/bootblocks/Makefile
+++ b/elkscmd/bootblocks/Makefile
@@ -1,6 +1,7 @@
 
 CC = ia16-elf-gcc
-CROSS_CFLAGS = -mregparmcall -fno-inline -mcmodel=tiny -mno-segment-relocation-stuff -ffreestanding -mtune=i8086
+# See boot_minix.c on -fno-top-level-reorder.
+CROSS_CFLAGS = -mregparmcall -fno-toplevel-reorder -fno-inline -mcmodel=tiny -mno-segment-relocation-stuff -ffreestanding -mtune=i8086
 INCLUDES = -I $(TOPDIR)/include
 CFLAGS = -Wall -Os $(CROSS_CFLAGS) $(INCLUDES)
 

--- a/elkscmd/bootblocks/boot_minix.c
+++ b/elkscmd/bootblocks/boot_minix.c
@@ -62,6 +62,14 @@ void run_prog ();
 
 //------------------------------------------------------------------------------
 
+// This must occur right at the start of the payload.  Currently this is done
+// by specifying -fno-toplevel-reorder in the Makefile, which forces GCC to
+// output all functions, variables, and __asm's in the same order as in the
+// source code.  FIXME: find a better way.
+__asm("jmp load_prog");
+
+//------------------------------------------------------------------------------
+
 static int strcmp (const char * s, const char * d)
 {
 	const char * p1 = s;

--- a/elkscmd/bootblocks/boot_sect.S
+++ b/elkscmd/bootblocks/boot_sect.S
@@ -128,9 +128,7 @@ _loop1:
 
 _next2:
 
-	.extern load_prog
-
-	call load_prog
+	call payload
 	mov $ERR_NO_SYSTEM,%al
 	// fall through to _except
 


### PR DESCRIPTION
This means that the OS-independent boot code (`boot_sect.S`) does not need to know where precisely the OS-specific `load_prog()` routine is.  It can instead simply do a `call` to the start of the second sector.