### PR TITLE
[fat] Fix create file bug on deleted FAT directories

### DIFF
--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -119,7 +119,7 @@ int msdos_readdir(struct inode *inode, register struct file *filp, char *dirent,
 	ino = msdos_get_entry(inode,&filp->f_pos,&bh,&de);
 	while (ino != (ino_t)-1L) {
 		/* Check for long filename entry */
-		if (de->name[0] == 0)	/* stop reading after nul dirname[0]*/
+		if (de->name[0] == 0)	/* stop reading after nul dirname[0] */
 			break;
 		else if (de->name[0] == (__s8) DELETED_FLAG) {
 			is_long = 0;

--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -119,7 +119,9 @@ int msdos_readdir(struct inode *inode, register struct file *filp, char *dirent,
 	ino = msdos_get_entry(inode,&filp->f_pos,&bh,&de);
 	while (ino != (ino_t)-1L) {
 		/* Check for long filename entry */
-		if (de->name[0] == (__s8) DELETED_FLAG) {
+		if (de->name[0] == 0)	/* stop reading after nul dirname[0]*/
+			break;
+		else if (de->name[0] == (__s8) DELETED_FLAG) {
 			is_long = 0;
 			oldpos = filp->f_pos;
 		} else if (de->attr ==  ATTR_EXT) {
@@ -202,6 +204,7 @@ int msdos_readdir(struct inode *inode, register struct file *filp, char *dirent,
 				else if (!strcmp(de->name,MSDOS_DOTDOT))
 					ino = msdos_parent_ino(inode,0);
 
+fsdebug("dir: '%s' attr %x\n", de->name, de->attr);
 				if (!is_long) {
 					filldir(dirent, bufname, i, oldpos, ino);
 					break;

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -161,7 +161,7 @@ printk("FAT: me=%x,csz=%d,#f=%d,floc=%d,fsz=%d,rloc=%d,#d=%d,dloc=%d,#s=%d,ts=%l
 	int i;
 	bh = NULL;
 
-	/* if /dev is first or second directory entry, turn on devfs filesystem*/
+	/* if /dev is first or second directory entry, turn on devfs filesystem */
 	for (i=0; i<2; i++) {
 		ino = msdos_get_entry(s->s_mounted, &pos, &bh, &de); 
 		if (ino < 0) break;
@@ -275,7 +275,7 @@ void msdos_read_inode(register struct inode *inode)
 		inode->i_op = &msdos_dir_inode_operations;
 		inode->i_nlink = 3;
 		inode->i_size = 0;
-		/* read FAT chain to set directory size*/
+		/* read FAT chain to set directory size */
 		for (this = inode->u.msdos_i.i_start; this && this != -1; this = fat_access(inode->i_sb,this,-1L))
 			inode->i_size += SECTOR_SIZE*MSDOS_SB(inode->i_sb)->cluster_size;
 	}

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -275,6 +275,7 @@ void msdos_read_inode(register struct inode *inode)
 		inode->i_op = &msdos_dir_inode_operations;
 		inode->i_nlink = 3;
 		inode->i_size = 0;
+		/* read FAT chain to set directory size*/
 		for (this = inode->u.msdos_i.i_start; this && this != -1; this = fat_access(inode->i_sb,this,-1L))
 			inode->i_size += SECTOR_SIZE*MSDOS_SB(inode->i_sb)->cluster_size;
 	}

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -186,7 +186,7 @@ void date_unix2dos(long unix_date,unsigned short *time, unsigned short *date)
 			((short)((unix_date/3600) % 24) << 11);
 
 	day = (short)(unix_date/86400L) - 3652;
-	if (day < 0)		/* correct for dates earlier than 1980*/
+	if (day < 0)		/* correct for dates earlier than 1980 */
 		day = 0;
 	year = day/365;
 	if ((year+3)/4 + 365*year > day)
@@ -252,7 +252,7 @@ ino_t msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head **bh,
 			continue;
 		*de = (struct msdos_dir_entry *) ((char *)data+(offset & (SECTOR_SIZE-1)));
 
-		/* return value will overfow for FAT16/32 if sector is beyond 2MB boundary*/
+		/* return value will overfow for FAT16/32 if sector is beyond 2MB boundary */
 #ifndef CONFIG_32BIT_INODES
 		if (sector > 4095) {
 			printk("FAT: disk too large, set CONFIG_32BIT_INODES\n");
@@ -282,8 +282,8 @@ int msdos_scan(struct inode *dir,char *name,struct buffer_head **res_bh,
 				&& !(de->attr & ATTR_VOLUME) && !strncmp(de->name,name,MSDOS_NAME)) break;
 		}
 		else if (!de->name[0] || ((unsigned char *) (de->name))[0] == DELETED_FLAG) {
-				/* unset directory bit so read_inode doesn't traverse FAT table*/
-				/* MSDOS sometimes has deleted DIR entries with non-zero first cluster*/
+				/* unset directory bit so read_inode doesn't traverse FAT table */
+				/* MSDOS sometimes has deleted DIR entries with non-zero first cluster */
 				de->attr &= ~ATTR_DIR;
 				if (!(inode = iget(dir->i_sb,*ino)))
 					break;

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -293,7 +293,7 @@ int msdos_scan(struct inode *dir,char *name,struct buffer_head **res_bh,
 				}
 				/* skip deleted files that haven't been closed yet */
 				iput(inode);
-			}
+		}
 	}
 	if (*ino == (ino_t)-1L) {
 		if (*res_bh) unmap_brelse(*res_bh);

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -254,8 +254,8 @@ ino_t msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head **bh,
 
 		/* return value will overfow for FAT16/32 if sector is beyond 2MB boundary*/
 #ifndef CONFIG_32BIT_INODES
-		if (sector > 8191) {
-			printk("FAT: disk too large, turn on CONFIG_32BIT_INODES\n");
+		if (sector > 4095) {
+			printk("FAT: disk too large, set CONFIG_32BIT_INODES\n");
 			return -1;
 		}
 #endif

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -282,6 +282,9 @@ int msdos_scan(struct inode *dir,char *name,struct buffer_head **res_bh,
 				&& !(de->attr & ATTR_VOLUME) && !strncmp(de->name,name,MSDOS_NAME)) break;
 		}
 		else if (!de->name[0] || ((unsigned char *) (de->name))[0] == DELETED_FLAG) {
+				/* unset directory bit so read_inode doesn't traverse FAT table*/
+				/* MSDOS sometimes has deleted DIR entries with non-zero first cluster*/
+				de->attr &= ~ATTR_DIR;
 				if (!(inode = iget(dir->i_sb,*ino)))
 					break;
 				if (!inode->u.msdos_i.i_busy) {


### PR DESCRIPTION
This fixes the first of @Mellvik 's reported FAT bugs in #123 from his supplied disk image, which is that running `touch` on a certain MSDOS floppy caused ELKS to hang.

This took a while. The technical problem is that @Mellvik 's floppy's first available unused directory entry happened to be that of a previously deleted directory entry. Apparently MSDOS does not zero the deleted directory 'first cluster'  entry when deleting directories, and when when our FAT code tried to compute the size of what was a directory entry (when building a 'fake' inode for it), it followed an invalid FAT chain that resulted in an infinite loop in the kernel FAT driver. 