### PR TITLE
[cmds] Fix ls -F option

### DIFF
--- a/elkscmd/file_utils/ls.c
+++ b/elkscmd/file_utils/ls.c
@@ -248,6 +248,7 @@ static void lsfile(char *name, struct stat *statbuf, int flags)
 #endif
     }
 
+#if 0 // broken - hangs in malloc in realloc()
 /* If a class character exists for the file name, add it on */
     if (class != '\0') {
 	    len = strlen(name);
@@ -263,14 +264,20 @@ static void lsfile(char *name, struct stat *statbuf, int flags)
 	    classp++;
 	    *classp = '\0';
     }
+#endif
 
     {
 	char *cp;
+	char buf[255];
 
 	cp = strrchr(name, '/');
 	if (!cp) cp = name;
 	else cp++;
-	printf(fmt, cp);
+	if (class)		/* handle class without realloc*/
+		sprintf(buf, "%s%c", cp, class);
+	else
+		strcpy(buf, cp);
+	printf(fmt, buf);
     }
 
 #ifdef S_ISLNK


### PR DESCRIPTION
Fixes previously reported `ls -F /` or `ls -lf /`, which hangs ELKS.

Upon further inspection, it was determined that ELKS wasn't hung, but instead the `ls` process busy-looping inside ELKS `malloc` inside `realloc`. Since I couldn't determine whether this was an `ls` bug overwriting memory, or an ELKS libc `malloc/realloc` bug, I rewrote `ls` to use a different method than calling `realloc`. Not sure whether there are regression tests for ELKS libc functions.