### PR TITLE
[elkscmd] `clock` now uses `clr_irq ()` & `set_irq ()` in `<arch/irq.h>`

### DIFF
--- a/elkscmd/sys_utils/clock.c
+++ b/elkscmd/sys_utils/clock.c
@@ -7,6 +7,7 @@
 #include <sys/time.h>
 #include <string.h>
 #ifdef __ia16__
+#include <arch/irq.h>
 #include <arch/io.h>
 #endif
 
@@ -186,29 +187,27 @@ _outb:
     pop bp
     ret
 #endasm
+
+#asm
+_clr_irq:
+    cli
+    ret
+#endasm
+
+#asm
+_set_irq:
+    sti
+    ret
+#endasm
 #endif
 
 unsigned char cmos_read(unsigned char reg)
 {
   register unsigned char ret;
-#ifdef __BCC__
-#asm
-  cli
-#endasm
-#endif
-#ifdef __ia16__
-  asm( "cli \n");
-#endif
-  outb (reg | 0x80, 0x70);
-  ret = inb (0x71);
-#ifdef __BCC__
-#asm
-  sti
-#endasm
-#endif
-#ifdef __ia16__
-  asm("sti \n");
-#endif
+  clr_irq ();
+  outb_p (reg | 0x80, 0x70);
+  ret = inb_p (0x71);
+  set_irq ();
   return ret;
 }
 
@@ -216,8 +215,10 @@ void cmos_write(reg, val)
 unsigned char reg;
 unsigned char val;
 {
-  outb (reg | 0x80, 0x70);
-  outb (val, 0x71);
+  clr_irq ();
+  outb_p (reg | 0x80, 0x70);
+  outb_p (val, 0x71);
+  set_irq ();
 }
 
 


### PR DESCRIPTION
This commit tidies up the code for the `/bin/clock` system utility, so that there is no longer a bunch of `#ifdef`'s just for disabling and enabling interrupts.  The `cli` and `sti` instructions are inlined under `gcc-ia16` --- as before --- but are now out-of-line, and thus a bit slower, if compiled with `bcc`.

I also slightly altered the port I/O code to use "pausing" versions of the port I/O operations, which should hopefully make the operations a bit more reliable.

(Side note: `<arch/irq.h>` should probably be cleaned up, and moved into `libc`, or explicitly shared between kernel and `libc`.)