### PR TITLE
[nano-x] Set default mouse driver to Microsoft Mouse in nano-X, QEMU

### DIFF
--- a/elkscmd/nano-X/Makefile
+++ b/elkscmd/nano-X/Makefile
@@ -10,9 +10,8 @@ LOCALFLAGS = -DELKS=1 -DUNIX=1 -DDEBUG=1 -Dconst= -Dvolatile= -I.
 MATHLIB =
 
 ## mouse and kbd drivers
-#DRIVERS += drivers/mou_ser.o
-#DRIVERS += drivers/mou_ser_qemu.o
-DRIVERS += drivers/mou_null.o
+DRIVERS += drivers/mou_ser.o
+#DRIVERS += drivers/mou_null.o
 DRIVERS += drivers/kbd_tty.o
 
 # The following line links the nano-X application with the server.

--- a/elkscmd/nano-X/drivers/mou_ser.c
+++ b/elkscmd/nano-X/drivers/mou_ser.c
@@ -37,13 +37,9 @@
 #endif
 
 /* default settings*/
-#if ELKS
 #define	MOUSE_PORT	"/dev/ttyS0"	/* default mouse tty port */
-#else
-#define	MOUSE_PORT	"/dev/ttyS1"	/* default mouse tty port */
-#endif
-#define	MOUSE_TYPE	"pc"		/* default mouse type ("ms" or "pc") */
-#define MAX_BYTES	128		/* number of bytes for buffer */
+#define	MOUSE_TYPE	"ms"			/* default mouse type ("ms" or "pc") */
+#define MAX_BYTES	128				/* number of bytes for buffer */
 
 /* states for the mouse*/
 #define	IDLE			0		/* start of byte sequence */

--- a/qemu.sh
+++ b/qemu.sh
@@ -39,6 +39,10 @@ echo "Using disk image: $IMAGE"
 # KEYBOARD="-k fr"
 KEYBOARD=
 
+# Select pty serial port or serial mouse driver
+SERIAL="-chardev pty,id=chardev1 -device isa-serial,chardev=chardev1,id=serial1"
+#SERIAL="-chardev msmouse,id=chardev1 -device isa-serial,chardev=chardev1,id=serial1"
+
 # Host forwarding for networking
 # No forwarding: only outgoing from ELKS to host
 # HOSTFWD="-net user"
@@ -55,8 +59,6 @@ HOSTFWD="-net user"
 [ `uname` != 'Darwin' ] && QDISPLAY="-display sdl"
 
 # Configure QEMU as pure ISA system
-
-SERIAL="-chardev pty,id=chardev1 -device isa-serial,chardev=chardev1,id=serial1"
 
 $QEMU -nodefaults -name ELKS -machine isapc -cpu 486,tsc -m 1M \
 $KEYBOARD $QDISPLAY -vga std -rtc base=utc $SERIAL \


### PR DESCRIPTION
This change allows the graphical 'landmine' game to work with a Microsoft mouse on the first serial port by default. The `qemu.sh` script was also updated to allow playing the game in the simulator by uncommenting the `SERIAL=` line in the script. Nano-X games can be exited by pressing the ESC key.

This is pretty much all that will likely be done on #401 for now, although there may be separate problems with bugs in the ELKS serial device driver.