### PR TITLE
[libc] use `_start' not `entry' as program entry point symbol

### DIFF
--- a/elks/elks-small.ld
+++ b/elks/elks-small.ld
@@ -11,7 +11,7 @@ SECTIONS {
 		LONG(SIZEOF (.text));
 		LONG(SIZEOF (.data));
 		LONG (SIZEOF (.bss));
-		LONG (entry);    /* entry point */
+		LONG (_start);    /* entry point */
 		LONG (_total_adjusted); /* total memory allocated */
 		LONG (0);        /* symbol table size */
 		}
@@ -24,6 +24,7 @@ SECTIONS {
 		ASSERT (. + 0x100 <= 0x10000,
 		    "Error: too large for a small-model ELKS a.out file.");
 	}
+	PROVIDE (_start = entry); /* `entry' was the old entry point symbol */
 	PROVIDE (_total = 0);
 	_total_adjusted = _total == 0 ? 0
 			  : MIN (0x10000, MAX (. + 0x100, _total));

--- a/elks/elks-tiny.ld
+++ b/elks/elks-tiny.ld
@@ -11,7 +11,7 @@ SECTIONS {
 		LONG (SIZEOF (.text));
 		LONG (0);        /* .data section size */
 		LONG (0);        /* .bss section size */
-		LONG (entry);    /* entry point */
+		LONG (_start);    /* entry point */
 		LONG (_total_adjusted); /* total memory allocated */
 		LONG (0);        /* symbol table size */
 		}
@@ -22,6 +22,7 @@ SECTIONS {
 		ASSERT (. + 0x100 <= 0x10000,
 		    "Error: too large for a tiny-model ELKS a.out file.");
 	}
+	PROVIDE (_start = entry); /* `entry' was the old entry point symbol */
 	PROVIDE (_total = 0);
 	_total_adjusted = _total == 0 ? 0
 			  : MIN (0x10000, MAX (. + 0x100, _total));

--- a/libc/crt0.S
+++ b/libc/crt0.S
@@ -13,12 +13,10 @@
 	.global _start
 
 _start:
-	jmp _startup
 
 // C runtime startup
 // Stack is empty and immediately followed by argc, argv and envp
 
-_startup:
 	push %bp
 	mov %sp,%bp
 	lea 4(%bp),%bx  // argv [0]

--- a/libc/crt0.S
+++ b/libc/crt0.S
@@ -10,9 +10,9 @@
 
 // This is the program entry point
 
-	.global entry
+	.global _start
 
-entry:
+_start:
 	jmp _startup
 
 // C runtime startup


### PR DESCRIPTION
This tackles an issue that cropped up earlier when trying to write ELKS programs that do not use the standard `crt0.o` (https://github.com/tkchia/gcc-ia16/issues/50#issuecomment-586292623).

The updated linker scripts will still recognize `entry` as an entry point, if `_start` happens to be undefined.