### PR TITLE
[tools] Update mfs boot -B option with new ELKS BPB locations

### DIFF
--- a/elks/tools/mfs/mkfs.c
+++ b/elks/tools/mfs/mkfs.c
@@ -113,9 +113,6 @@ void cmd_mkfs(char *filename, int argc,char **argv) {
 #define ELKS_BPB_SecPerTrk	505		/* offset of sectors per track (byte)*/
 #define ELKS_BPB_NumHeads	506		/* offset of number of heads (byte)*/
 
-/* MSDOS FAT parameters (unused at present)*/
-#define FAT_BPB_SecPerTrk	24		/* offset of sectors per track (short)*/
-#define FAT_BPB_NumHeads	26		/* offset of number of heads (short)*/
 /**
  * Write boot block to image file
  */

--- a/elks/tools/mfs/mkfs.c
+++ b/elks/tools/mfs/mkfs.c
@@ -109,8 +109,13 @@ void cmd_mkfs(char *filename, int argc,char **argv) {
   close_fs(fs);
 }
 
-#define BPB_SecPerTrk	24		/* offset of sectors per track (short)*/
-#define BPB_NumHeads	26		/* offset of number of heads (short)*/
+/* ELKS BPB parameters*/
+#define ELKS_BPB_SecPerTrk	505		/* offset of sectors per track (byte)*/
+#define ELKS_BPB_NumHeads	506		/* offset of number of heads (byte)*/
+
+/* MSDOS FAT parameters (unused at present)*/
+#define FAT_BPB_SecPerTrk	24		/* offset of sectors per track (short)*/
+#define FAT_BPB_NumHeads	26		/* offset of number of heads (short)*/
 /**
  * Write boot block to image file
  */
@@ -153,8 +158,8 @@ void cmd_boot(char *filename, int argc,char **argv) {
 		fprintf(stderr, "%s warning: may not be valid boot block\n", argv[1]);
   
 	if (opt_updatebpb) {	/* update BPB before writing*/
-		blk[BPB_SecPerTrk] = (unsigned char)SecPerTrk;
-		blk[BPB_NumHeads] = (unsigned char)NumHeads;
+		blk[ELKS_BPB_SecPerTrk] = (unsigned char)SecPerTrk;
+		blk[ELKS_BPB_NumHeads] = (unsigned char)NumHeads;
 	}
 	if (fwrite(blk,1,count,ofp) != count) die("fwrite(%s)", argv[1]);
 	fclose(ofp);
@@ -165,8 +170,8 @@ void cmd_boot(char *filename, int argc,char **argv) {
 
 	count = fread(blk,1,512,ofp);
 	if (count != 512) die("fread(%s)", filename);
-	blk[BPB_SecPerTrk] = (unsigned char)SecPerTrk;
-	blk[BPB_NumHeads] = (unsigned char)NumHeads;
+	blk[ELKS_BPB_SecPerTrk] = (unsigned char)SecPerTrk;
+	blk[ELKS_BPB_NumHeads] = (unsigned char)NumHeads;
 	if (fseek(ofp, 0L, SEEK_SET) != 0)
 		die("fseek(%s)", filename);
 	if (fwrite(blk,1,512,ofp) != 512) die("fwrite(%s)", filename);

--- a/elkscmd/rootfs_template/etc/rc.d/rc.sysinit
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sysinit
@@ -42,11 +42,11 @@ then
 fi
 
 #try to mount FAT file system disk
-if test /dev/fd1
+if test /dev/bda1
 then
   echo
   echo -n "Mounting FAT file system: "
-  mount -t msdos /dev/fd1 /mnt
+  mount -t msdos /dev/bda1 /mnt
 fi
 
 # 

--- a/elkscmd/rootfs_template/etc/rc.d/rc.sysinit
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sysinit
@@ -42,11 +42,11 @@ then
 fi
 
 #try to mount FAT file system disk
-if test /dev/bda1
+if test /dev/fd1
 then
   echo
   echo -n "Mounting FAT file system: "
-  mount -t msdos /dev/bda1 /mnt
+  mount -t msdos /dev/fd1 /mnt
 fi
 
 # 

--- a/image/Make.package
+++ b/image/Make.package
@@ -30,10 +30,9 @@ minix:
 	awk "/$(APPS)/{print}" Packages | cut -f 1 > Filelist
 	mfs $(VERBOSE) $(MINIX_IMAGE) mkfs $(MINIX_MKFSOPTS)
 	mfs $(VERBOSE) $(MINIX_IMAGE) addfs Filelist $(DESTDIR)
-	#rm Filelist
+	rm Filelist
 	$(MAKE) -f Make.devices "MKDEV=mfs $(MINIX_IMAGE) mknod"
-	mfs $(MINIX_IMAGE) boot $(FD_BSECT)
-#	mfs $(MINIX_IMAGE) boot $(BPB) $(FD_BSECT)
+	mfs $(MINIX_IMAGE) boot $(BPB) $(FD_BSECT)
 	#mfsck -fv $(MINIX_IMAGE)
 	mfs $(MINIX_IMAGE) stat
 


### PR DESCRIPTION
Also temporarily try mounting FAT filesystem on /dev/fd1 at boot for testing.

This has been tested on QEMU to work correctly on 1440k disks, but fails with 360 and 720 floppies as they will require @tkchia's recent kernel ELKS BPB commit to read the disk geometry using this new mechanism.

Note: The MFS -B option does NOT currently set max_tracks. Should the kernel start using track_max, then the -B parameters will have to include a track_max, and mfs updated as well.