### PR TITLE
[nanox] Include landmine game rather than nclock for Nano-X demo

### DIFF
--- a/elkscmd/nano-X/Makefile
+++ b/elkscmd/nano-X/Makefile
@@ -98,4 +98,5 @@ demo: $(NANOXDEMO) libnano-X.a
 
 install:
 #	install bin/demo $(DESTDIR)/bin/ndemo
-	install bin/nclock $(DESTDIR)/bin/nclock
+#	install bin/nclock $(DESTDIR)/bin/nclock
+	install bin/landmine $(DESTDIR)/bin/landmine

--- a/image/Packages
+++ b/image/Packages
@@ -94,7 +94,6 @@
 /bin/more				:base
 /bin/mount		:boot
 /bin/mv				:small
-/bin/nclock							:nanox
 /bin/netstat				:net
 /bin/nslookup				:net
 /bin/passwd				:base
@@ -181,11 +180,12 @@
 /var/run/utmp	:boot
 /var/www					:net
 /var/www/index.html			:net
-#/bin/ndemo								:nanox
 # The following Nano-X graphical apps will be added soon
+#/bin/ndemo								:nanox
 #/bin/demo2								:nanox
 #/bin/demo-vga							:nanox
-#/bin/landmine							:nanox
+/bin/landmine							:nanox
+#/bin/nclock							:nanox
 #/bin/nterm								:nanox
 #/bin/world								:nanox
 #/bin/world.map							:nanox


### PR DESCRIPTION
Suggest to use '/bin/landmine' rather than nclock to show off ELKS' graphical capabilities. It's actually a usable game and lots better looking.

<img width="752" alt="Screen Shot 2020-02-15 at 9 41 52 PM" src="https://user-images.githubusercontent.com/11985637/74599317-fc565e80-503c-11ea-8473-5b66d02d2853.png">
