### PR TITLE
[image] Standardize package mgr args for use with multiple package files

### DIFF
--- a/Documentation/text/package-manager.txt
+++ b/Documentation/text/package-manager.txt
@@ -1,0 +1,25 @@
+ELKS Package Manager
+
+The package manager facility lives in the files image/Makefile, image/Make.package and image/Packages.
+
+On the business of getting any group of new applications integrated into ELKS, the following process can be followed.
+
+The application-set contributor would create a custom, say, 'busyElks.package' file for their contribution, which would use the package manager to build a bootable FAT or MINIX floppy image with their intended application-set. This would very quickly and easily allow the ELKS community users access to images for testing and comment. It is also quite necessary, since we're completely out of space for existing applications, yet alone new ones, in the 1440k image.
+
+In the elks/images directory, the application-set contributor would do something like the following to create a packages file once, from the already built application tree:
+
+ls -R template > busyElks.package
+{edit package file to manually add or remove applications}
+
+Please see the existing image/Packages and Make.package to see how things currently work.
+This also necessitates any new command sets be placed in directories where they don't conflict with existing command names - only for the short term.
+
+After editing the new busyElks.package file created as above from the ELKS bootable image template tree (/template), the following package manager command would allow easily building the application-set image, which could then be added to the 'make images' Makefile:
+
+make -f Make.packages PACKAGE=busyElks.package NAME=busyelks FS=minix SIZE=360
+
+In the above usage, a bootable 360k minix disk image busyelks-minix.bin will be created with all files specified in the busyElks.package file.
+
+The package manager also uses a TAGS=:tag 'tags' mechanism that allows a single Package file to specify file inclusion in an image for different image sizes or types using one or more ":tags" placed on each application line. A TAGS= parameter added to 'make -f' above adds this functionality. Symlinks are also properly currently handled.
+
+The ELKS PB and minix or fat mkfs options are set automatically from the SIZE= parameter, which can be one of 360, 720, 1440 or 2880. An optional TAGS= parameter allows the use of a single package file for multiple disk sizes, if desired.

--- a/image/Make.package
+++ b/image/Make.package
@@ -1,6 +1,37 @@
 # Application package creation Makefile
-#	passed NAME=, APPS=, OPTS= and BPB= for MINIX, SIZE= for MSDOS
+#	passed NAME=, FS=, SIZE=, and optional PACKAGE= and TAGS=
 #	implicitly uses IMGDIR=, DESTDIR= and FD_BOOTBLOCK=
+
+
+# set BPB and mkfs options based on passed image size
+ifeq ($(SIZE),  360)
+	BPB=-B9,2
+	MINIX_MKFSOPTS=-1 -n14 -i192 -s360
+endif
+ifeq ($(SIZE), 720)
+	BPB=-B9,2
+	MINIX_MKFSOPTS=-1 -n14 -i256 -s720
+endif
+ifeq ($(SIZE), 1440)
+	BPB=-B18,2
+	MINIX_MKFSOPTS=-1 -n14 -i360 -s1440
+endif
+ifeq ($(SIZE), 2880)
+	BPB=-B36,2
+	MINIX_MKFSOPTS=-1 -n14 -i720 -s2880
+endif
+
+# select package file
+ifeq ($(PACKAGE), )
+	PACKAGE=Packages
+endif
+
+# set all if no TAGS specified
+ifeq ($(TAGS), )
+	TAGS=*
+endif
+
+all: $(FS)
 
 # Create bootable ELKS MINIX disk image:
 #	Select tagged files into filelist
@@ -12,7 +43,7 @@
 #	Print filesystem used inode and block count
 
 VERBOSE=-v
-MINIX_IMAGE=$(IMGDIR)/$(NAME).bin
+MINIX_IMAGE=$(IMGDIR)/$(NAME)-$(FS).bin
 
 # mfs options
 # -v		verbose
@@ -24,10 +55,9 @@ MINIX_IMAGE=$(IMGDIR)/$(NAME).bin
 # -n14		filename size 14
 # -i<size>	max inodes
 # -s<size>	image size in 1k blocks
-MINIX_MKFSOPTS=-1 -n14 $(OPTS)
 
 minix:
-	awk "/$(APPS)/{print}" Packages | cut -f 1 > Filelist
+	awk "/$(TAGS)/{print}" $(PACKAGE) | cut -f 1 > Filelist
 	mfs $(VERBOSE) $(MINIX_IMAGE) mkfs $(MINIX_MKFSOPTS)
 	mfs $(VERBOSE) $(MINIX_IMAGE) addfs Filelist $(DESTDIR)
 	rm Filelist
@@ -45,10 +75,9 @@ minix:
 #		Filename case is preserved
 #		Note: filenames larger than 8.3 will create VFAT LFN entries
 #	Write boot sector and modify ELKS PB
-
 # all mtools commands require image file
 # -i image	image filename
-MSDOS_IMAGE=$(IMGDIR)/$(NAME).bin
+MSDOS_IMAGE=$(IMGDIR)/$(NAME)-$(FS).bin
 
 # mformat options
 # -f size	image size in kilobytes
@@ -79,8 +108,8 @@ MSDOS_COPYOPTS=-pmQ -D o
 
 FD_BOOTSECT=$(TOPDIR)/elkscmd/bootblocks/fat.bin
 
-msdos:
-	awk "/$(APPS)/{print}" Packages | cut -f 1 | sed "/^#/d" > Filelist
+fat:
+	awk "/$(TAGS)/{print}" $(PACKAGE) | cut -f 1 | sed "/^#/d" > Filelist
 	dd if=/dev/zero of=$(MSDOS_IMAGE) bs=1024 count=$(SIZE)
 	mformat -i $(MSDOS_IMAGE) $(MSDOS_MKFSOPTS)
 	rm -f linux; touch linux
@@ -91,7 +120,7 @@ msdos:
 	do \
 		if [ ! -e $(DESTDIR)$$f ]; \
 		then \
-			echo "File specified in Package not found: $(DESTDIR)$$f"; \
+			echo "File specified in $(PACKAGE) not found: $(DESTDIR)$$f"; \
 			exit 1; \
 		else \
 			[ -d $(DESTDIR)/$$f ] && mmd -i $(MSDOS_IMAGE) ::$$f; \
@@ -102,16 +131,5 @@ msdos:
 	# Protect contiguous /linux by marking as R/O, System and Hidden
 	mattrib -i $(MSDOS_IMAGE) +r +s +h ::/linux
 	# Read boot sector, skip FAT BPB, set ELKS PB sectors/heads and write boot
-ifeq ($(SIZE), 360)
-	setboot $(MSDOS_IMAGE) -F -B9,2 $(FD_BOOTSECT)
-endif
-ifeq ($(SIZE), 720)
-	setboot $(MSDOS_IMAGE) -F -B9,2 $(FD_BOOTSECT)
-endif
-ifeq ($(SIZE), 1440)
-	setboot $(MSDOS_IMAGE) -F -B18,2 $(FD_BOOTSECT)
-endif
-ifeq ($(SIZE), 2880)
-	setboot $(MSDOS_IMAGE) -F -B36,2 $(FD_BOOTSECT)
-endif
+	setboot $(MSDOS_IMAGE) -F $(BPB) $(FD_BOOTSECT)
 	#mdir -i $(MSDOS_IMAGE) -/ -a ::

--- a/image/Makefile
+++ b/image/Makefile
@@ -116,26 +116,26 @@ images: images-minix images-fat
 images-minix: fd360-minix fd720-minix fd1440-minix
 
 fd360-minix:
-	$(MAKE) -f Make.package minix NAME=fd360-minix OPTS="-i192 -s360" BPB=-B9,2 APPS=":boot|:small"
+	$(MAKE) -f Make.package NAME=fd360 FS=minix SIZE=360 TAGS=":boot|:small"
 
 fd720-minix:
-	$(MAKE) -f Make.package minix NAME=fd720-minix OPTS="-i256 -s720" BPB=-B9,2 APPS=":boot|:small|:base|:net"
+	$(MAKE) -f Make.package NAME=fd720 FS=minix SIZE=720 TAGS=":boot|:small|:base|:net"
 
 fd1440-minix:
-	$(MAKE) -f Make.package minix NAME=fd1440-minix OPTS="-i360 -s1440" BPB=-B18,2 APPS=":boot|:small|:base|:net|:shutil|:fileutil|:app|:nanox"
+	$(MAKE) -f Make.package NAME=fd1440 FS=minix SIZE=1440 TAGS=":boot|:small|:base|:net|:shutil|:fileutil|:app|:nanox"
 
 
 images-fat: fd360-fat fd720-fat fd1440-fat fd2880-fat
 
 fd360-fat:
-	$(MAKE) -f Make.package msdos NAME=fd360-fat SIZE=360 APPS=":boot|:small"
+	$(MAKE) -f Make.package NAME=fd360 FS=fat SIZE=360 TAGS=":boot|:small"
 
 fd720-fat:
-	$(MAKE) -f Make.package msdos NAME=fd720-fat SIZE=720 APPS=":boot|:small|:base|:net"
+	$(MAKE) -f Make.package NAME=fd720 FS=fat SIZE=720 TAGS=":boot|:small|:base|:net"
 
 fd1440-fat:
-	$(MAKE) -f Make.package msdos NAME=fd1440-fat SIZE=1440 APPS=":boot|:small|:base|:net|:shutil|:fileutil|:app|:nanox"
+	$(MAKE) -f Make.package NAME=fd1440 FS=fat SIZE=1440 TAGS=":boot|:small|:base|:net|:shutil|:fileutil|:app|:nanox"
 
 # FAT16 image
 fd2880-fat:
-	$(MAKE) -f Make.package msdos NAME=fd2880-fat SIZE=2880 APPS=":boot|:small|:base|:net|:shutil|:fileutil|:app|:nanox"
+	$(MAKE) -f Make.package NAME=fd2880 FS=fat SIZE=2880 TAGS=":boot|:small|:base|:net|:shutil|:fileutil|:app|:nanox"


### PR DESCRIPTION
This commit allows easy creation of bootable busyElks or other application packages for testing by use of the following in `elks/images/Makefile`:
```
make -f Make.packages PACKAGE=busyElks.package NAME=busyelks FS=minix SIZE=360
```
In the above usage, a bootable 360k minix disk image `busyelks-minix.bin` will be created with all files specified in the `busyElks.package` file.

The ELKS PB and minix or fat mkfs options are set automatically from the SIZE= parameter, which can be one of 360, 720, 1440 or 2880. An optional TAGS= parameter allows the use of a single package file for multiple disk sizes, if desired.