### PR TITLE
[config] [boot] fix bootblocks build gremlins from config changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ endif
 
 include $(TOPDIR)/Make.defs
 
-.PHONY: all clean kconfig defconfig config menuconfig
+.PHONY: all clean kconfig defconfig reconfig config menuconfig
 
-all: .config
+all: .config reconfig
 	$(MAKE) -C libc all
 	$(MAKE) -C libc DESTDIR='$(TOPDIR)/cross' install
 	$(MAKE) -C elks all
@@ -30,7 +30,7 @@ clean:
 	    echo ' * `make config` or `make menuconfig` to configure it.' ;\
 	    echo ;\
 	fi
-	
+
 elks/arch/i86/drivers/char/KeyMaps/config.in:
 	$(MAKE) -C elks/arch/i86/drivers/char/KeyMaps config.in
 
@@ -38,6 +38,11 @@ kconfig:
 	$(MAKE) -C config all
 
 defconfig:
+	$(RM) .config
+	@yes '' | ${MAKE} config
+
+# Update include/autoconf.h from .config.
+reconfig: .config
 	@yes '' | ${MAKE} config
 
 config: elks/arch/i86/drivers/char/KeyMaps/config.in kconfig

--- a/bootblocks/Makefile
+++ b/bootblocks/Makefile
@@ -22,23 +22,23 @@ minix.bin: boot_sect.o boot_minix.o
 probe.bin: boot_sect.o boot_probe.o
 	$(LD) $(LDFLAGS) -M -o probe.bin boot_sect.o boot_probe.o > probe.map
 
-boot_sect.o: boot_sect.S
+boot_sect.o: boot_sect.S $(TOPDIR)/include/autoconf.h
 	$(CC) $(INCLUDES) -E -o boot_sect.tmp boot_sect.S
 	$(CC) $(INCLUDES) -E -UBOOT_FAT -o boot_sect.tmp boot_sect.S
 	$(AS) $(ASFLAGS) -o boot_sect.o boot_sect.tmp
 	rm -f boot_sect.tmp
 
-boot_probe.o: boot_probe.S
+boot_probe.o: boot_probe.S $(TOPDIR)/include/autoconf.h
 	$(CC) $(INCLUDES) -E -o boot_probe.tmp boot_probe.S
 	$(AS) $(ASFLAGS) -oboot_probe.o boot_probe.tmp
 	rm -f boot_probe.tmp
 
-boot_minix.o: boot_minix.c
+boot_minix.o: boot_minix.c $(TOPDIR)/include/autoconf.h
 
-fat.bin: boot_sect_fat.o
+fat.bin: boot_sect_fat.o $(TOPDIR)/include/autoconf.h
 	$(LD) $(LDFLAGS) -M -o fat.bin boot_sect_fat.o > fat.map
 
-boot_sect_fat.o: boot_sect.S boot_sect_fat.h
+boot_sect_fat.o: boot_sect.S boot_sect_fat.h $(TOPDIR)/include/autoconf.h
 	$(CC) $(INCLUDES) -E -DBOOT_FAT -o boot_sect_fat.tmp boot_sect.S
 	$(AS) $(ASFLAGS) -o boot_sect_fat.o boot_sect_fat.tmp
 	rm -f boot_sect_fat.tmp

--- a/bootblocks/boot_sect.S
+++ b/bootblocks/boot_sect.S
@@ -495,7 +495,8 @@ elks_parms_start:
 track_max:
 #   if defined(CONFIG_IMG_FD360)
 	.word 40
-#   elif defined(CONFIG_IMG_FD720) || defined(CONFIG_IMG_FD1440)
+#   elif defined(CONFIG_IMG_FD720) || defined(CONFIG_IMG_FD1200) \
+	  || defined(CONFIG_IMG_FD1440) || defined(CONFIG_IMG_FD1680)
 	.word 80
 #   elif defined(CONFIG_IMG_HD)
 	.word CONFIG_IMG_CYL


### PR DESCRIPTION
This should address some build issues reported by @ghaerr at https://github.com/jbruchon/elks/pull/433#issuecomment-596240964 .

Changes:
  * `make defconfig` now correctly starts from a clean slate; previously it was reusing some of the settings in the existing `.config`.
  * `make all` now regenerates `include/autoconf.h` to synchronize it with the `.config` settings.
  * `bootblocks/Makefile` now rebuilds the boot blocks whenever `include/autoconf.h` is updated.
  * The generic bootloader code in `bootblocks/boot_sect.S` now correctly sets the track count for 1.2 MiB and (?) 1.68 MiB floppy disks.