### PR TITLE
[elks] [boot] allow booting from Minix/FAT FS on whole hard disk

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: prepare
         if: steps.cache.outputs.cache-hit != 'true'
-        run: 'mkdir cross'
+        run: 'mkdir -p cross'
 
       - name: cross
         if: steps.cache.outputs.cache-hit != 'true'

--- a/bootblocks/boot_sect.S
+++ b/bootblocks/boot_sect.S
@@ -420,6 +420,9 @@ binfile:
 }
 */
 
+	mov drive_num,%dl
+	xor %dh,%dh
+
 	push %ds
 	mov $LOADSEG,%ax
 	mov %ax,%ds
@@ -445,11 +448,12 @@ boot_it:
 	pop %ax
 
 	// Signify that /linux was loaded as 1 blob
-.if (EF_AS_BLOB & 0xff) == 0
-	orb $EF_AS_BLOB>>8,elks_flags+1
+.if ((EF_AS_BLOB|EF_BIOS_DEV_NUM) & 0xff) == 0
+	orb $(EF_AS_BLOB|EF_BIOS_DEV_NUM)>>8,elks_flags+1
 .else
-	orw $EF_AS_BLOB,elks_flags
+	orw $(EF_AS_BLOB|EF_BIOS_DEV_NUM),elks_flags
 .endif
+	mov %dx,root_dev
 
 	mov $ELKS_INITSEG,%ax
 	mov %ax,%ds

--- a/bootblocks/boot_sect_fat.h
+++ b/bootblocks/boot_sect_fat.h
@@ -217,14 +217,17 @@ not_elks:
 
 boot_it:
 	// w00t!
+	mov drive_num,%al
+	xor %ah,%ah
 	push %es
 	pop %ds
 	// Signify that /linux was loaded as 1 blob
-.if (EF_AS_BLOB & 0xff) == 0
-	orb $EF_AS_BLOB>>8,elks_flags+1
+.if ((EF_AS_BLOB|EF_BIOS_DEV_NUM) & 0xff) == 0
+	orb $(EF_AS_BLOB|EF_BIOS_DEV_NUM)>>8,elks_flags+1
 .else
-	orw $EF_AS_BLOB,elks_flags
+	orw $(EF_AS_BLOB|EF_BIOS_DEV_NUM),elks_flags
 .endif
+	mov %ax,root_dev
 	ljmp $ELKS_INITSEG+0x20,$0
 
 kernel_name:

--- a/elks/arch/i86/drivers/block/init.c
+++ b/elks/arch/i86/drivers/block/init.c
@@ -16,6 +16,7 @@
  *  More flexible handling of extended partitions - aeb, 950831
  */
 
+#include <linuxmt/boot.h>
 #include <linuxmt/config.h>
 #include <linuxmt/fs.h>
 #include <linuxmt/genhd.h>
@@ -44,6 +45,34 @@ void device_setup(void)
 
 #ifdef CONFIG_BLK_DEV_RAM
     rd_load();
+#else
+    /*
+     * The bootloader may have passed us a ROOT_DEV which is actually a BIOS
+     * drive number.  If so, convert it into a proper <major, minor> block
+     * device number.  -- tkchia 20200308
+     */
+    if ((setupw(0x1f6) & EF_BIOS_DEV_NUM) != 0) {
+	printk("device_setup: root device is on BIOS drive number 0x%x\n",
+	       (unsigned) ROOT_DEV);
+
+	switch (ROOT_DEV) {
+	default:
+	    printk("device_setup: unknown BIOS drive, falling back on fd0\n");
+	    /* fall thru */
+	case 0x00:
+	    ROOT_DEV = MKDEV(BIOSHD_MAJOR, 0x80);
+	    break;
+	case 0x01:
+	    ROOT_DEV = MKDEV(BIOSHD_MAJOR, 0xc0);
+	    break;
+	case 0x80:
+	    ROOT_DEV = MKDEV(BIOSHD_MAJOR, 0x00);
+	    break;
+	case 0x81:
+	    ROOT_DEV = MKDEV(BIOSHD_MAJOR, 0x40);
+	    break;
+	}
+    }
 #endif
 
 }

--- a/elks/arch/i86/drivers/block/init.c
+++ b/elks/arch/i86/drivers/block/init.c
@@ -45,7 +45,9 @@ void device_setup(void)
 
 #ifdef CONFIG_BLK_DEV_RAM
     rd_load();
-#else
+#endif
+
+#if ! defined CONFIG_ROMCODE || ! defined CONFIG_ROMFS_FS
     /*
      * The bootloader may have passed us a ROOT_DEV which is actually a BIOS
      * drive number.  If so, convert it into a proper <major, minor> block

--- a/include/linuxmt/boot.h
+++ b/include/linuxmt/boot.h
@@ -23,19 +23,31 @@
 					   loaded as one blob at SETUPSEG:0,
 					   and setup may need to move kernel
 					   to SYSSEG:0 */
+#define EF_BIOS_DEV_NUM	0x4000		/* says that root_dev does not give
+					   a <major, minor> block device
+					   number, but only a BIOS drive
+					   number (and possibly other
+					   information); setup or kernel
+					   should use this drive number to
+					   figure out the correct root
+					   device */
 
-#define ELKSFLAGS	0
+#define ELKSFLAGS	EF_NONE
 
 /* If we are not building the (dummy) boot sector (elks/elks/arch/i86/boot/
    {bootsect.S, netbootsect.S}) at the start of /linux, then define
-   constants giving the offsets of various fields within /linux. */
+   constants giving the offsets of various fields within /linux.
+
+   The fields in /linux are mainly based on an old version of the Linux/x86
+   Boot Protocol (https://www.kernel.org/doc/html/latest/x86/boot.html).
+   Fields which are specific to ELKS are indicated below.  */
 
 #if defined __ASSEMBLER__ && !defined BOOTSEG
-elks_magic	=	0x1e6
+elks_magic	=	0x1e6		/* should read "ELKS" (45 4c 4b 53) */
 setup_sects	=	0x1f1
 root_flags	=	0x1f2
 syssize		=	0x1f4
-elks_flags	=	0x1f6
+elks_flags	=	0x1f6		/* 16-bit ELKS flags (EF_...) */
 root_dev	=	0x1fc
 boot_flag	=	0x1fe
 #endif


### PR DESCRIPTION
ELKS can now automatically start up from a Minix or FAT filesystem installed on an entire (unpartitioned) hard disk.

Partly addresses https://github.com/jbruchon/elks/issues/348 & https://github.com/jbruchon/elks/pull/422#issuecomment-595895145 .