### PR TITLE
[fat] Fix longstanding system crash on FAT directory write

### DIFF
--- a/elks/fs/inode.c
+++ b/elks/fs/inode.c
@@ -169,12 +169,8 @@ static void list_inode_status(void)
     register struct inode *inode = inode_llru;
 
     do {
-#ifdef CONFIG_32BIT_INODES
         printk("[#%u: c=%u d=%x nr=%lu]", ((int)(pi++)),
-#else
-        printk("[#%u: c=%u d=%x nr=%u]", ((int)(pi++)),
-#endif
-		inode->i_count, inode->i_dev, inode->i_ino);
+			inode->i_count, inode->i_dev, (unsigned long)inode->i_ino);
     } while ((inode = inode->i_prev) != NULL);
 }
 
@@ -227,12 +223,8 @@ void iput(register struct inode *inode)
 	wait_on_inode(inode);
 	if (!inode->i_count) {
 	    printk("VFS: iput: trying to free free inode\n"
-#ifdef CONFIG_32BIT_INODES
-		    "VFS: device %s, inode %lu, mode=0%06o\n",
-#else
-		    "VFS: device %s, inode %u, mode=0%06o\n",
-#endif
-		   kdevname(inode->i_rdev), inode->i_ino, inode->i_mode);
+			"VFS: device %s, inode %lu, mode=0%06o\n",
+			kdevname(inode->i_rdev), (unsigned long)inode->i_ino, inode->i_mode);
 	    return;
 	}
 #ifdef NOT_YET
@@ -329,11 +321,7 @@ struct inode *__iget(struct super_block *sb,
     register struct inode *inode;
     register struct inode *n_ino;
 
-#ifdef CONFIG_32BIT_INODES
-    debug3("iget called(%x, %lu, %d)\n", sb, inr, 0 /* crossmntp */ );
-#else
-    debug3("iget called(%x, %u, %d)\n", sb, inr, 0 /* crossmntp */ );
-#endif
+    debug3("iget called(%x, %lu, %d)\n", sb, (unsigned long)inr, 0 /* crossmntp */ );
     if (!sb)
 	panic("VFS: iget with sb==NULL");
 

--- a/elks/fs/msdos/namei.c
+++ b/elks/fs/msdos/namei.c
@@ -82,7 +82,6 @@ int msdos_lookup(register struct inode *dir,const char *name,int len,
 	int res;
 	struct msdos_dir_entry *de;
 	struct buffer_head *bh;
-	struct inode *next;
 	*result = NULL;
 
 /*	if (!dir) return -ENOENT; dir != NULL always, because reached this function dereferencing dir */
@@ -146,6 +145,7 @@ fsdebug("create_entry\n");
 	de->start = 0;
 	date_unix2dos(CURRENT_TIME,&de->time,&de->date);
 	de->size = 0;
+fsdebug("create_entry block write %d\n", bh->b_blocknr);
 	bh->b_dirty = 1;
 	if ((*result = iget(dir->i_sb,ino)) != 0) msdos_read_inode(*result);
 	unmap_brelse(bh);
@@ -279,6 +279,7 @@ int msdos_rmdir(register struct inode *dir,const char *name,int len)
 	dir->i_mtime = CURRENT_TIME;
 	inode->i_dirt = dir->i_dirt = 1;
 	de->name[0] = DELETED_FLAG;
+fsdebug("rmdir block write %d\n", bh->b_blocknr);
 	bh->b_dirty = 1;
 	res = 0;
 rmdir_done:
@@ -318,6 +319,7 @@ int msdos_unlink(register struct inode *dir,const char *name,int len)
 	inode->i_dirt = 1;
 	de->name[0] = DELETED_FLAG;
 	dir->i_dirt = 1;
+fsdebug("unlink block write %d\n", bh->b_blocknr);
 	bh->b_dirty = 1;
 unlink_done:
 	unmap_brelse(bh);

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -340,7 +340,7 @@ struct super_block {
  * to have different dirent layouts depending on the binary type.
  */
 
-typedef int (*filldir_t) ();
+typedef int (*filldir_t) (char *, char *, size_t, off_t, ino_t);
 
 struct file_operations {
     int				(*lseek) ();

--- a/elks/include/linuxmt/kdev_t.h
+++ b/elks/include/linuxmt/kdev_t.h
@@ -45,7 +45,7 @@ extern char *kdevname(kdev_t);	  /* note: returns pointer to static data! */
 #define kdev_t_to_nr(dev)	((__u16) dev)
 #define to_kdev_t(dev)		((kdev_t) dev)
 
-#else  /* __KERNEL__
+#else  /* __KERNEL__*/
 
 /* Some programs want their definitions of MAJOR and MINOR and MKDEV
  * from the kernel sources. These must be the externally visible ones.

--- a/elks/include/linuxmt/msdos_fs.h
+++ b/elks/include/linuxmt/msdos_fs.h
@@ -114,7 +114,7 @@ struct slot_info {
 
 struct fat_cache {
 	int device; /* device number. 0 means unused. */
-	long ino; /* inode number. */
+	ino_t ino; /* inode number. */
 	long file_cluster; /* cluster number in the file. */
 	long disk_cluster; /* cluster number on disk. */
 	struct fat_cache *next; /* next cache entry */

--- a/image/Make.package
+++ b/image/Make.package
@@ -55,7 +55,7 @@ MSDOS_IMAGE=$(IMGDIR)/$(NAME).bin
 # -f size	image size in kilobytes
 # -M 512	software sector size 512 (=physical sector size)
 # -d 2		2 FAT tables
-# -L 9		9 FAT sectors
+# -L 9		9 FAT sectors (mformat forces 3 for 360k, 5 for 720k)
 # -r 14		14 root directory sectors
 # -c 1		cluster size 1 sector
 # -R 1		1 reserve sector (boot, may need to reserve 2)

--- a/image/Makefile
+++ b/image/Makefile
@@ -99,7 +99,7 @@ fd1440-minix:
 	$(MAKE) -f Make.package minix NAME=fd1440-minix OPTS="-i360 -s1440" BPB=-B18,2 APPS=":boot|:small|:base|:net|:shutil|:fileutil|:app|:nanox"
 
 
-images-fat: fd360-fat fd720-fat fd1440-fat
+images-fat: fd360-fat fd720-fat fd1440-fat fd2880-fat
 
 fd360-fat:
 	$(MAKE) -f Make.package msdos NAME=fd360-fat SIZE=360 APPS=":boot|:small"
@@ -110,3 +110,6 @@ fd720-fat:
 fd1440-fat:
 	$(MAKE) -f Make.package msdos NAME=fd1440-fat SIZE=1440 APPS=":boot|:small|:base|:net|:shutil|:fileutil|:app|:nanox"
 
+# FAT16 image
+fd2880-fat:
+	$(MAKE) -f Make.package msdos NAME=fd2880-fat SIZE=2880 APPS=":boot|:small|:base|:net|:shutil|:fileutil|:app|:nanox"


### PR DESCRIPTION
	remove non-working backup FAT table code and increase speed greatly on cluster adds
	heavy cleanup and some refactoring of FAT filesystem code for speed and size
	add fsdebug macro for filesystem printk debugging, set with FSDEBUG=1
	add check for disk too large on FAT16/32 when CONFIG_32BIT_INODES off
	Remove unneeded CONFIG_32BIT_INODES #ifdefs
	create fd2880-fat.bin in package manager for FAT16 testing

No more known bugs in FAT filesystem. Ready for user testing.