### PR TITLE
[fat] More FAT filesystem cleanup

### DIFF
--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -15,6 +15,7 @@
 #include <linuxmt/msdos_fs.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/stat.h>
+#include <linuxmt/mm.h>
 
 static int msdos_dir_read(struct inode *inode, struct file *filp, char *buf, int count)
 {
@@ -98,7 +99,7 @@ int msdos_readdir(struct inode *inode, register struct file *filp, char *dirent,
 	/* Whether it is complete, and its long file name matches the long file name */
 	int is_long;
 	unsigned char alias_checksum = 0;	/* Make compiler warning go away */
-	unsigned char long_slots = 0;
+//	unsigned char long_slots = 0;
 	unsigned char unicode[52];          /* Limit to two long entries */
 
 	if (!inode || !S_ISDIR(inode->i_mode)) return -EBADF;
@@ -128,7 +129,7 @@ int msdos_readdir(struct inode *inode, register struct file *filp, char *dirent,
 
 			ds = (struct msdos_dir_slot *) de;
 			if (ds->id & 0x40) {
-				long_slots = slot = ds->id & ~0x40;
+//				long_slots = slot = ds->id & ~0x40;
 				is_long = 1;
 				alias_checksum = ds->alias_checksum;
 			}

--- a/elks/fs/msdos/file.c
+++ b/elks/fs/msdos/file.c
@@ -71,16 +71,16 @@ static int msdos_file_read(register struct inode *inode,register struct file *fi
 
 /* printk("msdos_file_read\n"); */
 	if (!inode) {
-		printk("msdos_file_read: inode = NULL\r\n");
+		printk("FAT: read NULL inode\n");
 		return -EINVAL;
 	}
 	if (!S_ISREG(inode->i_mode)) {
-		printk("msdos_file_read: mode = %07o\n",inode->i_mode);
+		printk("FAT: read bad mode %07o\n",inode->i_mode);
 		return -EINVAL;
 	}
 	if (filp->f_pos >= inode->i_size || count <= 0) return 0;
 	start = buf;
-	while (left = MIN(inode->i_size-filp->f_pos,count-(buf-start))) {
+	while ((left = MIN(inode->i_size-filp->f_pos,count-(buf-start))) != 0) {
 		if (!(sector = msdos_smap(inode,filp->f_pos >> SECTOR_BITS)))
 			break;
 		offset = (short)filp->f_pos & (SECTOR_SIZE-1);
@@ -99,18 +99,18 @@ static int msdos_file_write(register struct inode *inode,register struct file *f
     size_t count)
 {
 	long sector;
-	int offset,size,left,written;
+	int offset,size,written;
 	int error;
 	char *start;
 	struct buffer_head *bh;
 	void *data;
 
 	if (!inode) {
-		printk("msdos_file_write: inode = NULL\n");
+		printk("FAT: write NULL inode\n");
 		return -EINVAL;
 	}
 	if (!S_ISREG(inode->i_mode)) {
-		printk("msdos_file_write: mode = %07o\n",inode->i_mode);
+		printk("FAT: write bad mode %07o\n",inode->i_mode);
 		return -EINVAL;
 	}
 /*

--- a/elks/fs/msdos/namei.c
+++ b/elks/fs/msdos/namei.c
@@ -230,7 +230,8 @@ int msdos_mkdir(struct inode *dir,const char *name,int len,int mode)
 	return 0;
 mkdir_error:
 	iput(inode);
-	if (msdos_rmdir(dir,name,len) < 0) panic("rmdir in mkdir failed");
+	if (msdos_rmdir(dir,name,len) < 0)
+		printk("FAT: rmdir fail\n");
 	unlock_creation();
 	return res;
 }

--- a/elkscmd/rootfs_template/etc/rc.d/rc.sysinit
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sysinit
@@ -42,11 +42,11 @@ then
 fi
 
 #try to mount FAT file system disk
-if test /dev/bda1
+if test /dev/fd1
 then
   echo
   echo -n "Mounting FAT file system: "
-  mount -t msdos /dev/bda1 /mnt
+  mount -t msdos /dev/fd1 /mnt
 fi
 
 # 


### PR DESCRIPTION
	Reduce kernel data size by cleaning up and standardizing printk messages
	Remove all forced kernel panics from badly formatted fat images, printk instead
	Clean up source and compiler output warnings
	Change rc.sysinit to check mount /dev/fd1 rather than /dev/bda1 for easier testing