### PR TITLE
[image] Reinstate RAW image generation

### DIFF
--- a/image/Make.defs
+++ b/image/Make.defs
@@ -11,11 +11,10 @@ include $(TOPDIR)/Make.defs
 ELKS_DIR = $(TOPDIR)/elks
 ELKSCMD_DIR = $(TOPDIR)/elkscmd
 
-MINIX_BOOT = $(ELKSCMD_DIR)/bootblocks
-FD_BOOTBLOCK = $(MINIX_BOOT)/minix.bin
-FD_BOOTSECT = $(MINIX_BOOT)/fat.bin
+FD_MINIX_BOOT = $(ELKSCMD_DIR)/bootblocks/minix.bin
+FD_FAT_BOOT = $(ELKSCMD_DIR)/bootblocks/fat.bin
 # TODO: replace these exports by includes
-export FD_BOOTBLOCK
+export FD_MINIX_BOOT FD_FAT_BOOT
 
 # Image file options
 
@@ -56,6 +55,10 @@ endif
 ifdef CONFIG_IMG_HD
 TARGET_FILE = $(IMGDIR)/hd.bin
 TARGET_BLKS = $(CONFIG_IMG_BLOCKS)
+endif
+
+ifdef CONFIG_IMG_RAW
+TARGET_FILE = $(IMGDIR)/fd.bin
 endif
 
 # Image filesystem options

--- a/image/Make.package
+++ b/image/Make.package
@@ -1,6 +1,6 @@
 # Application package creation Makefile
 #	passed NAME=, FS=, SIZE=, and optional PACKAGE= and TAGS=
-#	implicitly uses IMGDIR=, DESTDIR= and FD_BOOTBLOCK=
+#	implicitly uses IMGDIR=, DESTDIR=, FD_MINIX_BOOT= and FD_FAT_BOOT=
 
 
 # set BPB and mkfs options based on passed image size
@@ -63,7 +63,7 @@ minix:
 	rm Filelist
 	$(MAKE) -f Make.devices "MKDEV=mfs $(MINIX_IMAGE) mknod"
 #	Write boot and override the parameters from the build configuration
-	setboot $(MINIX_IMAGE) $(BPB) $(FD_BOOTBLOCK)
+	setboot $(MINIX_IMAGE) $(BPB) $(FD_MINIX_BOOT)
 	#mfsck -fv $(MINIX_IMAGE)
 	mfs $(MINIX_IMAGE) stat
 
@@ -106,8 +106,6 @@ MSDOS_COPYOPTS=-pmQ -D o
 # -a		also list hidden files
 # -/		recursive output (buggy: will fail on empty, newly formatted disks!
 
-FD_BOOTSECT=$(TOPDIR)/elkscmd/bootblocks/fat.bin
-
 fat:
 	awk "/$(TAGS)/{print}" $(PACKAGE) | cut -f 1 | sed "/^#/d" > Filelist
 	dd if=/dev/zero of=$(MSDOS_IMAGE) bs=1024 count=$(SIZE)
@@ -131,5 +129,5 @@ fat:
 	# Protect contiguous /linux by marking as R/O, System and Hidden
 	mattrib -i $(MSDOS_IMAGE) +r +s +h ::/linux
 	# Read boot sector, skip FAT BPB, set ELKS PB sectors/heads and write boot
-	setboot $(MSDOS_IMAGE) -F $(BPB) $(FD_BOOTSECT)
+	setboot $(MSDOS_IMAGE) -F $(BPB) $(FD_FAT_BOOT)
 	#mdir -i $(MSDOS_IMAGE) -/ -a ::

--- a/image/Makefile
+++ b/image/Makefile
@@ -103,7 +103,8 @@ romfs: template
 # Create RAW filesystem
 
 raw: $(ELKS_DIR)/arch/i86/boot/Image
-	cp $(ELKS_DIR)/arch/i86/boot/Image $(TARGET_FILE)
+	dd if=/dev/zero of=$(TARGET_FILE) bs=1024 count=$(TARGET_BLKS)
+	dd if=$(ELKS_DIR)/arch/i86/boot/Image of=$(TARGET_FILE) conv=notrunc
 
 # Clean target
 

--- a/image/Makefile
+++ b/image/Makefile
@@ -19,21 +19,23 @@ export DESTDIR
 TARGETS =
 
 ifdef CONFIG_IMG_BOOT
-TARGETS += $(FD_BOOTBLOCK) $(FD_BOOTSECT) $(ELKS_DIR)/arch/i86/boot/Image
+TARGETS += $(FD_MINIX_BOOT) $(FD_FAT_BOOT) $(ELKS_DIR)/arch/i86/boot/Image
 endif
 
-TARGETS += template
-
 ifdef CONFIG_IMG_MINIX
-TARGETS += minixfs
+TARGETS += template minixfs
 endif
 
 ifdef CONFIG_IMG_FAT
-TARGETS += fatfs
+TARGETS += template fatfs
 endif
 
 ifdef CONFIG_IMG_ROM
-TARGETS += romfs
+TARGETS += template romfs
+endif
+
+ifdef CONFIG_IMG_RAW
+TARGETS += raw
 endif
 
 .PHONY: all $(TARGETS)
@@ -63,7 +65,7 @@ ifdef CONFIG_IMG_DEV
 	$(MAKE) -f Make.devices "MKDEV=mfs $(TARGET_FILE) mknod"
 endif
 ifdef CONFIG_IMG_BOOT
-	setboot $(TARGET_FILE) $(FD_BOOTBLOCK)
+	setboot $(TARGET_FILE) $(FD_MINIX_BOOT)
 endif
 	mfsck -fv $(TARGET_FILE)
 	mfs $(TARGET_FILE) stat
@@ -80,15 +82,15 @@ fatfs: template
 	rm linux
 	# Device folder has to be first or second for the 'fake dev' to work
 	mmd -i $(TARGET_FILE) ::/dev
-	for f in $$(cd $(DESTDIR); find -name '*'); do \
-		[ -d $(DESTDIR)/$$f -a "$$f" != "./dev" ] && mmd -i $(TARGET_FILE) ::$$f; \
+	for f in $$(cd $(DESTDIR); find * -name '*'); do \
+		[ -d $(DESTDIR)/$$f -a "$$f" != "dev" ] && mmd -i $(TARGET_FILE) ::$$f; \
 		[ -f $(DESTDIR)/$$f ] && mcopy -i $(TARGET_FILE) $(CPFS_OPTS) $(DESTDIR)/$$f ::$$f; \
 	done
 	# Protect contiguous /linux by marking as RO, System and Hidden
 	mattrib -i $(TARGET_FILE) +r +s +h ::/linux
 	# Read boot sector, skip FAT BPB, set ELKS PB sectors/heads and write boot
 ifdef CONFIG_IMG_BOOT
-	setboot $(TARGET_FILE) -F $(FD_BOOTSECT)
+	setboot $(TARGET_FILE) -F $(FD_FAT_BOOT)
 endif
 
 # Create ROM filesystem from template
@@ -97,6 +99,11 @@ romfs: template
 	-rm -f romfs.devices
 	$(MAKE) -f Make.devices "MKDEV=echo >> romfs.devices"
 	mkromfs -d romfs.devices $(DESTDIR)
+
+# Create RAW filesystem
+
+raw: $(ELKS_DIR)/arch/i86/boot/Image
+	cp $(ELKS_DIR)/arch/i86/boot/Image $(TARGET_FILE)
 
 # Clean target
 

--- a/image/config.in
+++ b/image/config.in
@@ -15,9 +15,7 @@ mainmenu_option next_comment
 		define_bool CONFIG_IMG_LINK y
 	fi
 
-	if [ "$CONFIG_IMG_RAW" == "y" ]; then
-		:
-	elif [ "$CONFIG_IMG_ROM" != "y" ]; then
+	if [ "$CONFIG_IMG_ROM" != "y" ]; then
 
 		choice 'Medium' \
 		"FD1680 CONFIG_IMG_FD1680 \

--- a/image/config.in
+++ b/image/config.in
@@ -13,9 +13,11 @@ mainmenu_option next_comment
 
 	if [ "$CONFIG_IMG_MINIX" == "y" -o "$CONFIG_IMG_ROM" == "y" ]; then
 		define_bool CONFIG_IMG_LINK y
-		fi
+	fi
 
-	if [ "$CONFIG_IMG_ROM" != "y" ]; then
+	if [ "$CONFIG_IMG_RAW" == "y" ]; then
+		:
+	elif [ "$CONFIG_IMG_ROM" != "y" ]; then
 
 		choice 'Medium' \
 		"FD1680 CONFIG_IMG_FD1680 \

--- a/image/config.in
+++ b/image/config.in
@@ -13,7 +13,7 @@ mainmenu_option next_comment
 
 	if [ "$CONFIG_IMG_MINIX" == "y" -o "$CONFIG_IMG_ROM" == "y" ]; then
 		define_bool CONFIG_IMG_LINK y
-	fi
+		fi
 
 	if [ "$CONFIG_IMG_ROM" != "y" ]; then
 


### PR DESCRIPTION
This fixes RAW image generation for #299.

@mfld-fr: Please also test with selecting FAT image generation, as I had to fiddle with the `find` command since the previous version didn't work on OSX (I had never tested building FAT through config, so this fixes that too on OSX).

