### PR TITLE
[kernel] FAT filesystem rework : devfs & fixups

### DIFF
--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -25,8 +25,7 @@ static int msdos_dir_read(inode, filp, buf, count)
     return -EISDIR;
 }
 
-static int msdos_readdir(struct inode *inode,
-			 struct file *filp,
+static int msdos_readdir(struct inode *inode, struct file *filp,
 			 char *dirent, filldir_t filldir);
 
 /*@-type@*/
@@ -92,20 +91,20 @@ uni16_to_x8(unsigned char *ascii, register unsigned char *uni)
  */
 #pragma GCC push_options
 #pragma GCC optimize ("O1")
-int msdos_readdir(
-	struct inode *inode,
-	register struct file *filp,
-	char *dirent,
+int msdos_readdir(struct inode *inode, register struct file *filp, char *dirent,
 	filldir_t filldir)
 {
 	ino_t ino;
 	struct buffer_head *bh;
 	struct msdos_dir_entry *de;
-	unsigned long oldpos = filp->f_pos; /* The location of the next starting directory entry */
-	int is_long;                        /* Whether it is complete, and its long file name matches the long file name */
-	unsigned char alias_checksum = 0; /* Make compiler warning go away */
+	/* The location of the next starting directory entry */
+	unsigned long oldpos = filp->f_pos;
+	/* Whether it is complete, and its long file name matches the long file name */
+	int is_long;
+	unsigned char alias_checksum = 0;	/* Make compiler warning go away */
 	unsigned char long_slots = 0;
 	unsigned char unicode[52];          /* Limit to two long entries */
+
 	if (!inode || !S_ISDIR(inode->i_mode)) return -EBADF;
 	if (inode->i_ino == MSDOS_ROOT_INO) {
 		/* Fake . and .. for the root directory. */
@@ -139,9 +138,8 @@ int msdos_readdir(
 			}
 
 			while (slot > 0) {
-				if (ds->attr !=  ATTR_EXT ||
-				    (ds->id & ~0x40) != slot ||
-				    ds->alias_checksum != alias_checksum) {
+				if (ds->attr !=  ATTR_EXT || (ds->id & ~0x40) != slot ||
+					ds->alias_checksum != alias_checksum) {
 					is_long = 0;
 					break;
 				}
@@ -214,12 +212,6 @@ int msdos_readdir(
 					break;
 				}
 				else {
-#ifdef CONFIG_UMSDOS_FS
-					if (inode->i_ino == MSDOS_ROOT_INO && filldir && 
-					    long_len == 3 && !strncmp(longname,"dev",3)) {
-						MSDOS_SB(inode->i_sb)->dev_ino = ino;
-					}
-#endif
 					filldir(dirent, longname, long_len, oldpos, (long) ino);
 					break;
 				}

--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -16,11 +16,7 @@
 #include <linuxmt/errno.h>
 #include <linuxmt/stat.h>
 
-static int msdos_dir_read(inode, filp, buf, count)
-     struct inode *inode;
-     struct file *filp;
-     char *buf;
-     int count;
+static int msdos_dir_read(struct inode *inode, struct file *filp, char *buf, int count)
 {
     return -EISDIR;
 }

--- a/elks/fs/msdos/fat.c
+++ b/elks/fs/msdos/fat.c
@@ -27,7 +27,7 @@ long fat_access(register struct super_block *sb,long this,long new_value)
 #endif
 		first = last = this*4;
 #ifndef FAT_BITS_32
-	else if fatsz == 16) first = last = this*2;
+	else if( fatsz == 16) first = last = this*2;
 	else {
 		first = this*3/2;
 		last = first+1;

--- a/elks/fs/msdos/fat.c
+++ b/elks/fs/msdos/fat.c
@@ -20,19 +20,20 @@ long fat_access(register struct super_block *sb,long this,long new_value)
 	unsigned char *p_first,*p_last;
 	void *data,*data2,*c_data,*c_data2;
 	long first,last,next,copy;
+	int fatsz = MSDOS_SB(sb)->fat_bits;
+
 #ifndef FAT_BITS_32
-	if(MSDOS_SB(sb)->fat_bits == 32) 
+	if(fatsz == 32)
 #endif
 		first = last = this*4;
 #ifndef FAT_BITS_32
-	else if (MSDOS_SB(sb)->fat_bits == 16) first = last = this*2;
+	else if fatsz == 16) first = last = this*2;
 	else {
 		first = this*3/2;
 		last = first+1;
 	}
 #endif
-	if (!(bh = msdos_sread(sb->s_dev,(long)(MSDOS_SB(sb)->fat_start+(first >>
-	    SECTOR_BITS)),&data))) {
+	if (!(bh = msdos_sread(sb->s_dev,(long)(MSDOS_SB(sb)->fat_start+(first >> SECTOR_BITS)),&data))) {
 		printk("bread in fat_access failed\r\n");
 		return 0;
 	}
@@ -41,31 +42,27 @@ long fat_access(register struct super_block *sb,long this,long new_value)
 		data2 = data;
 	}
 	else {
-		if (!(bh2 = msdos_sread(sb->s_dev,(long)(MSDOS_SB(sb)->fat_start+(last
-		    >> SECTOR_BITS)),&data2))) {
+		if (!(bh2 = msdos_sread(sb->s_dev,(long)(MSDOS_SB(sb)->fat_start+(last >> SECTOR_BITS)),&data2))) {
 			unmap_brelse(bh);
 			printk("bread in fat_access failed\r\n");
 			return 0;
 		}
 	}
 #ifndef FAT_BITS_32
-	if (MSDOS_SB(sb)->fat_bits == 32)
+	if (fatsz == 32)
 #endif
 	{
-		next = ((unsigned long *)data)[(first & (SECTOR_SIZE-1))
-		    >> 2];
+		next = ((unsigned long *)data)[(first & (SECTOR_SIZE-1)) >> 2];
 		if (next >= 0xffffff8L) next = -1;
 	}
 #ifndef FAT_BITS_32
-	else if (MSDOS_SB(sb)->fat_bits == 16) {
-		next = ((unsigned short *) data)[(first & (SECTOR_SIZE-1))
-		    >> 1];
+	else if (fatsz == 16) {
+		next = ((unsigned short *) data)[(first & (SECTOR_SIZE-1)) >> 1];
 		if (next >= 0xfff8) next = -1;
 	}
 	else {
 		p_first = &((unsigned char *) data)[first & (SECTOR_SIZE-1)];
-		p_last = &((unsigned char *) data2)[(first+1) &
-		    (SECTOR_SIZE-1)];
+		p_last = &((unsigned char *) data2)[(first+1) & (SECTOR_SIZE-1)];
 		if (this & 1) next = ((*p_first >> 4) | (*p_last << 4)) & 0xfff;
 		else next = (*p_first+(*p_last << 8)) & 0xfff;
 		if (next >= 0xff8) next = -1;
@@ -73,14 +70,12 @@ long fat_access(register struct super_block *sb,long this,long new_value)
 #endif
 	if (new_value != -1) {
 #ifndef FAT_BITS_32
-		if (MSDOS_SB(sb)->fat_bits == 32)
+		if (fatsz == 32)
 #endif
-			((unsigned long *)data)[(first & (SECTOR_SIZE -1))>>2] 
-				=(unsigned long) new_value;
+			((unsigned long *)data)[(first & (SECTOR_SIZE -1))>>2] = (unsigned long)new_value;
 #ifndef FAT_BITS_32
-		else if (MSDOS_SB(sb)->fat_bits == 16)
-			((unsigned short *) data)[(first & (SECTOR_SIZE-1)) >>
-			    1] = (unsigned short)new_value;
+		else if (fatsz == 16)
+			((unsigned short *) data)[(first & (SECTOR_SIZE-1)) >> 1] = (unsigned short)new_value;
 		else {
 			if (this & 1) {
 				*p_first = (*p_first & 0xf) | (new_value << 4);
@@ -95,16 +90,15 @@ long fat_access(register struct super_block *sb,long this,long new_value)
 #endif
 		bh->b_dirty = 1;
 		for (copy = 1; copy < MSDOS_SB(sb)->fats; copy++) {
-			if (!(c_bh = msdos_sread(sb->s_dev,(long)(MSDOS_SB(sb)->
-			    fat_start+(first >> SECTOR_BITS)+MSDOS_SB(sb)->
-			    fat_length*copy),&c_data))) break;
+			if (!(c_bh = msdos_sread(sb->s_dev,
+						(long)(MSDOS_SB(sb)-> fat_start+(first >> SECTOR_BITS) +
+						MSDOS_SB(sb)-> fat_length*copy),&c_data))) break;
 			memcpy(c_data,data,SECTOR_SIZE);
 			c_bh->b_dirty = 1;
 			if (data != data2 || bh != bh2) {
 				if (!(c_bh2 = msdos_sread(sb->s_dev,
-				    (long)(MSDOS_SB(sb)->fat_start+(first >>
-				    SECTOR_BITS)+MSDOS_SB(sb)->fat_length*copy
-				    +1),&c_data2))) {
+						(long)(MSDOS_SB(sb)->fat_start+(first >> SECTOR_BITS) +
+						MSDOS_SB(sb)->fat_length*copy +1),&c_data2))) {
 					unmap_brelse(c_bh);
 					break;
 				}
@@ -145,8 +139,7 @@ printk("cache lookup: %d\r\n",*f_clu);
 #endif
 	for (walk = fat_cache; walk; walk = walk->next)
 		if (inode->i_dev == walk->device && walk->ino == inode->i_ino &&
-		    walk->file_cluster <= cluster && walk->file_cluster >
-		    *f_clu) {
+		    walk->file_cluster <= cluster && walk->file_cluster > *f_clu) {
 			*d_clu = walk->disk_cluster;
 #ifdef DEBUG
 printk("cache hit: %ld (%ld)\r\n",walk->file_cluster,*d_clu);
@@ -236,8 +229,7 @@ long get_cluster(register struct inode *inode,long cluster)
 	if (!(this = inode->u.msdos_i.i_start)) return 0;
 	if (!cluster) return this;
 	count = 0;
-	for (cache_lookup(inode,cluster,&count,&this); count < cluster;
-	    count++) {
+	for (cache_lookup(inode,cluster,&count,&this); count < cluster; count++) {
 		if ((this = fat_access(inode->i_sb,this,-1L)) == -1) return 0;
 		if (!this) return 0;
 	}
@@ -254,9 +246,9 @@ long msdos_smap(struct inode *inode,long sector)
 
 	sb = MSDOS_SB(inode->i_sb);
 #ifndef FAT_BITS_32
-	if ((sb->fat_bits != 32) && 
+	if ((sb->fat_bits != 32) &&
 		(inode->i_ino == (ino_t)MSDOS_ROOT_INO || 
-		(S_ISDIR(inode->i_mode) && !inode->u.msdos_i.i_start))) {
+			(S_ISDIR(inode->i_mode) && !inode->u.msdos_i.i_start))) {
 		if (sector >= sb->dir_entries >> MSDOS_DPS_BITS) return 0;
 		return sector+sb->dir_start;
 	}

--- a/elks/fs/msdos/file.c
+++ b/elks/fs/msdos/file.c
@@ -150,7 +150,7 @@ static int msdos_file_write(register struct inode *inode,register struct file *f
 
 void msdos_truncate(register struct inode *inode)
 {
-	int cluster;
+	int cluster;		//FIXME should this be long for FAT32?
 
 	cluster = SECTOR_SIZE*MSDOS_SB(inode->i_sb)->cluster_size;
 	(void) fat_free(inode,(inode->i_size+(cluster-1))/cluster);

--- a/elks/fs/msdos/file.c
+++ b/elks/fs/msdos/file.c
@@ -69,7 +69,7 @@ static int msdos_file_read(register struct inode *inode,register struct file *fi
 	struct buffer_head *bh;
 	void *data;
 
-/* printk("msdos_file_read\r\n"); */
+/* printk("msdos_file_read\n"); */
 	if (!inode) {
 		printk("msdos_file_read: inode = NULL\r\n");
 		return -EINVAL;

--- a/elks/fs/msdos/file.c
+++ b/elks/fs/msdos/file.c
@@ -60,8 +60,8 @@ struct inode_operations msdos_file_inode_operations_no_bmap = {
 };
 
 
-static int msdos_file_read(register struct inode *inode,register struct file *filp,char *buf,
-    size_t count)
+static int msdos_file_read(register struct inode *inode,register struct file *filp,
+	char *buf,size_t count)
 {
 	char *start;
 	int left,offset,size;

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -209,7 +209,7 @@ ino_t msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head **bh,
 	int offset;
 	void *data;
 
-#ifdef CONFIG_UMSDOS_FS
+#ifdef CONFIG_MSDOS_DEV
 	if (dir->i_ino == MSDOS_SB(dir->i_sb)->dev_ino) {
 		unsigned i = (unsigned)*pos / sizeof(struct msdos_dir_entry);
 		if (i - 2 <= DEVDIR_SIZE) {
@@ -242,10 +242,8 @@ ino_t msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head **bh,
 		//printk("mge1\n");
 		if (!(*bh = msdos_sread(dir->i_dev,sector,&data)))
 			continue;
-		*de = (struct msdos_dir_entry *) ((char *)data+(offset &
-		    (SECTOR_SIZE-1)));
-		return (sector << MSDOS_DPS_BITS)+((offset & (SECTOR_SIZE-1)) >>
-		    MSDOS_DIR_BITS);
+		*de = (struct msdos_dir_entry *) ((char *)data+(offset & (SECTOR_SIZE-1)));
+		return (sector << MSDOS_DPS_BITS)+((offset & (SECTOR_SIZE-1)) >> MSDOS_DIR_BITS);
 	}
 }
 
@@ -263,12 +261,10 @@ int msdos_scan(struct inode *dir,char *name,struct buffer_head **res_bh,
 	*res_bh = NULL;
 	while ((*ino = msdos_get_entry(dir,&pos,res_bh,&de)) != -1) {
 		if (name) {
-			if (de->name[0] && ((unsigned char *) (de->name))[0]
-			    != DELETED_FLAG && !(de->attr & ATTR_VOLUME) &&
-			    !strncmp(de->name,name,MSDOS_NAME)) break;
+			if (de->name[0] && ((unsigned char *) (de->name))[0] != DELETED_FLAG
+				&& !(de->attr & ATTR_VOLUME) && !strncmp(de->name,name,MSDOS_NAME)) break;
 		}
-		else if (!de->name[0] || ((unsigned char *) (de->name))[0] ==
-			    DELETED_FLAG) {
+		else if (!de->name[0] || ((unsigned char *) (de->name))[0] == DELETED_FLAG) {
 				if (!(inode = iget(dir->i_dev,*ino))) break;
 				if (!inode->u.msdos_i.i_busy) {
 					iput(inode);

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -51,9 +51,10 @@ int msdos_add_cluster(register struct inode *inode)
 	long count,this,limit,last,current,sector;
 	void *data;
 	struct buffer_head *bh;
+	int fatsz = MSDOS_SB(inode->i_sb)->fat_bits;
 
 #ifndef FAT_BITS_32
-	if (MSDOS_SB(inode->i_sb)->fat_bits != 32)
+	if (fatsz != 32)
 		if (inode->i_ino == MSDOS_ROOT_INO) return -ENOSPC;
 #endif
 	while (lock) sleep_on(&wait);
@@ -75,8 +76,8 @@ printk("free cluster: %d\r\n",this);
 	}
 	fat_access(inode->i_sb,this,
 #ifndef FAT_BITS_32
-	    MSDOS_SB(inode->i_sb)->fat_bits == 12 ?
-	    0xff8UL : MSDOS_SB(inode->i_sb)->fat_bits == 16?0xfff8UL:
+	    fatsz == 12 ?
+	    0xff8UL : fatsz == 16?0xfff8UL:
 #endif
 	    0xffffff8UL);
 	lock = 0;
@@ -93,8 +94,7 @@ printk("set to %x\r\n",fat_access(inode->i_sb,this,-1L));
 		if (current = inode->u.msdos_i.i_start) {
 			cache_lookup(inode,0x7fffffffL,&last,&current);
 			while (current && current != -1)
-				if (!(current = fat_access(inode->i_sb,
-				    last = current,-1L)))
+				if (!(current = fat_access(inode->i_sb, last = current,-1L)))
 					panic("File without EOF");
 			}
 	}
@@ -111,13 +111,12 @@ if (last) printk("next set to %d\r\n",fat_access(inode->i_sb,last,-1L));
 #endif
 	for (current = 0; current < MSDOS_SB(inode->i_sb)->cluster_size;
 	    current++) {
-		sector = MSDOS_SB(inode->i_sb)->data_start+(this-2)*
-		    MSDOS_SB(inode->i_sb)->cluster_size+current;
+		sector = MSDOS_SB(inode->i_sb)->data_start+(this-2) *
+			MSDOS_SB(inode->i_sb)->cluster_size+current;
 #ifdef DEBUG
 printk("zeroing sector %d\r\n",sector);
 #endif
-		if (current < MSDOS_SB(inode->i_sb)->cluster_size-1 &&
-		    !(sector & 1)) {
+		if (current < MSDOS_SB(inode->i_sb)->cluster_size-1 && !(sector & 1)) {
 			if (!(bh = getblk(inode->i_dev,(block_t)(sector >> 1))))
 				printk("getblk failed\r\n");
 			else {
@@ -140,8 +139,7 @@ printk("zeroing sector %d\r\n",sector);
 	if (S_ISDIR(inode->i_mode)) {
 		if (inode->i_size & (SECTOR_SIZE-1))
 			panic("Odd directory size");
-		inode->i_size += SECTOR_SIZE*MSDOS_SB(inode->i_sb)->
-		    cluster_size;
+		inode->i_size += SECTOR_SIZE*MSDOS_SB(inode->i_sb)->cluster_size;
 #ifdef DEBUG
 printk("size is %d now (%x)\r\n",inode->i_size,inode);
 #endif
@@ -174,8 +172,7 @@ long date_dos2unix(unsigned short time,unsigned short date)
 
 /* Convert linear UNIX date to a MS-DOS time/date pair. */
 
-void date_unix2dos(long unix_date,unsigned short *time,
-    unsigned short *date)
+void date_unix2dos(long unix_date,unsigned short *time, unsigned short *date)
 {
 	int day,year,nl_day,month;
 
@@ -356,8 +353,7 @@ static long raw_scan_nonroot(register struct super_block *sb,long start,char *na
 }
 
 /* In the directory file (cluster start) within the name or cluster number number to retrieve the file, return to its ino and cluster number */
-static long raw_scan(struct super_block *sb,long start,char *name,long number,
-    ino_t *ino)
+static long raw_scan(struct super_block *sb,long start,char *name,long number, ino_t *ino)
 {
     if (start) return raw_scan_nonroot(sb,start,name,number,ino);
     else return raw_scan_root(sb,name,number,ino);
@@ -372,12 +368,11 @@ ino_t msdos_parent_ino(register struct inode *dir,int locked)
 	if (!S_ISDIR(dir->i_mode)) panic("Non-directory fed to m_p_i");
 	if (dir->i_ino == MSDOS_ROOT_INO) return dir->i_ino;
 	if (!locked) lock_creation(); /* prevent renames */
-	if ((current = raw_scan(dir->i_sb,dir->u.msdos_i.i_start,MSDOS_DOTDOT,0L,
-	    NULL)) < 0) {
+	if ((current = raw_scan(dir->i_sb,dir->u.msdos_i.i_start,MSDOS_DOTDOT,0L, NULL)) < 0) {
 	}
 	else if (!current) this = MSDOS_ROOT_INO;
 	else {
-		if ((prev = raw_scan(dir->i_sb,current,MSDOS_DOTDOT,0L,NULL))<0) {
+		if ((prev = raw_scan(dir->i_sb,current,MSDOS_DOTDOT,0L,NULL)) < 0) {
 		}
 		else {
 		if (prev == 0 

--- a/elks/fs/msdos/namei.c
+++ b/elks/fs/msdos/namei.c
@@ -31,8 +31,8 @@ static int msdos_format_name(register const char *name,int len,char *res)
 	unsigned char c;
 
 	if (get_fs_byte(name) == DELETED_FLAG) return -EINVAL;
-	if (get_fs_byte(name) == '.' && (len == 1 || (len == 2 &&
-	    get_fs_byte(name+1) == '.'))) {
+	if (get_fs_byte(name) == '.' &&
+		(len == 1 || (len == 2 && get_fs_byte(name+1) == '.'))) {
 		memset(res+1,' ',10);
 		while (len--) *res++ = '.';
 		return 0;
@@ -70,8 +70,7 @@ static int msdos_find(struct inode *dir,const char *name,int len,
 	char msdos_name[MSDOS_NAME];
 	int res;
 
-	if ((res = msdos_format_name(name,len,
-	    msdos_name)) < 0) return res;
+	if ((res = msdos_format_name(name,len, msdos_name)) < 0) return res;
 	return msdos_scan(dir,msdos_name,bh,de,ino);
 }
 
@@ -85,6 +84,7 @@ int msdos_lookup(register struct inode *dir,const char *name,int len,
 	struct buffer_head *bh;
 	struct inode *next;
 	*result = NULL;
+
 /*	if (!dir) return -ENOENT; dir != NULL always, because reached this function dereferencing dir */
 	if (!S_ISDIR(dir->i_mode)) {
 		iput(dir);
@@ -94,8 +94,7 @@ int msdos_lookup(register struct inode *dir,const char *name,int len,
 		*result = dir;
 		return 0;
 	}
-	if (len == 2 && get_fs_byte(name) == '.' && get_fs_byte(name+1) == '.')
-	    {
+	if (len == 2 && get_fs_byte(name) == '.' && get_fs_byte(name+1) == '.') {
 		ino = msdos_parent_ino(dir,0);
 		iput(dir);
 		if (ino < 0) return (int)ino;
@@ -107,7 +106,7 @@ int msdos_lookup(register struct inode *dir,const char *name,int len,
 		return res;
 	}
 	if (bh) unmap_brelse(bh);
-/* printk("lookup: ino=%ld\r\n",ino); */
+/* printk("lookup: ino=%d\n",ino); */
 	if (!(*result = iget(dir->i_sb,ino))) {
 		iput(dir);
 		return -EACCES;
@@ -146,8 +145,7 @@ static int msdos_create_entry(register struct inode *dir,char *name,int is_dir,
 	if (*result = iget(dir->i_sb,ino)) msdos_read_inode(*result);
 	unmap_brelse(bh);
 	if (!*result) return -EIO;
-	(*result)->i_mtime = 
-	    CURRENT_TIME;
+	(*result)->i_mtime = CURRENT_TIME;
 	(*result)->i_dirt = 1;
 	return 0;
 }
@@ -163,8 +161,7 @@ int msdos_create(register struct inode *dir,const char *name,int len,int mode,
 	int res;
 /*    dir != NULL always, because reached this function dereferencing dir */
 /*	if (!dir) return -ENOENT;*/
-	if ((res = msdos_format_name(name,len,
-	    msdos_name)) < 0) {
+	if ((res = msdos_format_name(name,len, msdos_name)) < 0) {
 		iput(dir);
 		return res;
 	}
@@ -191,15 +188,13 @@ int msdos_mkdir(struct inode *dir,const char *name,int len,int mode)
 	ino_t ino;
 	int res;
 
-	if ((res = msdos_format_name(name,len,
-	    msdos_name)) < 0) {
+	if ((res = msdos_format_name(name,len, msdos_name)) < 0) {
 		iput(dir);
 		return res;
 	}
 	lock_creation();
 
 	if (msdos_scan(dir,msdos_name,&bh,&de,&ino) >= 0) {
-
 		unlock_creation();
 		unmap_brelse(bh);
 		iput(dir);
@@ -267,10 +262,10 @@ int msdos_rmdir(register struct inode *dir,const char *name,int len)
 		pos = 0;
 		dbh = NULL;
 		while (msdos_get_entry(inode,&pos,&dbh,&dde) != -1)
-			if (dde->name[0] && ((unsigned char *) dde->name)[0] !=
-			    DELETED_FLAG && strncmp(dde->name,MSDOS_DOT,
-			    MSDOS_NAME) && strncmp(dde->name,MSDOS_DOTDOT,
-			    MSDOS_NAME)) goto rmdir_done; /* linux bug ??? */
+			if (dde->name[0] && ((unsigned char *) dde->name)[0] != DELETED_FLAG
+				&& strncmp(dde->name,MSDOS_DOT, MSDOS_NAME)
+				&& strncmp(dde->name,MSDOS_DOTDOT, MSDOS_NAME))
+					goto rmdir_done; /* linux bug ??? */
 		if (dbh) unmap_brelse(dbh);
 	}
 	inode->i_nlink = 0;

--- a/elks/include/linuxmt/msdos_fs_sb.h
+++ b/elks/include/linuxmt/msdos_fs_sb.h
@@ -10,12 +10,12 @@ struct msdos_sb_info { /* space in struct super_block is 28 bytes */
 	unsigned long clusters;      /* number of clusters */
 	unsigned long root_cluster;
 
-# ifdef CONFIG_UMSDOS_FS
+# ifdef CONFIG_MSDOS_DEV
 	ino_t dev_ino;               /* "/dev" ino */
 # endif
 };
 
-# ifdef CONFIG_UMSDOS_FS
+# ifdef CONFIG_MSDOS_DEV
 #define DEVINO_BASE MSDOS_DPB
 #define DEVDIR_SIZE 16
 

--- a/image/Make.package
+++ b/image/Make.package
@@ -34,7 +34,7 @@ minix:
 	$(MAKE) -f Make.devices "MKDEV=mfs $(MINIX_IMAGE) mknod"
 	mfs $(MINIX_IMAGE) boot $(FD_BSECT)
 #	mfs $(MINIX_IMAGE) boot $(BPB) $(FD_BSECT)
-	mfsck -fv $(MINIX_IMAGE)
+	#mfsck -fv $(MINIX_IMAGE)
 	mfs $(MINIX_IMAGE) stat
 
 # Create bootable ELKS MSDOS disk image:

--- a/image/Make.package
+++ b/image/Make.package
@@ -30,7 +30,7 @@ minix:
 	awk "/$(APPS)/{print}" Packages | cut -f 1 > Filelist
 	mfs $(VERBOSE) $(MINIX_IMAGE) mkfs $(MINIX_MKFSOPTS)
 	mfs $(VERBOSE) $(MINIX_IMAGE) addfs Filelist $(DESTDIR)
-	rm Filelist
+	#rm Filelist
 	$(MAKE) -f Make.devices "MKDEV=mfs $(MINIX_IMAGE) mknod"
 	mfs $(MINIX_IMAGE) boot $(FD_BSECT)
 #	mfs $(MINIX_IMAGE) boot $(BPB) $(FD_BSECT)

--- a/image/Packages
+++ b/image/Packages
@@ -41,7 +41,9 @@
 #									:fileutil
 #										:app
 #										:nanox
-# -------------	------------------------------------------------------
+# Note: For FAT disks, /dev must be first or second root directory to work
+# -------------	----------------------------------------------------------
+/dev			:boot
 /bin			:boot
 /bin/ash		:boot
 /bin/banner								:app
@@ -56,7 +58,7 @@
 /bin/cmp						:shutil
 /bin/cp				:small
 /bin/cut						:shutil
-/bin/date			:small
+/bin/date				:base
 /bin/dd								:fileutil
 /bin/decomp16						:fileutil
 /bin/diff							:fileutil
@@ -78,7 +80,7 @@
 /bin/knl			:small
 /bin/ktcp					:net
 /bin/l								:fileutil
-/bin/ln				:small
+/bin/ln					:base
 /bin/login		:boot
 /bin/logname					:shutil
 /bin/lp						:net
@@ -95,8 +97,8 @@
 /bin/netstat				:net
 /bin/nslookup				:net
 /bin/passwd				:base
-/bin/poweroff		:small
-/bin/printenv		:small
+/bin/poweroff			:base
+/bin/printenv					:shutil
 /bin/proto							:fileutil
 /bin/ps				:small
 /bin/pwd			:small
@@ -107,7 +109,7 @@
 /bin/rmdir			:small
 /bin/sed						:shutil
 /bin/sh			:boot
-/bin/shutdown		:small
+/bin/shutdown			:base
 /bin/sort							:fileutil
 /bin/stty				:base :net
 /bin/sum						:shutil
@@ -133,7 +135,6 @@
 /bin/whoami						:shutil
 /bin/xargs				:base
 /bin/yes				:base
-/dev			:boot
 /etc			:boot
 /etc/group		:boot
 /etc/inittab	:boot


### PR DESCRIPTION
	MSDOSFS implementation of /dev is automatic if /dev is first or second root dir entry
	Renamed CONFIG_UMSDOS_FS to CONFIG_MSDOS_DEV
	Fixed various initialization problems with fsdev
	Reformatted elks/fs/msdos source code with no compilation output changes
	Updated disk image package list for 360k filesystems

@mfld-fr: I have completed the work on getting an internal devfs working for MSDOS FAT disks. It is based on a rewritten CONFIG_UMSDOS_FS (renamed to CONFIG_MSDOS_DEV) and tested with CONFIG_32BIT_INODES=n for now. It also requires setting CONFIG_MSDOS_DEV=y. I am having serious problems getting my build to work correctly since KConfig is broken and I am manually editing .config and include/autoconf.h, and don't have the means to setup the config.in files since I can't test them. The build is acting strangely after hand-editing these files to various values for testing. I will be opening various bug reports for both KConfig on OSX as well as MSDOS FS issues in general (I have found many, this PR however works great).

Providing we can get the configuration system working with a couple of new .config entries, we now have all all that is needed to boot ELKS on FAT images except for the boot loader.

Have fun!