### PR TITLE
[fat] Add fsdebug() macro for FAT filesystem debugging

### DIFF
--- a/elks/fs/inode.c
+++ b/elks/fs/inode.c
@@ -349,7 +349,7 @@ struct inode *__iget(struct super_block *sb,
 	} while ((inode = inode->i_prev) != NULL);
     } while (n_ino == NULL);
     inode = n_ino;			/* Inode not found, use the new structure */
-    debug1("iget: got one... (%x)!\n", empty);
+    debug("iget: got one...\n");
 
     inode->i_sb = sb;
     inode->i_dev = sb->s_dev;

--- a/elks/fs/minix/bitmap.c
+++ b/elks/fs/minix/bitmap.c
@@ -169,7 +169,7 @@ void minix_free_inode(register struct inode *inode)
     else {
 	map_buffer(bh);
 	if (!clear_bit((unsigned int) ((unsigned int)inode->i_ino & 8191), bh->b_data)) {
-	    debug1("%s: bit %ld already cleared.\n",ino);
+	    debug1("minix_free_inode: bit %ld already cleared.\n",((unsigned int)inode->i_ino & 8191));
 	}
 	clear_inode(inode);
 	mark_buffer_dirty(bh, 1);

--- a/elks/fs/msdos/fat.c
+++ b/elks/fs/msdos/fat.c
@@ -270,6 +270,7 @@ int fat_free(register struct inode *inode,long skip)
 {
 	long this,last;
 
+fsdebug("fat_free\n");
 	if (!(this = inode->u.msdos_i.i_start)) return 0;
 	last = 0;
 	while (skip--) {

--- a/elks/fs/msdos/file.c
+++ b/elks/fs/msdos/file.c
@@ -69,7 +69,7 @@ static int msdos_file_read(register struct inode *inode,register struct file *fi
 	struct buffer_head *bh;
 	void *data;
 
-/* printk("msdos_file_read\n"); */
+//fsdebug("msdos_file_read\n");
 	if (!inode) {
 		printk("FAT: read NULL inode\n");
 		return -EINVAL;

--- a/elks/fs/msdos/file.c
+++ b/elks/fs/msdos/file.c
@@ -69,7 +69,7 @@ static int msdos_file_read(register struct inode *inode,register struct file *fi
 	struct buffer_head *bh;
 	void *data;
 
-//fsdebug("msdos_file_read\n");
+//fsdebug("file_read\n");
 	if (!inode) {
 		printk("FAT: read NULL inode\n");
 		return -EINVAL;
@@ -86,8 +86,8 @@ static int msdos_file_read(register struct inode *inode,register struct file *fi
 		offset = (short)filp->f_pos & (SECTOR_SIZE-1);
 		if (!(bh = msdos_sread(inode->i_dev,sector,&data))) break;
 		filp->f_pos += (size = MIN(SECTOR_SIZE-offset,left));
-			memcpy_tofs(buf,(char *)data+offset,size);
-			buf += size;
+		memcpy_tofs(buf,(char *)data+offset,size);
+		buf += size;
 		unmap_brelse(bh);
 	}
 	if (start == buf) return -EIO;
@@ -105,6 +105,7 @@ static int msdos_file_write(register struct inode *inode,register struct file *f
 	struct buffer_head *bh;
 	void *data;
 
+fsdebug("file_write\n");
 	if (!inode) {
 		printk("FAT: write NULL inode\n");
 		return -EINVAL;
@@ -130,9 +131,9 @@ static int msdos_file_write(register struct inode *inode,register struct file *f
 			error = -EIO;
 			break;
 		}
-			memcpy_fromfs((char *)data+((short)filp->f_pos & (SECTOR_SIZE-1)),
+		memcpy_fromfs((char *)data+((short)filp->f_pos & (SECTOR_SIZE-1)),
 			    buf,written = size);
-			buf += size;
+		buf += size;
 		filp->f_pos += written;
 		if (filp->f_pos > inode->i_size) {
 			inode->i_size = filp->f_pos;
@@ -152,6 +153,7 @@ void msdos_truncate(register struct inode *inode)
 {
 	int cluster;		//FIXME should this be long for FAT32?
 
+fsdebug("truncate\n");
 	cluster = SECTOR_SIZE*MSDOS_SB(inode->i_sb)->cluster_size;
 	(void) fat_free(inode,(inode->i_size+(cluster-1))/cluster);
 	inode->u.msdos_i.i_attrs |= ATTR_ARCH;

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -38,7 +38,7 @@ struct msdos_devdir_entry devnods[DEVDIR_SIZE] = {
 
 void msdos_put_inode(register struct inode *inode)
 {
-//printk("iput %ld count %d dirty %d\n", (unsigned long)inode->i_ino, inode->i_count, inode->i_dirt);
+fsdebug("iput %ld count %d dirty %d\n", (unsigned long)inode->i_ino, inode->i_count, inode->i_dirt);
 	if (!inode->i_nlink) {
 		inode->i_size = 0;
 		msdos_truncate(inode);
@@ -49,7 +49,7 @@ void msdos_put_inode(register struct inode *inode)
 
 void msdos_put_super(register struct super_block *sb)
 {
-//printk("put super\n");
+fsdebug("put super\n");
 	cache_inval_dev(sb->s_dev);
 	lock_super(sb);
 	sb->s_dev = 0;
@@ -205,7 +205,7 @@ void msdos_read_inode(register struct inode *inode)
 	long this,nr;
 	int fatsz = MSDOS_SB(inode->i_sb)->fat_bits;
 
-//printk("read inode %ld\n", (unsigned long)inode->i_ino);
+fsdebug("read inode %ld\n", (unsigned long)inode->i_ino);
 	inode->u.msdos_i.i_busy = 0;
 	inode->i_uid = current->uid;
 	inode->i_gid = current->gid;
@@ -291,7 +291,7 @@ void msdos_write_inode(register struct inode *inode)
 	struct buffer_head *bh;
 	register struct msdos_dir_entry *raw_entry;
 
-//printk("iwrite %ld %d\n", (unsigned long)inode->i_ino, inode->i_dirt);
+fsdebug("iwrite %ld %d\n", (unsigned long)inode->i_ino, inode->i_dirt);
 	inode->i_dirt = 0;
 	if (inode->i_ino == MSDOS_ROOT_INO || !inode->i_nlink) return;
 	if (!(bh = bread(inode->i_dev,(block_t)(inode->i_ino >> MSDOS_DPB_BITS)))) {

--- a/elks/fs/msdos/namei.c
+++ b/elks/fs/msdos/namei.c
@@ -106,7 +106,7 @@ int msdos_lookup(register struct inode *dir,const char *name,int len,
 		return res;
 	}
 	if (bh) unmap_brelse(bh);
-/* printk("lookup: ino=%ld\n",(unsigned long)ino); */
+//fsdebug("lookup: ino=%ld\n",(unsigned long)ino);
 	if (!(*result = iget(dir->i_sb,ino))) {
 		iput(dir);
 		return -EACCES;
@@ -315,8 +315,8 @@ int msdos_unlink(register struct inode *dir,const char *name,int len)
 	bh->b_dirty = 1;
 unlink_done:
 	unmap_brelse(bh);
-//if (inode) printk("unlink iput inode %u dirt %d count %d\n", inode->i_ino, inode->i_dirt, inode->i_count);
-//if (dir) printk("unlink iput dir %u dirt %d count %d\n", dir->i_ino, dir->i_dirt, dir->i_count);
+if (inode) fsdebug("unlink iput inode %u dirt %d count %d\n", inode->i_ino, inode->i_dirt, inode->i_count);
+if (dir) fsdebug("unlink iput dir %u dirt %d count %d\n", dir->i_ino, dir->i_dirt, dir->i_count);
 	iput(inode);
 	iput(inode);	/* 2nd call required from iget() above*/
 	iput(dir);

--- a/elks/fs/msdos/namei.c
+++ b/elks/fs/msdos/namei.c
@@ -121,7 +121,7 @@ int msdos_lookup(register struct inode *dir,const char *name,int len,
 }
 
 
-/* Creates a directory entry (name is already formatted). */
+/* Create a new directory entry (name is already formatted). */
 
 static int msdos_create_entry(register struct inode *dir,char *name,int is_dir,
     register struct inode **result)
@@ -131,9 +131,14 @@ static int msdos_create_entry(register struct inode *dir,char *name,int is_dir,
 	int res;
 	ino_t ino;
 
+fsdebug("create_entry\n");
+	/* find empty directory entry*/
 	if ((res = msdos_scan(dir,NULL,&bh,&de,&ino)) < 0) {
+		/* if rootdir return no space*/
 		if (dir->i_ino == MSDOS_ROOT_INO) return -ENOSPC;
+		/* try adding space to directory*/
 		if ((res = msdos_add_cluster(dir)) < 0) return res;
+		/* if can't find empty entry return error*/
 		if ((res = msdos_scan(dir,NULL,&bh,&de,&ino)) < 0) return res;
 	}
 	memcpy(de->name,name,MSDOS_NAME);
@@ -166,6 +171,7 @@ int msdos_create(register struct inode *dir,const char *name,int len,int mode,
 		return res;
 	}
 	lock_creation();
+	/* check for name already present*/
 	if (msdos_scan(dir,msdos_name,&bh,&de,&ino) >= 0) {
 		unlock_creation();
 		unmap_brelse(bh);

--- a/elks/include/linuxmt/msdos_fs.h
+++ b/elks/include/linuxmt/msdos_fs.h
@@ -9,7 +9,7 @@
 #include <linuxmt/ctype.h>
 
 /* temporary FAT filesystem debugging*/
-#if 0
+#ifdef FSDEBUG
 #define fsdebug			printk
 #else
 #define fsdebug(...)

--- a/elks/include/linuxmt/msdos_fs.h
+++ b/elks/include/linuxmt/msdos_fs.h
@@ -8,6 +8,13 @@
 #include <linuxmt/fs.h>
 #include <linuxmt/ctype.h>
 
+/* temporary FAT filesystem debugging*/
+#if 0
+#define fsdebug			printk
+#else
+#define fsdebug(...)
+#endif
+
 #ifndef toupper
 extern char toupper(char c);
 #endif
@@ -120,8 +127,6 @@ struct fat_cache {
 /* Convert the UNIX mode to MS-DOS attribute bits. */
 
 #define MSDOS_MKATTR(m) (!(m & 0200) ? ATTR_RO : ATTR_NONE)
-
-extern int fatbits; /*global*/
 
 extern struct buffer_head *msdos_sread(int dev,long sector,void **start);
 

--- a/elks/lib/chqueue.c
+++ b/elks/lib/chqueue.c
@@ -103,8 +103,8 @@ int chq_getch(register struct ch_queue *q)
 {
     register char *retval;
 
-    debug6("CHQ: chq_getch(%d, %d, %d) q->len=%d q->start=%d q->size=%d\n",
-	   q, c, wait, q->len, q->start, q->size);
+    debug4("CHQ: chq_getch(%d) q->len=%d q->start=%d q->size=%d\n",
+	   q, q->len, q->start, q->size);
 
     if (!q->len)
 	retval = (char *)(-EAGAIN);


### PR DESCRIPTION
Added varargs-capable fsdebug() macro in FAT code to eliminate the need to comment in and out printk for debugging. Default OFF but set to ON when #define FSDEBUG 1 set (probably in include/linuxmt/debug.h).

Fix kernel compile when #define DEBUG 1 set in debug.h.

The ELKS kernel is too large to link when built with DEBUG=1. In addition, the entire kernel source uses an extremely outdated method of debug(), debug1(), debug2() macros that specify how many extra arguments printk needs, all designed prior to GCC implementing the varargs-capable #define debug(...) mechanism in C.

It would be a bit of typing, but I propose that an improved method of kernel printk debugging be written, which does away with all the cruddy debugX() macros that require an explicit argument count, only to be replaced with a debug macro that uses the current kernel (set by a user program)  "debug level" that allows deeper levels of detail to be produced. A set of macros (same name, different meaning, I know) like debug1(), debug2(), debug3() would printk when the current debug level was set to 1, 2 or 3 etc., respectively. The current debug method is entirely unusable since the kernel won't even build with it turned on. Thoughts?

This PR uses a temporary fsdebug() macro to allow the nasty last known FAT bug to be tracked, without having to rewrite all the kernel debug statements.

On the business of debugging this last FAT problem, I am starting to think that is is not a straight-forward buffer overrun into data or code space, but instead, something to do with kernel lock timing, or corrupted kernel data as a result of not-working or unimplemented required locking in the FAT code. The reason for this is that I have *never* seen the bug when kernel printk is turned on, whose effect would be to massively slow down and change the kernel timing. With printk's off, an occasional hang is seen.

@mfld-fr: I need a mechanism to turn on and off fsdebug from userland. Thanks for your `knl` comments, after looking at its source and your direction, I think we should just remove it, as it doesn't work anyways. We still need a program and a way to communicate to some kernel global variable, or u-space structure that could allow fsdebug to be turned on or off... this will allow us to get closer to the last remaining FAT bug. Please let me know what you think.


