### PR TITLE
[libc] boost dependency checks, force recursive make in subdirectories

### DIFF
--- a/libc/Makefile
+++ b/libc/Makefile
@@ -127,9 +127,11 @@ $(LIBC): $(SUBDIRSINMULTILIB)
 
 $(CRT0): crt0.S
 
-$(TOPDIR)/libc/build-ml/$(MULTISUBDIR)/%: %
+$(SUBDIRSINMULTILIB) : $(TOPDIR)/libc/build-ml/$(MULTISUBDIR)/%: %
 	mkdir -p $@
 	$(MAKE) -C $@ VPATH=$(abspath $<) -f $(abspath $<)/Makefile all
+# Use .PHONY to force recursive `make' in all subdirectories for each multilib
+.PHONY: $(SUBDIRSINMULTILIB)
 
 $(SUBDIRS):
 


### PR DESCRIPTION
@Mellvik reported that modules in `libc` were not being rebuilt properly even when source files were updated.

This commit should strengthen the checks of whether the `.o` files are up to date: `elks/libc/`'s top-level makefile now forces `make` to always recursively run `make` within each subdirectory (`elks/libc/build-ml/elkslibc/misc/`, etc.).