### PR TITLE
[image] Cleanup MSDOS disk image creation and format

### DIFF
--- a/elks/tools/mfs/main.c
+++ b/elks/tools/mfs/main.c
@@ -40,6 +40,7 @@
  *	use ELKS defaults of -1 -n14 -i360 -s1440 for mkfs/genfs
  *	add genfs -k option to not copy 0 length (hidden) files starting with .
  *	add addfs option to add files/dirs specified in file from directory
+ *	add boot -B option to update BPB sector and head fields in boot block
  *
  * Bug fixes by ghaerr:
  * fix mkfs -1, -n overwriting -i, -n14
@@ -73,6 +74,7 @@ void usage(const char *name) {
 	"	-v	verbose\n"
 	"cmd:\n"
 	"	mkfs [-1|2] [-i<#inodes>] [-n<#direntlen>] [-s<#blocks>]\n"
+	"	boot [-B<sectors>,<heads>] [bootimage]\n"
 	"	genfs [-1|2] [-i<#inodes>] [-n<#direntlen>] [-s<#blocks>] [-k] <directory>\n"
 	"	addfs <file_of_filenames> <directory>\n"
 	"	[stat]\n"

--- a/image/Make.package
+++ b/image/Make.package
@@ -34,38 +34,52 @@ minix:
 #		Note: filenames larger than 8.3 will create VFAT LFN entries
 #	Write boot sector (not completed)
 
+# all mtools commands require image file
 # -i image	image filename
-MSDOS_IMAGE=-i $(IMGDIR)/$(NAME).bin
-# -C		create image
+MSDOS_IMAGE=$(IMGDIR)/$(NAME).bin
+
+# mformat options
 # -f size	image size in 1k
+# -M size	software sector size (=physical sector size)
 # -d 2		2 FAT tables
 # -L 9		9 FAT sectors
 # -r 14		14 root directory sectors
 # -c 1		cluster size 1 sector
-# -R 1		1 reserve sector (boot)
-# -k		only update boot block geometry and file system data fields
+# -R 1		1 reserve sector (boot, may need to reserve 2)
+# -k		only update offsets 11 through 61 in boot block, all else unchanged
 # -B boot	use passed boot file (not complete)
 # -N 0		serial number 0
-# -v label	volume label
-MSDOS_MKFSOPTS=-C $(OPTS) -M 512 -d 2 -L 9 -r 14 -c 1 -R 1 -k -N 0 -v ELKS
+# -v label	volume label (don't use with first format as uses two directory entries)
+# -C		create image (buggy, leaves nonzero data in image)
+MSDOS_MKFSOPTS=$(OPTS) -M 512 -d 2 -L 9 -r 14 -c 1 -R 1 -k -N 0
 
+# mcopy options
 # -v		verbose
 # -p		preserve attributes
 # -m		preserve file modtime
 # -Q		quit on error
-MSDOS_COPYOPTS=-vpmQ
+# -D o		overwrite primary name if exists
+MSDOS_COPYOPTS=-vpmQ -D o
+
+# mdir options
+# -a		also list hidden files
+# -/		recursive output (buggy: will fail on empty, newly formatted disks!
 
 msdos:
 	awk "/$(APPS)/{print}" Packages | cut -f 1 | sed "/^#/d" > Filelist
-	cat Filelist
-	mformat $(MSDOS_IMAGE) $(MSDOS_MKFSOPTS)
-	mdir $(MSDOS_IMAGE) -a ::
+	-rm $(MSDOS_IMAGE)
+	dd if=/dev/zero of=$(MSDOS_IMAGE) bs=512 count=2880
+	mformat -i $(MSDOS_IMAGE) $(MSDOS_MKFSOPTS)
+	-rm linux; touch linux
+	mcopy -i $(MSDOS_IMAGE) $(MSDOS_COPYOPTS) linux ::/linux
+	rm linux
+	mdir -i $(MSDOS_IMAGE) -/ -a ::
 	for f in `cat Filelist`; \
 	do \
-		[ -d $(DESTDIR)/$$f ] && mmd $(MSDOS_IMAGE) ::$$f; \
-		[ -f $(DESTDIR)/$$f ] && mcopy $(MSDOS_IMAGE) $(MSDOS_COPYOPTS) $(DESTDIR)$$f ::$$f; \
+		[ -d $(DESTDIR)/$$f ] && mmd -i $(MSDOS_IMAGE) ::$$f; \
+		[ -f $(DESTDIR)/$$f ] && mcopy -i $(MSDOS_IMAGE) $(MSDOS_COPYOPTS) $(DESTDIR)$$f ::$$f; \
 	done
 	rm Filelist
 # add boot sector and modify disk parameter block (not completed)
-#	mfs $(IMGDIR)/$(NAME).bin boot $(FD_BSECT)
-	mdir $(MSDOS_IMAGE) -/ -a ::
+#	mfs $(MSDOS_IMAGE) boot $(FD_BSECT)
+	mdir -i $(MSDOS_IMAGE) -/ -a ::

--- a/image/Make.package
+++ b/image/Make.package
@@ -1,19 +1,30 @@
 # Application package creation Makefile
-#	passed NAME=, OPTS=, APPS=
+#	passed NAME=, APPS=, OPTS= and BPB= for MINIX, SIZE= for MSDOS
 #	implicitly uses IMGDIR=, DESTDIR= and FD_BSECT=
-
-VERBOSE=-v
-MINIX_IMAGE=$(IMGDIR)/$(NAME).bin
-MINIX_MKFSOPTS=-1 -n14 $(OPTS)
 
 # Create bootable ELKS MINIX disk image:
 #	Select tagged files into filelist
 #	Create empty filesystem
 #	Add tagged files into filesystem (regular, directories, links)
 #	Create special files in /dev
-#	Write boot sector
+#	Write boot sector (and modify BPB (not completed))
 #	Check image integrity
 #	Print filesystem used inode and block count
+
+VERBOSE=-v
+MINIX_IMAGE=$(IMGDIR)/$(NAME).bin
+
+# mfs options
+# -v		verbose
+# mkfs		initialize filesystem
+# genfs		generate filesystem from template
+# addfs		generate filesytem from filelist
+# mfs genfs options
+# -1		create MINIX v1 filesystem
+# -n14		filename size 14
+# -i<size>	max inodes
+# -s<size>	image size in 1k blocks
+MINIX_MKFSOPTS=-1 -n14 $(OPTS)
 
 minix:
 	awk "/$(APPS)/{print}" Packages | cut -f 1 > Filelist
@@ -21,26 +32,27 @@ minix:
 	mfs $(VERBOSE) $(MINIX_IMAGE) addfs Filelist $(DESTDIR)
 	rm Filelist
 	$(MAKE) -f Make.devices "MKDEV=mfs $(MINIX_IMAGE) mknod"
-	# NOTE: mfs does not currently change DISKPARAMS struct in boot sector (coming!)
 	mfs $(MINIX_IMAGE) boot $(FD_BSECT)
+#	mfs $(MINIX_IMAGE) boot $(BPB) $(FD_BSECT)
 	mfsck -fv $(MINIX_IMAGE)
 	mfs $(MINIX_IMAGE) stat
 
 # Create bootable ELKS MSDOS disk image:
 #	Select tagged files into filelist
-#	Create empty filesystem (1440k only for now)
+#	Create empty filesystem
+#	Write boot sector (not completed)
+#	Create \linux as first directory entry
 #	Add tagged files into filesystem (regular, directories, links)
 #		Filename case is preserved
 #		Note: filenames larger than 8.3 will create VFAT LFN entries
-#	Write boot sector (not completed)
 
 # all mtools commands require image file
 # -i image	image filename
 MSDOS_IMAGE=$(IMGDIR)/$(NAME).bin
 
 # mformat options
-# -f size	image size in 1k
-# -M size	software sector size (=physical sector size)
+# -f size	image size in kilobytes
+# -M 512	software sector size 512 (=physical sector size)
 # -d 2		2 FAT tables
 # -L 9		9 FAT sectors
 # -r 14		14 root directory sectors
@@ -51,7 +63,7 @@ MSDOS_IMAGE=$(IMGDIR)/$(NAME).bin
 # -N 0		serial number 0
 # -v label	volume label (don't use with first format as uses two directory entries)
 # -C		create image (buggy, leaves nonzero data in image)
-MSDOS_MKFSOPTS=$(OPTS) -M 512 -d 2 -L 9 -r 14 -c 1 -R 1 -k -N 0
+MSDOS_MKFSOPTS=-f $(SIZE) -M 512 -d 2 -L 9 -r 14 -c 1 -R 1 -k -N 0
 
 # mcopy options
 # -v		verbose
@@ -67,8 +79,9 @@ MSDOS_COPYOPTS=-vpmQ -D o
 
 msdos:
 	awk "/$(APPS)/{print}" Packages | cut -f 1 | sed "/^#/d" > Filelist
-	-rm $(MSDOS_IMAGE)
-	dd if=/dev/zero of=$(MSDOS_IMAGE) bs=512 count=2880
+	dd if=/dev/zero of=$(MSDOS_IMAGE) bs=1024 count=$(SIZE)
+# add boot sector, mformat will modify BPB
+#	mfs $(MSDOS_IMAGE) boot $(FD_BSECT)
 	mformat -i $(MSDOS_IMAGE) $(MSDOS_MKFSOPTS)
 	-rm linux; touch linux
 	mcopy -i $(MSDOS_IMAGE) $(MSDOS_COPYOPTS) linux ::/linux
@@ -79,7 +92,5 @@ msdos:
 		[ -d $(DESTDIR)/$$f ] && mmd -i $(MSDOS_IMAGE) ::$$f; \
 		[ -f $(DESTDIR)/$$f ] && mcopy -i $(MSDOS_IMAGE) $(MSDOS_COPYOPTS) $(DESTDIR)$$f ::$$f; \
 	done
-	rm Filelist
-# add boot sector and modify disk parameter block (not completed)
-#	mfs $(MSDOS_IMAGE) boot $(FD_BSECT)
+#	rm Filelist
 	mdir -i $(MSDOS_IMAGE) -/ -a ::

--- a/image/Make.package
+++ b/image/Make.package
@@ -80,7 +80,7 @@ MSDOS_COPYOPTS=-vpmQ -D o
 msdos:
 	awk "/$(APPS)/{print}" Packages | cut -f 1 | sed "/^#/d" > Filelist
 	dd if=/dev/zero of=$(MSDOS_IMAGE) bs=1024 count=$(SIZE)
-# add boot sector, mformat will modify BPB
+# write MSDOS boot sector(s) only, mformat will modify BPB
 #	mfs $(MSDOS_IMAGE) boot $(FD_BSECT)
 	mformat -i $(MSDOS_IMAGE) $(MSDOS_MKFSOPTS)
 	-rm linux; touch linux
@@ -92,5 +92,5 @@ msdos:
 		[ -d $(DESTDIR)/$$f ] && mmd -i $(MSDOS_IMAGE) ::$$f; \
 		[ -f $(DESTDIR)/$$f ] && mcopy -i $(MSDOS_IMAGE) $(MSDOS_COPYOPTS) $(DESTDIR)$$f ::$$f; \
 	done
-#	rm Filelist
+	rm Filelist
 	mdir -i $(MSDOS_IMAGE) -/ -a ::

--- a/image/Makefile
+++ b/image/Makefile
@@ -79,24 +79,34 @@ clean:
 	-rm -f *.bin
 
 # Application package management
-# Type "make images" after normal ELKS build to create all disk image sets
+# Type "make images" after normal ELKS build to create all MINIX disk image sets
 # Applications are tagged for disk images in the 'Packages' file
+allimages: images dosimages
+
 images: fd320 fd360 fd720 fd1440
 
-msdosfs: fd1440-msdos
+dosimages: fd320-msdos fd360-msdos fd720-msdos fd1440-msdos
 
 fd320:
-	$(MAKE) -f Make.package minix NAME=fd320 OPTS="-i192 -s320" APPS=":boot"
+	$(MAKE) -f Make.package minix NAME=fd320 OPTS="-i192 -s320" BPB=-B8,1 APPS=":boot"
 
 fd360:
-	$(MAKE) -f Make.package minix NAME=fd360 OPTS="-i192 -s360" APPS=":boot|:small"
+	$(MAKE) -f Make.package minix NAME=fd360 OPTS="-i192 -s360" BPB=-B9,1 APPS=":boot|:small"
 
 fd720:
-	$(MAKE) -f Make.package minix NAME=fd720 OPTS="-i256 -s720" APPS=":boot|:small|:base|:net"
+	$(MAKE) -f Make.package minix NAME=fd720 OPTS="-i256 -s720" BPB=-B9,2 APPS=":boot|:small|:base|:net"
 
 fd1440:
-	$(MAKE) -f Make.package minix NAME=fd1440 OPTS="-i360 -s1440" APPS=":boot|:small|:base|:net|:shutil|:fileutil|:app|:nanox"
+	$(MAKE) -f Make.package minix NAME=fd1440 OPTS="-i360 -s1440" BPB=-B18,2 APPS=":boot|:small|:base|:net|:shutil|:fileutil|:app|:nanox"
+
+fd320-msdos:
+	$(MAKE) -f Make.package msdos NAME=fd320-msdos SIZE=320 APPS=":boot"
+
+fd360-msdos:
+	$(MAKE) -f Make.package msdos NAME=fd360-msdos SIZE=360 APPS=":boot|:small"
+
+fd720-msdos:
+	$(MAKE) -f Make.package msdos NAME=fd720-msdos SIZE=720 APPS=":boot|:small|:base|:net"
 
 fd1440-msdos:
-	$(MAKE) -f Make.package msdos NAME=fd1440-msdos OPTS="-f 1440" APPS=":boot|:small|:base|:net|:shutil|:fileutil|:app|:nanox"
-
+	$(MAKE) -f Make.package msdos NAME=fd1440-msdos SIZE=1440 APPS=":boot|:small|:base|:net|:shutil|:fileutil|:app|:nanox"

--- a/image/Packages
+++ b/image/Packages
@@ -111,7 +111,6 @@
 /bin/sort							:fileutil
 /bin/stty				:base :net
 /bin/sum						:shutil
-/bin/swapon							:fileutil
 /bin/sync			:small
 /bin/synctree						:fileutil
 /bin/tail							:fileutil


### PR DESCRIPTION
FAT12 image cleaned up to all zeros except boot block and ensure \linux is first dir entry
Confirmed only boot block offsets 11 through 62 are modified, nothing else

This PR cleans up previous submission where I found mformat has bugs and didn't create an all-zero filesystem, making it hard to confirm exactly which portions of the image are changed when mformat modifies the boot sector BPB.

I also confirmed that when using mformat for our MSDOS disk image creation, it will now *only* modify boot sector offsets 11 through 62. This means that the process to create MSDOS bootable images will be first to copy the ELKS boot sector (either one or two sectors) to the image start, *then* use mformat to update offsets 11 through 62 with the BPB with the disk format parameters and create the FAT12 filesystem. The initial format now ensures that \linux is the first directory entry, simplifying the boot loader. Finally, all applications and the real /linux will be copied, using the same first directory entry for \linux.

Updated elks/image/Make.packages documentation for mtools parameter used, for easier testing by others.

Also removes swapon from the disk images.