### PR TITLE
[image] Fix "make images-fat" build

### DIFF
--- a/image/Make.package
+++ b/image/Make.package
@@ -94,6 +94,7 @@ msdos:
 	do \
 		[ -d $(DESTDIR)/$$f ] && mmd -i $(MSDOS_IMAGE) ::$$f; \
 		[ -f $(DESTDIR)/$$f ] && mcopy -i $(MSDOS_IMAGE) $(MSDOS_COPYOPTS) $(DESTDIR)$$f ::$$f; \
+		true; \
 	done
 	rm Filelist
 	#mdir -i $(MSDOS_IMAGE) -/ -a ::

--- a/image/Make.package
+++ b/image/Make.package
@@ -84,7 +84,7 @@ msdos:
 #	write ELKS boot sector, mformat will only modify BPB
 #	setboot $(MSDOS_IMAGE) $(BPB) $(FD_BOOTSECT)
 	mformat -i $(MSDOS_IMAGE) $(MSDOS_MKFSOPTS)
-	-rm linux; touch linux
+	rm -f linux; touch linux
 	mcopy -i $(MSDOS_IMAGE) $(MSDOS_COPYOPTS) linux ::/linux
 #	change attributes of /linux to read-only, system, hidden (command broken)
 #	mattrib -i $(MSDOS_IMAGE) +r +s +h ::/linux
@@ -92,9 +92,14 @@ msdos:
 	#mdir -i $(MSDOS_IMAGE) -/ -a ::
 	for f in `cat Filelist`; \
 	do \
-		[ -d $(DESTDIR)/$$f ] && mmd -i $(MSDOS_IMAGE) ::$$f; \
-		[ -f $(DESTDIR)/$$f ] && mcopy -i $(MSDOS_IMAGE) $(MSDOS_COPYOPTS) $(DESTDIR)$$f ::$$f; \
-		true; \
+		if [ ! -e $(DESTDIR)$$f ]; \
+		then \
+			echo "File specified in Package not found: $(DESTDIR)$$f"; \
+			exit 1; \
+		else \
+			[ -d $(DESTDIR)/$$f ] && mmd -i $(MSDOS_IMAGE) ::$$f; \
+			[ -f $(DESTDIR)/$$f ] && mcopy -i $(MSDOS_IMAGE) $(MSDOS_COPYOPTS) $(DESTDIR)$$f ::$$f; \
+		fi \
 	done
 	rm Filelist
 	#mdir -i $(MSDOS_IMAGE) -/ -a ::

--- a/image/Makefile
+++ b/image/Makefile
@@ -12,7 +12,7 @@ export DESTDIR
 
 # add image block size to mkfs options for mfs
 MFS_OPTS=$(MKFS_OPTS) -s$(TARGET_BLKS) -k
-VERBOSE=-v
+#VERBOSE=-v
 
 # Determine what to build for 'all' target
 


### PR DESCRIPTION
@mfld-fr:

I pulled down the latest upstream master, which only included my two latest [fat] cleanup commits, and your latest branch 'next' to 'master' merge. I noticed that the "cd image; make images-fat" was now failing, after the last executed `mcopy` inside Make.packages at the end of the do/done shell loop. It appears, for reasons I just cannot find or understand, that the exit value from the last execution of mcopy is stopping the build??! I have double-checked everything and the mcopy is not changed, and is copying, created filesystem disk image is not full.

I have looked through your commit, and can't find anything that could cause this, there's also been nothing changed on my end. Perhaps another shell is being used within make? I saw some changes to use /bin/bash and removal of CFG_SHELL in your commit, but these have nothing to do with this, my env SHELL=/bin/bash. I just don't get it.

In any case, inserting a 'true' into the loop fixes this very strange problem! I would like to ask you try running 'make images' on your system to see whether this is only occurring on OSX. If so, then I guess this PR will be needed for me, for reasons I can't explain.

Thank you!!