### PR TITLE
[minix] Fix Minix umount super block unchecked flag, add new debug mechanism

### DIFF
--- a/elks/arch/i86/drivers/block/ll_rw_blk.c
+++ b/elks/arch/i86/drivers/block/ll_rw_blk.c
@@ -255,6 +255,7 @@ static void make_request(unsigned short int major, int rw,
     sector_t sector, count;
     int max_req;
 
+    debug_blk("BLK %d %s\n", bh->b_blocknr, rw==READ? "read": "write");
     count = (sector_t) (BLOCK_SIZE >> 9);
     sector = bh->b_blocknr * count;
 
@@ -347,10 +348,6 @@ void ll_rw_block(int rw, int nr, register struct buffer_head **bh)
     unsigned short int major;
     int i;
 
-#ifdef BLOAT_FS
-    int correct_size;
-#endif
-
     /* Make sure the first block contains something reasonable */
     while (!*bh) {
 	bh++;
@@ -396,10 +393,6 @@ void ll_rw_blk(int rw, register struct buffer_head *bh)
 {
     register struct blk_dev_struct *dev;
     unsigned short int major;
-
-#ifdef BLOAT_FS
-    int correct_size;
-#endif
 
     dev = NULL;
     if ((major = MAJOR(bh->b_dev)) < MAX_BLKDEV)

--- a/elks/fs/inode.c
+++ b/elks/fs/inode.c
@@ -406,8 +406,12 @@ int fs_may_remount_ro(kdev_t dev)
     do {
 	inode = file->f_inode;
 	if (!file->f_count || !inode || inode->i_dev != dev) continue;
-	if (S_ISREG(inode->i_mode) && (file->f_mode & 2)) return 0;
+	if (S_ISREG(inode->i_mode) && (file->f_mode & 2)) {
+		debug_sup("REMOUNT RO fail: open file\n");
+		return 0;
+	}
     } while (++file < &file_array[NR_FILE]);
+    debug_sup("REMOUNT RO ok\n");
     return 1;
 }
 

--- a/elks/fs/open.c
+++ b/elks/fs/open.c
@@ -17,6 +17,7 @@
 #include <linuxmt/fs.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/utime.h>
+#include <linuxmt/debug.h>
 
 #include <arch/segment.h>
 #include <arch/system.h>
@@ -342,6 +343,17 @@ int sys_fchown(unsigned int fd, uid_t user, gid_t group)
 	    : do_chown(filp->f_inode, user, group));
 }
 
+#if DEBUG_FILE
+static char *get_userspace_filename(char *filename)
+{
+	static char name[32];
+
+	memcpy_fromfs(name, filename, sizeof(name));
+	name[sizeof(name)-1] = 0;
+	return name;
+}
+#endif
+
 /*
  * Note that while the flag value (low two bits) for sys_open means:
  *	00 - read-only
@@ -367,6 +379,7 @@ int sys_open(char *filename, int flags, int mode)
     if ((mode_t)((flags + 1) & O_ACCMODE)) flag++;
     if (flag & (O_TRUNC | O_CREAT)) flag |= FMODE_WRITE;
 
+    debug_file("OPEN '%s' flags %x\n", get_userspace_filename(filename), flags);
     error = open_namei(filename, flag, mode, &inode, NULL);
     if (!error) {
 	pinode = inode;

--- a/elks/include/linuxmt/debug.h
+++ b/elks/include/linuxmt/debug.h
@@ -15,13 +15,6 @@
  * Al Riddoch <ajr@ecs.soton.ac.uk> 14th Oct. 1997
  */
 
-/* To enable debugging for any particular module, just include -DDEBUG
- * on the command line for that module. Note however that for the memory
- * management module, you will additionally need -DDEBUGMM included.
- *
- * Riley Williams <Riley@Williams.Name> 25 Apr 2002
- */
-
 /* This switches which version of the kstack-tracker gets used */
 
 /* Replaced by the 'true' kernel-strace */
@@ -31,9 +24,45 @@
 #define pstrace(_a)
 #endif
 
-/* This sets up a standard set of macros that can be used with any of the
+/*
+ * New kernel debug mechanism, set here or in autoconf.h, works across multiple files.
+ */
+#define DEBUG_BLK	0		/* block i/o*/
+#define DEBUG_FILE	0		/* sys open and file i/o*/
+#define DEBUG_FS	0		/* VFS and general filesystem*/
+#define DEBUG_FAT	0		/* FAT filesystem*/
+#define DEBUG_MINIX	0		/* Minix filesystem*/
+#define DEBUG_SIG	0		/* signals*/
+#define DEBUG_SUP	0		/* superblock, mount, umount*/
+
+#if DEBUG_BLK
+#define debug_blk	printk
+#else
+#define debug_blk(...)
+#endif
+
+#if DEBUG_FILE
+#define debug_file	printk
+#else
+#define debug_file(...)
+#endif
+
+#if DEBUG_SUP
+#define debug_sup	printk
+#else
+#define debug_sup(...)
+#endif
+
+/* Old debug mechanism - deprecated.
+ * This sets up a standard set of macros that can be used with any of the
  * files that make up the ELKS kernel. They can handle calls with up to 9
  * parameters after the format string.
+ *
+ * To enable debugging for any particular module, just include -DDEBUG
+ * on the command line for that module. Note however that for the memory
+ * management module, you will additionally need -DDEBUGMM included.
+ *
+ * Riley Williams <Riley@Williams.Name> 25 Apr 2002
  */
 
 #ifdef DEBUG

--- a/elks/include/linuxmt/minix_fs_sb.h
+++ b/elks/include/linuxmt/minix_fs_sb.h
@@ -20,7 +20,6 @@ struct minix_sb_info {
     unsigned short		s_namelen;
     struct buffer_head *	s_sbh;
     unsigned short		s_mount_state;
-	unsigned short		s_ondisk_state;		/* copy of fs state on disk*/
 };
 
 #endif

--- a/elks/tools/mfsck/mfsck.c
+++ b/elks/tools/mfsck/mfsck.c
@@ -1273,7 +1273,6 @@ check2 (void) {
 int
 main(int argc, char ** argv) {
 	struct termios tmp;
-	int count;
 	int retcode = 0;
 	char *p;
 
@@ -1323,8 +1322,10 @@ main(int argc, char ** argv) {
 	IN = open(device_name,repair?O_RDWR:O_RDONLY);
 	if (IN < 0)
 		die(_("unable to open '%s': %s"), device_name, strerror(errno));
-	for (count=0 ; count<3 ; count++)
-		sync();
+
+	/* unnecessary in ELKS build and for speed, remove sync*/
+	/***for (count=0 ; count<3 ; count++)
+		sync();***/
 	read_superblock();
 
 	/*

--- a/elkscmd/sys_utils/reboot.c
+++ b/elkscmd/sys_utils/reboot.c
@@ -16,8 +16,24 @@
  */
 
 #include <stdio.h>
-#include <unistd.h>
+#include <stdlib.h>
+//#include <unistd.h>		// FIXME can't include as sys_sleep defined which is a NOP
 #include <errno.h>
+#include <time.h>
+#include <sys/select.h>
+
+static unsigned int
+sleep(unsigned int seconds)
+{
+	struct timeval timeout;
+
+	time_t start = time(NULL);
+	timeout.tv_sec = seconds;
+	timeout.tv_usec = 0;
+	select(1, NULL, NULL, NULL, &timeout);
+	return seconds - (time(NULL) - start);
+}
+
 
 int main(int argc, char **argv)
 {

--- a/libc/include/unistd.h
+++ b/libc/include/unistd.h
@@ -54,7 +54,7 @@ int unlink(const char *fname);
 
 pid_t fork(void);
 pid_t getpid(void);
-pid_t setsidvoid();
+pid_t setsid(void);
 
 uid_t getuid (void);
 

--- a/libc/include/unistd.h
+++ b/libc/include/unistd.h
@@ -52,9 +52,9 @@ int isatty (int fd);
 off_t lseek (int fildes, off_t offset, int whence);
 int unlink(const char *fname);
 
-pid_t fork ();
-pid_t getpid ();
-pid_t setsid ();
+pid_t fork(void);
+pid_t getpid(void);
+pid_t setsidvoid();
 
 uid_t getuid (void);
 


### PR DESCRIPTION
This fixes #437. The Minix superblock is now force written on remounts, rather than previously trying to keep track of its status (which didn't work after `sync`). The `reboot` command does a sync, then mounts the root filesystem read-only, then sleeps for three seconds and reboots.

The `sleep` system call is not implemented (I recommend removing it entirely), and libc `sleep` is broken, so `sleep` is now (properly) written in reboot.c, for the time being. I will have a PR for libc `sleep`, although making any changes in `libc/system/sleep.c` are ignored (a problem in libc make?).

It took quite a bit to trace this down, and I've added an improved debug mechanism.
This mechanism allows for very interesting tracing, I will comment more on it after the next commit, which expands on it for the broken `signal` processing in ELKS.

@jbruchon, please commit this PR before my next PR (signal fix), as that may help with merge issues on my second PR.