### PR TITLE
[image] Remove unneeded chmod from image generation template

### DIFF
--- a/image/Makefile
+++ b/image/Makefile
@@ -52,10 +52,6 @@ template:
 ifdef CONFIG_IMG_BOOT
 	install $(ELKS_DIR)/arch/i86/boot/Image $(DESTDIR)/linux
 endif
-	# pull request #227
-	find $(DESTDIR) \
-		-type d ! -name root -execdir chmod go+rx '{}' ';' -o \
-		! -type d ! -name .profile -execdir chmod go+r '{}' ';'
 
 # Create MINIX filesystem from template
 


### PR DESCRIPTION
Remove commit from PR #227. 

This code used to change ownership of target files in the case of a git pull with a restricted umask, which then caused a build failure on the kernel-mounted filesystem when changing directory to /dev. Since ELKS now uses `mfs` and `mtools` to create and populate each disk image with the proper permissions under any UID/GID user, this code is no longer needed (and `chmod` emits an error message during the build anyways). 