### PR TITLE
[kernel] Implement /dev/tty

### DIFF
--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -74,9 +74,14 @@ int tty_intcheck(register struct tty *ttyp, unsigned char key)
 struct tty *determine_tty(dev_t dev)
 {
     register struct tty *ttyp = &ttys[0];
+    unsigned short minor = MINOR(dev);
+
+    /* handle /dev/tty*/
+    if (minor == 255 && current->pgrp && (current->pgrp == ttyp->pgrp))
+	return current->tty;
 
     do {
-	if (ttyp->minor == (unsigned short int)MINOR(dev))
+	if (ttyp->minor == minor)
 	    return ttyp;
     } while (++ttyp < &ttys[MAX_TTYS]);
 

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -24,16 +24,14 @@ struct msdos_devdir_entry devnods[DEVDIR_SIZE] = {
     { "kmem",	S_IFCHR | 0644, MKDEV(1, 2) },
     { "null",	S_IFCHR | 0644, MKDEV(1, 3) },
     { "zero",	S_IFCHR | 0644, MKDEV(1, 5) },
-//  { "full",	S_IFCHR | 0644, MKDEV(1, 7) },
     { "tcpdev",	S_IFCHR | 0644, MKDEV(8, 0) },
     { "eth",	S_IFCHR | 0644, MKDEV(9, 0) },
     { "tty1",	S_IFCHR | 0644, MKDEV(4, 0) },
     { "tty2",	S_IFCHR | 0644, MKDEV(4, 1) },
-    { "tty3",	S_IFCHR | 0644, MKDEV(4, 2) },
     { "ttyS0",	S_IFCHR | 0644, MKDEV(4, 64)},
     { "ttyS1",	S_IFCHR | 0644, MKDEV(4, 65)},
     { "ttyS2",	S_IFCHR | 0644, MKDEV(4, 66)},
-//  { "ttyS3",	S_IFCHR | 0644, MKDEV(4, 67)},
+    { "tty",	S_IFCHR | 0666, MKDEV(4, 255) },
 };
 #endif
 

--- a/elks/tools/mfs/writer.c
+++ b/elks/tools/mfs/writer.c
@@ -169,25 +169,27 @@ void cmd_mknode(struct minix_fs_dat *fs,int argc,char **argv) {
   int major = 0, minor = 0, count = 0,inc = 1;
 
   if (argc < 4 || (type = ftype(argv[2])) < 0)
-    fatalmsg("Usage: %s path [c|b] major minor [count inc]\n", argv[0]);
+    fatalmsg("Usage: %s path [c|b] major minor [count inc mode]\n", argv[0]);
   
-  mode = type | 0644;
+  mode = 0644;
   major = atoi(argv[3]);
   minor = atoi(argv[4]);
   if (argc > 5) count = atoi(argv[5]);
   if (argc > 6) inc = atoi(argv[6]);
+  if (argc > 7) sscanf(argv[7], "%o", &mode);
   if (inc < 1) fatalmsg("Invalid increment value: %d\n",inc);
+  if (mode == -1) fatalmsg("Invalid mode %s\n", argv[7]);
 
-  if (count && (type == S_IFBLK || type == S_IFCHR)) {
+  if (count > 1 && (type == S_IFBLK || type == S_IFCHR)) {
     int i = 0;
     char b[256];
     do {
       snprintf(b,sizeof b,"%s%d",argv[1],i++);
-      make_node(fs,b,mode,uid,gid,DEVNUM(major,minor),NOW,NOW,NOW,NULL);
+      make_node(fs,b,mode|type,uid,gid,DEVNUM(major,minor),NOW,NOW,NOW,NULL);
       minor += inc;
     } while (--count);
   } else {
-      make_node(fs, argv[1], mode, uid, gid, DEVNUM(major,minor), NOW, NOW, NOW, NULL);
+      make_node(fs, argv[1], mode|type, uid, gid, DEVNUM(major,minor), NOW, NOW, NOW, NULL);
   }
 }
 

--- a/image/Make.devices
+++ b/image/Make.devices
@@ -115,30 +115,24 @@ devices:
 #	$MKSET  64 63 $(MKDEV) /dev/hdb b 3	# Ought to be.
 
 ##############################################################################
-# Virtual consoles. Note that tty4 through tty7 can't be enabled at this
-# time because of the possible conflict with ttyS0 through ttyS3 which
-# used to use the node numbers these now use. However, it is expected that
-# this restriction can be removed in the near future.
-
-# CM: ELKS wants tty1 to be minor 0, so we can't use $MKSET
+# Virtual consoles and serial ports.
 
 	$(MKDEV) /dev/tty1	c 4 0
 	$(MKDEV) /dev/tty2	c 4 1
 	$(MKDEV) /dev/tty3	c 4 2
 	$(MKDEV) /dev/tty4	c 4 3
 
-#	$MKSET  0 3  $(MKDEV) /dev/tty c 4	# Currently
-#	$MKSET  0 15 $(MKDEV) /dev/tty c 4	# Soon to be
+# /dev/tty is minor 255, last of the /dev/ttye range
+
+	$(MKDEV) /dev/tty	c 4 255 1 1 0666
 
 # Serial ports, as detected by the ROM BIOS.
 
 	$(MKDEV) /dev/ttyS c 4 64 4
-#	$MKSET 64 3  $(MKDEV) /dev/ttyS c 4
 
 ##############################################################################
 # Alternate TTY devices. These are not yet supported.
 
-	$(MKDEV) /dev/tty	c 5 0
 #	$(MKDEV) /dev/console	c 5 1
 #	$(MKDEV) /dev/ptmx	c 5 2
 


### PR DESCRIPTION
This implements `/dev/tty` in the kernel, as well as for FAT in /dev fake devices.

Requested by #452.

@Mellvik, if this works for you, please close #452.
