### PR TITLE
[kernel] Implement task zombie state, rewrite wait, fix signal

### DIFF
--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -62,7 +62,7 @@ int tty_intcheck(register struct tty *ttyp, unsigned char key)
 	if (key == ttyp->termios.c_cc[VSUSP])
 	    sig = SIGTSTP;
 	if (sig) {
-	    debug_sig("TTY signal %d to pgrp %d pid %d\n", sig, ttyp->pgrp, current->pid);
+	    debug_tty("TTY signal %d to pgrp %d pid %d\n", sig, ttyp->pgrp, current->pid);
 	    kill_pg(ttyp->pgrp, sig, 1);
 	}
     }
@@ -97,7 +97,7 @@ int tty_open(struct inode *inode, struct file *file)
     if (!(otty = determine_tty(inode->i_rdev)))
 	return -ENODEV;
 
-    debug_sig("TTY open pid %d\n", currentp->pid);
+    debug_tty("TTY open pid %d\n", currentp->pid);
 #if 0
     memcpy(&otty->termios, &def_vals, sizeof(struct termios));
 #endif
@@ -106,7 +106,7 @@ int tty_open(struct inode *inode, struct file *file)
     if (!err) {
 	if (otty->pgrp == 0 && currentp->session == currentp->pid
 		&& currentp->tty == NULL) {
-	    debug_sig("TTY setting pgrp %d pid %d\n", currentp->pgrp, currentp->pid);
+	    debug_tty("TTY setting pgrp %d pid %d\n", currentp->pgrp, currentp->pid);
 	    otty->pgrp = currentp->pgrp;
 	    currentp->tty = otty;
 	}
@@ -130,9 +130,9 @@ void tty_release(struct inode *inode, struct file *file)
     if (!rtty)
 	return;
 
-    debug_sig("TTY close pid %d\n", current->pid);
+    debug_tty("TTY close pid %d\n", current->pid);
     if (current->pid == rtty->pgrp) {
-	debug_sig("TTY release pgrp %d\n", current->pid);
+	debug_tty("TTY release pgrp %d\n", current->pid);
 	kill_pg(rtty->pgrp, SIGHUP, 1);
 	rtty->pgrp = 0;
     }

--- a/elks/arch/i86/kernel/signal.c
+++ b/elks/arch/i86/kernel/signal.c
@@ -46,8 +46,7 @@ int do_signal(void)
 		debug_sig("SIGNAL pid %d stopped\n", currentp->pid);
 		currentp->state = TASK_STOPPED;
 		/* Let the parent know */
-		currentp->p_parent->child_lastend = currentp->pid;
-		currentp->p_parent->lastend_status = (int) signr;
+		currentp->exit_status = signr;
 		schedule();
 	    }
 	    else {					/* Default Core or Terminate */
@@ -56,6 +55,7 @@ int do_signal(void)
 		      (SM_SIGQUIT|SM_SIGILL|SM_SIGABRT|SM_SIGFPE|SM_SIGSEGV|SM_SIGTRAP))
 		    dump_core();
 #endif
+		debug_sig("SIGNAL terminating pid %d\n", currentp->pid);
 		do_exit((int) signr);			/* Default Terminate */
 	    }
 	}

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -87,7 +87,8 @@ int sys_execve(char *filename, char *sptr, size_t slen)
     seg_code = 0;
     currentp = &task[0];
     do {
-	if ((currentp->state != TASK_UNUSED) && (currentp->t_inode == inode)) {
+	if ((currentp->state <= TASK_STOPPED) && (currentp->t_inode == inode)) {
+	    debug_wait("EXEC found copy\n");
 	    seg_code = currentp->mm.seg_code;
 	    break;
 	}

--- a/elks/include/linuxmt/debug.h
+++ b/elks/include/linuxmt/debug.h
@@ -32,6 +32,8 @@
 #define DEBUG_FILE	0		/* sys open and file i/o*/
 #define DEBUG_SIG	0		/* signals*/
 #define DEBUG_SUP	0		/* superblock, mount, umount*/
+#define DEBUG_TTY	0		/* wait, exit*/
+#define DEBUG_WAIT	0		/* wait, exit*/
 
 #if DEBUG_BLK
 #define debug_blk	printk
@@ -61,6 +63,18 @@
 #define debug_sup	printk
 #else
 #define debug_sup(...)
+#endif
+
+#if DEBUG_TTY
+#define debug_tty	printk
+#else
+#define debug_tty(...)
+#endif
+
+#if DEBUG_WAIT
+#define debug_wait	printk
+#else
+#define debug_wait(...)
 #endif
 
 /* Old debug mechanism - deprecated.

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -80,8 +80,7 @@ struct task_struct {
     struct task_struct		*p_nextsib;
     struct task_struct		*p_child;
     struct wait_queue		child_wait;
-    pid_t			child_lastend;
-    int 			lastend_status;
+    int				exit_status;	/* process exit status*/
     struct inode		* t_inode;
     sigset_t			signal;		/* Signal status */
     struct signal_struct	sig;		/* Signal block */
@@ -102,14 +101,15 @@ struct task_struct {
 
 #define KSTACK_MAGIC 0x5476
 
+/* the order of these matter for signal handling*/
 #define TASK_RUNNING 		0
 #define TASK_INTERRUPTIBLE	1
 #define TASK_UNINTERRUPTIBLE 	2
-#define TASK_ZOMBIE		3
+#define TASK_WAITING		3
 #define TASK_STOPPED		4
-#define TASK_UNUSED		6
-#define TASK_WAITING		7
-#define TASK_EXITING		8
+#define TASK_ZOMBIE		5
+#define TASK_EXITING		6
+#define TASK_UNUSED		7
 
 /*@-namechecks@*/
 

--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -41,6 +41,10 @@ int sys_wait4(pid_t pid, int *status, int options)
 						return -EFAULT;
 				}
 
+				/* just return status on stopped state, don't release task*/
+				if (p->state == TASK_STOPPED)
+					return p->pid;
+
 				/* must reparent orphans before unassigning task slot*/
 				for_each_task(q) {
 					if (q->p_parent == p) {

--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -1,53 +1,85 @@
 /* linuxmt/kernel/exit.c
  * (C) 1997 Chad Page
  * 
- * This is the ELKS code to handle wait (partial V7-style implementation),
- * and sys_exit().  I've thrown this together to handle mini-sh so I can 
- * get this to 0.(0?)1.0 :)
+ * Handle sys_wait4() and sys_exit().
  */
 
 #include <linuxmt/sched.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/debug.h>
 
 extern int task_slots_unused;
 extern struct task_struct *next_task_slot;
 
-/* Note: sys_wait only keeps *one* task in the task_struct right now...
- * this is different than V7 symantics I think, but good enough for 0.0.51
- * Whoops - we have to do wait3 for now :) 
- */
-
 int sys_wait4(pid_t pid, int *status, int options)
 {
-    register __ptask p = current;
-    register pid_t *lastendp = &p->child_lastend;
+	register struct task_struct *p;
+	struct task_struct *q;
 
-    if (!((options & WNOHANG) || (*lastendp)))
-	interruptible_sleep_on(&p->child_wait);
-    if (*lastendp) {
-	if (status) {
-	    if (verified_memcpy_tofs(status,
-				     &p->lastend_status,
-				     sizeof(int)) != 0) {
-		return -EFAULT;
-	    }
+	debug_wait("WAIT(%d) for %d %s\n", current->pid, pid, (options & WNOHANG)? "nohang": "");
+
+	/* reparent orphan zombies to init*/
+	for_each_task(p) {
+		if (p->state == TASK_ZOMBIE) {
+			debug_wait("Zombie pid %d ppid %d\n", p->pid, p->p_parent->pid);
+			if (p->p_parent->state == TASK_UNUSED) {
+				debug_wait("WAIT(%d) reparenting %d to 1\n", current->pid, p->pid);
+				p->p_parent = &task[1];
+				wake_up(&task[1].child_wait);
+			}
+
+		}
 	}
-	options = *lastendp;	/* TRASHING options!!! */
-	*lastendp = 0;
-	return options;
-    }
-    return -EINTR;
+
+	for_each_task(p) {
+		if (p->p_parent == current
+		   && (p->state == TASK_ZOMBIE || p->state == TASK_STOPPED)) {
+			if (pid == -1 || p->pid == pid || (!pid && p->pgrp == current->pgrp)) {
+				if (status) {
+					if (verified_memcpy_tofs(status, &p->exit_status, sizeof(int)))
+						return -EFAULT;
+				}
+
+				/* must reparent orphans before unassigning task slot*/
+				for_each_task(q) {
+					if (q->p_parent == p) {
+						debug_wait("Orphan child %d\n", q->pid);
+						q->p_parent = &task[1];
+					}
+				}
+
+				/* unassign now that no orphans pointing to it*/
+				p->state = TASK_UNUSED;
+				next_task_slot = p;
+				task_slots_unused++;
+
+				debug_wait("WAIT(%d) got %d\n", current->pid, p->pid);
+				return p->pid;
+			}
+		}
+	}
+
+	if (options & WNOHANG)
+		return 0;
+
+	debug_wait("WAIT sleep\n");
+	interruptible_sleep_on(&current->child_wait);
+	debug_wait("WAIT wakeup\n");
+
+	return -EINTR;
 }
 
 void do_exit(int status)
 {
-    register __ptask pcurrent = current;
-#define current pcurrent
-     __ptask parent;
-    register __ptask task;
+    struct task_struct *parent, *task;
 
+    debug_wait("EXIT(%d) status %d\n", current->pid, status);
     _close_allfiles();
+
+    /* release process group and TTY*/
+    current->pgrp = 0;
+    current->tty = 0;
 
     /* Let go of the process */
     current->state = TASK_EXITING;
@@ -67,42 +99,19 @@ void do_exit(int status)
     }
 
     /* Ack. I hate repeating code like this */
-#if 0
-    parent = current->p_parent;
-    if (parent->p_child == current) {
-	if ((task = current->p_prevsib)) {
-	    parent->p_child = task;
-	} else if ((task = current->p_nextsib)) {
-	    parent->p_child = task;
-	}
-    }
-#else
     if ((parent = current->p_parent)->p_child == current) {
-	if ((task = current->p_prevsib)
-	    || (task = current->p_nextsib)
-	    ) {
+	if ((task = current->p_prevsib) || (task = current->p_nextsib))
 	    parent->p_child = task;
-	}
     }
-
-    /* Ok... we're done with task, but we still need parent a few
-     * times.  Since task is a register and parent isn't, stuff
-     * parent in task and use that. */
-    task = parent;
-#define parent task
-
-#endif
 
     /* UN*X process take their children out with them...
      * I'm not going to implement that for 0.0.51 because we don't
      * have signals and we don't need them *yet*. */
 
+    current->exit_status = status;
+
     /* Let the parent know */
     kill_process(current->ppid, SIGCHLD, 1);
-
-    /* Send control back to the parent */
-    parent->child_lastend = current->pid;
-    parent->lastend_status = status;
 
     /* Free the text, pwd, and root inodes */
     iput(current->t_inode);
@@ -111,14 +120,11 @@ void do_exit(int status)
 
     /* Now the task should never run again... - I hope this can still
      * be used outside of an int... :) */
-    current->state = TASK_UNUSED;
-    next_task_slot = current;
-    task_slots_unused++;
+    current->state = TASK_ZOMBIE;
     wake_up(&parent->child_wait);
     schedule();
-    panic("Returning from sys_exit!\n");
+    panic("sys_exit\n");
 }
-#undef current
 
 void sys_exit(int status)
 {

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -107,11 +107,12 @@ pid_t do_fork(int virtual)
     t->fs.root->i_count++;
     t->fs.pwd->i_count++;
 
+    t->exit_status = 0;
+
     /* Set up our family tree */
     t->ppid = currentp->pid;
     t->p_parent = currentp;
     t->p_nextsib = t->p_child = NULL;
-    t->child_lastend = t->lastend_status = 0;
     if ((t->p_prevsib = currentp->p_child) != NULL) {
 	currentp->p_child->p_nextsib = t;
     }

--- a/elks/kernel/signal.c
+++ b/elks/kernel/signal.c
@@ -39,7 +39,7 @@ int send_sig(sig_t sig, register struct task_struct *p, int priv)
     register __ptask currentp = current;
     sigset_t msksig;
 
-    if (sig != SIGCHLD) debug_sig("SIGNAL send_sig %d pid %d.\n", sig, p->pid);
+    if (sig != SIGCHLD) debug_sig("SIGNAL send_sig %d pid %d\n", sig, p->pid);
     if (!priv && ((sig != SIGCONT) || (currentp->session != p->session)) &&
 	(currentp->euid ^ p->suid) && (currentp->euid ^ p->uid) &&
 	(currentp->uid ^ p->suid) && (currentp->uid ^ p->uid) && !suser())
@@ -71,7 +71,9 @@ int kill_pg(pid_t pgrp, sig_t sig, int priv)
 	if (p->pgrp == pgrp) {
 		if (p->state < TASK_ZOMBIE)
 		    err = send_sig(sig, p, priv);
-		else debug_sig("SIGNAL skip kill_pg pgrp %d pid %d state %d\n", pgrp, p->pid, p->state);
+		else if (p->state != TASK_UNUSED)
+		    debug_sig("SIGNAL skip kill_pg pgrp %d pid %d state %d\n",
+					pgrp, p->pid, p->state);
 	}
     }
     return err;

--- a/elkscmd/ash/jobs.c
+++ b/elkscmd/ash/jobs.c
@@ -642,7 +642,7 @@ waitforjob(jp)
 	int st;
 
 	INTOFF;
-	TRACE(("waitforjob(%%%d) called\n", jp - jobtab + 1));
+	TRACE(("waitforjob(%d) called\n", jp - jobtab + 1));
 	while (jp->state == 0 && dowait(1, jp) != -1) ;
 #if JOBS
 	if (jp->jobctl) {
@@ -838,15 +838,6 @@ waitproc(block, status)
 	return wait(status);
 #else
 #if POSIX
-        /*
-         * 19980216 Vincent Zweije <zweije@xs4all.nl>
-         * ELKS does not obey WNOHANG
-         * If requested, return -1 with errno==EINVAL
-         */
-        if (block==0) {
-                errno = EINVAL;
-                return -1;
-        }
 	return waitpid(-1, status, block == 0 ? WNOHANG : 0);
 #else
 	if (block == 0)

--- a/elkscmd/ash/show.c
+++ b/elkscmd/ash/show.c
@@ -239,7 +239,7 @@ indent(amount, pfx, fp)
 
 FILE *tracefile;
 
-#if DEBUG == 2
+#if DEBUG >= 2
 int debug = 1;
 #else
 int debug = 0;
@@ -351,6 +351,9 @@ opentrace() {
 	}
 	scopy(p, s);
 	strcat(s, "/trace");
+#if DEBUG == 3
+tracefile = stderr;
+#else
 	if ((tracefile = fopen(s, "a")) == NULL) {
 		fprintf(stderr, "Can't open %s\n", s);
 		return;
@@ -359,6 +362,7 @@ opentrace() {
 	if ((flags = fcntl(fileno(tracefile), F_GETFL, 0)) >= 0)
 		fcntl(fileno(tracefile), F_SETFL, flags | O_APPEND);
 #endif
+#endif /* DEBUG*/
 	fputs("\nTracing started.\n", tracefile);
 	fflush(tracefile);
 }

--- a/elkscmd/sash/sash.c
+++ b/elkscmd/sash/sash.c
@@ -551,8 +551,7 @@ trybuiltin(int wildargc, char **wildargv, int argc, char **argv)
 static void
 runcmd(char *cmd, int argc, char **argv)
 {
-	int		pid;
-	int		status;
+	int		pid, status, ret;
 
 	/*
 	 * If a full shell is required, run 'sh -c cmd' unless we are the only shell.
@@ -561,10 +560,11 @@ runcmd(char *cmd, int argc, char **argv)
 		if (isbinshell)
 			fprintf(stderr, "%s: No such file or directory\n", argv[0]);
 		else {
-			system(cmd);
-			wait(&status);	/* synchronize shell prompt*/
+			status = system(cmd);
+			if (status & 0xff)
+				fprintf(stderr, "killed (signal %d)\n", status & 0x7f);
+			return;
 		}
-		return;
 	}
 
 	/*
@@ -583,8 +583,8 @@ runcmd(char *cmd, int argc, char **argv)
 		status = 0;
 		intcrlf = FALSE;
 
-		while (((pid = wait(&status)) < 0) && (errno == EINTR))
-			;
+		while ((ret = waitpid(pid, &status, 0)) != pid)
+			continue;
 
 		intcrlf = TRUE;
 		if ((status & 0xff) == 0)

--- a/elkscmd/sash/sash.c
+++ b/elkscmd/sash/sash.c
@@ -591,7 +591,8 @@ runcmd(char *cmd, int argc, char **argv)
 			return;
 
 		fprintf(stderr, "pid %d: %s (signal %d)\n", pid,
-			(status & 0x80) ? "core dumped" : "killed",
+			(status & 0x80) ? "core dumped" :
+			(((status & 0x7f) == SIGTSTP)? "stopped" : "killed"),
 			status & 0x7f);
 
 		return;

--- a/libc/misc/system.c
+++ b/libc/misc/system.c
@@ -1,12 +1,10 @@
-
 #include <stddef.h>
 #include <signal.h>
 
 int
-system(command)
-char * command;
+system(char *command)
 {
-   int wait_val, wait_ret, pid;
+   int status, ret, pid;
    __sighandler_t save_quit;
    __sighandler_t save_int;
 
@@ -14,7 +12,6 @@ char * command;
 
    save_quit = signal(SIGQUIT, SIG_IGN);
    save_int  = signal(SIGINT,  SIG_IGN);
-
    if( (pid=vfork()) < 0 )
    {
       signal(SIGQUIT, save_quit);
@@ -29,21 +26,16 @@ char * command;
       execl("/bin/sh", "sh", "-c", command, (char*)0);
       _exit(127);
    }
-   /* Signals are not absolutly guarenteed with vfork */
+
+   /* Signals are not absolutely guarenteed with vfork */
    signal(SIGQUIT, SIG_IGN);
    signal(SIGINT,  SIG_IGN);
 
-   do
-   {
-      if( (wait_ret = wait(&wait_val)) == -1 )
-      {
-         wait_val = -1;
-	 break;
-      }
-   }
-   while( wait_ret != pid );
+   /* wait for child termination*/
+   while ((ret = waitpid(pid, &status, 0)) != pid)
+		continue;
 
    signal(SIGQUIT, save_quit);
    signal(SIGINT,  save_int);
-   return wait_val;
+   return status;
 }

--- a/libc/system/signal.c
+++ b/libc/system/signal.c
@@ -45,10 +45,5 @@ Sig signal(int number, Sig pointer)
    old_sig = _sigtable[number-1];
    _sigtable[number-1] = pointer;
 
-   switch(rv)
-   {
-   case 0: return SIG_DFL;
-   case 1: return SIG_IGN;
    return old_sig;
-   }
 }


### PR DESCRIPTION
Fixes issue in #387.

Implements new TASK_ZOMBIE task state in kernel. `sys_wait` rewritten to handle zombie task retrieval and orphaned task reparenting.

Libc `signal` fixed to return proper value on setting SIG_IGN/SIG_DFL.
Libc `system` fixed to wait until command completes before returning.

Updated wait handling in `sh` and `sash`.

Enhanced `ps` to show all task states. 'S' is interruptible sleep, 's' uninterruptible, 'Z' zombie, 'T' stopped.

Added new debug_wait and debug_tty options for kernel tracing, and DEBUG=3 option for `sh` tracing.