### PR TITLE
[setboot] Update setboot to set numtracks for HD testing

### DIFF
--- a/image/Make.package
+++ b/image/Make.package
@@ -5,19 +5,19 @@
 
 # set BPB and mkfs options based on passed image size
 ifeq ($(SIZE),  360)
-	BPB=-B9,2
+	BPB=-B9,2,40
 	MINIX_MKFSOPTS=-1 -n14 -i192 -s360
 endif
 ifeq ($(SIZE), 720)
-	BPB=-B9,2
+	BPB=-B9,2,80
 	MINIX_MKFSOPTS=-1 -n14 -i256 -s720
 endif
 ifeq ($(SIZE), 1440)
-	BPB=-B18,2
+	BPB=-B18,2,80
 	MINIX_MKFSOPTS=-1 -n14 -i360 -s1440
 endif
 ifeq ($(SIZE), 2880)
-	BPB=-B36,2
+	BPB=-B36,2,80
 	MINIX_MKFSOPTS=-1 -n14 -i720 -s2880
 endif
 ifeq ($(SIZE), 31752)

--- a/image/Make.package
+++ b/image/Make.package
@@ -20,6 +20,10 @@ ifeq ($(SIZE), 2880)
 	BPB=-B36,2
 	MINIX_MKFSOPTS=-1 -n14 -i720 -s2880
 endif
+ifeq ($(SIZE), 31752)
+	BPB=-B63,16,63
+	MINIX_MKFSOPTS=-1 -n14 -i720 -s31752
+endif
 
 # select package file
 ifeq ($(PACKAGE), )

--- a/image/Makefile
+++ b/image/Makefile
@@ -122,7 +122,7 @@ clean:
 images: images-minix images-fat
 
 
-images-minix: fd360-minix fd720-minix fd1440-minix
+images-minix: fd360-minix fd720-minix fd1440-minix hd32-minix
 
 fd360-minix:
 	$(MAKE) -f Make.package NAME=fd360 FS=minix SIZE=360 TAGS=":boot|:small"
@@ -132,6 +132,9 @@ fd720-minix:
 
 fd1440-minix:
 	$(MAKE) -f Make.package NAME=fd1440 FS=minix SIZE=1440 TAGS=":boot|:small|:base|:net|:shutil|:fileutil|:app|:nanox"
+
+hd32-minix:
+	$(MAKE) -f Make.package NAME=hd32 FS=minix SIZE=31752 TAGS=":boot|:small|:base|:net|:shutil|:fileutil|:app|:nanox"
 
 
 images-fat: fd360-fat fd720-fat fd1440-fat fd2880-fat
@@ -148,3 +151,8 @@ fd1440-fat:
 # FAT16 image
 fd2880-fat:
 	$(MAKE) -f Make.package NAME=fd2880 FS=fat SIZE=2880 TAGS=":boot|:small|:base|:net|:shutil|:fileutil|:app|:nanox"
+
+# FAT32 image (fails on mformat currently)
+hd32-fat:
+	$(MAKE) -f Make.package NAME=hd32 FS=fat SIZE=31752 TAGS=":boot|:small|:base|:net|:shutil|:fileutil|:app|:nanox"
+


### PR DESCRIPTION
This updates `setboot` to allow an optional third parameter in the -B option for setting the number of tracks to write in the ELKS PB. Discussed in #433.

The package manager is updated for testing HD images and now successfully creates a 32MB test image 'hd32-minix.bin' along with the fd*.bin images. This is for testing purposes for others to easily test (currently flat) HD images along with floppy images on their equipment. 

Note: Currently unable to create a FAT HD image for testing, as `mformat` won't allow a size larger than 2.88M. Does anyone have any ideas for other tools for large FAT filesystem creation?

Hello @tkchia, on another note, while looking at bootblocks/boot_sect.S for this, I noticed what I think ultimately caused the bootblocks build error to go unnoticed (until you fixed it). That is, the following code is used as a last resort when the number of tracks, heads or sectors is unknown:
```
#   else
    .warning "Unknown number of disk tracks!"
    .word 0
#   endif
```
I'm thinking that perhaps the code should throw up an error that will stop the build, rather than issuing a warning and continuing. I'm sure that the warning went unnoticed during the build, and inserted 0 tracks for the CONFIG_IMG_FD1440 case that happened to be left out.