### PR TITLE
[cmds] Sash and ls enhancements

### DIFF
--- a/elks/arch/i86/defconfig
+++ b/elks/arch/i86/defconfig
@@ -176,11 +176,8 @@ CONFIG_PSEUDO_TTY=y
 # Shell
 #
 CONFIG_APP_ASH=y
+CONFIG_APP_SASH=y
 CONFIG_APP_SH_UTILS=y
-
-#
-# (sash not needed with ash)
-#
 
 #
 # Other commands
@@ -227,7 +224,6 @@ CONFIG_IMG_MINIX=y
 # CONFIG_IMG_FAT is not set
 # CONFIG_IMG_RAW is not set
 # CONFIG_IMG_ROM is not set
-CONFIG_IMG_LINK=y
 # CONFIG_IMG_FD1680 is not set
 CONFIG_IMG_FD1440=y
 # CONFIG_IMG_FD1200 is not set

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -87,6 +87,7 @@ void start_kernel(void)
 static void init_task()
 {
     int num;
+	char *s;
 
     mount_root();
 #ifndef CONFIG_SMALL_KERNEL
@@ -100,21 +101,17 @@ static void init_task()
      * run_init_process("/etc/init");
      * run_init_process("/bin/init");
      * run_init_process("/bin/sh");
-     *
-     * So, I've modified the ELKS kernel to follow this tradition.
      */
 
-//	run_init_process("/sbin/init");
-//	run_init_process("/etc/init");
 	run_init_process("/bin/init");
 
 #ifdef CONFIG_CONSOLE_SERIAL
-    num = sys_open("/dev/ttyS0", 2, 0);		/* These are for stdin */
+    num = sys_open(s="/dev/ttyS0", 2, 0);		/* These are for stdin */
 #else
-    num = sys_open("/dev/tty1", 2, 0);
+    num = sys_open(s="/dev/tty1", 2, 0);
 #endif
     if (num < 0)
-	printk("Unable to open /dev/tty1 (error %u)\n", -num);
+	printk("Unable to open %s (error %d)\n", s, -num);
 
     if (sys_dup(num) != 1)			/* This is for stdout */
 	printk("dup failed\n");
@@ -122,6 +119,7 @@ static void init_task()
     printk("No init - running /bin/sh\n");
 
     run_init_process("/bin/sh");
+    run_init_process("/bin/sash");
     panic("No init or sh found");
 }
 

--- a/elkscmd/ash/Makefile
+++ b/elkscmd/ash/Makefile
@@ -28,6 +28,8 @@ OBJS=	builtins.o cd.o dirent.o error.o eval.o exec.o expand.o input.o \
 	output.o var.o init.o \
 	bltin/echo.o bltin/expr.o bltin/regexp.o bltin/operators.o
 
+#LDFLAGS += -maout-chmem=0xc000
+
 #
 # Set READLINE in shell.h and add -ledit to LIBS if you want to use the
 # editline package by Simmule Turner and Rich Salz.  (The big, bloated

--- a/elkscmd/ash/var.c
+++ b/elkscmd/ash/var.c
@@ -89,7 +89,7 @@ const struct varinit varinit[] = {
 	{&vifs,	VSTRFIXED|VTEXTFIXED,		"IFS= \t\n"},
 	{&vmail,	VSTRFIXED|VTEXTFIXED|VUNSET,	"MAIL="},
 	{&vmpath,	VSTRFIXED|VTEXTFIXED|VUNSET,	"MAILPATH="},
-	{&vpath,	VSTRFIXED|VTEXTFIXED,		"PATH=:/bin:/usr/bin"},
+	{&vpath,	VSTRFIXED|VTEXTFIXED,		"PATH=/bin:/usr/bin:/sbin"},
 	/*
 	 * vps1 depends on uid
 	 */

--- a/elkscmd/config.in
+++ b/elkscmd/config.in
@@ -8,14 +8,8 @@ mainmenu_option next_comment
 	comment "Shell"
 
 	bool 'ash'        CONFIG_APP_ASH        y
+	bool 'sash'       CONFIG_APP_SASH       y
 	bool 'shutils'    CONFIG_APP_SH_UTILS   y
-
-	if [ "$CONFIG_APP_ASH" != "y" ]; then
-		comment 'sash as default shell'
-		define_bool CONFIG_APP_SASH y
-	else
-		comment '(sash not needed with ash)'
-	fi
 
 	comment 'Other commands'
 

--- a/elkscmd/file_utils/Makefile
+++ b/elkscmd/file_utils/Makefile
@@ -10,7 +10,7 @@ include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
-OUTS = grep l ln ls mkdir mkfifo mknod more mv rm rmdir sync touch
+OUTS = grep ln ls mkdir mkfifo mknod more mv rm rmdir sync touch
 OUTS_BE += cat chgrp chmod chown cmp cp dd
 
 PRGS = $(OUTS)

--- a/elkscmd/file_utils/more.c
+++ b/elkscmd/file_utils/more.c
@@ -37,13 +37,13 @@ int main(int argc, char **argv)
 				perror(name);
 				exit(1);
 			}
-			printf("<< %s >>\n", name);
+			/*printf("<< %s >>\n", name);*/
 		} else {
 			fd = 0;
 			/* FIXME: these open commands are not the way to open stdin */
 			cin = open("/dev/tty1", O_RDONLY);
 			if (!cin) cin = fopen("/dev/console", "r");
-			printf("<< stdin >>\n");
+			/*printf("<< stdin >>\n");*/
 		}
 		line = 1;
 		col = 0;

--- a/elkscmd/inet/urlget/Makefile
+++ b/elkscmd/inet/urlget/Makefile
@@ -22,11 +22,6 @@ urlget:	$(OBJS)
 
 install: urlget
 	$(INSTALL) urlget $(DESTDIR)/bin
-ifdef CONFIG_IMG_LINK
-	$(LN) -sf urlget $(DESTDIR)/bin/ftpget
-else
-	$(INSTALL) urlget $(DESTDIR)/bin/ftpget
-endif
 
 clean:
 	rm -f urlget *.o

--- a/elkscmd/rootfs_template/root/.profile
+++ b/elkscmd/rootfs_template/root/.profile
@@ -1,2 +1,2 @@
-PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:~/bin
+PATH=/bin:/usr/bin:/sbin
 export PATH

--- a/elkscmd/sash/Makefile
+++ b/elkscmd/sash/Makefile
@@ -13,6 +13,7 @@ include $(BASEDIR)/Make.rules
 ###############################################################################
 
 OBJS = sash.o cmds.o cmd_dd.o cmd_ed.o cmd_grep.o cmd_ls.o cmd_tar.o utils.o
+#LDFLAGS += -maout-chmem=0xc000
 
 all: sash
 
@@ -23,10 +24,10 @@ clean:
 	rm -f core sash $(OBJS)
 
 install: sash
-ifdef CONFIG_IMG_LINK
+ifdef CONFIG_APP_ASH
 	$(INSTALL) sash $(DESTDIR)/bin/sash
-	$(LN) -sf sash $(DESTDIR)/bin/sh
 else
+	# install as /bin/sh if no ash shell
 	$(INSTALL) sash $(DESTDIR)/bin/sh
 endif
 

--- a/elkscmd/sash/cmd_ls.c
+++ b/elkscmd/sash/cmd_ls.c
@@ -213,7 +213,7 @@ lsfile(name, statbuf, flags)
 	*cp = '\0';
 
 	if (flags & LSF_INODE) {
-		sprintf(cp, "%5d ", statbuf->st_ino);
+		sprintf(cp, "%5d ", (unsigned long)statbuf->st_ino);
 		cp += strlen(cp);
 	}
 

--- a/elkscmd/sash/cmds.c
+++ b/elkscmd/sash/cmds.c
@@ -626,7 +626,7 @@ do_more(argc, argv)
 			return;
 		}
 
-		printf("<< %s >>\n", name);
+		/*printf("<< %s >>\n", name);*/
 		line = 1;
 		col = 0;
 

--- a/elkscmd/sash/config.h
+++ b/elkscmd/sash/config.h
@@ -2,36 +2,38 @@
  * Comment out #define for commands you do not require
  */
 
-/* #define CMD_ALIAS     /* 1048 bytes. Includes unalias */
-/* #define CMD_CHGRP     /* 2164 bytes */
-/* #define CMD_CHMOD     /*  260 bytes */
-/* #define CMD_CHOWN     /* 2080 bytes */
-/* #define CMD_CMP       /*  904 bytes */
-/* #define CMD_CP        /* 1108 bytes */
-/* #define CMD_DD        /* 2524 bytes */
+#define WILDCARDS
+
+#define CMD_ALIAS     /* 1048 bytes. Includes unalias */
+#define CMD_CHGRP     /* 2164 bytes */
+#define CMD_CHMOD     /*  260 bytes */
+#define CMD_CHOWN     /* 2080 bytes */
+#define CMD_CMP       /*  904 bytes */
+#define CMD_CP        /* 1108 bytes */
+#define CMD_DD        /* 2524 bytes */
 #define CMD_ECHO      /*  264 bytes 
-/* #define CMD_ED        /* 8300 bytes */
-/* #define CMD_GREP      /*  144 bytes */
-/* #define CMD_HELP      /*   88 bytes */
-/* #define CMD_KILL      /*  532 bytes */
-/* #define CMD_LN        /*  716 bytes */
+#define CMD_ED        /* 8300 bytes */
+#define CMD_GREP      /*  144 bytes */
+#define CMD_HELP      /*   88 bytes */
+#define CMD_KILL      /*  532 bytes */
+#define CMD_LN        /*  716 bytes */
 #define CMD_LS        /* 7092 bytes */
-/* #define CMD_MKDIR     /*  140 bytes */
-/* #define CMD_MKNOD     /*  516 bytes */
+#define CMD_MKDIR     /*  140 bytes */
+#define CMD_MKNOD     /*  516 bytes */
 #define CMD_MORE      /*  608 bytes */
-/* #define CMD_MOUNT     /*  600 bytes. Includes umount */
-/* #define CMD_MV        /* 1272 bytes */
-/* #define CMD_PRINTENV  /*  260 bytes */
-/* #define CMD_PROMPT    /*      bytes */
+#define CMD_MOUNT     /*  600 bytes. Includes umount */
+#define CMD_MV        /* 1272 bytes */
+#define CMD_PRINTENV  /*  260 bytes */
+#define CMD_PROMPT    /*            */
 #define CMD_PWD       /*  928 bytes */
-/* #define CMD_RM        /*  140 bytes */
-/* #define CMD_RMDIR     /*  140 bytes */
-/* #define CMD_SETENV    /*  129 bytes */
-/* #define CMD_SOURCE    /*      bytes */
-/* #define CMD_SYNC      /*   80 bytes */
-/* #define CMD_TAR       /* 5576 bytes */
-/* #define CMD_TOUCH     /*  236 bytes */
-/* #define CMD_UMASK     /*  272  bytes */
+#define CMD_RM        /*  140 bytes */
+#define CMD_RMDIR     /*  140 bytes */
+#define CMD_SETENV    /*  129 bytes */
+#define CMD_SOURCE    /*      bytes */
+#define CMD_SYNC      /*   80 bytes */
+#define CMD_TAR       /* 5576 bytes */
+#define CMD_TOUCH     /*  236 bytes */
+#define CMD_UMASK     /*  272  bytes */
 
 #ifdef CMD_CP
 #define FUNC_COPYFILE

--- a/elkscmd/sash/sash.c
+++ b/elkscmd/sash/sash.c
@@ -12,9 +12,6 @@
 #include <signal.h>
 #include <errno.h>
 
-static	char	*version = "1.0";
-
-
 typedef struct {
 	char	*name;
 	char	*usage;
@@ -201,25 +198,25 @@ static	CMDTAB	cmdtab[] = {
 };
 
 
+#ifdef CMD_ALIAS
 typedef struct {
 	char	*name;
 	char	*value;
 } ALIAS;
 
-
 static	ALIAS	*aliastable;
 static	int	aliascount;
+static	ALIAS	*findalias();
+#endif
+
+static	BOOL	intcrlf = TRUE;
+static	char	*prompt;
+static BOOL		isbinshell;
 
 #ifdef CMD_SOURCE
 static	FILE	*sourcefiles[MAXSOURCE];
 static	int	sourcecount;
 #endif
-
-static	BOOL	intcrlf = TRUE;
-#ifdef CMD_PROMPT
-static	char	*prompt;
-#endif
-
 
 static	void	catchint();
 static	void	catchtstp();
@@ -229,35 +226,41 @@ static	void	command();
 static	void	runcmd();
 static	void	showprompt();
 static	BOOL	trybuiltin();
-#ifdef CMD_ALIAS
-static	ALIAS	*findalias();
-#endif
 
 BOOL	intflag;
 
 
-main(argc, argv)
-	char	**argv;
+int main(int argc, char **argv)
 {
 	char	*cp;
 	char	buf[PATHLEN];
 
-	printf("Stand-alone shell (version %s)\n", version);
-	fflush(stdout);
 	signal(SIGINT, catchint);
 	signal(SIGQUIT, catchquit);
 	signal(SIGTSTP, SIG_IGN);
 
+	/* check if we are /bin/sh*/
+	if ((cp = strrchr(argv[0], '/')) != 0)
+		cp++;
+	else cp = argv[0];
+	isbinshell = !strcmp(cp, "sh");
+
+#ifdef CMD_PROMPT
+	if ((prompt = malloc(3)) == 0)
+#endif
+		prompt = "  ";
+	strcpy(prompt, getuid()? "$ ": "# ");
+
 	if (getenv("PATH") == NULL)
-		putenv("PATH=/bin:/usr/bin:/etc");
+		putenv("PATH=/bin:/usr/bin:/sbin");
 
 #ifdef CMD_SOURCE
-#ifdef CMD_ALIAS
+#ifdef LATER
 	cp = getenv("HOME");
 	if (cp) {
 		strcpy(buf, cp);
 		strcat(buf, "/");
-		strcat(buf, ".aliasrc");
+		strcat(buf, ".sashrc");
 
 		if ((access(buf, 0) == 0) || (errno != ENOENT))
 			readfile(buf);
@@ -361,6 +364,36 @@ readfile(name)
 #endif
 }
 
+/* check if command line requires a real shell to run it*/
+static BOOL
+needfullshell(char *cmd)
+{
+	char 	*cp;
+
+	for (cp = cmd; *cp; cp++) {
+		if ((*cp >= 'a') && (*cp <= 'z'))
+			continue;
+		if ((*cp >= 'A') && (*cp <= 'Z'))
+			continue;
+		if (isdecimal(*cp))
+			continue;
+		if (isblank(*cp))
+			continue;
+
+		if ((*cp == '.') || (*cp == '/') || (*cp == '-') ||
+			(*cp == '+') || (*cp == '=') || (*cp == '_') ||
+			(*cp == ':') || (*cp == ',') || (*cp == '#'))
+				continue;
+#ifdef WILDCARDS
+		if ((*cp == '*') || (*cp == '?') || (*cp == '[') || (*cp == ']'))
+			continue;
+#endif
+
+		return TRUE;
+	}
+	return FALSE;
+}
+
 
 /*
  * Parse and execute one null-terminated command line string.
@@ -368,8 +401,7 @@ readfile(name)
  * command is an alias, and expands wildcards.
  */
 static void
-command(cmd)
-	char	*cmd;
+command(char *cmd)
 {
 	char	**argv;
 	int	argc;
@@ -386,7 +418,7 @@ command(cmd)
 	while (isblank(*cmd))
 		cmd++;
 
-	if ((*cmd == '\0') || !makeargs(cmd, &argc, &argv))
+	if ((*cmd == '\0') || (*cmd == '#') || !makeargs(cmd, &argc, &argv))
 		return;
 
 #ifdef CMD_ALIAS
@@ -414,7 +446,7 @@ command(cmd)
 	 * Now look for the command in the builtin table, and execute
 	 * the command if found.
 	 */
-	if (trybuiltin(argc, argv))
+	if (!needfullshell(cmd) && trybuiltin(argc, argv))
 		return;
 
 	/*
@@ -423,15 +455,13 @@ command(cmd)
 	runcmd(cmd, argc, argv);
 }
 
-
 /*
  * Try to execute a built-in command.
  * Returns TRUE if the command is a built in, whether or not the
  * command succeeds.  Returns FALSE if this is not a built-in command.
  */
 static BOOL
-trybuiltin(argc, argv)
-	char	**argv;
+trybuiltin(int argc, char **argv)
 {
 	CMDTAB	*cmdptr;
 #ifdef WILDCARDS
@@ -456,9 +486,7 @@ trybuiltin(argc, argv)
 	 * or too small.
 	 */
 	if ((argc < cmdptr->minargs) || (argc > cmdptr->maxargs)) {
-		fprintf(stderr, "usage: %s %s\n",
-			cmdptr->name, cmdptr->usage);
-
+		fprintf(stderr, "usage: %s %s\n", cmdptr->name, cmdptr->usage);
 		return TRUE;
 	}
 
@@ -466,24 +494,17 @@ trybuiltin(argc, argv)
 	 * Check here for several special commands which do not
 	 * have wildcarding done for them.
 	 */
+	if (
 #ifdef CMD_ALIAS
+	(cmdptr->func == do_alias) ||
+#endif
 #ifdef CMD_PROMPT
-	if ((cmdptr->func == do_alias) || (cmdptr->func == do_prompt)) {
-#else /* CMD_PROMPT */
-	if (cmdptr->func == do_alias) {
-#endif /* CMD_PROMPT */
+	(cmdptr->func == do_prompt) ||
+#endif
+	   0) {
 		(*cmdptr->func)(argc, argv);
 		return TRUE;
 	}
-#else /* CMD_ALIAS */
-#ifdef CMD_PROMPT
-        if (cmdptr->func == do_prompt) {
-		(*cmdptr->func)(argc, argv);
-		return TRUE;
-	}
-#else
-#endif /* CMD_PROMPT */
-#endif /* CMD_ALIAS */
 
 #ifdef WILDCARDS
 	/*
@@ -524,42 +545,20 @@ trybuiltin(argc, argv)
  * Execute the specified command.
  */
 static void
-runcmd(cmd, argc, argv)
-	char	*cmd;
-	char	**argv;
+runcmd(char *cmd, int argc, char **argv)
 {
-	register char *	cp;
 	int		pid;
 	int		status;
 
-#if POINTLESS
-	BOOL		magic;
-	magic = FALSE;
-
-	for (cp = cmd; *cp; cp++) {
-		if ((*cp >= 'a') && (*cp <= 'z'))
-			continue;
-		if ((*cp >= 'A') && (*cp <= 'Z'))
-			continue;
-		if (isdecimal(*cp))
-			continue;
-		if (isblank(*cp))
-			continue;
-
-		if ((*cp == '.') || (*cp == '/') || (*cp == '-') ||
-			(*cp == '+') || (*cp == '=') || (*cp == '_') ||
-			(*cp == ':') || (*cp == ','))
-				continue;
-
-		magic = TRUE;
+	if (needfullshell(cmd)) {
+		if (isbinshell)
+			printf("%s: no such file or directory\n", argv[0]);
+		else {
+			system(cmd);
+			wait(&status);
+		}
+		return;
 	}
-
-	if (magic) {
-		printf("%s: no such file or directory\n", cmd);
-/*		system(cmd);
-*/		return;
-	}
-#endif
 
 	/*
 	 * No magic characters in the command, so do the fork and
@@ -605,9 +604,13 @@ runcmd(cmd, argc, argv)
 	execvp(argv[0], argv);
 
 	if (errno == ENOEXEC) {
-		printf("%s: no such file or directory\n");
-		/*system(cmd);
-*/		exit(0);
+		if (isbinshell)
+			printf("%s: no such file or directory\n", argv[0]);
+		else {
+			system(cmd);
+			wait(&status);
+		}
+		exit(0);
 	}
 
 	perror(argv[0]);
@@ -825,15 +828,7 @@ do_unalias(argc, argv)
 static void
 showprompt()
 {
-	char	*cp;
-
-	cp = "> ";
-#ifdef PROMPT
-	if (prompt)
-		cp = prompt;
-#endif
-
-	write(STDOUT, cp, strlen(cp));
+	write(STDOUT, prompt, strlen(prompt));
 }
 
 

--- a/elkscmd/sash/sash.h
+++ b/elkscmd/sash/sash.h
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <malloc.h>
 #include <ctype.h>
+#include <unistd.h>
 #include "config.h"
 
 #define	PATHLEN		256	

--- a/elkscmd/sash/utils.c
+++ b/elkscmd/sash/utils.c
@@ -545,9 +545,7 @@ makeargs(cmd, argcptr, argvptr)
  * arguments correctly.
  */
 BOOL
-makestring(argc, argv, buf, buflen)
-	char	**argv;
-	char	*buf;
+makestring(int argc, char **argv, char *buf, int buflen)
 {
 	int	len;
 

--- a/elkscmd/xvi/Makefile
+++ b/elkscmd/xvi/Makefile
@@ -16,7 +16,7 @@ xvi: xvi.o
 	$(CC) $(LDFLAGS) xvi.o -o xvi
 
 install: xvi
-	$(INSTALL) xvi $(DESTDIR)/bin$
+	$(INSTALL) xvi $(DESTDIR)/bin
 
 clean:
 	rm -f core xvi *.o

--- a/image/Packages
+++ b/image/Packages
@@ -45,7 +45,6 @@
 # -------------	----------------------------------------------------------
 /dev			:boot
 /bin			:boot
-#/bin/ash		:boot
 /bin/banner								:app
 /bin/basename					:shutil
 /bin/bc									:app
@@ -72,7 +71,6 @@
 /bin/fgrep						:shutil
 /bin/file							:fileutil
 /bin/find				:base
-/bin/ftpget					:net
 /bin/getty		:boot
 /bin/grep				:base
 /bin/head							:fileutil
@@ -81,7 +79,6 @@
 /bin/kill			:small
 #/bin/knl			:small
 /bin/ktcp					:net
-/bin/l								:fileutil
 /bin/ln					:base
 /bin/login		:boot
 /bin/logname					:shutil
@@ -109,7 +106,7 @@
 /bin/remsync						:fileutil
 /bin/rm				:small
 /bin/rmdir			:small
-#/bin/sash						:shutil
+/bin/sash		:boot
 /bin/sed						:shutil
 /bin/sh			:boot
 /bin/shutdown			:base

--- a/image/config.in
+++ b/image/config.in
@@ -11,10 +11,6 @@ mainmenu_option next_comment
 	 RAW    CONFIG_IMG_RAW     \
 	 ROM    CONFIG_IMG_ROM" MINIX
 
-	if [ "$CONFIG_IMG_MINIX" == "y" -o "$CONFIG_IMG_ROM" == "y" ]; then
-		define_bool CONFIG_IMG_LINK y
-		fi
-
 	if [ "$CONFIG_IMG_ROM" != "y" ]; then
 
 		choice 'Medium' \


### PR DESCRIPTION
This is the first round of ELKS commands reorganization (#410) - enhance `sash` (/bin/sash) to have the `core_utils` set of builtin commands, and have it seamlessly operate with `ash` (/bin/sh).

The `ash` and `sash` shells now are able to be configured for using one, or the other, or both. If selecting only the `sash` shell, many `core_utils` commands will be available builtin, and there will be no disk access (or symlinks) to run them, which allows it to run well as a FAT boot default shell.

Please run `make config` or `make menuconfig` and select both shells or just `sash` before compiling.

If both `ash` and `sash` are selected (default), `ash` will still be the default shell for now (this can be changed outside config by editing `elkscmd/rootfs_template/etc/passwd`). Running 'sash' will run the standalone shell for testing the pre-built commands on for speed tests on floppy systems (@Mellvik, please try this and let me know what you think).

I also went ahead and added all of the requests made by @Mellvik in #388 to `ls`. (Note: the various versions of `core_utils` are not yet integrated, so you'll need to run `/bin/ls` from `sash` to see these if testing the standalone shell). `/bin/ls` now supports the `ls -1` option, which is also turned on when redirecting output to a file. If this works, please close #388.

When running the standalone shell `sash`, if a command is typed that is not builtin, the disk is searched for that file. If that file is a BASH shell script, then `/bin/sh` will be run for seamless BASH compatibility. This also occurs if pipes or output redirection is requested. 

I am very interested in comments as to the speed and usability of `sash` on floppy systems. As said above, this can be tested by either only selecting this shell in config, by editing `/etc/passwd`, or just running `sash` from BASH shell prompt.