### PR TITLE
[fat] More FAT build tuning

### DIFF
--- a/elks/tools/setboot/setboot.c
+++ b/elks/tools/setboot/setboot.c
@@ -31,8 +31,8 @@
 #define ELKS_BPB_NumHeads	0x1FA		/* offset of number of heads (byte)*/
 
 /* FAT BPB start and end offsets*/
-#define FATBPB_START	3
-#define FATBPB_END		61
+#define FATBPB_START	11				/* start at bytes per sector*/
+#define FATBPB_END		61				/* through end of file system type*/
 
 static int SecPerTrk, NumHeads;
 

--- a/elkscmd/sh_utils/date.c
+++ b/elkscmd/sh_utils/date.c
@@ -81,7 +81,7 @@ struct timeval *tv;
 	char * p;
 	struct tm tm;
 	
-	p = strtok(datestring, '-');
+	p = strtok(datestring, "-");
 	
 	tm.tm_year= tm.tm_mon= tm.tm_mday= tm.tm_hour= tm.tm_min= tm.tm_sec=0;
 

--- a/image/Make.package
+++ b/image/Make.package
@@ -85,8 +85,6 @@ msdos:
 	mformat -i $(MSDOS_IMAGE) $(MSDOS_MKFSOPTS)
 	rm -f linux; touch linux
 	mcopy -i $(MSDOS_IMAGE) $(MSDOS_COPYOPTS) linux ::/linux
-#	change attributes of /linux to read-only, system, hidden (command broken)
-#	mattrib -i $(MSDOS_IMAGE) +r +s +h ::/linux
 	rm linux
 	#mdir -i $(MSDOS_IMAGE) -/ -a ::
 	for f in `cat Filelist`; \
@@ -101,6 +99,8 @@ msdos:
 		fi \
 	done
 	rm Filelist
+	# Protect contiguous /linux by marking as R/O, System and Hidden
+	mattrib -i $(MSDOS_IMAGE) +r +s +h ::/linux
 	# Read boot sector, skip FAT BPB, set ELKS PB sectors/heads and write boot
 ifeq ($(SIZE), 360)
 	setboot $(MSDOS_IMAGE) -F -B9,2 $(FD_BOOTSECT)


### PR DESCRIPTION
	Adjust setboot FAT BPB start location to Microsoft Spec (11-61)
	Set RHS attributes on /linux to ensure it remains as contiguous sectors

Setboot now excludes OEMNAME from the FAT BPB "protected area", as per MS specifications, and copies this field from the passed boot sector. `mformat` doesn't write the OEMNAME field on format, and this change keeps our 'ELKSFAT1' oem name in the boot sector, rather than 0 as it was.

Add Read-only, Hidden and System attributes to /linux on FAT images, thus assuring that no MSDOS system will overwrite or change the file location on disk and cause boot failure. Note that ELKS currently ignores the System and Hidden file attributes on mounted FAT filesystems, so /linux will still be visible there.

