### PR TITLE
[signal] Fix userland signals

### DIFF
--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -23,7 +23,7 @@
 #include <linuxmt/chqueue.h>
 #include <linuxmt/ntty.h>
 #include <linuxmt/init.h>
-#include <linuxmt/major.h>
+#include <linuxmt/debug.h>
 
 /*
  * XXX plac: setting default to B9600 instead of B1200
@@ -54,17 +54,19 @@ extern struct tty_ops ttyp_ops;
 
 int tty_intcheck(register struct tty *ttyp, unsigned char key)
 {
-    register char *psig = 0;
+    sig_t sig = 0;
 
-    if ((ttyp->termios.c_lflag & ISIG) && (ttyp->pgrp)) {
+    if ((ttyp->termios.c_lflag & ISIG) && ttyp->pgrp) {
 	if (key == ttyp->termios.c_cc[VINTR])
-	    psig = (char *) SIGINT;
+	    sig = SIGINT;
 	if (key == ttyp->termios.c_cc[VSUSP])
-	    psig = (char *) SIGTSTP;
-	if (psig)
-	    kill_pg(ttyp->pgrp, (sig_t) psig, 1);
+	    sig = SIGTSTP;
+	if (sig) {
+	    debug_sig("TTY signal %d to pgrp %d pid %d\n", sig, ttyp->pgrp, current->pid);
+	    kill_pg(ttyp->pgrp, sig, 1);
+	}
     }
-    return (int)psig;
+    return sig;
 }
 
 /* Turns a dev_t variable into its tty, or NULL if it's not valid */
@@ -90,6 +92,7 @@ int tty_open(struct inode *inode, struct file *file)
     if (!(otty = determine_tty(inode->i_rdev)))
 	return -ENODEV;
 
+    debug_sig("TTY open pid %d\n", currentp->pid);
 #if 0
     memcpy(&otty->termios, &def_vals, sizeof(struct termios));
 #endif
@@ -98,6 +101,7 @@ int tty_open(struct inode *inode, struct file *file)
     if (!err) {
 	if (otty->pgrp == 0 && currentp->session == currentp->pid
 		&& currentp->tty == NULL) {
+	    debug_sig("TTY setting pgrp %d pid %d\n", currentp->pgrp, currentp->pid);
 	    otty->pgrp = currentp->pgrp;
 	    currentp->tty = otty;
 	}
@@ -121,8 +125,10 @@ void tty_release(struct inode *inode, struct file *file)
     if (!rtty)
 	return;
 
+    debug_sup("TTY close pid %d\n", current->pid);
     if (current->pid == rtty->pgrp) {
 	kill_pg(rtty->pgrp, SIGHUP, 1);
+	debug_sup("TTY release pgrp %d\n", current->pid);
 	rtty->pgrp = 0;
     }
     rtty->flags &= ~TTY_OPEN;
@@ -144,11 +150,11 @@ void tty_release(struct inode *inode, struct file *file)
  */
 int tty_outproc(register struct tty *tty)
 {
-    register char *t_oflag;	/* WARNING: highly arch dependent! */
+    int t_oflag;	/* WARNING: highly arch dependent, termios.c_oflag truncated to 16 bits*/
     int ch;
 
     ch = tty->outq.base[tty->outq.start];
-    if ((int)(t_oflag = (char *)tty->termios.c_oflag) & OPOST) {
+    if ((t_oflag = (int)tty->termios.c_oflag) & OPOST) {
 	switch(tty->ostate & ~0x0F) {
 	case 0x20:		/* Expand tabs to spaces */
 	    ch = ' ';
@@ -160,19 +166,19 @@ int tty_outproc(register struct tty *tty)
 	default:
 	    switch(ch) {
 	    case '\n':
-		if ((unsigned)t_oflag & ONLCR) {
+		if (t_oflag & ONLCR) {
 		    ch = '\r';				/* Expand NL -> CR NL */
 		    tty->ostate = 0x10;
 		}
 		break;
 #if 0
 	    case '\r':
-		if ((unsigned)t_oflag & OCRNL)
+		if (t_oflag & OCRNL)
 		    ch = '\n';				/* Map CR to NL */
 		break;
 #endif
 	    case '\t':
-		if (((unsigned)t_oflag & TABDLY) == TAB3) {
+		if ((t_oflag & TABDLY) == TAB3) {
 		    ch = ' ';				/* Expand tabs to spaces */
 		    tty->ostate = 0x20 + TAB_SPACES - 1;
 		}
@@ -208,28 +214,27 @@ void tty_echo(register struct tty *tty, unsigned char ch)
 size_t tty_write(struct inode *inode, struct file *file, char *data, int len)
 {
     register struct tty *tty = determine_tty(inode->i_rdev);
-    register char *pi;
-    int s;
+    int i, s;
 
-    pi = 0;
-    while (((int)pi) < len) {
+    i = 0;
+    while (i < len) {
 	s = chq_wait_wr(&tty->outq, file->f_flags & O_NONBLOCK);
 	if (s < 0) {
-	    if ((int)pi == 0)
-		pi = (char *)s;
+	    if (i == 0)
+		i = s;
 	    break;
 	}
 	chq_addch(&tty->outq, get_user_char((void *)(data++)));
 	tty->ops->write(tty);
-	pi++;
+	i++;
     }
-    return (size_t)pi;
+    return i;
 }
 
 size_t tty_read(struct inode *inode, struct file *file, char *data, int len)
 {
     register struct tty *tty = determine_tty(inode->i_rdev);
-    register char *pi = 0;
+    int i = 0;
     int ch, k, icanon;
     int nonblock = (file->f_flags & O_NONBLOCK);
 
@@ -242,16 +247,16 @@ size_t tty_read(struct inode *inode, struct file *file, char *data, int len)
 	    }
 	    ch = chq_wait_rd(&tty->inq, nonblock);
 	    if (ch < 0) {
-		if ((int)pi == 0)
-		    pi = (char *)ch;
+		if (i == 0)
+		    i = ch;
 		break;
 	    }
 	    ch = chq_getch(&tty->inq);
 
 	    if (icanon) {
 		if (ch == tty->termios.c_cc[VERASE]) {
-		    if ((int)pi > 0) {
-			pi--;
+		    if (i > 0) {
+			i--;
 			k = ((get_user_char((void *)(--data))
 			    == '\t') ? TAB_SPACES : 1);
 			do {
@@ -268,12 +273,12 @@ size_t tty_read(struct inode *inode, struct file *file, char *data, int len)
 	    }
 	    put_user_char(ch, (void *)(data++));
 	    tty_echo(tty, ch);
-	    if ((int)(++pi) >= len)
+	    if (++i >= len)
 		break;
 	} while ((icanon && (ch != '\n') && (ch != tty->termios.c_cc[VEOL]))
-		    || (!icanon && (pi < tty->termios.c_cc[VMIN])));
+		    || (!icanon && (i < tty->termios.c_cc[VMIN])));
     }
-    return (int)pi;
+    return i;
 }
 
 int tty_ioctl(struct inode *inode, struct file *file, int cmd, char *arg)
@@ -347,7 +352,7 @@ static struct file_operations tty_fops = {
 void tty_init(void)
 {
     register struct tty *ttyp;
-    register char *pi;
+    int i;
 
     ttyp = &ttys[MAX_TTYS];
     do {
@@ -358,14 +363,14 @@ void tty_init(void)
 
 #if defined(CONFIG_CONSOLE_DIRECT) || defined(CONFIG_SIBO_CONSOLE_DIRECT) || defined(CONFIG_CONSOLE_BIOS)
 
-    for (pi = 0 ; ((int)pi) < NR_CONSOLES ; pi++) {
+    for (i = 0 ; i < NR_CONSOLES ; i++) {
 #ifdef CONFIG_CONSOLE_BIOS
 	ttyp->ops = &bioscon_ops;
 #else
 	ttyp->ops = &dircon_ops;
 #endif
 	chq_init(&ttyp->inq, ttyp->inq_buf, INQ_SIZE);
-	(ttyp++)->minor = (int)pi;
+	(ttyp++)->minor = i;
     }
 
 #endif
@@ -373,9 +378,9 @@ void tty_init(void)
 #ifdef CONFIG_CHAR_DEV_RS
 
     /* put serial entries after console entries */
-    for (pi = RS_MINOR_OFFSET; ((int)pi) < NR_SERIAL + RS_MINOR_OFFSET; pi++) {
+    for (i = RS_MINOR_OFFSET; i < NR_SERIAL + RS_MINOR_OFFSET; i++) {
 	ttyp->ops = &rs_ops;
-	(ttyp++)->minor = ((int)pi);		/* ttyS0 = RS_MINOR_OFFSET */
+	(ttyp++)->minor = i;		/* ttyS0 = RS_MINOR_OFFSET */
     }
 
 #endif
@@ -383,9 +388,9 @@ void tty_init(void)
 #ifdef CONFIG_PSEUDO_TTY
     /* start at minor = 8 fixed to match pty entries in MAKEDEV */
     /* put slave pseudo tty entries after serial entries */
-    for (pi = 8; ((int)pi) < NR_PTYS + 8; pi++) {
+    for (i = 8; (i) < NR_PTYS + 8; i++) {
 	ttyp->ops = &ttyp_ops;
-	(ttyp++)->minor = (int)pi;
+	(ttyp++)->minor = i;
     }
 #endif
 

--- a/elks/arch/i86/kernel/signal.c
+++ b/elks/arch/i86/kernel/signal.c
@@ -34,7 +34,7 @@ int do_signal(void)
 	}
 	currentp->signal ^= mask;
 
-	debug2("Process %d has signal %d.\n", currentp->pid, signr);
+	debug_sig("SIGNAL process signal %d pid %d\n", signr, currentp->pid);
 	sah = &currentp->sig.action[signr - 1].sa_handler;
 	if (*sah == SIG_DFL) {				/* Default */
 	    if ((mask &					/* Default Ignore */
@@ -43,6 +43,7 @@ int do_signal(void)
 		continue;
 	    else if (mask &				/* Default Stop */
 			(SM_SIGSTOP | SM_SIGTSTP | SM_SIGTTIN | SM_SIGTTOU)) {
+		debug_sig("SIGNAL pid %d stopped\n", currentp->pid);
 		currentp->state = TASK_STOPPED;
 		/* Let the parent know */
 		currentp->p_parent->child_lastend = currentp->pid;
@@ -59,16 +60,18 @@ int do_signal(void)
 	    }
 	}
 	else if (*sah != SIG_IGN) {			/* Set handler */
-	    debug1("Setting up return stack for sig handler %x.\n",(unsigned)(*sah));
-	    debug1("Stack at %x\n", currentp->t_regs.sp);
+	    debug_sig("SIGNAL setup return stack for handler %x\n",(unsigned)(*sah));
+	    //debug_sig("Stack at %x\n", currentp->t_regs.sp);
 	    arch_setup_sighandler_stack(currentp, *sah, signr);
-	    debug1("Stack at %x\n", currentp->t_regs.sp);
+	    //debug_sig("Stack at %x\n", currentp->t_regs.sp);
 	    *sah = SIG_DFL;
+	    debug_sig("SIGNAL reset pending signals\n");
 	    currentp->signal = 0;
 
 	    return 1;
 	}
-	/* else (*sah == SIG_IGN) Ignore */
+	else /* else (*sah == SIG_IGN) Ignore */
+	    debug_sig("SIGNAL signal %d ignored pid %d\n", signr, currentp->pid);
     }
     return 0;
 }

--- a/elks/include/linuxmt/debug.h
+++ b/elks/include/linuxmt/debug.h
@@ -31,7 +31,47 @@
 #define pstrace(_a)
 #endif
 
+<<<<<<< HEAD
+/*
+ * New kernel debug mechanism, set here or in autoconf.h, works across multiple files.
+ */
+#define DEBUG_BLK	0		/* block i/o*/
+#define DEBUG_FILE	0		/* sys open and file i/o*/
+#define DEBUG_FS	0		/* VFS and general filesystem*/
+#define DEBUG_FAT	0		/* FAT filesystem*/
+#define DEBUG_MINIX	0		/* Minix filesystem*/
+#define DEBUG_SIG	0		/* signals*/
+#define DEBUG_SUP	0		/* superblock, mount, umount*/
+
+#if DEBUG_BLK
+#define debug_blk	printk
+#else
+#define debug_blk(...)
+#endif
+
+#if DEBUG_FILE
+#define debug_file	printk
+#else
+#define debug_file(...)
+#endif
+
+#if DEBUG_SIG
+#define debug_sig	printk
+#else
+#define debug_sig(...)
+#endif
+
+#if DEBUG_SUP
+#define debug_sup	printk
+#else
+#define debug_sup(...)
+#endif
+
+/* Old debug mechanism - deprecated.
+ * This sets up a standard set of macros that can be used with any of the
+=======
 /* This sets up a standard set of macros that can be used with any of the
+>>>>>>> parent of 283a2260... [minix] Fix Minix umount super block unchecked flag, add new debug mechanism
  * files that make up the ELKS kernel. They can handle calls with up to 9
  * parameters after the format string.
  */

--- a/elks/include/linuxmt/signal.h
+++ b/elks/include/linuxmt/signal.h
@@ -9,9 +9,9 @@
  * So we can have much tighter signal code if we have 16 bit signal
  * mask by losing all these unused signals.
  */
-#define SMALLSIG
-
 #include <linuxmt/types.h>
+
+#define SMALLSIG		/* 16-bit sigset_t*/
 
 #ifdef SMALLSIG
 
@@ -34,6 +34,8 @@ typedef unsigned short sigset_t;	/* at least 16 bits */
 #define SIGPIPE		13
 #define SIGALRM		14
 #define SIGTERM		15
+#define SIGTTIN		0		/* FIXME not implemented*/
+#define SIGUSR2		0		/* FIXME not implemented*/
 
 #define _NSIG		16
 
@@ -173,7 +175,7 @@ typedef unsigned long sigset_t;	/* at least 32 bits */
 
 #endif
 
-#endif
+#endif /* __KERNEL__*/
 
 /*@-namechecks@*/
 
@@ -182,7 +184,7 @@ typedef unsigned long sigset_t;	/* at least 32 bits */
 #define SIG_SETMASK        2	/* for setting the signal mask */
 
 /* Type of a signal handler.  */
-typedef void (*__sighandler_t) ();
+typedef void (*__sighandler_t)(int);
 
 /*@+namechecks@*/ /*@ignore@*/
 
@@ -203,10 +205,12 @@ struct sigaction {
 
 };
 
+#ifdef __KERNEL__
 struct task_struct;
 extern int send_sig(sig_t,struct task_struct *,int);
 extern void arch_setup_sighandler_stack(register struct task_struct *,
 					__sighandler_t,unsigned);
 extern void ctrl_alt_del(void);
+#endif /* __KERNEL__*/
 
 #endif

--- a/elks/include/linuxmt/types.h
+++ b/elks/include/linuxmt/types.h
@@ -39,9 +39,7 @@ typedef __u16			uid_t;
 typedef __u16			umode_t;
 
 typedef __u8			cc_t;
-#ifndef sig_t
-typedef __u8			sig_t;
-#endif
+typedef __u16			sig_t;
 
 /*@ignore@*/
 

--- a/elks/kernel/sys.c
+++ b/elks/kernel/sys.c
@@ -20,6 +20,7 @@
 #include <linuxmt/string.h>
 #include <linuxmt/stat.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/debug.h>
 
 #include <arch/segment.h>
 #include <arch/io.h>
@@ -297,9 +298,9 @@ int sys_setsid(void)
 {
     register __ptask currentp = current;
 
-    if (currentp->session == currentp->pid) {
+    if (currentp->session == currentp->pid)
 	return -EPERM;
-    }
+    debug_sig("SETSID pgrp %d\n", currentp->pid);
     currentp->session = currentp->pgrp = currentp->pid;
     currentp->tty = NULL;
 

--- a/elkscmd/ash/Makefile
+++ b/elkscmd/ash/Makefile
@@ -7,7 +7,7 @@ BASEDIR = ..
 
 include $(BASEDIR)/Make.defs
 
-LOCALFLAGS = -DSHELL -I. -D_MINIX -D_POSIX_SOURCE
+LOCALFLAGS = -DSHELL -I. -D_MINIX -D_POSIX_SOURCE -Dlint
 
 ###############################################################################
 #

--- a/elkscmd/ash/main.c
+++ b/elkscmd/ash/main.c
@@ -105,6 +105,9 @@ main(argc, argv)  char **argv; {
 	register char *profile = NULL;
 	register char *ashrc = NULL;
 
+#if !JOBS
+	signal(SIGTSTP, SIG_IGN);	/* ignore ^Z stop signal on ELKS*/
+#endif
 #if PROFILE
 	monitor(4, etext, profile_buf, sizeof profile_buf, 50);
 #endif

--- a/elkscmd/rootfs_template/etc/rc.d/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sys
@@ -33,8 +33,7 @@ then
 	echo ' ktcp'
 	
 	echo -n "Starting network services: "
-	for daemon in telnetd 
-	#ftpd httpd
+	for daemon in telnetd httpd
 	do
 		if test -f /bin/$daemon 
 		then

--- a/elkscmd/sash/sash.c
+++ b/elkscmd/sash/sash.c
@@ -219,7 +219,6 @@ static	int	sourcecount;
 #endif
 
 static	void	catchint();
-static	void	catchtstp();
 static	void	catchquit();
 static	void	readfile();
 static	void	command();
@@ -834,17 +833,6 @@ showprompt()
 	write(STDOUT, prompt, strlen(prompt));
 }
 
-
-static void
-catchtstp()
-{
-	signal(SIGTSTP, catchtstp);
-
-	intflag = TRUE;
-
-	if (intcrlf)
-		write(STDOUT, "\n", 1);
-}
 
 static void
 catchint()

--- a/elkscmd/sys_utils/getty.c
+++ b/elkscmd/sys_utils/getty.c
@@ -74,6 +74,7 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <signal.h>
 
 #define LOGIN		"/bin/login"
 #define HOSTFILE	"/etc/HOSTNAME"
@@ -184,6 +185,7 @@ int main(int argc, char **argv) {
     char *ptr;
     int n;
 
+    signal(SIGTSTP, SIG_IGN);		/* ignore ^Z stop signal*/
     debug1("DEBUG: main( %d, **argv )\n",argc);
     if (argc < 2 || argc > 3) {
 	fprintf(stderr,

--- a/elkscmd/sys_utils/login.c
+++ b/elkscmd/sys_utils/login.c
@@ -25,6 +25,7 @@
 #include <dirent.h>
 #include <utmp.h>
 #include <limits.h>
+#include <signal.h>
 
 /*#define USE_UTMP*/	/* Disabled until we fix the "utmp file corrupt" */
 			/* issue. 17/4/2002 Harry Kalogirou */
@@ -102,6 +103,7 @@ int main(int argc, char ** argv)
 	char *p;
 
 
+	signal(SIGTSTP, SIG_IGN);		/* ignore ^Z stop signal*/
 	for (;;) {
 		if (argc == 1) {
 			write(STDOUT_FILENO,"login: ",7);

--- a/elkscmd/sys_utils/ps.c
+++ b/elkscmd/sys_utils/ps.c
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
 	struct task_struct task_table;
 	struct passwd * pwent;
 
-	printf("  PID   GRP USER  STAT INODE COMMAND\n");
+	printf("  PID   GRP  TTY USER  STAT INODE COMMAND\n");
 	if ((fd = open("/dev/kmem", O_RDONLY)) < 0) {
 		perror("ps");
 		exit(1);
@@ -87,9 +87,10 @@ int main(int argc, char **argv)
 		if (task_table.t_kstackm != KSTACK_MAGIC) break;
 		if (task_table.t_regs.ss == 0) continue;
 			pwent = (getpwuid(task_table.uid));
-			printf("%5d %5d %-8s %c %5u ",
+			printf("%5d %5d %4x %-8s %c %5u ",
 				task_table.pid,
 				task_table.pgrp,
+				task_table.tty,
 				(pwent ? pwent->pw_name : "unknown"),
 				((task_table.state == TASK_RUNNING) ? 'R' : 'S'),
 				task_table.t_inode);

--- a/libc/include/signal.h
+++ b/libc/include/signal.h
@@ -1,88 +1,16 @@
-
 #ifndef __SIGNAL_H
 #define __SIGNAL_H
 
 #include <types.h>
 #include <features.h>
 
-typedef unsigned long sigset_t;		/* at least 32 bits */
+#undef __KERNEL__
+#include __SYSINC__(signal.h)
 
-#define _NSIG             32
-#define NSIG		_NSIG
-
-#define SIGHUP		 1
-#define SIGINT		 2
-#define SIGQUIT		 3
-#define SIGILL		 4
-#define SIGTRAP		 5
-#define SIGABRT		 6
-#define SIGIOT		 6
-#define SIGBUS		 7
-#define SIGFPE		 8
-#define SIGKILL		 9
-#define SIGUSR1		10
-#define SIGSEGV		11
-#define SIGUSR2		12
-#define SIGPIPE		13
-#define SIGALRM		14
-#define SIGTERM		15
-#define SIGSTKFLT	16
-#define SIGCHLD		17
-#define SIGCONT		18
-#define SIGSTOP		19
-#define SIGTSTP		20
-#define SIGTTIN		21
-#define SIGTTOU		22
-#define SIGURG		23
-#define SIGXCPU		24
-#define SIGXFSZ		25
-#define SIGVTALRM	26
-#define SIGPROF		27
-#define SIGWINCH	28
-#define SIGIO		29
-#define SIGPOLL		SIGIO
-/*
-#define SIGLOST		29
-*/
-#define SIGPWR		30
-#define	SIGUNUSED	31
-
-/*
- * sa_flags values: SA_STACK is not currently supported, but will allow the
- * usage of signal stacks by using the (now obsolete) sa_restorer field in
- * the sigaction structure as a stack pointer. This is now possible due to
- * the changes in signal handling. LBT 010493.
- * SA_INTERRUPT is a no-op, but left due to historical reasons. Use the
- * SA_RESTART flag to get restarting signals (which were the default long ago)
- */
-#define SA_NOCLDSTOP	1
-#define SA_STACK	0x08000000
-#define SA_RESTART	0x10000000
-#define SA_INTERRUPT	0x20000000
-#define SA_NOMASK	0x40000000
-#define SA_ONESHOT	0x80000000
-
-#define SIG_BLOCK          0	/* for blocking signals */
-#define SIG_UNBLOCK        1	/* for unblocking signals */
-#define SIG_SETMASK        2	/* for setting the signal mask */
-
-/* Type of a signal handler.  */
-typedef void (*__sighandler_t)(int);
 /* Type of a signal handler to pass to the kernel.  This is always a `stdcall'
    function, even if the user program is being compiled for a different
    calling convention.  */
 typedef void (__attribute__((stdcall)) *__kern_sighandler_t)(int);
-
-#define SIG_DFL	((__sighandler_t)0)	/* default signal handling */
-#define SIG_IGN	((__sighandler_t)1)	/* ignore signal */
-#define SIG_ERR	((__sighandler_t)-1)	/* error return from signal */
-
-struct sigaction {
-	__sighandler_t sa_handler;
-	sigset_t sa_mask;
-	unsigned long sa_flags;
-	void (*sa_restorer)( /*void*/ );
-};
 
 /* BSDisms */
 #ifdef BSD


### PR DESCRIPTION
This PR fixes #387.

Getting ^C and ^Z handling working involved fixing one big thing and lots of little things: 
First, the entire userland signal numbers were incorrect, due to libc having it own list of signals requiring 32-bit signal masks, and the kernel's version, which uses 16-bit masks. Since the signal numbers themselves were all different, an entirely different signal was being generated on any signal event. Libc now includes the kernel signal.h header to rectify this.

Various important utilities, include getty, login, ash and sash, didn't handle ^Z (SIGTSTP) properly and had to be modified. I went through all applications and found that there are still a couple that won't work properly, as SIGTTIN and SIGUSR2 aren't implemented.

This fix normally works well, but there is still a ELKS startup race problem having to do with /bin/init and `setsid`, which sets the controlling terminal/process group. When this race condition manifests itself, one will see that ^C and ^Z have no effect, since there is no controlling terminal. This seems to occur 20% of the time, and is related to the process startup and termination when running the /etc/rc.s/rc.sys script. More details upon request. I added a TTY field to `ps` to see whether a process has a controlling terminal.

For the files that had to be modified, I've also started cleanups, which can be seen in ntty.c, for example. Also trying to pare down the warnings for compilations of each file touched as well.

This PR also expands the debug mechanism (see linuxmt/debug.h) and allows tracing of signals, which is quite interesting. I will give a complete writeup once I change the FAT filesystem debug mechanism, which is very similar, to the new mechanism, which allows for fine granular control of seeing what's happening in the kernel. One may well be surprised with what is seen!

@jbruchon, please commit this PR after the #441, just in case of merge issues thanks!