### PR TITLE
[msdosfs] Complete work on MSDOS filesystem internal /dev devfs support

### DIFF
--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -25,8 +25,7 @@ static int msdos_dir_read(inode, filp, buf, count)
     return -EISDIR;
 }
 
-static int msdos_readdir(struct inode *inode,
-			 struct file *filp,
+static int msdos_readdir(struct inode *inode, struct file *filp,
 			 char *dirent, filldir_t filldir);
 
 /*@-type@*/
@@ -92,20 +91,20 @@ uni16_to_x8(unsigned char *ascii, register unsigned char *uni)
  */
 #pragma GCC push_options
 #pragma GCC optimize ("O1")
-int msdos_readdir(
-	struct inode *inode,
-	register struct file *filp,
-	char *dirent,
+int msdos_readdir(struct inode *inode, register struct file *filp, char *dirent,
 	filldir_t filldir)
 {
 	ino_t ino;
 	struct buffer_head *bh;
 	struct msdos_dir_entry *de;
-	unsigned long oldpos = filp->f_pos; /* The location of the next starting directory entry */
-	int is_long;                        /* Whether it is complete, and its long file name matches the long file name */
-	unsigned char alias_checksum = 0; /* Make compiler warning go away */
+	/* The location of the next starting directory entry */
+	unsigned long oldpos = filp->f_pos;
+	/* Whether it is complete, and its long file name matches the long file name */
+	int is_long;
+	unsigned char alias_checksum = 0;	/* Make compiler warning go away */
 	unsigned char long_slots = 0;
 	unsigned char unicode[52];          /* Limit to two long entries */
+
 	if (!inode || !S_ISDIR(inode->i_mode)) return -EBADF;
 	if (inode->i_ino == MSDOS_ROOT_INO) {
 		/* Fake . and .. for the root directory. */
@@ -139,9 +138,8 @@ int msdos_readdir(
 			}
 
 			while (slot > 0) {
-				if (ds->attr !=  ATTR_EXT ||
-				    (ds->id & ~0x40) != slot ||
-				    ds->alias_checksum != alias_checksum) {
+				if (ds->attr !=  ATTR_EXT || (ds->id & ~0x40) != slot ||
+					ds->alias_checksum != alias_checksum) {
 					is_long = 0;
 					break;
 				}
@@ -214,12 +212,6 @@ int msdos_readdir(
 					break;
 				}
 				else {
-#ifdef CONFIG_UMSDOS_FS
-					if (inode->i_ino == MSDOS_ROOT_INO && filldir && 
-					    long_len == 3 && !strncmp(longname,"dev",3)) {
-						MSDOS_SB(inode->i_sb)->dev_ino = ino;
-					}
-#endif
 					filldir(dirent, longname, long_len, oldpos, (long) ino);
 					break;
 				}

--- a/elks/fs/msdos/file.c
+++ b/elks/fs/msdos/file.c
@@ -69,7 +69,7 @@ static int msdos_file_read(register struct inode *inode,register struct file *fi
 	struct buffer_head *bh;
 	void *data;
 
-/* printk("msdos_file_read\r\n"); */
+/* printk("msdos_file_read\n"); */
 	if (!inode) {
 		printk("msdos_file_read: inode = NULL\r\n");
 		return -EINVAL;

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -209,7 +209,7 @@ ino_t msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head **bh,
 	int offset;
 	void *data;
 
-#ifdef CONFIG_UMSDOS_FS
+#ifdef CONFIG_MSDOS_DEV
 	if (dir->i_ino == MSDOS_SB(dir->i_sb)->dev_ino) {
 		unsigned i = (unsigned)*pos / sizeof(struct msdos_dir_entry);
 		if (i - 2 <= DEVDIR_SIZE) {
@@ -242,10 +242,8 @@ ino_t msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head **bh,
 		//printk("mge1\n");
 		if (!(*bh = msdos_sread(dir->i_dev,sector,&data)))
 			continue;
-		*de = (struct msdos_dir_entry *) ((char *)data+(offset &
-		    (SECTOR_SIZE-1)));
-		return (sector << MSDOS_DPS_BITS)+((offset & (SECTOR_SIZE-1)) >>
-		    MSDOS_DIR_BITS);
+		*de = (struct msdos_dir_entry *) ((char *)data+(offset & (SECTOR_SIZE-1)));
+		return (sector << MSDOS_DPS_BITS)+((offset & (SECTOR_SIZE-1)) >> MSDOS_DIR_BITS);
 	}
 }
 
@@ -263,12 +261,10 @@ int msdos_scan(struct inode *dir,char *name,struct buffer_head **res_bh,
 	*res_bh = NULL;
 	while ((*ino = msdos_get_entry(dir,&pos,res_bh,&de)) != -1) {
 		if (name) {
-			if (de->name[0] && ((unsigned char *) (de->name))[0]
-			    != DELETED_FLAG && !(de->attr & ATTR_VOLUME) &&
-			    !strncmp(de->name,name,MSDOS_NAME)) break;
+			if (de->name[0] && ((unsigned char *) (de->name))[0] != DELETED_FLAG
+				&& !(de->attr & ATTR_VOLUME) && !strncmp(de->name,name,MSDOS_NAME)) break;
 		}
-		else if (!de->name[0] || ((unsigned char *) (de->name))[0] ==
-			    DELETED_FLAG) {
+		else if (!de->name[0] || ((unsigned char *) (de->name))[0] == DELETED_FLAG) {
 				if (!(inode = iget(dir->i_dev,*ino))) break;
 				if (!inode->u.msdos_i.i_busy) {
 					iput(inode);

--- a/elks/fs/msdos/namei.c
+++ b/elks/fs/msdos/namei.c
@@ -31,8 +31,8 @@ static int msdos_format_name(register const char *name,int len,char *res)
 	unsigned char c;
 
 	if (get_fs_byte(name) == DELETED_FLAG) return -EINVAL;
-	if (get_fs_byte(name) == '.' && (len == 1 || (len == 2 &&
-	    get_fs_byte(name+1) == '.'))) {
+	if (get_fs_byte(name) == '.' &&
+		(len == 1 || (len == 2 && get_fs_byte(name+1) == '.'))) {
 		memset(res+1,' ',10);
 		while (len--) *res++ = '.';
 		return 0;
@@ -70,8 +70,7 @@ static int msdos_find(struct inode *dir,const char *name,int len,
 	char msdos_name[MSDOS_NAME];
 	int res;
 
-	if ((res = msdos_format_name(name,len,
-	    msdos_name)) < 0) return res;
+	if ((res = msdos_format_name(name,len, msdos_name)) < 0) return res;
 	return msdos_scan(dir,msdos_name,bh,de,ino);
 }
 
@@ -85,6 +84,7 @@ int msdos_lookup(register struct inode *dir,const char *name,int len,
 	struct buffer_head *bh;
 	struct inode *next;
 	*result = NULL;
+
 /*	if (!dir) return -ENOENT; dir != NULL always, because reached this function dereferencing dir */
 	if (!S_ISDIR(dir->i_mode)) {
 		iput(dir);
@@ -94,8 +94,7 @@ int msdos_lookup(register struct inode *dir,const char *name,int len,
 		*result = dir;
 		return 0;
 	}
-	if (len == 2 && get_fs_byte(name) == '.' && get_fs_byte(name+1) == '.')
-	    {
+	if (len == 2 && get_fs_byte(name) == '.' && get_fs_byte(name+1) == '.') {
 		ino = msdos_parent_ino(dir,0);
 		iput(dir);
 		if (ino < 0) return (int)ino;
@@ -107,7 +106,7 @@ int msdos_lookup(register struct inode *dir,const char *name,int len,
 		return res;
 	}
 	if (bh) unmap_brelse(bh);
-/* printk("lookup: ino=%ld\r\n",ino); */
+/* printk("lookup: ino=%d\n",ino); */
 	if (!(*result = iget(dir->i_sb,ino))) {
 		iput(dir);
 		return -EACCES;
@@ -146,8 +145,7 @@ static int msdos_create_entry(register struct inode *dir,char *name,int is_dir,
 	if (*result = iget(dir->i_sb,ino)) msdos_read_inode(*result);
 	unmap_brelse(bh);
 	if (!*result) return -EIO;
-	(*result)->i_mtime = 
-	    CURRENT_TIME;
+	(*result)->i_mtime = CURRENT_TIME;
 	(*result)->i_dirt = 1;
 	return 0;
 }
@@ -163,8 +161,7 @@ int msdos_create(register struct inode *dir,const char *name,int len,int mode,
 	int res;
 /*    dir != NULL always, because reached this function dereferencing dir */
 /*	if (!dir) return -ENOENT;*/
-	if ((res = msdos_format_name(name,len,
-	    msdos_name)) < 0) {
+	if ((res = msdos_format_name(name,len, msdos_name)) < 0) {
 		iput(dir);
 		return res;
 	}
@@ -191,15 +188,13 @@ int msdos_mkdir(struct inode *dir,const char *name,int len,int mode)
 	ino_t ino;
 	int res;
 
-	if ((res = msdos_format_name(name,len,
-	    msdos_name)) < 0) {
+	if ((res = msdos_format_name(name,len, msdos_name)) < 0) {
 		iput(dir);
 		return res;
 	}
 	lock_creation();
 
 	if (msdos_scan(dir,msdos_name,&bh,&de,&ino) >= 0) {
-
 		unlock_creation();
 		unmap_brelse(bh);
 		iput(dir);
@@ -267,10 +262,10 @@ int msdos_rmdir(register struct inode *dir,const char *name,int len)
 		pos = 0;
 		dbh = NULL;
 		while (msdos_get_entry(inode,&pos,&dbh,&dde) != -1)
-			if (dde->name[0] && ((unsigned char *) dde->name)[0] !=
-			    DELETED_FLAG && strncmp(dde->name,MSDOS_DOT,
-			    MSDOS_NAME) && strncmp(dde->name,MSDOS_DOTDOT,
-			    MSDOS_NAME)) goto rmdir_done; /* linux bug ??? */
+			if (dde->name[0] && ((unsigned char *) dde->name)[0] != DELETED_FLAG
+				&& strncmp(dde->name,MSDOS_DOT, MSDOS_NAME)
+				&& strncmp(dde->name,MSDOS_DOTDOT, MSDOS_NAME))
+					goto rmdir_done; /* linux bug ??? */
 		if (dbh) unmap_brelse(dbh);
 	}
 	inode->i_nlink = 0;

--- a/elks/include/linuxmt/msdos_fs_sb.h
+++ b/elks/include/linuxmt/msdos_fs_sb.h
@@ -10,12 +10,12 @@ struct msdos_sb_info { /* space in struct super_block is 28 bytes */
 	unsigned long clusters;      /* number of clusters */
 	unsigned long root_cluster;
 
-# ifdef CONFIG_UMSDOS_FS
+# ifdef CONFIG_MSDOS_DEV
 	ino_t dev_ino;               /* "/dev" ino */
 # endif
 };
 
-# ifdef CONFIG_UMSDOS_FS
+# ifdef CONFIG_MSDOS_DEV
 #define DEVINO_BASE MSDOS_DPB
 #define DEVDIR_SIZE 16
 

--- a/image/Make.package
+++ b/image/Make.package
@@ -30,7 +30,7 @@ minix:
 	awk "/$(APPS)/{print}" Packages | cut -f 1 > Filelist
 	mfs $(VERBOSE) $(MINIX_IMAGE) mkfs $(MINIX_MKFSOPTS)
 	mfs $(VERBOSE) $(MINIX_IMAGE) addfs Filelist $(DESTDIR)
-	rm Filelist
+	#rm Filelist
 	$(MAKE) -f Make.devices "MKDEV=mfs $(MINIX_IMAGE) mknod"
 	mfs $(MINIX_IMAGE) boot $(FD_BSECT)
 #	mfs $(MINIX_IMAGE) boot $(BPB) $(FD_BSECT)

--- a/image/Packages
+++ b/image/Packages
@@ -41,7 +41,9 @@
 #									:fileutil
 #										:app
 #										:nanox
-# -------------	------------------------------------------------------
+# Note: For FAT disks, /dev must be first or second root directory to work
+# -------------	----------------------------------------------------------
+/dev			:boot
 /bin			:boot
 /bin/ash		:boot
 /bin/banner								:app
@@ -56,7 +58,7 @@
 /bin/cmp						:shutil
 /bin/cp				:small
 /bin/cut						:shutil
-/bin/date			:small
+/bin/date				:base
 /bin/dd								:fileutil
 /bin/decomp16						:fileutil
 /bin/diff							:fileutil
@@ -78,7 +80,7 @@
 /bin/knl			:small
 /bin/ktcp					:net
 /bin/l								:fileutil
-/bin/ln				:small
+/bin/ln					:base
 /bin/login		:boot
 /bin/logname					:shutil
 /bin/lp						:net
@@ -95,8 +97,8 @@
 /bin/netstat				:net
 /bin/nslookup				:net
 /bin/passwd				:base
-/bin/poweroff		:small
-/bin/printenv		:small
+/bin/poweroff			:base
+/bin/printenv					:shutil
 /bin/proto							:fileutil
 /bin/ps				:small
 /bin/pwd			:small
@@ -107,7 +109,7 @@
 /bin/rmdir			:small
 /bin/sed						:shutil
 /bin/sh			:boot
-/bin/shutdown		:small
+/bin/shutdown			:base
 /bin/sort							:fileutil
 /bin/stty				:base :net
 /bin/sum						:shutil
@@ -133,7 +135,6 @@
 /bin/whoami						:shutil
 /bin/xargs				:base
 /bin/yes				:base
-/dev			:boot
 /etc			:boot
 /etc/group		:boot
 /etc/inittab	:boot


### PR DESCRIPTION
	MSDOSFS implementation of /dev is automatic if /dev is first or second root dir entry
	Renamed CONFIG_UMSDOS_FS to CONFIG_MSDOS_DEV
	Fixed various initialization problems with fsdev
	Reformatted elks/fs/msdos source code with no compilation output changes
	Updated disk image package list for 360k filesystems

@mfld-fr: I have completed the work on getting an internal devfs working for MSDOS FAT disks. It is  based on a rewritten CONFIG_UMSDOS_FS (renamed to CONFIG_MSDOS_DEV) and tested with CONFIG_32BIT_INODES=n for now. It also requires setting CONFIG_MSDOS_DEV=y. I am having serious problems getting my build to work correctly since KConfig is broken and I am manually editing .config and include/autoconf.h, and don't have the means to setup the config.in files since I can't test them. The build is acting strangely after hand-editing these files to various values for testing. I will be opening various bug reports for both KConfig on OSX as well as MSDOS FS issues in general (I have found many, this PR however works great).

Providing we can get the configuration system working with a couple of new .config entries, we now have all all that is needed to boot ELKS on FAT images except for the boot loader.

Have fun!