### PR TITLE
[cmds] Reorganize ELKS command installation

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -1,0 +1,155 @@
+# ELKSCMD Application Installation Table
+#	3/13/20 Greg Haerr
+#
+# This file is used to specify when each application in elkscmd/ should
+# be installed to $(DESTDIR).
+#
+# The file format is the application build filename in the first field,
+# followed by a tab and optional '::' installation filename (default is /bin),
+# followed by tabs and any number of tags specifying which configuration
+# sets each application belongs to.
+# A tag is an alphanumeric name preceded by a colon.
+#
+# Multiple tags are combined with the | character in elkscmd/Makefile
+# to specify the set of files to be installed.
+# The applications are installed from their build directory to $(DESTDIR).
+#
+# Following are the current ELKS application packages and description:
+#	Tag			Description									Directory
+#	--------	-----------------------------------------	-----------
+#	:boot		Required for ELKS to boot
+#	:360k		Minimal set of apps for very small disks
+#	:ash		Ash (bash) shell							ash
+#	:sash		Sash (standalone very small) shell			sash
+#	:sysutil	System utilities							sys_utils
+#	:fileutil	File handling utilies						file_utils
+#	:shutil		Shell utilities								shell_utils
+#	:diskutil	Disk utilities								disk_utils
+#	:miscutil	Miscellaneous utilities						misc_utils
+#	:minix1,2,3	Minix utilities								minix{1,2,3}
+#	:mtools		MSDOS utilities								mtools
+#	:levee		Vi editor									levee
+#	:net		Networking apps								ktcp,inet
+#	:nanox		Nano-X graphical apps						nano-X
+#	:other		Other apps
+#	:busyelks	Busyelks									busyelks
+#	:be-*		File created as symlink if busyelks option 'B' set
+#	::path/file	path/file to install file as on $(DESTDIR)
+# 
+# -------------	----------------------------------------------------------
+sys_utils/init			:boot	:sysutil
+sys_utils/getty			:boot	:sysutil
+sys_utils/login			:boot	:sysutil
+ash/ash		::bin/sh	:boot	:ash	# install as /bin/sh
+#sash/sash	::bin/sh	:boot	:~ash	# install as /bin/sh if no ASH
+sash/sash				:boot	:sash
+sys_utils/mount			:boot	:sysutil
+sys_utils/umount		:boot	:sysutil
+sys_utils/clock			:boot	:sysutil
+sys_utils/shutdown		:boot	:sysutil
+sh_utils/test			:boot	:shutil
+sh_utils/echo			:boot	:be-shutil
+file_utils/cat					:be-fileutil	:360k
+file_utils/chgrp				:be-fileutil
+file_utils/chmod				:be-fileutil
+file_utils/chown				:be-fileutil
+file_utils/cmp					:be-fileutil
+file_utils/cp					:be-fileutil	:360k
+file_utils/dd					:be-fileutil
+file_utils/grep					:fileutil
+file_utils/mkdir				:fileutil		:360k
+file_utils/mknod				:fileutil
+file_utils/mkfifo				:fileutil
+file_utils/more					:fileutil
+file_utils/mv					:fileutil		:360k
+file_utils/ln					:fileutil
+file_utils/ls					:fileutil		:360k
+file_utils/rm					:fileutil		:360k
+file_utils/rmdir				:fileutil		:360k
+file_utils/sync					:fileutil		:360k
+file_utils/touch				:fileutil
+sys_utils/chmem					:sysutil
+sys_utils/kill					:sysutil		:360k
+sys_utils/ps					:sysutil		:360k
+sys_utils/reboot				:sysutil		:360k
+sys_utils/man					:sysutil
+sys_utils/meminfo				:sysutil
+sys_utils/mouse					:sysutil
+sys_utils/passwd				:sysutil
+sys_utils/poweroff				:sysutil
+sys_utils/who					:sysutil
+sys_utils/unreal16				:sysutil
+sh_utils/basename				:be-shutil
+sh_utils/date					:be-shutil		:360k
+sh_utils/dirname				:be-shutil
+sh_utils/false					:be-shutil
+sh_utils/true					:be-shutil
+sh_utils/logname				:shutil
+sh_utils/mesg					:shutil			:360k
+sh_utils/stty					:shutil			:360k
+sh_utils/printenv				:shutil
+sh_utils/pwd					:shutil			:360k
+sh_utils/tr						:shutil
+sh_utils/which					:shutil
+sh_utils/whoami					:shutil
+sh_utils/xargs					:shutil
+sh_utils/yes					:shutil
+misc_utils/miniterm				:miscutil
+misc_utils/tar					:miscutil
+misc_utils/ed					:be-miscutil
+levee/lev	::bin/vi			:levee			:360k
+minix1/banner					:minix1
+minix1/decomp16					:minix1
+minix1/fgrep					:minix1
+#minix1/grep					:minix1
+minix1/sum						:minix1
+minix1/uniq						:minix1
+minix1/wc						:minix1
+minix1/proto					:minix1
+minix1/cut						:be-minix1
+minix1/cksum					:be-minix1
+minix1/du						:be-minix1		:360k
+minix2/env						:minix2			:360k
+minix2/lp						:minix2
+minix2/pwdauth					:minix2
+minix2/remsync					:minix2
+minix2/synctree					:minix2
+minix2/tget						:minix2
+minix3/sed						:minix3
+minix3/file						:minix3
+minix3/head						:minix3
+minix3/sort						:minix3
+minix3/tail						:minix3
+minix3/tee						:minix3
+minix3/cal						:be-minix3
+minix3/diff						:be-minix3
+minix3/find						:be-minix3
+disk_utils/fsck					:diskutil
+disk_utils/mkfs					:diskutil
+disk_utils/partype				:diskutil
+disk_utils/ramdisk				:diskutil
+disk_utils/fdisk				:be-diskutil
+busyelks/busyelks				:busyelks
+inet/httpd/httpd				:net
+inet/httpd/sample_index.html	::var/www/index.html	:net
+ktcp/ktcp						:net
+ktcp/resolv.conf	::etc/resolv.conf	:net
+inet/nettools/netstat			:net
+inet/nettools/nslookup			:net
+inet/telnet/telnet				:net
+inet/telnetd/telnetd			:net
+inet/tinyirc/tinyirc			:net
+inet/urlget/urlget				:net
+mtools/mcopy					:mtools
+mtools/mdel						:mtools
+mtools/mdir						:mtools
+mtools/mkdfs					:mtools
+mtools/mmd						:mtools
+mtools/mrd						:mtools
+mtools/mread					:mtools
+mtools/mren						:mtools
+mtools/mtype					:mtools
+mtools/mwrite					:mtools
+bc/bc							:other
+prems/pres/pres					:other
+nano-X/bin/landmine				:nanox

--- a/elkscmd/Makefile
+++ b/elkscmd/Makefile
@@ -14,6 +14,8 @@ include $(BASEDIR)/Make.defs
 
 # All subdirectories to build & clean
 
+# TODO: broken command compilations
+# byacc elvis screen m4 xvi
 SUBDIRS =       \
 	ash         \
 	bc          \
@@ -36,87 +38,101 @@ SUBDIRS =       \
 	test        \
 	# EOL
 
-# TODO: fix broken command compilations
-# misc_utils/lpfilter.c
-#SUBDIRS += byacc elvis screen xvi
+# Application Package List
+PACKAGE=$(ELKSCMD_DIR)/Applications
+# Install destination
+DESTDIR=$(TOPDIR)/target
+TAGS=
+# Old-style installation
+INSTDIRS=
 
-# Directories to install
-
-INSTDIRS = \
-	inet \
-	# EOL
-
-ifeq ($(CONFIG_APP_ASH), y)
-INSTDIRS += ash
+ifdef CONFIG_APP_ASH
+	TAGS += :ash|
 endif
 
-ifeq ($(CONFIG_APP_BC), y)
-INSTDIRS += bc
-endif
-
-ifeq ($(CONFIG_APP_BUSYELKS), y)
-INSTDIRS += busyelks
+ifdef CONFIG_APP_BUSYELKS
+	TAGS += :busyelks|
 endif
 
 ifdef CONFIG_APP_DISK_UTILS
-INSTDIRS += disk_utils
+	TAGS += :diskutil|
+	ifeq ($(CONFIG_APP_DISK_UTILS), y)
+		TAGS += :be-diskutil|
+	endif
 endif
 
 ifdef CONFIG_APP_FILE_UTILS
-INSTDIRS += file_utils
+	TAGS += :fileutil|
+	ifeq ($(CONFIG_APP_FILE_UTILS), y)
+		TAGS += :be-fileutil|
+	endif
 endif
 
-ifeq ($(CONFIG_APP_LEVEE), y)
-INSTDIRS += levee
+ifdef CONFIG_APP_LEVEE
+	TAGS += :levee|
 endif
 
-ifeq ($(CONFIG_APP_KTCP), y)
-INSTDIRS += ktcp
+ifdef CONFIG_APP_KTCP
+	TAGS += :net|
 endif
 
 ifdef CONFIG_APP_MINIX1
-INSTDIRS += minix1
+	TAGS += :minix1|
+	ifeq ($(CONFIG_APP_MINIX1), y)
+		TAGS += :be-minix1|
+	endif
 endif
 
-ifeq ($(CONFIG_APP_MINIX2), y)
-INSTDIRS += minix2
+ifdef CONFIG_APP_MINIX2
+	TAGS += :minix2|
 endif
 
 ifdef CONFIG_APP_MINIX3
-INSTDIRS += minix3
+	TAGS += :minix3|
+	ifeq ($(CONFIG_APP_MINIX3), y)
+		TAGS += :be-minix3|
+	endif
 endif
 
-ifeq ($(CONFIG_APP_MTOOLS), y)
-INSTDIRS += mtools
+ifdef CONFIG_APP_MTOOLS
+	TAGS += :mtools|
 endif
 
 ifdef CONFIG_APP_MISC_UTILS
-INSTDIRS += misc_utils
+	TAGS += :miscutil|
+	ifeq ($(CONFIG_APP_MISC_UTILS), y)
+		TAGS += :be-miscutil|
+	endif
 endif
 
-ifeq ($(CONFIG_APP_NANOX), y)
-INSTDIRS += nano-X
+ifdef CONFIG_APP_NANOX
+	TAGS += :nanox|
 endif
 
-ifeq ($(CONFIG_APP_PREMS), y)
-INSTDIRS += prems
+ifdef CONFIG_APP_OTHER
+	TAGS += :other|
 endif
 
-ifeq ($(CONFIG_APP_SASH), y)
-INSTDIRS += sash
+ifdef CONFIG_APP_SASH
+	TAGS += :sash|
 endif
 
-ifeq ($(CONFIG_APP_SH_UTILS), y)
-INSTDIRS += sh_utils
+ifdef CONFIG_APP_SH_UTILS
+	TAGS += :shutil|
+	ifeq ($(CONFIG_APP_SH_UTILS), y)
+		TAGS += :be-shutil|
+	endif
 endif
 
-ifeq ($(CONFIG_APP_SYS_UTILS), y)
-INSTDIRS += sys_utils
+ifdef CONFIG_APP_SYS_UTILS
+	TAGS += :sysutil|
 endif
 
 ifdef CONFIG_APP_TEST
-INSTDIRS += test
+	INSTDIRS += test
 endif
+
+TAGS += :end
 
 ###############################################################################
 #
@@ -130,7 +146,33 @@ all:
 	for DIR in $(SUBDIRS); do $(MAKE) -C $$DIR all || exit 1; done
 
 install:
-	for i in $(INSTDIRS); do $(MAKE) -C $$i install || exit 1; done
+	@echo "TAGS=$(TAGS)" | tr -d ' '
+	awk /`echo "$(TAGS)" | tr -d ' '`/{print} $(PACKAGE) | sed "/^#/d" > Filelist
+	@while IFS= read -r line; \
+	do \
+		file=`echo $$line | cut -d" " -f 1`; \
+		dir=`echo $$line | cut -d" " -f 2`; \
+		if [ "$${dir:0:2}" == "::" ]; \
+		then \
+			instdir=$${dir:2}; \
+		else \
+			instdir=bin; \
+		fi; \
+		echo install $$file to $$instdir; \
+		if [ ! -e $$file ]; \
+		then \
+			echo "File specified in $(PACKAGE) not found: $$file"; \
+			exit 1; \
+		else \
+			[ ! -d $$file ] && mkdir -p $$(dirname $(DESTDIR)/$$instdir); \
+			[ -f $$file ] && $(INSTALL) $$file $(DESTDIR)/$$instdir; \
+		fi \
+	done < Filelist
+	rm Filelist
+ifdef CONFIG_APP_BUSYELKS
+	$(MAKE) -C busyelks links
+endif
+	for DIR in $(INSTDIRS); do $(MAKE) -C $$DIR clean || exit 1; done
 
 clean:
 	for DIR in $(SUBDIRS); do $(MAKE) -C $$DIR clean || exit 1; done

--- a/elkscmd/Makefile
+++ b/elkscmd/Makefile
@@ -145,6 +145,8 @@ all:
 	then echo -e "\n*** ERROR: You must configure ELKS first ***\n" >&2; exit 1; fi
 	for DIR in $(SUBDIRS); do $(MAKE) -C $$DIR all || exit 1; done
 
+# use bash instead of /bin/sh for curly brace expansion
+SHELL=/bin/bash
 install:
 	@echo "TAGS=$(TAGS)" | tr -d ' '
 	awk /`echo "$(TAGS)" | tr -d ' '`/{print} $(PACKAGE) | sed '/^#/d' > Filelist

--- a/elkscmd/Makefile
+++ b/elkscmd/Makefile
@@ -147,7 +147,7 @@ all:
 
 install:
 	@echo "TAGS=$(TAGS)" | tr -d ' '
-	awk /`echo "$(TAGS)" | tr -d ' '`/{print} $(PACKAGE) | sed "/^#/d" > Filelist
+	awk /`echo "$(TAGS)" | tr -d ' '`/{print} $(PACKAGE) | sed '/^#/d' > Filelist
 	@while IFS= read -r line; \
 	do \
 		file=`echo $$line | cut -d" " -f 1`; \

--- a/elkscmd/busyelks/config.mk
+++ b/elkscmd/busyelks/config.mk
@@ -31,9 +31,11 @@ ifeq "$(CONFIG_APP_MISC_UTILS)" "b"
 	CMD_ed		= yes
 endif
 
-#CMD_basename	= yes
-#CMD_date	= yes
-#CMD_dirname	= yes
-#CMD_echo	= yes
-#CMD_false	= yes
-#CMD_true	= yes
+ifeq "$(CONFIG_APP_SH_UTILS)" "b"
+	CMD_basename= yes
+	CMD_date	= yes
+	CMD_dirname	= yes
+	CMD_echo	= yes
+	CMD_false	= yes
+	CMD_true	= yes
+endif

--- a/elkscmd/busyelks/makefile
+++ b/elkscmd/busyelks/makefile
@@ -2,6 +2,9 @@ BASEDIR	= ..
 include $(BASEDIR)/Make.defs
 include $(BASEDIR)/Make.rules
 
+# Install destination
+DESTDIR=$(TOPDIR)/target
+
 NAME	= busyelks
 
 OUT	= $(NAME)
@@ -131,7 +134,26 @@ doc:	README.html
 README.html:	README
 	asciidoc README
 
-install: $(OUT) busyelks.tar.xz
+install: inst links
+
+inst: $(OUT)
+	$(INSTALL) $(OUT) $(DESTDIR)/bin
+
+# create symlinks for each command compiled into busyelks
+links:
+	@echo "$(CFLAGS)" | tr -s '[:blank:]' '[\n*]' \
+		| grep -- "-DCMD_" | sed 's/-DCMD_INFO.*//' | sed 's/-DCMD_//' \
+		| while read f; \
+			do \
+				if [ "$$f" != "" ]; \
+				then \
+					echo ln -s /bin/$(OUT) $(DESTDIR)/bin/$$f; \
+					ln -s /bin/$(OUT) $(DESTDIR)/bin/$$f; \
+				fi \
+			done
+
+# unused
+oldinstall: $(OUT) busyelks.tar.xz
 	$(INSTALL) $(OUT) $(DESTDIR)/bin
 	tar Jxf busyelks.tar.xz -C $(DESTDIR)
 

--- a/elkscmd/config.in
+++ b/elkscmd/config.in
@@ -9,13 +9,13 @@ mainmenu_option next_comment
 
 	bool 'ash'        CONFIG_APP_ASH        y
 	bool 'sash'       CONFIG_APP_SASH       y
-	bool 'shutils'    CONFIG_APP_SH_UTILS   y
 
-	comment 'Other commands'
+	comment 'Applications'
 
 	bool 'busyelks'			CONFIG_APP_BUSYELKS		n
 	busyelks 'diskutils'	CONFIG_APP_DISK_UTILS	y
 	busyelks 'fileutils'	CONFIG_APP_FILE_UTILS	y
+	busyelks 'shutils'	 	CONFIG_APP_SH_UTILS		y
 	bool 'sysutils'			CONFIG_APP_SYS_UTILS	y
 	bool 'vi'				CONFIG_APP_LEVEE		y
 	busyelks 'minix1'		CONFIG_APP_MINIX1		y
@@ -24,38 +24,36 @@ mainmenu_option next_comment
 	busyelks 'miscutils'	CONFIG_APP_MISC_UTILS	y
 	bool 'mtools'			CONFIG_APP_MTOOLS		y
 	bool 'nano-X'			CONFIG_APP_NANOX		y
-
-	bool 'bc'         CONFIG_APP_BC         y
-	bool 'm4'         CONFIG_APP_M4         y
-	bool 'prems'      CONFIG_APP_PREMS      y
+	bool 'other'         	CONFIG_APP_OTHER         y
 
 	#comment 'Commands not compiling'
 
 	bool 'byacc'      CONFIG_APP_BYACC      n
 	bool 'elvis'      CONFIG_APP_ELVIS      n
+	bool 'm4'         CONFIG_APP_M4         n
 	bool 'screen'     CONFIG_APP_SCREEN     n
 	bool 'test'       CONFIG_APP_TEST       n
 	bool 'xvi'        CONFIG_APP_XVI        n
 
-	comment "Internet stack"
+	comment "Internet stack and utilities"
 
 	if [ "$CONFIG_INET" == "y" ]; then
 		bool 'ktcp' CONFIG_APP_KTCP y
 
-		if [ "$CONFIG_APP_KTCP" == "y" ]; then
+		#if [ "$CONFIG_APP_KTCP" == "y" ]; then
 
-			comment "Internet applets"
+			#comment "Internet applets"
 
-			bool 'httpd'      CONFIG_APP_HTTPD      y
-			bool 'nettools'   CONFIG_APP_NET_TOOLS  y
-			bool 'telnet'     CONFIG_APP_TELNET     y
-			bool 'telnetd'    CONFIG_APP_TELNETD    y
-			bool 'tinyirc'    CONFIG_APP_TINYIRC    y
-			bool 'urlget'     CONFIG_APP_URLGET     y
+			#bool 'httpd'      CONFIG_APP_HTTPD      y
+			#bool 'nettools'   CONFIG_APP_NET_TOOLS  y
+			#bool 'telnet'     CONFIG_APP_TELNET     y
+			#bool 'telnetd'    CONFIG_APP_TELNETD    y
+			#bool 'tinyirc'    CONFIG_APP_TINYIRC    y
+			#bool 'urlget'     CONFIG_APP_URLGET     y
 
-		else
-			comment "(internet applets need ktcp)"
-		fi
+		#else
+			#comment "(internet applets need ktcp)"
+		#fi
 
 	else
 		comment '(ktcp needs TCP/IP sockets)'

--- a/elkscmd/disk_utils/Makefile
+++ b/elkscmd/disk_utils/Makefile
@@ -10,23 +10,17 @@ include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
-OUTS = ramdisk mkfs fsck partype
-OUTS_BE = fdisk
+PRGS = ramdisk mkfs fsck partype fdisk
 
-PROGS = $(OUTS)
-ifeq "$(CONFIG_APP_DISK_UTILS)" "y"
-	PROGS += $(OUTS_BE)
-endif
+SPRGS=mkfs
 
-SPROGS=mkfs
-
-all: $(PROGS)
+all: $(PRGS)
 
 install_sibo: all
-	$(INSTALL) $(SPROGS) $(DESTDIR)/bin
+	$(INSTALL) $(SPRGS) $(DESTDIR)/bin
 
 install: all
-	$(INSTALL) $(PROGS) $(DESTDIR)/bin
+	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 fsck: fsck.o
 	$(LD) $(LDFLAGS) -o fsck fsck.o $(LDLIBS)
@@ -44,4 +38,4 @@ ramdisk: ramdisk.o
 	$(LD) $(LDFLAGS) -o ramdisk ramdisk.o $(LDLIBS)
 
 clean:
-	rm -f *.o $(FORMATMOD) core $(OUTS) $(OUTS_BE)
+	rm -f *.o $(FORMATMOD) core $(PRGS)

--- a/elkscmd/file_utils/Makefile
+++ b/elkscmd/file_utils/Makefile
@@ -10,13 +10,8 @@ include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
-OUTS = grep ln ls mkdir mkfifo mknod more mv rm rmdir sync touch
-OUTS_BE += cat chgrp chmod chown cmp cp dd
-
-PRGS = $(OUTS)
-ifeq "$(CONFIG_APP_FILE_UTILS)" "y"
-	PRGS += $(OUTS_BE)
-endif
+PRGS = grep ln ls mkdir mkfifo mknod more mv rm rmdir sync touch \
+	cat chgrp chmod chown cmp cp dd
 
 all: $(PRGS)
 
@@ -84,4 +79,4 @@ install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 clean:
-	rm -f $(OUTS) $(OUTS_BE) *.o
+	rm -f $(PRGS) *.o

--- a/elkscmd/inet/Makefile
+++ b/elkscmd/inet/Makefile
@@ -21,39 +21,11 @@ SUBDIRS = \
     urlget \
     # EOL
 
-# Directories to install
-
-INSTDIRS =
-
-ifdef CONFIG_APP_HTTPD
-INSTDIRS += httpd
-endif
-
-ifdef CONFIG_APP_NET_TOOLS
-INSTDIRS += nettools
-endif
-
-ifdef CONFIG_APP_TELNET
-INSTDIRS += telnet
-endif
-
-ifdef CONFIG_APP_TELNETD
-INSTDIRS += telnetd
-endif
-
-ifdef CONFIG_APP_TINYIRC
-INSTDIRS += tinyirc
-endif
-
-ifdef CONFIG_APP_URLGET
-INSTDIRS += urlget
-endif
-
 all:
 	for i in $(SUBDIRS); do $(MAKE) -C $$i all || exit 1 ; done
 
 install:
-	for i in $(INSTDIRS); do $(MAKE) -C $$i install || exit 1; done
+	for i in $(SUBDIRS); do $(MAKE) -C $$i install || exit 1; done
 
 clean:
 	for i in $(SUBDIRS); do $(MAKE) -C $$i clean || exit 1; done

--- a/elkscmd/minix1/Makefile
+++ b/elkscmd/minix1/Makefile
@@ -12,15 +12,8 @@ include $(BASEDIR)/Make.rules
 
 LOCALFLAGS=-D_POSIX_SOURCE
 
-OUTS =	banner decomp16 fgrep grep proto sum uniq wc
-OUTS_BE = cksum cut du
-
-PRGS = $(OUTS)
-ifeq "$(CONFIG_APP_MINIX1)" "y"
-	PRGS += $(OUTS_BE)
-endif
-
-NETPRGS = decomp16 du grep wc
+# TODO: grep removed for now, duplicated in file_utils
+PRGS = banner decomp16 fgrep proto sum uniq wc cksum cut du
 
 all: $(PRGS)
 
@@ -61,4 +54,4 @@ install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 clean:
-	rm -f $(OUTS) $(OUTS_BE) *.o
+	rm -f $(PRGS) *.o

--- a/elkscmd/minix2/Makefile
+++ b/elkscmd/minix2/Makefile
@@ -12,6 +12,7 @@ include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
+# TODO: lpd mt	# Do not compile.
 PRGS=env lp pwdauth remsync synctree tget
 
 env: env.o
@@ -32,10 +33,6 @@ synctree: synctree.o
 tget: tget.o
 	$(LD) $(LDFLAGS) -o tget tget.o $(LDLIBS)
 
-# install   # Same name as phony target install
-# lpd mt	# Do not compile.
-
-NETPRGS=env
 
 all: $(PRGS)
 

--- a/elkscmd/minix3/Makefile
+++ b/elkscmd/minix3/Makefile
@@ -12,14 +12,7 @@ include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
-OUTS = file head sed sort tail tee
-OUTS_BE = cal diff find
-
-PRGS = $(OUTS)
-ifeq "$(CONFIG_APP_MINIX1)" "y"
-	PRGS += $(OUTS_BE)
-endif
-
+PRGS = file head sed sort tail tee cal diff find
 
 #
 # Rules
@@ -65,4 +58,4 @@ install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 clean:
-	rm -f core *.o $(OUTS) $(OUTS_BE)
+	rm -f core *.o $(PRGS)

--- a/elkscmd/misc_utils/Makefile
+++ b/elkscmd/misc_utils/Makefile
@@ -13,16 +13,8 @@ HOST_CFLAGS = -O2
 
 ###############################################################################
 
-OUTS = tar miniterm
-OUTS_BE = ed
-
 #TODO: fix compress uncompress zcat lpfilter disabled
-
-PRGS = $(OUTS)
-ifeq "$(CONFIG_APP_MISC_UTILS)" "y"
-	PRGS += $(OUTS_BE)
-endif
-
+PRGS = tar miniterm ed
 PRGS_HOST=compress.host
 
 all: $(PRGS) $(PRGS_HOST)
@@ -52,4 +44,4 @@ install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 clean:
-	rm -f $(OUTS) $(OUTS_BE) $(PRGS_HOST) *~ *.o
+	rm -f $(PRGS) $(PRGS_HOST) *~ *.o

--- a/elkscmd/sh_utils/Makefile
+++ b/elkscmd/sh_utils/Makefile
@@ -10,10 +10,9 @@ include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
+# TODO: uname write	# Do not compile
 PRGS=basename date dirname echo false printenv pwd true which whoami yes \
 	logname tr xargs mesg stty test
-
-# uname write	# Do not compile
 
 write: write.o ../sys_utils/utent.o
 

--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -10,6 +10,9 @@ include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
+# clock enabled and has direct I/O port access
+# knl removed as useless
+# exitemu disabled because it calls INT directly to DOSEMU
 PRGS = \
 	init \
 	getty \
@@ -30,10 +33,6 @@ PRGS = \
 	unreal16 \
 	mouse \
 	# EOL
-
-# clock enabled and has direct I/O port access
-# knl removed as useless
-# exitemu disabled because it calls INT directly to DOSEMU
 
 init: init.o
 	$(LD) $(LDFLAGS) -o init init.o $(LDLIBS)

--- a/image/Make.package
+++ b/image/Make.package
@@ -120,7 +120,7 @@ fat:
 	#mdir -i $(MSDOS_IMAGE) -/ -a ::
 	for f in `cat Filelist`; \
 	do \
-		if [ ! -e $(DESTDIR)$$f ]; \
+		if [ ! -e $(DESTDIR)$$f -a ! -L $(DESTDIR)$$f ]; \
 		then \
 			echo "File specified in $(PACKAGE) not found: $(DESTDIR)$$f"; \
 			exit 1; \


### PR DESCRIPTION
First big step forward on reorganizing ELKS command building and installation Makefiles.

All (working) source directories in elkscmd/ are always compiled during 'make'. CONFIG_APP_XXX installation information is no longer present in any build Makefiles. Instead, (almost) all application installation is handled in 'elkscmd/Makefile', where config-specified options are used to install all commands into $(DESTDIR) using the new table-driven specification file 'elkscmd/Applications'. Symlink creation is currently handled in 'busyelks/Makefile', but could be moved out later.

This PR also fixes all busyelks issues and properly creates portable symlinks in /bin to /bin/busyelks for any command sets specified with the busyelks config 'B' options. It is now quite simple to add or subtract commands from busyelks or other directories, without having to modify any Makefiles. Only the 'Applications' specification file is edited, everything else is automatic.

Everything works well, but this is tested only on OSX. There is more to do with possibly allowing more specificity to include/exclude individual programs within command sets using config, as well as automatic selection of smaller command sets when smaller (360k) disk images are created.

This is the first step in allowing the 'package manager' to be moved out of image building, but those changes will come in a subsequent PR, after more discussion about the next steps.