### PR TITLE
[fat] Finish up 360k, 720k, 1440k and 2880k FAT boot images

### DIFF
--- a/elks/tools/setboot/setboot.c
+++ b/elks/tools/setboot/setboot.c
@@ -3,7 +3,7 @@
  *
  * 7 Feb 2020 Greg Haerr <greg@censoft.com>
  *
- * Usage: setboot <image> [-B<sectors>,<heads>] [<input_boot_sector>]
+ * Usage: setboot <image> [-F] [-B<sectors>,<heads>] [<input_boot_sector>]
  *
  *	setboot writes image after optionally reading an input boot sector and
  *		optionally modifying boot sector disk parameters passed as parameters.
@@ -13,6 +13,8 @@
  * 			-> set 9 sectors 2 heads on boot sector or bootable disk <image> file
  *		setboot <image> -B18,2 <bootsector>
  *			-> read <bootsector>, set 18 sectors 2 heads, write <image>
+ *		setboot <image> -F <bootsector>
+ *			-> read <bootsector>, copy skipping FAT BPB to output <image>
  *
  *	Currently only writes ELKS sector_max and head_max values.
  */
@@ -27,6 +29,10 @@
 /* See bootblocks/minix.map for the offsets */
 #define ELKS_BPB_SecPerTrk	0x1F9		/* offset of sectors per track (byte)*/
 #define ELKS_BPB_NumHeads	0x1FA		/* offset of number of heads (byte)*/
+
+/* FAT BPB start and end offsets*/
+#define FATBPB_START	3
+#define FATBPB_END		61
 
 static int SecPerTrk, NumHeads;
 
@@ -66,34 +72,49 @@ int main(int argc,char **argv)
 {
 	FILE *ifp = NULL, *ofp;
 	struct stat sb;
-	int count;
+	int count, i;
 	int opt_new_bootsect = 0, opt_updatebpb = 0;
+	int opt_skipfatbpb = 0;
 	char *outfile, *infile = NULL;
-	unsigned char blk[SECT_SIZE];
+	unsigned char blk[SECT_SIZE*2];
+	unsigned char inblk[SECT_SIZE];
 
-	if (argc != 3 && argc != 4)
-		fatalmsg("Usage: %s <image> [-B<sectors>,<heads>] [<input_boot_image>]\n", argv[0]);
+	if (argc != 3 && argc != 4 && argc != 5)
+		fatalmsg("Usage: %s <image> [-F] [-B<sectors>,<heads>] [<input_boot_image>]\n", argv[0]);
 
 	outfile = *++argv; argc--;
 
-	if (argv[1][0] == '-' && argv[1][1] == 'B') {
-		opt_updatebpb = 1;			/* BPB update specified*/
-		if (sscanf(&argv[1][2], "%d,%d", &SecPerTrk, &NumHeads) != 2)
-			fatalmsg("Invalid -B<sectors>,<heads> option\n");
-		printf("Updating BPB to %d sectors, %d heads\n", SecPerTrk, NumHeads);
-		argv++;
-		argc--;
+	while (argv[1] && argv[1][0] == '-') {
+		if (argv[1][1] == 'B') {
+			opt_updatebpb = 1;			/* BPB update specified*/
+			if (sscanf(&argv[1][2], "%d,%d", &SecPerTrk, &NumHeads) != 2)
+				fatalmsg("Invalid -B<sectors>,<heads> option\n");
+			printf("Updating BPB to %d sectors, %d heads\n", SecPerTrk, NumHeads);
+			argv++;
+			argc--;
+		}
+		else if (argv[1][1] == 'F') {
+			opt_skipfatbpb = 1;			/* skip FAT BPB specified*/
+			printf("Skipping FAT BPB\n");
+			argv++;
+			argc--;
+		}
 	}
 	if (argc == 2) {			/* new boot sector specified*/
 		infile = *++argv;
 		opt_new_bootsect = 1;
 	}
 
+	if (opt_skipfatbpb && !opt_new_bootsect)
+		fatalmsg("-F option requires input_boot_image\n");
+
 	if (opt_new_bootsect) {
 		if (stat(infile,&sb)) die("stat(%s)",infile);
 		if (!S_ISREG(sb.st_mode)) fatalmsg("%s: not a regular file\n",infile);
-		if (sb.st_size != SECT_SIZE)
-				fatalmsg("%s: boot sector size not equal to %d bytes\n", infile, SECT_SIZE);
+		if (opt_skipfatbpb && sb.st_size != SECT_SIZE)
+			fatalmsg("%s: boot sector size not equal to %d bytes\n", infile, SECT_SIZE);
+		else if (sb.st_size > SECT_SIZE * 2)
+			fatalmsg("%s: Bad boot sector size: %d bytes\n", sb.st_size);
 
 		ifp = fopen(infile,"rb");
 		if (!ifp) die(infile);
@@ -101,9 +122,28 @@ int main(int argc,char **argv)
 		ofp = fopen(outfile,"r+b");
 		if (!ofp) die(outfile);
 
-		count = fread(blk,1,SECT_SIZE,ifp);
-		if (count != sb.st_size) die("fread(%s)", infile);
+		if (opt_skipfatbpb) {
+			/* read boot block into temp buffer*/
+			count = fread(inblk,1,SECT_SIZE,ifp);
+			if (count != sb.st_size) die("fread(%s)", infile);
 
+			/* read image boot sector into output buffer*/
+			count = fread(blk,1,SECT_SIZE,ofp);
+			if (count != sb.st_size) die("fread(%s)", infile);
+			if (fseek(ofp, 0L, SEEK_SET) != 0)
+				die("fseek(%s)", outfile);
+
+			/* copy boot sector skipping FAT BPB*/
+			for (i=0; i<SECT_SIZE; i++) {
+				if (i < FATBPB_START || i > FATBPB_END)
+					blk[i] = inblk[i];
+			}
+		} else {
+			/* read boot block directly into output block*/
+			count = fread(blk,1,SECT_SIZE*2,ifp);
+			if (count != sb.st_size) die("fread(%s)", infile);
+
+		}
 		if (blk[510] != 0x55 || blk[511] != 0xaa)
 		fprintf(stderr, "Warning: '%s' may not be valid bootable sector\n", infile);
 
@@ -118,9 +158,10 @@ int main(int argc,char **argv)
 
 			count = fread(blk,1,SECT_SIZE,ofp);
 			if (count != 512) die("fread(%s)", outfile);
+
 			setSHparms(blk);
 			if (fseek(ofp, 0L, SEEK_SET) != 0)
-			die("fseek(%s)", outfile);
+				die("fseek(%s)", outfile);
 			if (fwrite(blk,1,SECT_SIZE,ofp) != SECT_SIZE) die("fwrite(%s)", outfile);
 			fclose(ofp);
 		}

--- a/elkscmd/bootblocks/boot_sect.S
+++ b/elkscmd/bootblocks/boot_sect.S
@@ -261,12 +261,8 @@ _disk_read:
 dr_loop:
 	// Compute the CHS from logical sector
 	// AX = logical sector
-#ifndef BOOT_FAT
 	mov sect_max,%bl
 	xor %bh,%bh
-#else
-	mov sect_max,%bx
-#endif
 	xor %dx,%dx
 	divw %bx
 	mov %dl,%cl      // CL = physical sector number in track, minus 1
@@ -507,14 +503,16 @@ copy_sect:
 //------------------------------------------------------------------------------
 
 msg_boot:
-	.asciz "ELKS boot\r\n"
+	.asciz "ELKS"
 
 msg_error:
 	.asciz "!\r\n"
 
 msg_reboot:
-	.asciz "Press key\r\n"
+	.asciz "Presskey\r\n"
 
+	.global last_code
+last_code:
 //------------------------------------------------------------------------------
 
 // ELKS disk parameter structure

--- a/elkscmd/bootblocks/boot_sect_fat.h
+++ b/elkscmd/bootblocks/boot_sect_fat.h
@@ -6,19 +6,19 @@
 
 .macro FAT_BPB
 #if defined(CONFIG_IMG_FD360)
-	.set FAT_SEC_PER_CLUS, 2
-	.set FAT_ROOT_ENT_CNT, 112
+	.set FAT_SEC_PER_CLUS, 1
+	.set FAT_ROOT_ENT_CNT, 224
 	.set FAT_TOT_SEC, 720
 	.set FAT_MEDIA_BYTE, 0xfd
-	.set FAT_TABLE_SIZE, 2
+	.set FAT_TABLE_SIZE, 3
 	.set FAT_SEC_PER_TRK, 9
 	.set FAT_NUM_HEADS, 2
 #elif defined(CONFIG_IMG_FD720)
-	.set FAT_SEC_PER_CLUS, 2
-	.set FAT_ROOT_ENT_CNT, 112
+	.set FAT_SEC_PER_CLUS, 1
+	.set FAT_ROOT_ENT_CNT, 224
 	.set FAT_TOT_SEC, 1440
 	.set FAT_MEDIA_BYTE, 0xf9
-	.set FAT_TABLE_SIZE, 3
+	.set FAT_TABLE_SIZE, 9
 	.set FAT_SEC_PER_TRK, 9
 	.set FAT_NUM_HEADS, 2
 #elif defined(CONFIG_IMG_FD1200)
@@ -124,6 +124,18 @@ bpb_tot_sec_32:				// Total number of sectors, 32-bit
 .else
 	.long 0
 .endif
+bpb_drv_num:				// INT 13 drive number
+	.byte 0
+bpb_reserved1:				// Reserved
+	.byte 0
+bpb_bootsig:				// Extended boot signature
+	.byte 0x29
+bpb_vol_id:					// Volume serial number
+	.long 0
+bpb_vol_label:				// Volume label (11 bytes)
+	.ascii "NO NAME    "
+bpb_fil_sys_type:			// Filesystem type (8 bytes)
+	.ascii "FAT12   "
 .endm
 
 .macro FAT_LOAD_AND_RUN_KERNEL

--- a/image/Make.package
+++ b/image/Make.package
@@ -32,20 +32,19 @@ minix:
 	mfs $(VERBOSE) $(MINIX_IMAGE) addfs Filelist $(DESTDIR)
 	rm Filelist
 	$(MAKE) -f Make.devices "MKDEV=mfs $(MINIX_IMAGE) mknod"
-	mfs $(MINIX_IMAGE) boot $(FD_BOOTBLOCK)
-#	This overrides the parameters from the build configuration
-	setboot $(MINIX_IMAGE) $(BPB)
+#	Write boot and override the parameters from the build configuration
+	setboot $(MINIX_IMAGE) $(BPB) $(FD_BOOTBLOCK)
 	#mfsck -fv $(MINIX_IMAGE)
 	mfs $(MINIX_IMAGE) stat
 
 # Create bootable ELKS MSDOS disk image:
 #	Select tagged files into filelist
 #	Create empty filesystem
-#	Write boot sector (not completed)
 #	Create \linux as first directory entry
 #	Add tagged files into filesystem (regular, directories, links)
 #		Filename case is preserved
 #		Note: filenames larger than 8.3 will create VFAT LFN entries
+#	Write boot sector and modify ELKS PB
 
 # all mtools commands require image file
 # -i image	image filename
@@ -59,7 +58,7 @@ MSDOS_IMAGE=$(IMGDIR)/$(NAME).bin
 # -r 14		14 root directory sectors
 # -c 1		cluster size 1 sector
 # -R 1		1 reserve sector (boot, may need to reserve 2)
-# -B boot      use passed boot file (not complete)
+# -B boot      use passed boot file (not used)
 # -k		only update offsets 11 through 61 in boot block, all else unchanged
 # -N 0		serial number 0
 # -v label	volume label (don't use with first format as uses two directory entries)
@@ -81,8 +80,6 @@ MSDOS_COPYOPTS=-pmQ -D o
 msdos:
 	awk "/$(APPS)/{print}" Packages | cut -f 1 | sed "/^#/d" > Filelist
 	dd if=/dev/zero of=$(MSDOS_IMAGE) bs=1024 count=$(SIZE)
-#	write ELKS boot sector, mformat will only modify BPB
-#	setboot $(MSDOS_IMAGE) $(BPB) $(FD_BOOTSECT)
 	mformat -i $(MSDOS_IMAGE) $(MSDOS_MKFSOPTS)
 	-rm linux; touch linux
 	mcopy -i $(MSDOS_IMAGE) $(MSDOS_COPYOPTS) linux ::/linux
@@ -96,10 +93,17 @@ msdos:
 		[ -f $(DESTDIR)/$$f ] && mcopy -i $(MSDOS_IMAGE) $(MSDOS_COPYOPTS) $(DESTDIR)$$f ::$$f; \
 	done
 	rm Filelist
-	#mdir -i $(MSDOS_IMAGE) -/ -a ::
-	## FIXME setboot needed to copy fat.bin to FAT sector 1 for .config configuration
-	## setboot hasn't been updated yet for -B<secs>,<heads> and not overwrite FAT BPB
-	## thus package manager builds won't create non-.config based FAT boot images yet
-ifeq ($(SIZE), 1440)
-	setboot $(MSDOS_IMAGE) $(TOPDIR)/elkscmd/bootblocks/fat.bin
+	# Read boot sector, skip FAT BPB, set ELKS PB sectors/heads and write boot
+ifeq ($(SIZE), 360)
+	setboot $(MSDOS_IMAGE) -F -B9,2 $(TOPDIR)/elkscmd/bootblocks/fat.bin
 endif
+ifeq ($(SIZE), 720)
+	setboot $(MSDOS_IMAGE) -F -B9,2 $(TOPDIR)/elkscmd/bootblocks/fat.bin
+endif
+ifeq ($(SIZE), 1440)
+	setboot $(MSDOS_IMAGE) -F -B18,2 $(TOPDIR)/elkscmd/bootblocks/fat.bin
+endif
+ifeq ($(SIZE), 2880)
+	setboot $(MSDOS_IMAGE) -F -B36,2 $(TOPDIR)/elkscmd/bootblocks/fat.bin
+endif
+	#mdir -i $(MSDOS_IMAGE) -/ -a ::

--- a/image/Make.package
+++ b/image/Make.package
@@ -77,6 +77,8 @@ MSDOS_COPYOPTS=-pmQ -D o
 # -a		also list hidden files
 # -/		recursive output (buggy: will fail on empty, newly formatted disks!
 
+FD_BOOTSECT=$(TOPDIR)/elkscmd/bootblocks/fat.bin
+
 msdos:
 	awk "/$(APPS)/{print}" Packages | cut -f 1 | sed "/^#/d" > Filelist
 	dd if=/dev/zero of=$(MSDOS_IMAGE) bs=1024 count=$(SIZE)
@@ -95,15 +97,15 @@ msdos:
 	rm Filelist
 	# Read boot sector, skip FAT BPB, set ELKS PB sectors/heads and write boot
 ifeq ($(SIZE), 360)
-	setboot $(MSDOS_IMAGE) -F -B9,2 $(TOPDIR)/elkscmd/bootblocks/fat.bin
+	setboot $(MSDOS_IMAGE) -F -B9,2 $(FD_BOOTSECT)
 endif
 ifeq ($(SIZE), 720)
-	setboot $(MSDOS_IMAGE) -F -B9,2 $(TOPDIR)/elkscmd/bootblocks/fat.bin
+	setboot $(MSDOS_IMAGE) -F -B9,2 $(FD_BOOTSECT)
 endif
 ifeq ($(SIZE), 1440)
-	setboot $(MSDOS_IMAGE) -F -B18,2 $(TOPDIR)/elkscmd/bootblocks/fat.bin
+	setboot $(MSDOS_IMAGE) -F -B18,2 $(FD_BOOTSECT)
 endif
 ifeq ($(SIZE), 2880)
-	setboot $(MSDOS_IMAGE) -F -B36,2 $(TOPDIR)/elkscmd/bootblocks/fat.bin
+	setboot $(MSDOS_IMAGE) -F -B36,2 $(FD_BOOTSECT)
 endif
 	#mdir -i $(MSDOS_IMAGE) -/ -a ::

--- a/image/Makefile
+++ b/image/Makefile
@@ -61,7 +61,7 @@ ifdef CONFIG_IMG_LINK
 	$(MAKE) -f Make.devices "MKDEV=mfs $(TARGET_FILE) mknod"
 endif
 ifdef CONFIG_IMG_BOOT
-	mfs $(TARGET_FILE) boot $(FD_BOOTBLOCK)
+	setboot $(TARGET_FILE) $(FD_BOOTBLOCK)
 endif
 	mfsck -fv $(TARGET_FILE)
 	mfs $(TARGET_FILE) stat


### PR DESCRIPTION
	Add setboot -F parameter to skip FAT BPB's when writing boot sector
	Expand FAT BPB boot sector to be fully compatible with all FAT filesystems and MSDOS tools
	Update build and image scripts to only use setboot for all boot sector operations

This PR adds the ability to boot from all ELKS FAT images, including 360k, 720k, 1440k and 2880k FAT12 and FAT16 disks. In addition the FAT boot sector is expanded to a full FAT BPB (offsets 3-61), thus fixing the problem of ELKS-created FAT images being incompatible with any MSDOS version or MSDOS filesystem utility. Finally, all ELKS boot sector operations are solely managed by a single execution of `setboot` per image build, thus simplifying the build process for ELKS-specific parameters and boot sector writing to a single tool.

Tested and working with all ELKS supported images, including .config MINIX build and all package manager builds (3 for MINIX and 4 for FAT).

[EDIT: All the .config-based initialization in the FAT BPB boot sector, questioned by @mfld-fr in another thread, can now be removed and set to 0, as the standard FAT filesystem utility `mformat` is used to initialize all FAT BPB contents at image creation time.]