### PR TITLE
[fat] Cleanup of FAT filesystem debugging macros

### DIFF
--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -16,6 +16,7 @@
 #include <linuxmt/errno.h>
 #include <linuxmt/stat.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/debug.h>
 
 static int msdos_dir_read(struct inode *dir, struct file *filp, char *buf, int count)
 {
@@ -196,7 +197,7 @@ int msdos_get_entry_long(
 				else if (!strcmp(de->name,MSDOS_DOTDOT))
 					*ino = msdos_parent_ino(dir,0);
 
-fsdebug("dir: '%s' attr %x\n", de->name, de->attr);
+				debug_fat("dir: '%s' attr %x\n", de->name, de->attr);
 				if (is_long) {
 					*namelen = long_len;
 					*dirpos = oldpos;

--- a/elks/fs/msdos/fat.c
+++ b/elks/fs/msdos/fat.c
@@ -9,6 +9,7 @@
 #include <linuxmt/errno.h>
 #include <linuxmt/stat.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/debug.h>
 
 static struct fat_cache *fat_cache,cache[FAT_CACHE];
 
@@ -87,11 +88,11 @@ long fat_access(register struct super_block *sb,long this,long new_value)
 				*p_first = new_value & 0xff;
 				*p_last = (*p_last & 0xf0) | (new_value >> 8);
 			}
-if (bh != bh2) fsdebug("fat_access block bh2 dirty %d\n", bh2->b_blocknr);
+			if (bh != bh2) debug_fat("fat_access block bh2 dirty %d\n", bh2->b_blocknr);
 			bh2->b_dirty = 1;
 		}
 #endif
-fsdebug("fat_access block bh dirty %d\n", bh->b_blocknr);
+		debug_fat("fat_access block bh dirty %d\n", bh->b_blocknr);
 		bh->b_dirty = 1;
 #if 0000 //FIXME
 		/* update extra FAT table copies*/
@@ -105,7 +106,7 @@ fsdebug("fat_access block bh dirty %d\n", bh->b_blocknr);
 						(long)(MSDOS_SB(sb)->fat_start+(first >> SECTOR_BITS) +
 						MSDOS_SB(sb)->fat_length*copy),&c_data))) break;
 			memcpy(c_data,data,SECTOR_SIZE);
-fsdebug("fat_access block cbh write %d\n", bh->b_blocknr);
+		debug_fat("fat_access block cbh write %d\n", bh->b_blocknr);
 			c_bh->b_dirty = 1;
 			if (data != data2 || bh != bh2) {
 				if (!(c_bh2 = msdos_sread(sb->s_dev,
@@ -116,7 +117,7 @@ fsdebug("fat_access block cbh write %d\n", bh->b_blocknr);
 				}
 				memcpy(c_data2,data2,SECTOR_SIZE);
 				c_bh2->b_dirty = 1;		//FIXME looks like bug without this
-fsdebug("fat_access block cbh2 write %d\n", c_bh2->b_blocknr);
+		debug_fat("fat_access block cbh2 write %d\n", c_bh2->b_blocknr);
 				unmap_brelse(c_bh2);
 			}
 			unmap_brelse(c_bh);
@@ -283,7 +284,7 @@ int fat_free(register struct inode *inode,long skip)
 {
 	long this,last;
 
-fsdebug("fat_free\n");
+	debug_fat("fat_free\n");
 	if (!(this = inode->u.msdos_i.i_start)) return 0;
 	last = 0;
 	while (skip--) {

--- a/elks/fs/msdos/file.c
+++ b/elks/fs/msdos/file.c
@@ -16,6 +16,7 @@
 #include <linuxmt/fcntl.h>
 #include <linuxmt/stat.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/debug.h>
 
 #define MIN(a,b) (((a) < (b)) ? (a) : (b))
 
@@ -69,7 +70,7 @@ static int msdos_file_read(register struct inode *inode,register struct file *fi
 	struct buffer_head *bh;
 	void *data;
 
-//fsdebug("file_read cnt %u\n", count);
+	//debug_fat("file_read cnt %u\n", count);
 	if (!inode) {
 		printk("FAT: read NULL inode\n");
 		return -EINVAL;
@@ -105,7 +106,7 @@ static int msdos_file_write(register struct inode *inode,register struct file *f
 	struct buffer_head *bh;
 	void *data;
 
-fsdebug("file_write\n");
+	debug_fat("file_write\n");
 	if (!inode) {
 		printk("FAT: write NULL inode\n");
 		return -EINVAL;
@@ -139,7 +140,7 @@ fsdebug("file_write\n");
 			inode->i_size = filp->f_pos;
 			inode->i_dirt = 1;
 		}
-fsdebug("file block write %d\n", bh->b_blocknr);
+		debug_fat("file block write %d\n", bh->b_blocknr);
 		bh->b_dirty = 1;
 		unmap_brelse(bh);
 	}
@@ -154,7 +155,7 @@ void msdos_truncate(register struct inode *inode)
 {
 	int cluster;
 
-fsdebug("truncate\n");
+	debug_fat("truncate\n");
 	cluster = SECTOR_SIZE*MSDOS_SB(inode->i_sb)->cluster_size;
 	(void)fat_free(inode,(inode->i_size + (cluster-1)) / cluster);
 	inode->u.msdos_i.i_attrs |= ATTR_ARCH;

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -12,6 +12,7 @@
 #include <linuxmt/errno.h>
 #include <linuxmt/string.h>
 #include <linuxmt/stat.h>
+#include <linuxmt/debug.h>
 
 #ifdef CONFIG_FS_DEV
 struct msdos_devdir_entry devnods[DEVDIR_SIZE] = {
@@ -38,7 +39,8 @@ struct msdos_devdir_entry devnods[DEVDIR_SIZE] = {
 
 void msdos_put_inode(register struct inode *inode)
 {
-if (inode->i_dirt) fsdebug("put_inode %ld count %d dirty %d\n", (unsigned long)inode->i_ino, inode->i_count, inode->i_dirt);
+	if (inode->i_dirt) debug_fat("put_inode %ld count %d dirty %d\n",
+		(unsigned long)inode->i_ino, inode->i_count, inode->i_dirt);
 	if (!inode->i_nlink) {
 		inode->i_size = 0;
 		msdos_truncate(inode);
@@ -49,7 +51,7 @@ if (inode->i_dirt) fsdebug("put_inode %ld count %d dirty %d\n", (unsigned long)i
 
 void msdos_put_super(register struct super_block *sb)
 {
-fsdebug("put_super\n");
+	debug_fat("put_super\n");
 	cache_inval_dev(sb->s_dev);
 	lock_super(sb);
 	sb->s_dev = 0;
@@ -214,7 +216,7 @@ void msdos_read_inode(register struct inode *inode)
 	long this,nr;
 	int fatsz = MSDOS_SB(inode->i_sb)->fat_bits;
 
-//fsdebug("read_inode %ld\n", (unsigned long)inode->i_ino);
+	//debug_fat("read_inode %ld\n", (unsigned long)inode->i_ino);
 	inode->u.msdos_i.i_busy = 0;
 	inode->i_uid = current->uid;
 	inode->i_gid = current->gid;
@@ -307,7 +309,7 @@ void msdos_write_inode(register struct inode *inode)
 	if (inode->i_ino < DEVINO_BASE + DEVDIR_SIZE)
 		return;
 #endif
-fsdebug("write_inode %ld %d\n", (unsigned long)inode->i_ino, inode->i_dirt);
+	debug_fat("write_inode %ld %d\n", (unsigned long)inode->i_ino, inode->i_dirt);
 	if (inode->i_ino == MSDOS_ROOT_INO || !inode->i_nlink) return;
 	if (!(bh = bread(inode->i_dev,(block_t)(inode->i_ino >> MSDOS_DPB_BITS)))) {
 	    printk("FAT: write inode fail\n");
@@ -326,7 +328,7 @@ fsdebug("write_inode %ld %d\n", (unsigned long)inode->i_ino, inode->i_dirt);
 	raw_entry->start = (unsigned short)inode->u.msdos_i.i_start;
 	raw_entry->starthi = ((unsigned short *)&inode->u.msdos_i.i_start)[1];
 	date_unix2dos(inode->i_mtime,&raw_entry->time,&raw_entry->date);
-fsdebug("write_inode block write %d\n", bh->b_blocknr);
+	debug_fat("write_inode block write %d\n", bh->b_blocknr);
 	bh->b_dirty = 1;
 	unmap_brelse(bh);
 }

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -10,6 +10,7 @@
 #include <linuxmt/errno.h>
 #include <linuxmt/string.h>
 #include <linuxmt/stat.h>
+#include <linuxmt/debug.h>
 
 struct buffer_head *msdos_sread(int dev,long sector,void **start)
 {
@@ -19,7 +20,7 @@ struct buffer_head *msdos_sread(int dev,long sector,void **start)
 		return NULL;
 
 	map_buffer(bh);
-//fsdebug("msread sector %ld block %d\n", sector, bh->b_blocknr);
+	//debug_fat("msread sector %ld block %d\n", sector, bh->b_blocknr);
 	*start = bh->b_data + (((int)sector & 1) << SECTOR_BITS);
 	return bh;
 }
@@ -54,7 +55,7 @@ int msdos_add_cluster(register struct inode *inode)
 	struct buffer_head *bh;
 	int fatsz = MSDOS_SB(inode->i_sb)->fat_bits;
 
-fsdebug("add_cluster\n");
+	debug_fat("add_cluster\n");
 #ifndef FAT_BITS_32
 	if (fatsz != 32)
 		if (inode->i_ino == MSDOS_ROOT_INO) return -ENOSPC;
@@ -134,7 +135,7 @@ printk("zeroing sector %d\r\n",sector);
 			else memset(data,0,SECTOR_SIZE);
 		}
 		if (bh) {
-fsdebug("add_cluster block write %d\n", bh->b_blocknr);
+			debug_fat("add_cluster block write %d\n", bh->b_blocknr);
 			bh->b_dirty = 1;
 			unmap_brelse(bh);
 		}
@@ -259,7 +260,7 @@ ino_t msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head **bh,
 			return -1;
 		}
 #endif
-//fsdebug("get entry %ld\n", sector);
+		//debug_fat("get entry %ld\n", sector);
 		return (sector << MSDOS_DPS_BITS)+((offset & (SECTOR_SIZE-1)) >> MSDOS_DIR_BITS);
 	}
 }

--- a/elks/include/linuxmt/debug.h
+++ b/elks/include/linuxmt/debug.h
@@ -1,12 +1,12 @@
+#ifndef LX86_LINUXMT_DEBUG_H
+#define LX86_LINUXMT_DEBUG_H
+
 /* linuxmt/include/linuxmt/debug.h for ELKS v. >=0.0.47
  * (C) 1997 Chad Page
  * 
  * This file contains the #defines to turn on and off various printk()-related
  * functions...
  */
-
-#ifndef LX86_LINUXMT_DEBUG_H
-#define LX86_LINUXMT_DEBUG_H
 
 /* Found that strings were still included if debugging disabled so
  * re-organised so that each has a different macro depending on the number
@@ -25,13 +25,11 @@
 #endif
 
 /*
- * New kernel debug mechanism, set here or in autoconf.h, works across multiple files.
+ * Kernel debug options, set =1 to turn on. Works across multiple files.
  */
 #define DEBUG_BLK	0		/* block i/o*/
-#define DEBUG_FILE	0		/* sys open and file i/o*/
-#define DEBUG_FS	0		/* VFS and general filesystem*/
 #define DEBUG_FAT	0		/* FAT filesystem*/
-#define DEBUG_MINIX	0		/* Minix filesystem*/
+#define DEBUG_FILE	0		/* sys open and file i/o*/
 #define DEBUG_SIG	0		/* signals*/
 #define DEBUG_SUP	0		/* superblock, mount, umount*/
 
@@ -39,6 +37,12 @@
 #define debug_blk	printk
 #else
 #define debug_blk(...)
+#endif
+
+#if DEBUG_FAT
+#define debug_fat	printk
+#else
+#define debug_fat(...)
 #endif
 
 #if DEBUG_FILE

--- a/elks/include/linuxmt/msdos_fs.h
+++ b/elks/include/linuxmt/msdos_fs.h
@@ -8,13 +8,6 @@
 #include <linuxmt/fs.h>
 #include <linuxmt/ctype.h>
 
-/* temporary FAT filesystem debugging*/
-#ifdef FSDEBUG
-#define fsdebug			printk
-#else
-#define fsdebug(...)
-#endif
-
 #ifndef toupper
 extern char toupper(char c);
 #endif


### PR DESCRIPTION
Cleans up the existing FAT filesystem debug code to use the newer system described in 'elks/include/linuxmt/debug.h'. 

I'm finding this set of switchable debug options very helpful for understanding what is going on within the ELKS kernel. For instance, to see exactly which files are opened starting at boot/init time and afterwards for all commands, set the following line in debug.h and `make`:
```
#define DEBUG_FILE  1       /* sys open and file i/o*/
```
I have used the DEBUG_SIG and DEBUG_SUP to display all signal and superblock activity, for instance. When set to 0 (default), no additional code is added to the kernel.