### PR TITLE
[elks] remove CONFIG_SHORT_FILES checks in defining fd_set etc.

### DIFF
--- a/elks/include/arch/posix_types.h
+++ b/elks/include/arch/posix_types.h
@@ -14,36 +14,27 @@
 
 #undef	__FD_SET
 #ifndef __KERNEL__
-#define __FD_SET(fd,fdsetp) {				\
-		int mask, addr = ((int) fdsetp);	\
-							\
-		addr += fd >> 4;			\
-		mask = 1 << (fd & 0xf); 		\
-		*(int*)addr |= mask;			\
-	}
+#define __FD_SET(fd,fdsetp) (*(fdsetp) |= (__u32)1 << (fd))
 #else
 #define __FD_SET(fd,fdsetp) set_bit(fd, fdsetp)
 #endif
 
 #undef	__FD_CLR
 #ifndef __KERNEL__
-#define __FD_CLR(fd,fdsetp) {				\
-		int mask, addr = ((int) fdsetp);	\
-							\
-		addr += fd >> 4;			\
-		mask = 1 << (fd & 0xf); 		\
-		*(int*)addr &= ~mask;			\
-	}
+#define __FD_CLR(fd,fdsetp) (*(fdsetp) &= ~((__u32)1 << (fd)))
 #else
 #define __FD_CLR(fd,fdsetp) clear_bit(fd, fdsetp)
 #endif
 
 #undef	__FD_ISSET
-#define __FD_ISSET(fd,fdsetp)				\
-	((((unsigned long *)fdsetp)[0] & (1<<(fd & 0x1f))) != 0)
+#ifndef __KERNEL__
+#define __FD_ISSET(fd,fdsetp) ((*(fdsetp) >> (fd)) & 1)
+#else
+#define __FD_ISSET(fd,fdsetp) test_bit(fd, fdsetp)
+#endif
 
 #undef	__FD_ZERO
-#define __FD_ZERO(fdsetp)	(((unsigned long *)fdsetp)[0] = 0UL)
+#define __FD_ZERO(fdsetp)	(*(fdsetp) = 0UL)
 
 /*@+namechecks@*/
 

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -40,11 +40,7 @@
  *  longs, but uses the new fd_set structure..
  */
 
-#ifdef CONFIG_SHORT_FILES
-#define NR_OPEN 	16
-#else
 #define NR_OPEN 	20
-#endif
 
 #define NR_INODE	96	/* this should be bigger than NR_FILE */
 #define NR_FILE 	64	/* this can well be larger on a larger system */

--- a/elks/include/linuxmt/posix_types.h
+++ b/elks/include/linuxmt/posix_types.h
@@ -27,18 +27,6 @@
 
 /*@-namechecks@*/
 
-#ifdef CONFIG_SHORT_FILES
-
-#undef __NFDBITS
-#define __NFDBITS	(8 * sizeof(unsigned short))
-
-#undef __FD_SETSIZE
-#define __FD_SETSIZE	16
-
-typedef __u16 __kernel_fd_set;
-
-#else
-
 #undef __NFDBITS
 #define __NFDBITS	(8 * sizeof(unsigned long))
 
@@ -46,8 +34,6 @@ typedef __u16 __kernel_fd_set;
 #define __FD_SETSIZE	20
 
 typedef __u32 __kernel_fd_set;
-
-#endif
 
 /*@+namechecks@*/
 

--- a/elks/include/linuxmt/types.h
+++ b/elks/include/linuxmt/types.h
@@ -46,11 +46,7 @@ typedef __u32			time_t;
 
 /*@end@*/
 
-#ifdef CONFIG_SHORT_FILES
-typedef __u16			fd_mask_t;
-#else
 typedef __u32			fd_mask_t;
-#endif
 
 #include <linuxmt/config.h>
 #include <linuxmt/posix_types.h>


### PR DESCRIPTION
`Documentation/historic/CHANGELOG` says of ELKS 0.0.79, "Added `CONFIG_SHORT_FILES` which limits file descriptors to 16."  However, this is no longer a configuration option now, so there is no real need to check for it.

Removing this check simplifies the code for processing `fd_set`'s in `select(`...`)` calls, and removes a potential source of ABI instability.