### PR TITLE
[boot] [elks] allow bootloaders to load /linux as one blob

### DIFF
--- a/elks/arch/i86/boot/bootsect.S
+++ b/elks/arch/i86/boot/bootsect.S
@@ -563,8 +563,8 @@ root_flags:
 	.word ROOTFLAGS
 syssize:
 	.word SYSSIZE
-unused:
-	.word 0
+elks_flags:
+	.word ELKSFLAGS
 ram_size:
 	.word RAMDISK
 vid_mode:

--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -23,6 +23,9 @@
 !   This code is called after the BIOS-POST and replaces
 !   the BIOS OS/loader
 !
+! changes to support having setup + ELKS kernel as one single blob
+! March 2020 https://github.com/tkchia
+!
 ! The following data is passed to the main kernel (relative to INITSEG)
 !
 ! index
@@ -83,7 +86,7 @@
 !	0x1f1:	SETUPSECS
 !	0x1f2:	ROOTFLAGS
 !	0x1f4:	SYSSIZE
-!	0x1f6:	unused (was SWAP_DEV)
+!	0x1f6:	ELKSFLAGS
 !	0x1f8:	RAMDISK
 !	0x1fa:	SVGA_MODE
 !	0x1fc:	ROOT_DEV
@@ -93,8 +96,14 @@
 ! NOTE! These had better be the same as in bootsect.s!
 */
 
+setup_sects = 0x1f1
+syssize = 0x1f4
+elks_flags = 0x1f6
+boot_flag = 0x1fe
+
 #define __ASSEMBLY__
 #include <linuxmt/config.h>
+#include <linuxmt/boot.h>
 
 // Signature words to ensure LILO loaded us right
 #define SIG1	0xAA55
@@ -137,10 +146,10 @@ entry:
 	mov	$SETUPSEG,%ax      //;setup codesegment
 	mov	%ax,%ds
 	cmpw	$SIG1,setup_sig1
-	jne	bad_sig
+	jne	no_sig
 	cmpw	$SIG2,setup_sig2
-	jne	bad_sig
-	jmp	good_sig     //;why double jmp
+	jne	no_sig
+	jmp	move_kernel     //;why double jmp
 	nop
 
 
@@ -156,46 +165,63 @@ prtstr:	lodsb
 
 
 
-// We now have to find the rest of the setup code/data
-// in ROM the code is complete
+// If setup and kernel were loaded as a blob, we need to separate them out,
+// then move to a more spacious stack
 
-bad_sig:
+move_kernel:
 #ifndef CONFIG_ROMCODE
-	mov	$INITSEG,%ax     //;code setup
+	mov	$INITSEG,%ax
 	mov	%ax,%ds
-	xor	%bh,%bh
-	mov	497,%bl		// get setup sects from boot sector (SETUPSECS)
-	sub	$4,%bx		// LILO loads 4 sectors of setup
-	mov	$8,%cl
-	shl	%cl,%bx		// convert to words
-	mov	%bx,%cx
-	push	%cx		// This may not be needed - Chad.
-	mov	$3,%cl
-	shr	%cl,%bx		// convert to segment
-	pop	%cx
-	add	$SYSSEG,%bx
-//	seg cs
-	mov	%bx,%cs:start_sys_seg
-
-// Move rest of setup code/data to here
-	mov	$2048,%di	// four sectors loaded by LILO
-	sub	%si,%si
-	mov	$SETUPSEG,%ax
-	mov	%ax,%es
-	mov	$SYSSEG,%ax
-	mov	%ax,%ds
+.if (EF_AS_BLOB & 0xff) == 0
+	testb	$(EF_AS_BLOB>>8),elks_flags+1
+.else
+	testw	$EF_AS_BLOB,elks_flags
+.endif
+	jz	good_sig
+	std			// move backwards --- we are moving from a
+				// lower address to a higher one
+	mov	setup_sects,%al	// find start of a.out kernel
+	xor	%ah,%ah
+	mov	$5,%cl
+	shl	%cl,%ax
+	add	$SETUPSEG,%ax
+	mov	syssize,%bp
+	mov	%bp,%cx		// first move the last sub-64KiB piece in place
+	and	$0x0fff,%cx
+	xor	%cx,%bp
+	mov	%ax,%dx
+	add	%bp,%dx
+	mov	%dx,%ds
+	lea	SYSSEG(%bp),%dx
+	mov	%dx,%es
+	jcxz	move_kernel_in_64ks
+	shl	%cx
+	shl	%cx
+	shl	%cx
+	mov	%cx,%si
+	dec	%si
+	shl	%si
+	mov	%si,%di
 	rep
 	movsw
-
-	mov	$SETUPSEG,%ax
+move_kernel_in_64ks:
+	mov	%es,%ax
+	cmp	$SYSSEG,%ax
+	jz	done_move_kernel
+	sub	$0x1000,%ax
+	mov	%ax,%es
+	mov	%ds,%ax
+	sub	$0x1000,%ax
 	mov	%ax,%ds
-	cmpw	$SIG1,setup_sig1
-	jne	no_sig
-	cmpw	$SIG2,setup_sig2
-	je	good_sig
-no_sig:
+	mov	$0x80,%ch
+	mov	$0xfffe,%si
+	mov	%si,%di
+	rep
+	movsw
+	jmp	move_kernel_in_64ks
 #endif
 
+no_sig:
 	lea	no_sig_mess,%si
 	call	prtstr
 no_sig_loop:			// And halt
@@ -203,6 +229,14 @@ no_sig_loop:			// And halt
 
 
 //;------------------------------------------------
+#ifndef CONFIG_ROMCODE
+done_move_kernel:
+	cld
+	mov	$INITSEG,%ax
+	mov	%ax,%ss
+	mov	$0x4000-12,%sp
+#endif
+
 good_sig:
 #ifdef CONFIG_ROMCODE
 	xor %ax,%ax
@@ -298,13 +332,13 @@ novga:	mov	%al,14		// CGA 25 rows
 
 //	mov	ax,#INITSEG     //ds was not changed sinse good_gig
 //	mov	ds,ax
-	movb	$0,0x1ff	// default is no pointing device
+	movb	$0,boot_flag+1	// default is no pointing device
 	nop
 #ifdef CONFIG_HW_PS2_MOUSE
 	int	$0x11		// int 0x11: equipment determination
 	test	$0x04,%al	// check if pointing device installed
 	jz	no_psmouse
-	movb	$0xaa,0x1ff	// device present
+	movb	$0xaa,boot_flag+1 // device present
 	nop
 no_psmouse:
 #endif

--- a/elks/include/linuxmt/boot.h
+++ b/elks/include/linuxmt/boot.h
@@ -16,4 +16,14 @@
 #define ROOTFLAGS	RF_NONE
 #endif
 
+/* ELKS flags */
+
+#define EF_NONE		0
+#define EF_AS_BLOB	0x8000		/* says that setup and kernel are
+					   loaded as one blob at SETUPSEG:0,
+					   and setup may need to move kernel
+					   to SYSSEG:0 */
+
+#define ELKSFLAGS	0
+
 #endif

--- a/elkscmd/bootblocks/boot_minix.c
+++ b/elkscmd/bootblocks/boot_minix.c
@@ -9,7 +9,7 @@
 
 // Global constants
 
-#define LOADSEG 0x1000
+#define LOADSEG 0x0100
 
 // Global variables
 

--- a/elkscmd/bootblocks/boot_sect.S
+++ b/elkscmd/bootblocks/boot_sect.S
@@ -13,11 +13,12 @@
 #include "boot_err.h"
 
 #define BOOTADDR  0x7C00
-#define LOADSEG   0x1000
+#define LOADSEG   ELKS_INITSEG
 
 // Must match ELKS
 #define ELKS_INITSEG (0x0100)
 #define ELKS_SYSSEG  (0x1000)
+#define EF_AS_BLOB   (0x8000)
 
 	.code16
 
@@ -222,16 +223,6 @@ drive_reset:
 //------------------------------------------------------------------------------
 
 // void disk_read (int sect, int count, byte_t * buf, int seg)
-
-#ifdef BOOT_FAT
-_disk_read_at_bx_0:
-	// Load sectors at the absolute address BX:0 --- used by FAT loader
-	pop %cx
-	push %bx
-	push %cx
-	xor %cx,%cx
-	// fall through
-#endif
 
 	.global disk_read
 
@@ -446,60 +437,17 @@ not_elks:
 	jmp _except
 
 boot_it:
+.if LOADSEG != ELKS_INITSEG
+	.error
+.endif
 
 	pop %ax
-	mov $ELKS_INITSEG,%ax
-	mov %ax,%es
-
-	mov 497,%bl  // fetch number of setup sectors
-	xor %bh,%bh
-	inc %bx
-	mov 500,%ax  // fetch system executable size
-	mov $5,%cl
-	add $31,%ax
-	shr %cl,%ax
-	mov %ax,%dx
-
-// Put the setup where it belongs
-
-looping:
-	call copy_sect
-	dec %bx
-	jnz looping
-
-	mov	$ELKS_SYSSEG,%ax
-	mov %ax,%es
-
-// Put the system code at the right place
-
-looping2:
-	call copy_sect
-	dec %dx
-	jnz looping2
-
-// Ok, everything should be where it belongs call it
+	orb $EF_AS_BLOB>>8,0x01F7  // signify that setup + kernel is 1 blob
 
 	mov $ELKS_INITSEG,%ax
 	mov %ax,%ds
 	mov %ax,%es
-	mov %ax,%ss
-	mov $0x4000-12,%sp
 	ljmp $ELKS_INITSEG+0x20,$0
-
-copy_sect:
-	mov $256,%cx
-	xor %si,%si
-	xor %di,%di
-	rep
-	movsw
-
-	mov %ds,%ax
-	add $32,%ax
-	mov %ax,%ds
-	mov %es,%ax
-	add $32,%ax
-	mov %ax,%es
-	ret
 #endif
 
 //------------------------------------------------------------------------------

--- a/elkscmd/bootblocks/boot_sect_fat.h
+++ b/elkscmd/bootblocks/boot_sect_fat.h
@@ -177,15 +177,17 @@ bpb_fil_sys_type:			// Filesystem type (8 bytes)
 	mov $4,%cl
 	shr %cl,%ax
 	add %bx,%ax
-	push %ax
 
-	// Load 1 sector first --- this has metadata on the sector counts for
-	// the setup code (to be at ELKS_INITSEG) and for the kernel (at
-	// ELKS_SYSSEG)
-	inc %dx				// Again assume DX was 0 (from mul)
+	// Load the file as one single blob at ELKS_INITSEG:0
+	mov (0x1d-0xb)(%si),%dx		// File size divided by 0x100
+	shr %dx				// Now by 0x200 --- a sector count
+	inc %dx				// Account for any incomplete sector
+					// (this may overestimate a bit)
+	xor %cx,%cx
 	mov $ELKS_INITSEG,%bx
 	mov %bx,%es
-	call _disk_read_at_bx_0
+	push %bx
+	call disk_read
 
 	// Check for ELKS magic number
 	mov $0x1E6,%di
@@ -201,31 +203,10 @@ not_elks:
 	jmp _except
 
 boot_it:
-	// Load the setup code
-	cwtd				// DX = 0
-	pop %ax
-	inc %ax
-	mov %ax,%si			// SI = starting sector of setup code
-	mov %es:(0x1F1-0x1E6-4)(%di),%dl
-	add %dx,%si			// Precompute starting sector of kernel
-	mov $ELKS_INITSEG+0x20,%bx
-	call _disk_read_at_bx_0
-
-	// Load the kernel
-	xchg %ax,%si			// AX = starting sector of kernel
-	mov %es:(0x1F4-0x1E6-4)(%di),%dx
-	add $31,%dx
-	mov $5,%cl
-	shr %cl,%dx
-	mov $ELKS_SYSSEG,%bx
-	call _disk_read_at_bx_0
-
 	// w00t!
 	push %es
 	pop %ds
-	push %es
-	pop %ss
-	mov $0x4000-12,%sp
+	orb $EF_AS_BLOB>>8,0x1F7	// Signify /linux was loaded as 1 blob
 	ljmp $ELKS_INITSEG+0x20,$0
 
 kernel_name:


### PR DESCRIPTION
Previously, bootloaders have to do the job of splitting up `/linux` into its "setup" portion (which goes to `INITSEG:0` and `SETUPSEG:0`) and its "kernel" portion (`SYSSEG:0`) in memory.

With this change, a bootloader can load `/linux` as one single binary blob at `INITSEG:0`, and inform `/linux`'s "setup" portion about this (via a new `elks_flags` field in the loaded `/linux`).

This helps simplify the logic (and shrink the sizes) of the Minix and FAT filesystems' boot code.