### PR TITLE
[libc] use alarm & signal, not sleep syscall, to realize sleep(.)

### DIFF
--- a/elks/arch/i86/kernel/syscall.dat
+++ b/elks/arch/i86/kernel/syscall.dat
@@ -53,7 +53,7 @@ chroot		+31	1
 vfork		+32	0
 access		+33	2	 
 nice		34	1
-sleep		35	1	- use alarm & signal instead
+sleep		35	1	- use alarm & signal, or select, instead
 sync		+36	0	 
 kill		+37	2	 
 rename		+38	2	 

--- a/elks/arch/i86/kernel/syscall.dat
+++ b/elks/arch/i86/kernel/syscall.dat
@@ -53,7 +53,7 @@ chroot		+31	1
 vfork		+32	0
 access		+33	2	 
 nice		34	1
-sleep		35	1
+sleep		35	1	- use alarm & signal instead
 sync		+36	0	 
 kill		+37	2	 
 rename		+38	2	 

--- a/libc/include/sys/select.h
+++ b/libc/include/sys/select.h
@@ -1,5 +1,7 @@
 #pragma once
 
-int select (int nfds, fd_set * restrict readfds,
-	fd_set * restrict writefds, fd_set * restrict errorfds,
-	struct timeval * restrict timeout);
+struct timeval;
+
+int select (int __nfds, fd_set * restrict __readfds,
+	fd_set * restrict __writefds, fd_set * restrict __errorfds,
+	struct timeval * restrict __timeout);

--- a/libc/include/unistd.h
+++ b/libc/include/unistd.h
@@ -3,6 +3,7 @@
 
 #include <features.h>
 #include <sys/types.h>
+#include <sys/select.h>
 
 typedef int intptr_t;
 typedef intptr_t ssize_t;

--- a/libc/system/out.mk
+++ b/libc/system/out.mk
@@ -1,6 +1,6 @@
 include $(TOPDIR)/libc/Makefile.inc
 
-CFLAGS	+= -DL_execlp
+CFLAGS	+= -DL_execlp -DL_sleep
 
 ifneq "$(VPATH)" ""
 	dir	= $(VPATH)/

--- a/libc/system/sleep.c
+++ b/libc/system/sleep.c
@@ -1,4 +1,5 @@
 #ifdef L_sleep
+#include <signal.h>
 #include <unistd.h>
 
 #ifdef __ELKS__

--- a/libc/system/sleep.c
+++ b/libc/system/sleep.c
@@ -1,8 +1,10 @@
 #ifdef L_sleep
 #include <signal.h>
 #include <unistd.h>
+#include <sys/time.h>
+#include <sys/types.h>
 
-#ifdef __ELKS__
+#if 0
 /* This uses SIGALRM, it does keep the previous alarm call but will lose
  * any alarms that go off during the sleep
  */


### PR DESCRIPTION
This commit addresses an issue mentioned by @ghaerr at https://github.com/jbruchon/elks/pull/455#issuecomment-597746144 .

This disables the `sleep(.)` syscall routine which invokes syscall number 35, which happens to be unimplemented --- and enables the alternate implementation of `sleep(.)` (in `libc/system/sleep.c`) using the `alarm(.)` and `signal(, )` syscalls.