### PR TITLE
[kernel] [boot] further tidy up header files

### DIFF
--- a/elks/include/arch/asm.h
+++ b/elks/include/arch/asm.h
@@ -1,5 +1,5 @@
-#ifndef LX86_ARCH_ASM_H
-#define LX86_ARCH_ASM_H
+#ifndef __ARCH_8086_ASM_H
+#define __ARCH_8086_ASM_H
 
 #ifdef S_SPLINT_S
 

--- a/elks/include/arch/bitops.h
+++ b/elks/include/arch/bitops.h
@@ -1,5 +1,5 @@
-#ifndef LX86_ARCH_BITOPS_H
-#define LX86_ARCH_BITOPS_H
+#ifndef __ARCH_8086_BITOPS_H
+#define __ARCH_8086_BITOPS_H
 
 extern unsigned char clear_bit(unsigned int,void *);
 extern unsigned char set_bit(unsigned int,void *);

--- a/elks/include/arch/border.h
+++ b/elks/include/arch/border.h
@@ -1,5 +1,5 @@
-#ifndef LX86_ARCH_BORDER_H
-#define LX86_ARCH_BORDER_H
+#ifndef __ARCH_8086_BORDER_H
+#define __ARCH_8086_BORDER_H
 
 extern unsigned long int htonl(unsigned long int);
 extern unsigned long int ntohl(unsigned long int);

--- a/elks/include/arch/debug_disp.h
+++ b/elks/include/arch/debug_disp.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef LX86_ARCH_DEBUG_DISP_H
-#define LX86_ARCH_DEBUG_DISP_H
+#ifndef __ARCH_8086_DEBUG_DISP_H
+#define __ARCH_8086_DEBUG_DISP_H
 
 #define DEBUG_DISP_PORT   0x0280
 

--- a/elks/include/arch/dma.h
+++ b/elks/include/arch/dma.h
@@ -5,8 +5,8 @@
  * and John Boyd, Nov. 1992.
  */
 
-#ifndef LX86_ARCH_DMA_H
-#define LX86_ARCH_DMA_H
+#ifndef __ARCH_8086_DMA_H
+#define __ARCH_8086_DMA_H
 
 #include <arch/io.h>		/* need byte IO */
 

--- a/elks/include/arch/errno.h
+++ b/elks/include/arch/errno.h
@@ -1,5 +1,5 @@
-#ifndef LX86_ARCH_ERRNO_H
-#define LX86_ARCH_ERRNO_H
+#ifndef __ARCH_8086_ERRNO_H
+#define __ARCH_8086_ERRNO_H
 
 /*@-namechecks@*/
 

--- a/elks/include/arch/io.h
+++ b/elks/include/arch/io.h
@@ -1,5 +1,5 @@
-#ifndef LX86_ARCH_IO_H
-#define LX86_ARCH_IO_H
+#ifndef __ARCH_8086_IO_H
+#define __ARCH_8086_IO_H
 
 extern void bell(void);
 
@@ -51,4 +51,4 @@ _v; \
 
 #endif /* __ia16__ */
 
-#endif /* !LX86_ARCH_IO_H*/
+#endif /* !__ARCH_8086_IO_H*/

--- a/elks/include/arch/ioctl.h
+++ b/elks/include/arch/ioctl.h
@@ -1,5 +1,5 @@
-#ifndef ARCH_IOCTL_H
-#define ARCH_IOCTL_H
+#ifndef __ARCH_8086_IOCTL_H
+#define __ARCH_8086_IOCTL_H
 
 
 // Use MAJOR as high-level byte for numbering

--- a/elks/include/arch/irq.h
+++ b/elks/include/arch/irq.h
@@ -1,5 +1,5 @@
-#ifndef LX86_ARCH_IRQ_H
-#define LX86_ARCH_IRQ_H
+#ifndef __ARCH_8086_IRQ_H
+#define __ARCH_8086_IRQ_H
 
 #include <linuxmt/types.h>
 

--- a/elks/include/arch/keyboard.h
+++ b/elks/include/arch/keyboard.h
@@ -1,5 +1,5 @@
-#ifndef LX86_ARCH_KEYBOARD_H
-#define LX86_ARCH_KEYBOARD_H
+#ifndef __ARCH_8086_KEYBOARD_H
+#define __ARCH_8086_KEYBOARD_H
 
 struct pt_regs;
 extern void keyboard_irq(int,struct pt_regs *,void *);

--- a/elks/include/arch/limits.h
+++ b/elks/include/arch/limits.h
@@ -1,10 +1,9 @@
-
-#ifndef ARCH_LIMITS_H
-#define ARCH_LIMITS_H
+#ifndef __ARCH_8086_LIMITS_H
+#define __ARCH_8086_LIMITS_H
 
 /* Maximum packet size for NE2K interface */
 /* 6 blocks of 256 bytes = 1536 */
 
 #define MAX_PACKET_ETH 1536
 
-#endif /* !ARCH_LIMITS_H */
+#endif /* !__ARCH_8086_LIMITS_H */

--- a/elks/include/arch/param.h
+++ b/elks/include/arch/param.h
@@ -1,5 +1,5 @@
-#ifndef LX86_ARCH_PARAM_H
-#define LX86_ARCH_PARAM_H
+#ifndef __ARCH_8086_PARAM_H
+#define __ARCH_8086_PARAM_H
 
 #include <linuxmt/config.h>
 

--- a/elks/include/arch/posix_types.h
+++ b/elks/include/arch/posix_types.h
@@ -1,8 +1,10 @@
-#ifndef LX86_ARCH_POSIX_TYPES_H
-#define LX86_ARCH_POSIX_TYPES_H
+#ifndef __ARCH_8086_POSIX_TYPES_H
+#define __ARCH_8086_POSIX_TYPES_H
 
+#ifdef __KERNEL__
 #include <arch/irq.h>
 #include <arch/bitops.h>
+#endif
 
 /*
  * This file is generally used by user-level software, so you need to

--- a/elks/include/arch/segment.h
+++ b/elks/include/arch/segment.h
@@ -1,5 +1,5 @@
-#ifndef LX86_ARCH_SEGMENT_H
-#define LX86_ARCH_SEGMENT_H
+#ifndef __ARCH_8086_SEGMENT_H
+#define __ARCH_8086_SEGMENT_H
 
 #include <linuxmt/types.h>
 
@@ -16,4 +16,4 @@ extern pid_t get_pid(void);
 
 extern short *_endtext, *_enddata, *_endbss;
 
-#endif /* !LX86_ARCH_SEGMENT_H */
+#endif /* !__ARCH_8086_SEGMENT_H */

--- a/elks/include/arch/stat.h
+++ b/elks/include/arch/stat.h
@@ -1,5 +1,5 @@
-#ifndef LX86_ARCH_STAT_H
-#define LX86_ARCH_STAT_H
+#ifndef __ARCH_8086_STAT_H
+#define __ARCH_8086_STAT_H
 
 #include <linuxmt/types.h>
 

--- a/elks/include/arch/statfs.h
+++ b/elks/include/arch/statfs.h
@@ -1,5 +1,5 @@
-#ifndef LX86_ARCH_STATFS_H
-#define LX86_ARCH_STATFS_H
+#ifndef __ARCH_8086_STATFS_H
+#define __ARCH_8086_STATFS_H
 
 typedef struct {
     long	val[2];

--- a/elks/include/arch/string.h
+++ b/elks/include/arch/string.h
@@ -1,5 +1,5 @@
-#ifndef LX86_ARCH_STRING_H
-#define LX86_ARCH_STRING_H
+#ifndef __ARCH_8086_STRING_H
+#define __ARCH_8086_STRING_H
 
 /*
  * String functions for the 8086 architecture.

--- a/elks/include/arch/system.h
+++ b/elks/include/arch/system.h
@@ -1,5 +1,5 @@
-#ifndef LX86_ARCH_SYSTEM_H
-#define LX86_ARCH_SYSTEM_H
+#ifndef __ARCH_8086_SYSTEM_H
+#define __ARCH_8086_SYSTEM_H
 
 #include <linuxmt/types.h>
 

--- a/elks/include/arch/types.h
+++ b/elks/include/arch/types.h
@@ -1,7 +1,7 @@
 /* arch/i86/include/asm/types.h - Basic Linux/MT data types. */
 
-#ifndef LX86_ARCH_TYPES_H
-#define LX86_ARCH_TYPES_H
+#ifndef __ARCH_8086_TYPES_H
+#define __ARCH_8086_TYPES_H
 
 /*@-namechecks@*/
 
@@ -60,4 +60,4 @@ typedef __u16			__pptr;
 #define NULL		((void *) 0)
 #endif
 
-#endif /* !LX86_ARCH_TYPES_H */
+#endif /* !__ARCH_8086_TYPES_H */

--- a/elks/include/linuxmt/atomic.h
+++ b/elks/include/linuxmt/atomic.h
@@ -1,7 +1,8 @@
 // Atomic primitives
 // Architecture dependent
 
-#pragma once
+#ifndef __LINUXMT_ATOMIC_H
+#define __LINUXMT_ATOMIC_H
 
 #include <linuxmt/types.h>
 
@@ -29,3 +30,5 @@ volatile lock_t try_lock (lock_t * lock);
 // Unconditional unlock
 
 void unlock (lock_t * lock);
+
+#endif

--- a/elks/include/linuxmt/bioshd.h
+++ b/elks/include/linuxmt/bioshd.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_BIOSHD_H
-#define LX86_LINUXMT_BIOSHD_H
+#ifndef __LINUXMT_BIOSHD_H
+#define __LINUXMT_BIOSHD_H
 
 /* bioshd.h
  * Copyright (C) 1994 Yggdrasil Computing, Incorporated

--- a/elks/include/linuxmt/biosparm.h
+++ b/elks/include/linuxmt/biosparm.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_BIOSPARM_H
-#define LX86_LINUXMT_BIOSPARM_H
+#ifndef __LINUXMT_BIOSPARM_H
+#define __LINUXMT_BIOSPARM_H
 
 /* biosparm.h
  * Copyright (C) 1994 Yggdrasil Computing, Incorporated

--- a/elks/include/linuxmt/chqueue.h
+++ b/elks/include/linuxmt/chqueue.h
@@ -1,7 +1,7 @@
 /* chqueue.h (C) 1997 Chad Page */
 
-#ifndef LX86_LINUXMT_CHQ_H
-#define LX86_LINUXMT_CHQ_H
+#ifndef __LINUXMT_CHQ_H
+#define __LINUXMT_CHQ_H
 
 struct ch_queue {
     char		*base;

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_CONFIG_H
-#define LX86_LINUXMT_CONFIG_H
+#ifndef __LINUXMT_CONFIG_H
+#define __LINUXMT_CONFIG_H
 
 #include <autoconf.h>
 

--- a/elks/include/linuxmt/debug.h
+++ b/elks/include/linuxmt/debug.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_DEBUG_H
-#define LX86_LINUXMT_DEBUG_H
+#ifndef __LINUXMT_DEBUG_H
+#define __LINUXMT_DEBUG_H
 
 /* linuxmt/include/linuxmt/debug.h for ELKS v. >=0.0.47
  * (C) 1997 Chad Page

--- a/elks/include/linuxmt/directhd.h
+++ b/elks/include/linuxmt/directhd.h
@@ -1,8 +1,8 @@
 /* directhd.h header for ELKS kernel - Copyright (C) 1998 Blaz Antonic
  */
 
-#ifndef LX86_LINUXMT_DIRECTHD_H
-#define LX86_LINUXMT_DIRECTHD_H
+#ifndef __LINUXMT_DIRECTHD_H
+#define __LINUXMT_DIRECTHD_H
 
 /* define offsets from base port address */
 #define DIRECTHD_ERROR 1

--- a/elks/include/linuxmt/dirent.h
+++ b/elks/include/linuxmt/dirent.h
@@ -1,5 +1,5 @@
-#ifndef LX86_ARCH_DIR_H
-#define LX86_ARCH_DIR_H
+#ifndef __LINUXMT_DIRENT_H
+#define __LINUXMT_DIRENT_H
 
 #include <linuxmt/types.h>
 

--- a/elks/include/linuxmt/errno.h
+++ b/elks/include/linuxmt/errno.h
@@ -3,8 +3,8 @@
  * combined into a single file.
  */
 
-#ifndef LX86_LINUXMT_ERRNO_H
-#define LX86_LINUXMT_ERRNO_H
+#ifndef __LINUXMT_ERRNO_H
+#define __LINUXMT_ERRNO_H
 
 /*@-namechecks@*/
 

--- a/elks/include/linuxmt/fcntl.h
+++ b/elks/include/linuxmt/fcntl.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_FCNTL_H
-#define LX86_LINUXMT_FCNTL_H
+#ifndef __LINUXMT_FCNTL_H
+#define __LINUXMT_FCNTL_H
 
 /*
  *	Definitions taken from the i386 Linux kernel.

--- a/elks/include/linuxmt/fd.h
+++ b/elks/include/linuxmt/fd.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_FD_H
-#define LX86_LINUXMT_FD_H
+#ifndef __LINUXMT_FD_H
+#define __LINUXMT_FD_H
 
 #define FDCLRPRM 0		/* clear user-defined parameters */
 #define FDSETPRM 1		/* set user-defined parameters for current media */

--- a/elks/include/linuxmt/fdreg.h
+++ b/elks/include/linuxmt/fdreg.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_FDREG_H
-#define LX86_LINUXMT_FDREG_H
+#ifndef __LINUXMT_FDREG_H
+#define __LINUXMT_FDREG_H
 
 /* This file contains some defines for the floppy disk controller. Various
  * sources. Mostly "IBM Microcomputers: A Programmers Handbook" by Sanches

--- a/elks/include/linuxmt/genhd.h
+++ b/elks/include/linuxmt/genhd.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_GENHD_H
-#define LX86_LINUXMT_GENHD_H
+#ifndef __LINUXMT_GENHD_H
+#define __LINUXMT_GENHD_H
 
 #include <linuxmt/types.h>
 

--- a/elks/include/linuxmt/hdreg.h
+++ b/elks/include/linuxmt/hdreg.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_HDREG_H
-#define LX86_LINUXMT_HDREG_H
+#ifndef __LINUXMT_HDREG_H
+#define __LINUXMT_HDREG_H
 
 /* This file contains some defines for the AT-hd-controller. Various sources.
  */

--- a/elks/include/linuxmt/in.h
+++ b/elks/include/linuxmt/in.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_IN_H
-#define LX86_LINUXMT_IN_H
+#ifndef __LINUXMT_IN_H
+#define __LINUXMT_IN_H
 
 struct in_addr {
     unsigned long s_addr;

--- a/elks/include/linuxmt/init.h
+++ b/elks/include/linuxmt/init.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_INIT_H
-#define LX86_LINUXMT_INIT_H
+#ifndef __LINUXMT_INIT_H
+#define __LINUXMT_INIT_H
 
 /* Assorted initializers */
 

--- a/elks/include/linuxmt/ioctl.h
+++ b/elks/include/linuxmt/ioctl.h
@@ -1,5 +1,5 @@
-#ifndef LINUXMT_IOCTL_H
-#define LINUXMT_IOCTL_H
+#ifndef __LINUXMT_IOCTL_H
+#define __LINUXMT_IOCTL_H
 
 #include <arch/ioctl.h>
 

--- a/elks/include/linuxmt/kdev_t.h
+++ b/elks/include/linuxmt/kdev_t.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_KDEV_T_H
-#define LX86_LINUXMT_KDEV_T_H
+#ifndef __LINUXMT_KDEV_T_H
+#define __LINUXMT_KDEV_T_H
 
 #define MINORBITS	8
 #define MINORMASK	((1<<MINORBITS) - 1)

--- a/elks/include/linuxmt/kernel.h
+++ b/elks/include/linuxmt/kernel.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_KERNEL_H
-#define LX86_LINUXMT_KERNEL_H
+#ifndef __LINUXMT_KERNEL_H
+#define __LINUXMT_KERNEL_H
 
 #include <linuxmt/types.h>
 #include <stddef.h>

--- a/elks/include/linuxmt/limits.h
+++ b/elks/include/linuxmt/limits.h
@@ -1,10 +1,9 @@
-
-#ifndef LINUXMT_LIMITS_H
-#define LINUXMT_LIMITS_H
+#ifndef __LINUXMT_LIMITS_H
+#define __LINUXMT_LIMITS_H
 
 #include <arch/limits.h>
 
 /* Maximum number of polled queues per process */
 #define POLL_MAX 4
 
-#endif /* !LINUXMT_LIMITS_H */
+#endif /* !__LINUXMT_LIMITS_H */

--- a/elks/include/linuxmt/lock.h
+++ b/elks/include/linuxmt/lock.h
@@ -1,6 +1,7 @@
 // Locking primitives
 
-#pragma once
+#ifndef __LINUXMT_LOCK_H
+#define __LINUXMT_LOCK_H
 
 #include <linuxmt/atomic.h>
 
@@ -13,3 +14,5 @@ void wait_lock (lock_t * lock);
 
 void event_unlock (lock_t * lock);
 #define unlock_event event_unlock
+
+#endif

--- a/elks/include/linuxmt/lp.h
+++ b/elks/include/linuxmt/lp.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_LP_H
-#define LX86_LINUXMT_LP_H
+#ifndef __LINUXMT_LP_H
+#define __LINUXMT_LP_H
 
 /* lp.h header for ELKS kernel
  * Copyright (C) 1997 Blaz Antonic

--- a/elks/include/linuxmt/major.h
+++ b/elks/include/linuxmt/major.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_MAJOR_H
-#define LX86_LINUXMT_MAJOR_H
+#ifndef __LINUXMT_MAJOR_H
+#define __LINUXMT_MAJOR_H
 
 /*
  * This file has definitions for major device numbers
@@ -54,4 +54,4 @@
 #define ROMFLASH_MAJOR    6
 
 
-#endif  /* !LX86_LINUXMT_MAJOR_H */
+#endif  /* !__LINUXMT_MAJOR_H */

--- a/elks/include/linuxmt/mem.h
+++ b/elks/include/linuxmt/mem.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_MEM_H
-#define LX86_LINUXMT_MEM_H
+#ifndef __LINUXMT_MEM_H
+#define __LINUXMT_MEM_H
 
 #define DATASIZE 2048
 #define TEXTSIZE 2048

--- a/elks/include/linuxmt/minix.h
+++ b/elks/include/linuxmt/minix.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_MINIX_H
-#define LX86_LINUXMT_MINIX_H
+#ifndef __LINUXMT_MINIX_H
+#define __LINUXMT_MINIX_H
 
 /*
  *	Minix binary formats

--- a/elks/include/linuxmt/minix_fs.h
+++ b/elks/include/linuxmt/minix_fs.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_MINIX_FS_H
-#define LX86_LINUXMT_MINIX_FS_H
+#ifndef __LINUXMT_MINIX_FS_H
+#define __LINUXMT_MINIX_FS_H
 
 /* The minix filesystem constants/structures
  *

--- a/elks/include/linuxmt/minix_fs_sb.h
+++ b/elks/include/linuxmt/minix_fs_sb.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUX_MINIX_FS_SB
-#define LX86_LINUX_MINIX_FS_SB
+#ifndef __LINUXMT_MINIX_FS_SB_H
+#define __LINUXMT_MINIX_FS_SB_H
 
 /*
  * minix super-block data in memory

--- a/elks/include/linuxmt/mm.h
+++ b/elks/include/linuxmt/mm.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_MM_H
-#define LX86_LINUXMT_MM_H
+#ifndef __LINUXMT_MM_H
+#define __LINUXMT_MM_H
 
 #include <linuxmt/sched.h>
 #include <linuxmt/errno.h>

--- a/elks/include/linuxmt/msdos.h
+++ b/elks/include/linuxmt/msdos.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_MSDOS_H
-#define LX86_LINUXMT_MSDOS_H
+#ifndef __LINUXMT_MSDOS_H
+#define __LINUXMT_MSDOS_H
 
 /*
  *	MSDOS binary formats

--- a/elks/include/linuxmt/na.h
+++ b/elks/include/linuxmt/na.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_NA_H
-#define LX86_LINUXMT_NA_H
+#ifndef __LINUXMT_NA_H
+#define __LINUXMT_NA_H
 
 struct sockaddr_na {
     unsigned short sun_family;	/* AF_NANO */

--- a/elks/include/linuxmt/net.h
+++ b/elks/include/linuxmt/net.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_NET_H
-#define LX86_LINUXMT_NET_H
+#ifndef __LINUXMT_NET_H
+#define __LINUXMT_NET_H
 
 #include <linuxmt/types.h>
 #include <linuxmt/config.h>

--- a/elks/include/linuxmt/ntty.h
+++ b/elks/include/linuxmt/ntty.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_NTTY_H
-#define LX86_LINUXMT_NTTY_H
+#ifndef __LINUXMT_NTTY_H
+#define __LINUXMT_NTTY_H
 
 /*
  * 'ntty.h' defines some structures used by ntty.c and some defines.

--- a/elks/include/linuxmt/pipe_fs_i.h
+++ b/elks/include/linuxmt/pipe_fs_i.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_PIPE_FS_I_H
-#define LX86_LINUXMT_PIPE_FS_I_H
+#ifndef __LINUXMT_PIPE_FS_I_H
+#define __LINUXMT_PIPE_FS_I_H
 
 #include <linuxmt/chqueue.h>
 

--- a/elks/include/linuxmt/posix_types.h
+++ b/elks/include/linuxmt/posix_types.h
@@ -1,17 +1,12 @@
-#ifndef LX86_LINUXMT_POSIX_TYPES_H
-#define LX86_LINUXMT_POSIX_TYPES_H
+#ifndef __LINUXMT_POSIX_TYPES_H
+#define __LINUXMT_POSIX_TYPES_H
 
-#include <linuxmt/config.h>
 #include <linuxmt/types.h>
 
 /* This file is generally used by user-level software, so you need to
  * be a little careful about namespace pollution etc.  Also, we cannot
  * assume GCC is being used.
  */
-
-#ifndef NULL
-#define NULL		((void *) 0)
-#endif
 
 /* This allows for 20 file descriptors: if NR_OPEN is ever grown beyond
  * that you'll have to change this too. For now 20 fd's seem to be

--- a/elks/include/linuxmt/rd.h
+++ b/elks/include/linuxmt/rd.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_RD_H
-#define LX86_LINUXMT_RD_H
+#ifndef __LINUXMT_RD_H
+#define __LINUXMT_RD_H
 
 #define RDCREATE	0
 #define RDDESTROY	1

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_SCHED_H
-#define LX86_LINUXMT_SCHED_H
+#ifndef __LINUXMT_SCHED_H
+#define __LINUXMT_SCHED_H
 
 #define MAX_TASKS 15
 #define NGROUPS	13		/* Supplementary groups */

--- a/elks/include/linuxmt/serial_reg.h
+++ b/elks/include/linuxmt/serial_reg.h
@@ -11,8 +11,8 @@
  * a 8250, 16450, or 16550(A).
  */
 
-#ifndef LX86_LINUXMT_SERIAL_REG_H
-#define LX86_LINUXMT_SERIAL_REG_H
+#ifndef __LINUXMT_SERIAL_REG_H
+#define __LINUXMT_SERIAL_REG_H
 
 #define UART_RX		0	/* In:  Receive buffer (DLAB=0) */
 #define UART_TX		0	/* Out: Transmit buffer (DLAB=0) */

--- a/elks/include/linuxmt/signal.h
+++ b/elks/include/linuxmt/signal.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_SIGNAL_H
-#define LX86_LINUXMT_SIGNAL_H
+#ifndef __LINUXMT_SIGNAL_H
+#define __LINUXMT_SIGNAL_H
 
 /* The following signals mean nothing under ELKS currently:
  *

--- a/elks/include/linuxmt/socket.h
+++ b/elks/include/linuxmt/socket.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_SOCKET_H
-#define LX86_LINUXMT_SOCKET_H
+#ifndef __LINUXMT_SOCKET_H
+#define __LINUXMT_SOCKET_H
 
 #include <stddef.h>
 #include <linuxmt/types.h>

--- a/elks/include/linuxmt/stat.h
+++ b/elks/include/linuxmt/stat.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_STAT_H
-#define LX86_LINUXMT_STAT_H
+#ifndef __LINUXMT_STAT_H
+#define __LINUXMT_STAT_H
 
 #include "types.h"
 #include <arch/stat.h>

--- a/elks/include/linuxmt/strace.h
+++ b/elks/include/linuxmt/strace.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_STRACE_H
-#define LX86_LINUXMT_STRACE_H
+#ifndef __LINUXMT_STRACE_H
+#define __LINUXMT_STRACE_H
 
 /* include/linuxmt/strace.h (C) 1997 Chad Page
  *

--- a/elks/include/linuxmt/string.h
+++ b/elks/include/linuxmt/string.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_STRING_H
-#define LX86_LINUXMT_STRING_H
+#ifndef __LINUXMT_STRING_H
+#define __LINUXMT_STRING_H
 
 #include <linuxmt/types.h>
 #include <stddef.h>

--- a/elks/include/linuxmt/tcpdev.h
+++ b/elks/include/linuxmt/tcpdev.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_TCPDEV_H
-#define LX86_LINUXMT_TCPDEV_H
+#ifndef __LINUXMT_TCPDEV_H
+#define __LINUXMT_TCPDEV_H
 
 /* tcpdev.h header for ELKS kernel
  * Copyright (C) 2001 Harry Kalogirou

--- a/elks/include/linuxmt/termios.h
+++ b/elks/include/linuxmt/termios.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_TERMIOS_H
-#define LX86_LINUXMT_TERMIOS_H
+#ifndef __LINUXMT_TERMIOS_H
+#define __LINUXMT_TERMIOS_H
 
 #include <linuxmt/types.h>
 

--- a/elks/include/linuxmt/time.h
+++ b/elks/include/linuxmt/time.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_TIME_H
-#define LX86_LINUXMT_TIME_H
+#ifndef __LINUXMT_TIME_H
+#define __LINUXMT_TIME_H
 
 #define DST_NONE        0	/* not on dst */
 #define DST_USA         1	/* USA style dst */

--- a/elks/include/linuxmt/timer.h
+++ b/elks/include/linuxmt/timer.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_TIMER_H
-#define LX86_LINUXMT_TIMER_H
+#ifndef __LINUXMT_TIMER_H
+#define __LINUXMT_TIMER_H
 
 #include <linuxmt/types.h>
 

--- a/elks/include/linuxmt/timex.h
+++ b/elks/include/linuxmt/timex.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_TIMEX_H
-#define LX86_LINUXMT_TIMEX_H
+#ifndef __LINUXMT_TIMEX_H
+#define __LINUXMT_TIMEX_H
 
 #include <linuxmt/config.h>
 

--- a/elks/include/linuxmt/types.h
+++ b/elks/include/linuxmt/types.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_TYPES_H
-#define LX86_LINUXMT_TYPES_H
+#ifndef __LINUXMT_TYPES_H
+#define __LINUXMT_TYPES_H
 
 #include <arch/types.h>
 #include <linuxmt/config.h>
@@ -54,16 +54,9 @@ typedef __u32			time_t;
 
 typedef __u32			fd_mask_t;
 
-#include <linuxmt/config.h>
 #include <linuxmt/posix_types.h>
 
 typedef __kernel_fd_set 	fd_set;
-
-#define PRINT_STATS(a) {					\
-	int __counter;						\
-	printk("Entering %s : (%x, %x)\n",			\
-		a, current->t_regs.sp, current->t_kstack);	\
-}
 
 struct ustat {
     daddr_t			f_tfree;

--- a/elks/include/linuxmt/udd.h
+++ b/elks/include/linuxmt/udd.h
@@ -9,8 +9,8 @@
  * Header file for the ELKS meta driver for user space device drivers
  */
 
-#ifndef LX86_LINUXMT_UDD_H
-#define LX86_LINUXMT_UDD_H
+#ifndef __LINUXMT_UDD_H
+#define __LINUXMT_UDD_H
 
 #include <linuxmt/fs.h>
 

--- a/elks/include/linuxmt/uio.h
+++ b/elks/include/linuxmt/uio.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_UIO_H
-#define LX86_LINUXMT_UIO_H
+#ifndef __LINUXMT_UIO_H
+#define __LINUXMT_UIO_H
 
 struct iovec {
     void *iov_base;	/* BSD uses caddr_t (same thing in effect) */

--- a/elks/include/linuxmt/un.h
+++ b/elks/include/linuxmt/un.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_UN_H
-#define LX86_LINUXMT_UN_H
+#ifndef __LINUXMT_UN_H
+#define __LINUXMT_UN_H
 
 #define UNIX_PATH_MAX	108
 

--- a/elks/include/linuxmt/utime.h
+++ b/elks/include/linuxmt/utime.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_UTIME_H
-#define LX86_LINUXMT_UTIME_H
+#ifndef __LINUXMT_UTIME_H
+#define __LINUXMT_UTIME_H
 
 struct utimbuf {
     time_t actime;		/* Access time.  */

--- a/elks/include/linuxmt/utsname.h
+++ b/elks/include/linuxmt/utsname.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_UTSNAME_H
-#define LX86_LINUXMT_UTSNAME_H
+#ifndef __LINUXMT_UTSNAME_H
+#define __LINUXMT_UTSNAME_H
 
 struct utsname {
     char sysname[16];

--- a/elks/include/linuxmt/vfs.h
+++ b/elks/include/linuxmt/vfs.h
@@ -1,5 +1,5 @@
-#ifndef LX86_LINUXMT_VFS_H
-#define LX86_LINUXMT_VFS_H
+#ifndef __LINUXMT_VFS_H
+#define __LINUXMT_VFS_H
 
 #include <arch/statfs.h>
 

--- a/elks/include/linuxmt/wait.h
+++ b/elks/include/linuxmt/wait.h
@@ -1,6 +1,7 @@
 // Wait functions
 
-#pragma once
+#ifndef __LINUXMT_WAIT_H
+#define __LINUXMT_WAIT_H
 
 #include <linuxmt/types.h>
 
@@ -45,3 +46,5 @@ bool_t _wait_event (cond_t * c, bool_t i);
 
 #define wait_event(_c) _wait_event ((_c), 0)
 #define wait_event_interruptible(_c) _wait_event ((_c), 1)
+
+#endif

--- a/include/linuxmt/boot.h
+++ b/include/linuxmt/boot.h
@@ -2,8 +2,8 @@
  * boot variables, ready for use by any file needing access to them.
  */
 
-#ifndef LX86_LINUXMT_BOOT_H
-#define LX86_LINUXMT_BOOT_H
+#ifndef __LINUXMT_BOOT_H
+#define __LINUXMT_BOOT_H
 
 /* Root flags */
 


### PR DESCRIPTION
Changes:
  * Include guards (`#ifndef` ... `#define` ... `#endif`) now use macro identifiers that do not intrude on the non-reserved namespace for user programs.
  * `<linuxmt/types.h>` and friends have been modified to avoid defining kernel-internal symbols when used in user code.