### PR TITLE
[config] `make all` no longer regenerates .config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ endif
 
 include $(TOPDIR)/Make.defs
 
-.PHONY: all clean kconfig defconfig reconfig config menuconfig
+.PHONY: all clean kconfig defconfig config menuconfig
 
-all: .config reconfig
+all: .config include/autoconf.h
 	$(MAKE) -C libc all
 	$(MAKE) -C libc DESTDIR='$(TOPDIR)/cross' install
 	$(MAKE) -C elks all
@@ -41,9 +41,8 @@ defconfig:
 	$(RM) .config
 	@yes '' | ${MAKE} config
 
-# Update include/autoconf.h from .config.
-reconfig: .config
-	@yes '' | ${MAKE} config
+include/autoconf.h: .config
+	@yes '' | config/Configure -D config.in
 
 config: elks/arch/i86/drivers/char/KeyMaps/config.in kconfig
 	config/Configure config.in

--- a/config/Configure
+++ b/config/Configure
@@ -146,7 +146,7 @@ function help () {
 #	readln prompt default oldval
 #
 function readln () {
-    if [ "$DEFAULT" = "-d" -a -n "$3" ]; then
+    if [ -n "$DEFAULT" -a -n "$3" ]; then
 	echo "$1"
 	ans=$2
     else
@@ -665,6 +665,10 @@ if [ "$1" = "-d" ] ; then
     DEFAULT="-d"
     shift
 fi
+if [ "$1" = "-D" ] ; then	# only update autoconf.h  -- tkchia 20200310
+    DEFAULT="-D"
+    shift
+fi
 CFG_IN=./config.in
 if [ "$1" != "" ] ; then
     CFG_IN=$1
@@ -692,10 +696,14 @@ else
 fi
 . $CFG_IN
 rm -f .config.old
-if [ -f .config ]; then
-    mv .config .config.old
+if [ "$DEFAULT" = -D ]; then
+    rm .tmpconfig
+else
+    if [ -f .config ]; then
+	mv .config .config.old
+    fi
+    mv .tmpconfig .config
 fi
-mv .tmpconfig .config
 mv .tmpconfig.h include/autoconf.h
 echo
 exit 0


### PR DESCRIPTION
`include/autoconf.h` may still be regenerated, but only if it is out of date with respect to `.config`.

This addresses some issues brought up by @ghaerr (https://github.com/jbruchon/elks/pull/438#issuecomment-596903198).