### PR TITLE
Revert 3 commits concerning ino_t

### DIFF
--- a/busyelks/cmd/ls.c
+++ b/busyelks/cmd/ls.c
@@ -170,7 +170,7 @@ static void lsfile(char *name, struct stat *statbuf, int flags)
     *cp = '\0';
 
     if (flags & LSF_INODE) {
-	sprintf(cp, "%5"PRIino" ", statbuf->st_ino);
+	sprintf(cp, "%5ld ", statbuf->st_ino);
 	cp += strlen(cp);
     }
 

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -253,14 +253,12 @@ ino_t msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head **bh,
 		*de = (struct msdos_dir_entry *) ((char *)data+(offset & (SECTOR_SIZE-1)));
 
 		/* return value will overfow for FAT16/32 if sector is beyond 2MB boundary*/
-
 #ifndef CONFIG_32BIT_INODES
-		if (sector > 4095) {
-			printk("FAT: disk too large: set CONFIG_32BIT_INODES\n");
+		if (sector > 8191) {
+			printk("FAT: disk too large, turn on CONFIG_32BIT_INODES\n");
 			return -1;
 		}
 #endif
-
 //fsdebug("get entry %ld\n", sector);
 		return (sector << MSDOS_DPS_BITS)+((offset & (SECTOR_SIZE-1)) >> MSDOS_DIR_BITS);
 	}

--- a/elks/fs/readdir.c
+++ b/elks/fs/readdir.c
@@ -40,7 +40,6 @@ static int fillonedir(register char *__buf, char *name, size_t namlen, off_t off
     if (((struct readdir_callback *)__buf)->count) return -EINVAL;
     ((struct readdir_callback *)__buf)->count++;
     dirent = ((struct readdir_callback *)__buf)->dirent;
-    // FIXME: variable length for ino_t and off_t opaque types
     put_user_long((__u32)ino, &dirent->d_ino);
     put_user_long((__u32) offset, &dirent->d_offset);
     put_user((__u16) namlen, &dirent->d_namlen);

--- a/elks/fs/readdir.c
+++ b/elks/fs/readdir.c
@@ -21,7 +21,7 @@
  *
  */
 struct linux_dirent {
-    ino_t  d_ino;
+    u_ino_t d_ino;
     loff_t d_offset;
     size_t d_namlen;
     char d_name[255];

--- a/elks/include/arch/stat.h
+++ b/elks/include/arch/stat.h
@@ -1,0 +1,24 @@
+#ifndef LX86_ARCH_STAT_H
+#define LX86_ARCH_STAT_H
+
+#include <linuxmt/types.h>
+
+struct stat {
+    dev_t	st_dev;
+#ifdef CONFIG_32BIT_INODES
+    __u16	st_ino;
+#else
+    ino_t	st_ino;
+#endif
+    mode_t	st_mode;
+    nlink_t	st_nlink;
+    uid_t	st_uid;
+    gid_t	st_gid;
+    dev_t	st_rdev;
+    off_t	st_size;
+    time_t	st_atime;
+    time_t	st_mtime;
+    time_t	st_ctime;
+};
+
+#endif

--- a/elks/include/linuxmt/stat.h
+++ b/elks/include/linuxmt/stat.h
@@ -1,8 +1,8 @@
-// This is the actual "sys/stat.h"
+#ifndef LX86_LINUXMT_STAT_H
+#define LX86_LINUXMT_STAT_H
 
-#pragma once
-
-#include <linuxmt/types.h>
+#include "types.h"
+#include <arch/stat.h>
 
 #define S_IFMT  00170000
 #define S_IFSOCK 0140000
@@ -47,16 +47,4 @@
 #define S_IXUGO		(S_IXUSR|S_IXGRP|S_IXOTH)
 #endif
 
-struct stat {
-	dev_t   st_dev;
-	ino_t   st_ino;
-	mode_t  st_mode;
-	nlink_t st_nlink;
-	uid_t   st_uid;
-	gid_t   st_gid;
-	dev_t   st_rdev;
-	off_t   st_size;
-	time_t  st_atime;
-	time_t  st_mtime;
-	time_t  st_ctime;
-};
+#endif

--- a/elks/include/linuxmt/types.h
+++ b/elks/include/linuxmt/types.h
@@ -23,16 +23,11 @@ typedef __u16			flag_t;
 typedef __u16			gid_t;
 
 // Large FAT volumes need 32-bit inode number
-// to store both sector number and directory entry relative index
-
-// PRIino is C99-like macro for portability
 
 #ifdef CONFIG_32BIT_INODES
 typedef __u32 ino_t;
-#define PRIino "lu"
 #else
 typedef __u16 ino_t;
-#define PRIino "u"
 #endif
 
 typedef __u16			mode_t;

--- a/elks/include/linuxmt/types.h
+++ b/elks/include/linuxmt/types.h
@@ -1,6 +1,5 @@
-// This is the actual "sys/types.h"
-
-#pragma once
+#ifndef LX86_LINUXMT_TYPES_H
+#define LX86_LINUXMT_TYPES_H
 
 #include <arch/types.h>
 #include <linuxmt/config.h>
@@ -15,21 +14,19 @@ typedef __u32			lflag_t;
 typedef __u32			lsize_t;
 typedef __u32			speed_t;
 typedef __u32			tcflag_t;
+typedef __u32			u_ino_t;
 
 typedef __u16			block_t;
 typedef __u32			block32_t;
 typedef __u16			dev_t;
 typedef __u16			flag_t;
 typedef __u16			gid_t;
-
-// Large FAT volumes need 32-bit inode number
-
 #ifdef CONFIG_32BIT_INODES
-typedef __u32 ino_t;
+typedef __u32			ino_t;
 #else
-typedef __u16 ino_t;
+typedef __u16			ino_t;
 #endif
-
+typedef __u32			ino32_t;
 typedef __u16			mode_t;
 typedef __u16			nlink_t;
 typedef __u16			segext_t;
@@ -72,3 +69,5 @@ struct ustat {
     char			f_fname[6];
     char			f_fpack[6];
 };
+
+#endif

--- a/elkscmd/file_utils/ls.c
+++ b/elkscmd/file_utils/ls.c
@@ -183,7 +183,13 @@ static void lsfile(char *name, struct stat *statbuf, int flags)
     *cp = '\0';
 
     if (flags & LSF_INODE) {
-    	sprintf(cp, "%5"PRIino" ", statbuf->st_ino);
+
+#ifdef CONFIG_32BIT_INODES
+    	sprintf(cp, "%5ld ", statbuf->st_ino);
+#else
+    	sprintf(cp, "%5d ", statbuf->st_ino);
+#endif
+
     	cp += strlen(cp);
     }
 

--- a/elkscmd/file_utils/ls.c
+++ b/elkscmd/file_utils/ls.c
@@ -183,14 +183,8 @@ static void lsfile(char *name, struct stat *statbuf, int flags)
     *cp = '\0';
 
     if (flags & LSF_INODE) {
-
-#ifdef CONFIG_32BIT_INODES
-    	sprintf(cp, "%5ld ", statbuf->st_ino);
-#else
-    	sprintf(cp, "%5d ", statbuf->st_ino);
-#endif
-
-    	cp += strlen(cp);
+	sprintf(cp, "%5ld ", statbuf->st_ino);
+	cp += strlen(cp);
     }
 
     if (flags & LSF_LONG) {

--- a/elkscmd/sash/cmd_ls.c
+++ b/elkscmd/sash/cmd_ls.c
@@ -213,13 +213,7 @@ lsfile(name, statbuf, flags)
 	*cp = '\0';
 
 	if (flags & LSF_INODE) {
-
-#ifdef CONFIG_32BIT_INODES
-		sprintf(cp, "%5ld ", statbuf->st_ino);
-#else
 		sprintf(cp, "%5d ", statbuf->st_ino);
-#endif
-
 		cp += strlen(cp);
 	}
 

--- a/elkscmd/sash/cmd_ls.c
+++ b/elkscmd/sash/cmd_ls.c
@@ -213,7 +213,13 @@ lsfile(name, statbuf, flags)
 	*cp = '\0';
 
 	if (flags & LSF_INODE) {
-		sprintf(cp, "%5"PRIino" ", statbuf->st_ino);
+
+#ifdef CONFIG_32BIT_INODES
+		sprintf(cp, "%5ld ", statbuf->st_ino);
+#else
+		sprintf(cp, "%5d ", statbuf->st_ino);
+#endif
+
 		cp += strlen(cp);
 	}
 

--- a/libc/include/dirent.h
+++ b/libc/include/dirent.h
@@ -24,9 +24,8 @@ typedef int (*__dir_compar_fn_t) __P ((
                 __const struct dirent * __const *
                 ));
 
-// FIXME: duplicate declaration
 struct dirent {
-	ino_t		d_ino;
+	long		d_ino;
 	off_t		d_off;
 	unsigned short	d_reclen;
 	char		d_name[MAXNAMLEN+1];


### PR DESCRIPTION
This reverts the 3 commits that built upon a variable-sized ino_t in outward facing interfaces.

Approved by myself and @tkchia, and should be committed ASAP.

@mfld-fr: I will fix the max sector check to 4095 in my FAT directory bugfix commit coming soon, so that change won't be lost.