### PR TITLE
[fat] Add VFAT long filename support

### DIFF
--- a/elks/fs/msdos/namei.c
+++ b/elks/fs/msdos/namei.c
@@ -15,7 +15,7 @@
 #include <linuxmt/stat.h>
 #include <linuxmt/mm.h>
 
-unsigned char get_fs_byte(void *dv)
+unsigned char get_fs_byte(const void *dv)
 {
     unsigned char retv;
 
@@ -62,28 +62,60 @@ static int msdos_format_name(register const char *name,int len,char *res)
 }
 
 
-/* Locates a directory entry. */
-
+/* Locates a shortname directory entry. */
 static int msdos_find(struct inode *dir,const char *name,int len,
     struct buffer_head **bh,struct msdos_dir_entry **de,ino_t *ino)
 {
-	char msdos_name[MSDOS_NAME+1];
 	int res;
+	char msdos_name[MSDOS_NAME+1];
 
 	if ((res = msdos_format_name(name,len, msdos_name)) < 0) return res;
-	int t = msdos_scan(dir,msdos_name,bh,de,ino);
+	res = msdos_scan(dir,msdos_name,bh,de,ino);
 msdos_name[MSDOS_NAME] = 0;
 fsdebug("find '%11s', ino=%ld\n", msdos_name, (unsigned long)*ino);
-	return t;
+	return res;
 }
 
+static int compare(char *s1, char *s2, int len)
+{
+	while (len--)
+		if (*s1++ != *s2++)
+			return 0;
+	return 1;
+}
+
+/* Locate a long or shortname directory entry*/
+static int msdos_find_long(struct inode *dir, const char *name, int len,
+    struct buffer_head **bh, ino_t *ino)
+{
+	int i, entry_len, res;
+	off_t dirpos, pos = 0;
+	char entry_name[14];
+	char msdos_name[14];
+
+	for (i=0; i<len; i++)
+		msdos_name[i] = get_fs_byte(name++);
+
+	*bh = NULL;
+	do {
+		res = msdos_get_entry_long(dir, &pos, bh, entry_name, &entry_len, &dirpos, ino);
+		if (res) {
+			if ((len == entry_len) && compare(entry_name, msdos_name, len))
+				return 0;
+		}
+	} while(res != 0);
+	if (*bh)
+		unmap_brelse(*bh);
+	*bh = NULL;
+	return -ENOENT;
+
+}
 
 int msdos_lookup(register struct inode *dir,const char *name,int len,
     register struct inode **result)
 {
 	ino_t ino;
 	int res;
-	struct msdos_dir_entry *de;
 	struct buffer_head *bh;
 	*result = NULL;
 
@@ -102,7 +134,7 @@ int msdos_lookup(register struct inode *dir,const char *name,int len,
 		if (!(*result = iget(dir->i_sb,ino))) return -EACCES;
 		return 0;
 	}
-	if ((res = msdos_find(dir,name,len,&bh,&de,&ino)) < 0) {
+	if ((res = msdos_find_long(dir,name,len,&bh,&ino)) < 0) {
 		iput(dir);
 		return res;
 	}

--- a/elks/include/linuxmt/msdos_fs.h
+++ b/elks/include/linuxmt/msdos_fs.h
@@ -91,6 +91,8 @@ struct msdos_dir_entry {
 	unsigned long size;  /* file size (in bytes) */
 };
 
+#define LAST_LONG_ENTRY		0x40	/* marks last entry in slot seqno*/
+
 /* Up to 13 characters of the name */
 struct msdos_dir_slot {
 	__u8    id;		/* sequence number for slot */
@@ -183,6 +185,8 @@ extern int init_msdos_fs(void);
 
 //extern struct file_operations msdos_dir_operations;
 extern struct inode_operations msdos_dir_inode_operations;
+extern int msdos_get_entry_long(struct inode *dir, off_t *pos, struct buffer_head **bh,
+    char *name, int *namelen, off_t *dirpos, ino_t *ino);
 
 /* file.c */
 

--- a/image/Packages
+++ b/image/Packages
@@ -152,6 +152,7 @@
 /mnt			:boot
 /root			:boot
 /root/.profile	:boot
+#/root/thisisaverylongfilenameandthatisallthereistoit	:boot
 /sbin					:base :fileutil
 /sbin/fdisk							:fileutil
 /sbin/fsck				:base


### PR DESCRIPTION
Reading and listing long filenames is now supported on all FAT filesystem types. Files like /root/.profile, /etc/resolve.conf, and /var/www/index.html now work with their associated programs.

No long filename support yet for `create`, `unlink`, `mkdir` or `rmdir`, as quite a bit more complicated, and not really needed (for this release, at least).

<img width="832" alt="Screen Shot 2020-03-07 at 8 06 04 PM" src="https://user-images.githubusercontent.com/11985637/76156302-c3e2f700-60b5-11ea-810b-1060baa8a21e.png">

Enjoy!