### PR TITLE
[tools] [elkscmd] compile `bc` & `sort` programs with new gcc-ia16 `-maout-chmem=` option

### DIFF
--- a/elkscmd/bc/Makefile
+++ b/elkscmd/bc/Makefile
@@ -30,6 +30,9 @@ LEX = flex -I -8
 
 LOCALFLAGS=-D_POSIX_SOURCE
 
+# For ELKS, bc needs more data segment space than the kernel-given default.
+LDFLAGS += -maout-chmem=0xc000
+
 OFILES = scan.o util.o main.o number.o storage.o load.o execute.o 
 
 SUBDIRS = Examples Test

--- a/elkscmd/minix3/Makefile
+++ b/elkscmd/minix3/Makefile
@@ -36,8 +36,11 @@ head: head.o
 sed: sed.o
 	$(LD) $(LDFLAGS) -o sed sed.o $(LDLIBS)
 
+# For ELKS, sort needs more data segment space than the kernel-given default.
+# Use gcc-ia16's -maout-chmem= option so that the a.out header will ask the
+# kernel for more non-static memory.
 sort: sort.o
-	$(LD) $(LDFLAGS) -o sort sort.o $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-chmem=0xc000 -o sort sort.o $(LDLIBS)
 
 tail: tail.o
 	$(LD) $(LDFLAGS) -o tail tail.o $(LDLIBS)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -49,7 +49,7 @@ all:: $(CROSSDIR)/.binutils.install
 
 # GCC for IA16
 
-GCC_VER=2dd73a5500dce4be8f0f7d4bab02f5ed6bf849b0
+GCC_VER=53a9614cbbc5880a1e11bdd73f8af933202ff24c
 GCC_DIST=gcc-ia16-$(GCC_VER)
 
 $(DISTDIR)/$(GCC_DIST).zip:


### PR DESCRIPTION
These commits do a few things to allow the `bc` and `sort` programs to finally work, rather than bail out due to lack of memory.

  * I updated the `gcc-ia16` version to a more recent one (https://github.com/tkchia/gcc-ia16/commit/53a9614cbbc5880a1e11bdd73f8af933202ff24c) which includes a `-maout-chmem=`_x_ option for setting the amount of memory reserved for non-static data (stack, heap, etc.).  The new `gcc-ia16` version also allows a simpler command line syntax for building ELKS programs (`-melks-libc -mcmodel=small` → `-melks`), and includes some other features and fixes.  I have already run the new version through GCC's (plus my own) regression test suite; so it is well-tested.
  * I modified the makefiles for `bc` and `sort`, so that they now use `-maout-chmem=`_x_ when building these programs.

All this should further advance the solving of issue https://github.com/jbruchon/elks/issues/241 .