### PR TITLE
LD scripts: allow setting non-static data size, via a _chmem variable

### DIFF
--- a/elks/elks-small.ld
+++ b/elks/elks-small.ld
@@ -21,13 +21,13 @@ SECTIONS {
 	.data 0 : AT(_begindata) { *(.nildata*) *(.rodata*) *(.data*) }
 	.bss : {
 		*(.bss) *(COMMON)
-		ASSERT (. + 0x100 <= 0x10000,
+		ASSERT (. + 0x100 <= 0xfff0,
 		    "Error: too large for a small-model ELKS a.out file.");
 	}
 	PROVIDE (_start = entry); /* `entry' was the old entry point symbol */
 	PROVIDE (_chmem = 0);
 	PROVIDE (_total = _chmem == 0 ? 0 : . + _chmem);
 	_total_adjusted = _total == 0 ? 0
-			  : MIN (0x10000, MAX (. + 0x100, _total));
+			  : MIN (0xfff0, MAX (. + 0x100, _total));
 	/DISCARD/ : { *(.comment) }
 }

--- a/elks/elks-small.ld
+++ b/elks/elks-small.ld
@@ -25,7 +25,8 @@ SECTIONS {
 		    "Error: too large for a small-model ELKS a.out file.");
 	}
 	PROVIDE (_start = entry); /* `entry' was the old entry point symbol */
-	PROVIDE (_total = 0);
+	PROVIDE (_chmem = 0);
+	PROVIDE (_total = _chmem == 0 ? 0 : . + _chmem);
 	_total_adjusted = _total == 0 ? 0
 			  : MIN (0x10000, MAX (. + 0x100, _total));
 	/DISCARD/ : { *(.comment) }

--- a/elks/elks-tiny.ld
+++ b/elks/elks-tiny.ld
@@ -19,13 +19,13 @@ SECTIONS {
 	.text 0 : AT(_begintext) { *(.text*) *(.rodata*) *(.data*) }
 	.bss : {
 		*(.bss) *(COMMON)
-		ASSERT (. + 0x100 <= 0x10000,
+		ASSERT (. + 0x100 <= 0xfff0,
 		    "Error: too large for a tiny-model ELKS a.out file.");
 	}
 	PROVIDE (_start = entry); /* `entry' was the old entry point symbol */
 	PROVIDE (_chmem = 0);
 	PROVIDE (_total = _chmem == 0 ? 0 : . + _chmem);
 	_total_adjusted = _total == 0 ? 0
-			  : MIN (0x10000, MAX (. + 0x100, _total));
+			  : MIN (0xfff0, MAX (. + 0x100, _total));
 	/DISCARD/ : { *(.comment) }
 }

--- a/elks/elks-tiny.ld
+++ b/elks/elks-tiny.ld
@@ -23,7 +23,8 @@ SECTIONS {
 		    "Error: too large for a tiny-model ELKS a.out file.");
 	}
 	PROVIDE (_start = entry); /* `entry' was the old entry point symbol */
-	PROVIDE (_total = 0);
+	PROVIDE (_chmem = 0);
+	PROVIDE (_total = _chmem == 0 ? 0 : . + _chmem);
 	_total_adjusted = _total == 0 ? 0
 			  : MIN (0x10000, MAX (. + 0x100, _total));
 	/DISCARD/ : { *(.comment) }

--- a/elksemu/elks.h
+++ b/elksemu/elks.h
@@ -77,7 +77,7 @@ struct elks_exec_hdr
 	uint32_t dseg;
 	uint32_t bseg;
 	uint32_t entry;
-	uint32_t chmem;
+	uint32_t total;
 	uint32_t unused2; 
 };
 


### PR DESCRIPTION
This is to support setting the size of the non-static data space from an `ia16-elf-gcc` command line, i.e. while building an ELKS program (https://github.com/elks-org/elks/issues/241).

Newer versions of `ia16-elf-gcc` will have a `-maout-chmem=`... option to set this `_chmem` value.  Alternatively, even without such an option, one can say e.g. `-Wl,--defsym=_chmem=0x4000`.

(_This is complementary to @ghaerr's pull request_ (https://github.com/elks-org/elks/pull/337) _which adds support for changing the data segment allocation of ELKS binaries after they are built._)