### PR TITLE
[chmem] Add ELKS chmem command

### DIFF
--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -26,6 +26,7 @@ PRGS = \
 	knl \
 	man \
 	poweroff \
+	chmem \
 	# EOL
 
 # clock disabled because direct I/O port access
@@ -81,6 +82,9 @@ man: man.o
 
 poweroff: poweroff.o
 	$(LD) $(LDFLAGS) -o poweroff poweroff.o $(LDLIBS)
+
+chmem: chmem.o
+	$(LD) $(LDFLAGS) -o chmem chmem.o $(LDLIBS)
 
 all: $(PRGS)
 

--- a/elkscmd/sys_utils/chmem.c
+++ b/elkscmd/sys_utils/chmem.c
@@ -1,0 +1,100 @@
+/* chmem - set total memory size for execution	Author: Andy Tanenbaum */
+/* from original Minix 1 source in "Operating Systems: Design and Implentation", 1st ed.*/
+/* ported to ELKS by Greg Haerr*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <unistd.h>
+
+#define HLONG            8	/* header size in longs */
+#define TEXT             2	/* where is text size in header */
+#define DATA             3	/* where is data size in header */
+#define BSS              4	/* where is bss size in header */
+#define TOT              6	/* where in header is total allocation */
+#define TOTPOS          24	/* where is total in header */
+#define SEPBIT   0x00200000	/* this bit is set for separate I/D */
+#define MAGIC       0x0301	/* magic number for executable progs */
+#define MAX         65536L	/* maximum allocation size */
+
+/* Print an error message and die*/
+static void fatalmsg(const char *s,...)
+{
+	va_list p;
+	va_start(p,s);
+	vfprintf(stderr,s,p);
+	va_end(p);
+	putc('\n',stderr);
+	exit(-1);
+}
+
+static void usage(void)
+{
+	fatalmsg("Usage: %s {=+-}<# bytes dynamic data> <executable>\n");
+}
+
+int main(int argc, char **argv)
+{
+/* The 8088 architecture does not make it possible to catch stacks that grow
+ * big.  The only way to deal with this problem is to let the stack grow down
+ * towards the data segment and the data segment grow up towards the stack.
+ * Normally, a total of 64K is allocated for the two of them, but if the
+ * programmer knows that a smaller amount is sufficient, he can change it
+ * using chmem.
+ *
+ * chmem =4096 prog  sets the total space for stack + data growth to 4096
+ * chmem +200  prog  increments the total space for stack + data growth by 200
+ */
+
+
+  char *p;
+  unsigned int n;
+  int fd, separate;
+  unsigned long lsize, olddynam, newdynam = 0, newtot, overflow, dsegsize, header[HLONG];
+
+  p = argv[1];
+  if (argc != 3) 
+	fatalmsg("Usage: %s {=+-}<# bytes dynamic data> <executable>\n", argv[0]);
+  if (*p != '=' && *p != '+' && *p != '-') usage();
+  n = atoi(p+1);
+  lsize = n;
+  if (n > 65520) fatalmsg("chmem: ", p+1, " too large\n");
+
+  fd = open(argv[2], 2);
+  if (fd < 0) fatalmsg("chmem: can't open ", argv[2], "\n");
+
+  if (read(fd, header, sizeof(header)) != sizeof(header))
+	fatalmsg("chmem: ", argv[2], "bad header\n");
+  if ( (header[0] & 0xFFFF) != MAGIC)
+	fatalmsg("chmem: ", argv[2], " not executable\n");
+  separate = (header[0] & SEPBIT ? 1 : 0);
+  dsegsize = header[DATA] + header[BSS];
+  if (header[TOT] == 0)		/* handle ELKS default INIT_STACK case*/
+	olddynam = 0;
+  else olddynam = header[TOT] - dsegsize;
+  if (separate == 0) olddynam -= header[TEXT];
+
+  printf("Old %s: DATA %lu BSS %ld TOT %lu DYNMEM %lu\n",
+	argv[2], header[DATA], header[BSS], header[TOT], olddynam);
+
+  if (*p == '=') newdynam = lsize;
+  else if (*p == '+') newdynam = olddynam + lsize;
+  else if (*p == '-') newdynam = olddynam - lsize;
+  newtot = dsegsize + newdynam;
+  overflow = (newtot > MAX ? newtot - MAX : 0);	/* 64K max */
+  newdynam -= overflow;
+  newtot -= overflow;
+
+  if (newtot == dsegsize)	/* handle ELKS default INIT_STACK case*/
+	newtot = 0;
+  printf("New %s: DATA %lu BSS %ld TOT %lu DYNMEM %lu\n",
+	argv[2], header[DATA], header[BSS], newtot, newdynam);
+
+  if (separate == 0) newtot += header[TEXT];
+  lseek(fd, (long) TOTPOS, SEEK_SET);
+  if (write(fd, &newtot, 4) < 0)
+	fatalmsg("chmem: can't modify ", argv[2], "\n");
+  printf("%s: Stack+malloc area changed from %lu to %lu bytes.\n",
+			 argv[2], olddynam, newdynam);
+  return 0;
+}

--- a/elkscmd/sys_utils/chmem.c
+++ b/elkscmd/sys_utils/chmem.c
@@ -15,7 +15,7 @@
 #define TOTPOS          24	/* where is total in header */
 #define SEPBIT   0x00200000	/* this bit is set for separate I/D */
 #define MAGIC       0x0301	/* magic number for executable progs */
-#define MAX         65536L	/* maximum allocation size */
+#define MAX         65520L	/* maximum allocation size */
 
 /* Print an error message and die*/
 static void fatalmsg(const char *s,...)
@@ -48,17 +48,16 @@ int main(int argc, char **argv)
 
 
   char *p;
-  unsigned int n;
   int fd, separate;
-  unsigned long lsize, olddynam, newdynam = 0, newtot, overflow, dsegsize, header[HLONG];
+  unsigned long lsize, olddynam, newdynam = 0, newtot, overflow, dsegsize;
+  unsigned long header[HLONG];
 
   p = argv[1];
   if (argc != 3) 
 	fatalmsg("Usage: %s {=+-}<# bytes dynamic data> <executable>\n", argv[0]);
   if (*p != '=' && *p != '+' && *p != '-') usage();
-  n = atoi(p+1);
-  lsize = n;
-  if (n > 65520) fatalmsg("chmem: ", p+1, " too large\n");
+  lsize = atol(p+1);
+  if (lsize > MAX) fatalmsg("chmem: %lu too large, max %lu\n", lsize, MAX);
 
   fd = open(argv[2], 2);
   if (fd < 0) fatalmsg("chmem: can't open ", argv[2], "\n");

--- a/image/Packages
+++ b/image/Packages
@@ -52,6 +52,7 @@
 /bin/cal								:app
 /bin/cat		:boot
 /bin/chgrp				:base
+/bin/chmem				:base
 /bin/chmod				:base
 /bin/chown				:base
 /bin/cksum						:shutil


### PR DESCRIPTION
Implements ELKS /bin/chmem.

Sort now works with `chmem +48000 /bin/sort`, and bc is running with `chmem +32768 /bin/bc`.

It was a little tricky setting the total data segment size correctly, and I have not yet tested with non-seperate I&D (how would that be specified to `gcc-ia16`?

This solves @Mellvik problem listed in #123 regarding running out of memory.

Added debug messages to `chmem` for the time being (see below).

<img width="832" alt="Screen Shot 2020-02-15 at 3 13 58 PM" src="https://user-images.githubusercontent.com/11985637/74596019-8b944f80-5006-11ea-8488-26c8004a55cf.png">
