### PR TITLE
[cmds] Fix clock and getopt

### DIFF
--- a/elkscmd/rootfs_template/etc/rc.d/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sys
@@ -6,6 +6,9 @@ umask 022
 PATH=/bin:/usr/bin
 export PATH
 
+# init date from hardware
+clock -s
+
 #
 # Network initialization
 #

--- a/elkscmd/sys_utils/.gitignore
+++ b/elkscmd/sys_utils/.gitignore
@@ -1,4 +1,5 @@
 clock
+chmem
 exitemu
 getty
 init

--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -27,9 +27,10 @@ PRGS = \
 	man \
 	poweroff \
 	chmem \
+	clock \
 	# EOL
 
-# clock disabled because direct I/O port access
+# clock enabled and has direct I/O port access
 # exitemu disabled because it calls INT directly to DOSEMU
 
 init: init.o

--- a/image/Packages
+++ b/image/Packages
@@ -56,6 +56,7 @@
 /bin/chmod				:base
 /bin/chown				:base
 /bin/cksum						:shutil
+/bin/clock		:boot
 /bin/cmp						:shutil
 /bin/cp				:small
 /bin/cut						:shutil

--- a/libc/misc/getopt.c
+++ b/libc/misc/getopt.c
@@ -1,128 +1,99 @@
+/*
+**	@(#)getopt.c	2.2 (smail) 1/26/87
+*/
 
 /*
- * From: gwyn@brl-tgr.ARPA (Doug Gwyn <gwyn>) Newsgroups: net.sources
- * Subject: getopt library routine Date: 30 Mar 85 04:45:33 GMT
+ * Here's something you've all been waiting for:  the AT&T public domain
+ * source for getopt(3).  It is the code which was given out at the 1985
+ * UNIFORUM conference in Dallas.  I obtained it by electronic mail
+ * directly from AT&T.	The people there assure me that it is indeed
+ * in the public domain.
+ *
+ * There is no manual page.  That is because the one they gave out at
+ * UNIFORUM was slightly different from the current System V Release 2
+ * manual page.	 The difference apparently involved a note about the
+ * famous rules 5 and 6, recommending using white space between an option
+ * and its first argument, and not grouping options that have arguments.
+ * Getopt itself is currently lenient about both of these things White
+ * space is allowed, but not mandatory, and the last option in a group can
+ * have an argument.  That particular version of the man page evidently
+ * has no official existence, and my source at AT&T did not send a copy.
+ * The current SVR2 man page reflects the actual behavor of this getopt.
+ * However, I am not about to post a copy of anything licensed by AT&T.
  */
-/*
- * getopt -- public domain version of standard System V routine
- * 
- * Strictly enforces the System V Command Syntax Standard; provided by D A
- * Gwyn of BRL for generic ANSI C implementations
- * 
- * #define STRICT to prevent acceptance of clustered options with arguments
- * and ommision of whitespace between option and arg.
- */
 
-#include <stdio.h>
-#include <string.h>
-
-int   opterr = 1;		/* error => print message */
-int   optind = 1;		/* next argv[] index */
-char *optarg = NULL;		/* option parameter if any */
-
-static int
-Err(name, mess, c)		/* returns '?' */
-char *name;			/* program name argv[0] */
-char *mess;			/* specific message */
-int   c;			/* defective option letter */
-{
-   if (opterr)
-   {
-      (void) fprintf(stderr,
-		     "%s: %s -- %c\n",
-		     name, mess, c
-	  );
-   }
-
-   return '?';			/* erroneous-option marker */
-}
-
-int
-getopt(argc, argv, optstring)	/* returns letter, '?', EOF */
-int   argc;			/* argument count from main */
-char *argv[];			/* argument vector from main */
-char *optstring;		/* allowed args, e.g. "ab:c" */
-{
-   static int sp = 1;		/* position within argument */
-#ifdef STRICT
-   register int osp;		/* saved `sp' for param test */
-#endif
-#ifndef STRICT
-   register int oind;		/* saved `optind' for param test */
-#endif
-   register int c;		/* option letter */
-   register char *cp;		/* -> option in `optstring' */
-
-   optarg = NULL;
-
-   if (sp == 1)			/* fresh argument */
-   {
-      if (optind >= argc	/* no more arguments */
-	  || argv[optind][0] != '-'	/* no more options */
-	  || argv[optind][1] == '\0'	/* not option; stdin */
-	  )
-	 return EOF;
-      else if (strcmp(argv[optind], "--") == 0)
-      {
-	 ++optind;		/* skip over "--" */
-	 return EOF;		/* "--" marks end of options */
-      }
-   }
-
-   c = argv[optind][sp];	/* option letter */
-#ifdef STRICT
-   osp = sp++;			/* get ready for next letter */
-#endif
-
-#ifndef STRICT
-   oind = optind;		/* save optind for param test */
-#endif
-   if (argv[optind][sp] == '\0')/* end of argument */
-   {
-      ++optind;			/* get ready for next try */
-      sp = 1;			/* beginning of next argument */
-   }
-
-   if (c == ':' || c == '?'	/* optstring syntax conflict */
-       || (cp = strchr(optstring, c)) == NULL	/* not found */
-       )
-      return Err(argv[0], "illegal option", c);
-
-   if (cp[1] == ':')		/* option takes parameter */
-   {
-#ifdef STRICT
-      if (osp != 1)
-	 return Err(argv[0],
-		    "option must not be clustered",
-		    c
-	     );
-
-      if (sp != 1)		/* reset by end of argument */
-	 return Err(argv[0],
-		    "option must be followed by white space",
-		    c
-	     );
-
+/*#include "global.h"*/
+#define index strchr
+#ifdef BSD
+#include <strings.h>
 #else
-      if (oind == optind)	/* argument w/o whitespace */
-      {
-	 optarg = &argv[optind][sp];
-	 sp = 1;		/* beginning of next argument */
-      }
-
-      else
+#include <string.h>
 #endif
-      if (optind >= argc)
-	 return Err(argv[0],
-		    "option requires an argument",
-		    c
-	     );
 
-      else			/* argument w/ whitespace */
-	 optarg = argv[optind];
+#ifdef	__TURBOC__
+#include <io.h>			/* added by KA9Q for Turbo-C */
+#endif
+#ifdef	AMIGA
+#include <fcntl.h>
+#endif
 
-      ++optind;			/* skip over parameter */
-   }
+ /*LINTLIBRARY*/
+#ifndef NULL
+#define NULL	0
+#endif
+#define EOF	(-1)
+#define ERR(s, c)	if (opterr){\
+	extern int write();\
+	char errbuf[2];\
+	errbuf[0] = c; errbuf[1] = '\n';\
+	(void) write(2, argv[0], (unsigned)strlen(argv[0]));\
+	(void) write(2, s, (unsigned)strlen(s));\
+	(void) write(2, errbuf, 2);}
+extern char *index();
 
-   return c;
+int opterr = 1;
+int optind = 1;
+int optopt;
+char *optarg;
+
+int getopt(int argc, char **argv, char *opts)
+{
+    register char *cp;
+    static int sp = 1;
+    register int c;
+
+    if (sp == 1)
+	if (optind >= argc || argv[optind][0] != '-' || argv[optind][1] == '\0')
+	    return EOF;
+	else if (strcmp(argv[optind], "--") == 0) {
+	    optind++;
+	    return EOF;
+	}
+    optopt = c = argv[optind][sp];
+    if (c == ':' || (cp = index(opts, c)) == NULL) {
+	ERR(": illegal option -- ", c);
+	if (argv[optind][++sp] == '\0') {
+	    optind++;
+	    sp = 1;
+	}
+	return '?';
+    }
+    if (*++cp == ':') {
+	if (argv[optind][sp + 1] != '\0')
+	    optarg = &argv[optind++][sp + 1];
+	else if (++optind >= argc) {
+	    ERR(": option requires an argument -- ", c);
+	    sp = 1;
+	    return '?';
+	} else
+	    optarg = argv[optind++];
+	sp = 1;
+    } else {
+	if (argv[optind][++sp] == '\0') {
+	    sp = 1;
+	    optind++;
+	}
+	optarg = NULL;
+    }
+    return c;
 }

--- a/qemu.sh
+++ b/qemu.sh
@@ -10,10 +10,8 @@ echo "Using QEMU: $QEMU"
 
 # Select disk image to use
 # MINIX or FAT .config build
-[ -f image/fd1440.bin ] && IMAGE="-fda image/fd1440.bin"
-[ -f image/hd.bin ] && IMAGE="-hda image/hd.bin"
-[ -z "$IMAGE" ] && { echo 'Disk image not found!'; exit 1; }
-echo "Using disk image: $IMAGE"
+IMAGE="-fda image/fd1440.bin"
+#IMAGE="-hda image/hd.bin"
 
 # FAT package manager build
 #IMAGE="-fda image/fd360-fat.bin"
@@ -32,6 +30,9 @@ echo "Using disk image: $IMAGE"
 #DISK2="-fdb image/fd1440-fat.bin"
 #DISK2="-fdb image/fd2880-fat.bin"
 #DISK2="-fdb image/fd1440-minix.bin"
+
+[ -z "$IMAGE" ] && { echo 'Disk image not found!'; exit 1; }
+echo "Using disk image: $IMAGE"
 
 # Select your keyboard mapping here:
 # KEYBOARD="-k en-us"


### PR DESCRIPTION
This replaces libc/misc/getopt.c with elks/arch/i86/tools/getopt.c, and updates the clock command to `gcc-ia16` and a working -s option. `clock -s` is now run in rc.sys at init time so today's date is set by the hardware at boot.

This fixes @Mellvik 's issue #355 and #359.

Tested on MINIX and FAT using QEMU.

Note: The rc.sys init script now runs clock at boot, which directly uses I/O access.