### PR TITLE
[cmds] Fix ls -l date/time display

### DIFF
--- a/elkscmd/file_utils/ls.c
+++ b/elkscmd/file_utils/ls.c
@@ -365,7 +365,7 @@ static char *timestring(long t)
     strcpy(buf, &str[4]);
     buf[12] = '\0';
 
-    if ((t > now) || (t < now - 180*24*60*60L)) {
+    if ((t > now) || (t < now - 180*24*60L*60)) {
 	strcpy(&buf[7], &str[20]);
 	buf[11] = '\0';
     }


### PR DESCRIPTION
This fixes the integer overflow bug, previously displayed as a gcc compiler warning, so that `ls -l` properly displays the time or year following the month and day, depending on the current time.

Bug: It seems that the time set by `clock -s` run by rc.sys sets the time according to GMT, not local time, (tested only in QEMU). Thus, the new `ls -l` time is in GMT, versus all other time (like those prepared with `mfs` or `mformat`, which display the time in local time. Anyone have any ideas on how to easily fix this in `clock`, or what the BIOS time is supposed to be set to (local or GMT)?