### PR TITLE
[stat] Fix st_ino type to be constant size in stat system call

### DIFF
--- a/elks/include/arch/stat.h
+++ b/elks/include/arch/stat.h
@@ -5,11 +5,7 @@
 
 struct stat {
     dev_t	st_dev;
-#ifdef CONFIG_32BIT_INODES
-    __u16	st_ino;
-#else
-    ino_t	st_ino;
-#endif
+    u_ino_t	st_ino;
     mode_t	st_mode;
     nlink_t	st_nlink;
     uid_t	st_uid;


### PR DESCRIPTION
Use 32-bit `u_ino_t` size for `st_ino` field in `stat` system call, which allows applications to run without special coding for CONFIG_32BIT_INODE setting.

Since this was required to get `ls -i` operational, I'm submitting this PR. If the `gcc-ia16` toolchain also needs stat.h to be fixed internally, I'll defer that to @tkchia.