### PR TITLE
[net] Fix networking startup and shutdown issues

### DIFF
--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -75,6 +75,8 @@ static int inet_release(struct socket *sock, struct socket *peer)
     int ret;
 
     debug1("inet_release(sock: 0x%x)\n", sock);
+	if (!tcpdev_inuse)
+		return -EINVAL;
     cmd = (struct tdb_release *)get_tdout_buf();
     cmd->cmd = TDC_RELEASE;
     cmd->sock = sock;

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -49,6 +49,7 @@ sys_utils/umount		:boot	:sysutil
 sys_utils/clock			:boot	:sysutil
 sys_utils/shutdown		:boot	:sysutil
 sh_utils/test			:boot	:shutil
+sh_utils/true			:boot	:be-shutil
 sh_utils/echo			:boot	:be-shutil
 file_utils/cat			:boot	:be-fileutil
 file_utils/chgrp				:be-fileutil		:720k
@@ -84,7 +85,6 @@ sh_utils/basename				:be-shutil			:720k
 sh_utils/date					:be-shutil		:360k
 sh_utils/dirname				:be-shutil			:720k
 sh_utils/false					:be-shutil			:720k
-sh_utils/true					:be-shutil			:720k
 sh_utils/logname				:shutil
 sh_utils/mesg					:shutil
 sh_utils/stty					:shutil			:360k

--- a/elkscmd/inet/httpd/httpd.c
+++ b/elkscmd/inet/httpd/httpd.c
@@ -28,6 +28,8 @@
 #include <unistd.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
 #ifndef __linux__
 #include <linuxmt/in.h>
 #include <linuxmt/net.h>
@@ -162,8 +164,28 @@ char** argv;
 	int ret;
 	struct sockaddr_in localadr;
 
+	strcpy(doc_base, DEF_DOCBASE);
+
+	if ((listen_sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+		perror("socket error");
+		exit(-1);
+	}
+
+	localadr.sin_family = AF_INET;
+	localadr.sin_port = htons(DEF_PORT);
+	localadr.sin_addr.s_addr = INADDR_ANY;
+
+	if (bind(listen_sock, (struct sockaddr *)&localadr, sizeof(struct sockaddr_in)) < 0) {
+		perror("bind error");
+		exit(-1);
+	}
+	if (listen(listen_sock, 5) < 0) {
+		perror("listen error");
+		exit(-1);
+	}
+
 	ret = fork();
-	if (ret > 0 || ret == -1){
+	if (ret > 0 || ret == -1) {
 		exit(0);	
 	}
 	ret = open("/dev/null", O_RDWR); /* our log file! */
@@ -173,25 +195,14 @@ char** argv;
 	close(ret);
 	setsid();
 
-	strcpy(doc_base, DEF_DOCBASE);
-	
-	listen_sock = socket(AF_INET, SOCK_STREAM, 0);
-	
-	localadr.sin_family = AF_INET;
-	localadr.sin_port = htons(DEF_PORT);
-	localadr.sin_addr.s_addr = INADDR_ANY;
-
-	ret = bind(	listen_sock,
-    			(struct sockaddr *)&localadr,
-    			sizeof(struct sockaddr_in));
-
-	ret = listen(listen_sock, 5);
-
 	while (1){
 		conn_sock = accept(listen_sock, NULL, NULL);
 		
-		if (conn_sock < 0)
+		if (conn_sock < 0) {
+			if (errno == ENOTSOCK)
+				exit(-1);
 			continue;
+		}
 
 		ret = fork();
 		if (ret == 0){

--- a/elkscmd/inet/telnetd/telnetd.c
+++ b/elkscmd/inet/telnetd/telnetd.c
@@ -173,8 +173,7 @@ int main(int argc, char *argv[]) {
 
   char	*cp;
   struct sockaddr_in addr_in;
-  int sockfd,connectionfd,rc,afunix,lv;
-  afunix=0;
+  int sockfd,connectionfd,ret,lv = 10;
   
 #ifndef __linux__  
   if (argv[1][0] == '-') {
@@ -195,7 +194,6 @@ int main(int argc, char *argv[]) {
 	  
 #endif
 
-  lv=10;
   if ( (sockfd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
     perror("socket error");
     exit(-1);
@@ -214,6 +212,14 @@ int main(int argc, char *argv[]) {
     close(sockfd);
     exit(-1);
   } 
+
+	if (fork())
+		exit(0);
+	ret = open("/dev/null", O_RDWR);
+	dup2(ret, 0);
+	dup2(ret, 1);
+	dup2(ret, 2);
+	close(ret);
 
 	while (1) {
 		connectionfd = accept (sockfd, (struct sockaddr *) NULL, NULL);

--- a/elkscmd/ktcp/deveth.c
+++ b/elkscmd/ktcp/deveth.c
@@ -53,7 +53,7 @@ int deveth_init(char *fdev)
 
     devfd = open(fdev, O_NONBLOCK|O_RDWR);
     if (devfd < 0) {
-	printf("ERROR: failed to open eth device %s\n", fdev);
+	printf("ktcp: failed to open eth device %s\n", fdev);
 	return -1;
     }
 

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -100,7 +100,7 @@ int main(int argc,char **argv)
     sprintf(dname, "/dev/eth");
 
     if (argc < 3) {
-	printf("Syntax :\n    %s local_ip [interface] [gateway] [netmask]\n", argv[0]);
+	printf("Usage: %s local_ip [interface] [gateway] [netmask]\n", argv[0]);
 	exit(3);
     }
 
@@ -130,10 +130,7 @@ int main(int argc,char **argv)
 	debug("Init /dev/eth\n");
     	dev->type = 1;
 	intfd = deveth_init(dname);
-	if (intfd < 0) {
-	      printf("failed to open /dev/eth [%d]\n", intfd);
-	      exit(1);
-	}
+	if (intfd < 0) exit(1);
     } else { /* fall back to slip */
 	dev->type=0;
 	intfd = slip_init(argv[2]);

--- a/elkscmd/ktcp/slip.c
+++ b/elkscmd/ktcp/slip.c
@@ -42,8 +42,10 @@ int slip_init(char *fdev)
     struct termios tios;
 
     devfd = open(fdev, O_NONBLOCK|O_RDWR);
-    if (devfd < 0)
-	printf("ERROR : failed to open serial device %s\n",fdev);
+    if (devfd < 0) {
+	printf("ktcp: failed to open serial device %s\n",fdev);
+	return -1;
+    }
 
     /* Setup the tty
      */

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -68,7 +68,7 @@ struct tcpcb_list_s *tcpcb_new(void)
 
     n = (struct tcpcb_list_s *) malloc(sizeof(struct tcpcb_list_s));
     if (n == NULL) {
-	printf("ERROR : Out of memory\n");
+	printf("ktcp: Out of memory\n");
 	return NULL;
     }
 

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -220,7 +220,7 @@ void add_for_retrans(struct tcpcb_s *cb, struct tcphdr_s *th, __u16 len,
 
     n = (struct tcp_retrans_list_s *)malloc(sizeof(struct tcp_retrans_list_s));
     if (n == NULL) {
-	printf("ERROR : Out of memory\n");
+	printf("ktcp: Out of memory\n");
 
 	/* In this case has to be avoided */
 	exit(0);

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -34,7 +34,7 @@ int tcpdev_init(char *fdev)
 {
     tcpdevfd = open(fdev, O_NONBLOCK | O_RDWR);
     if (tcpdevfd < 0)
-	printf("ERROR : failed to open tcpdev device %s\n",fdev);
+	printf("ktcp: failed to open tcpdev device %s\n",fdev);
     return tcpdevfd;
 }
 

--- a/elkscmd/rootfs_template/etc/rc.d/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sys
@@ -3,8 +3,7 @@
 echo Running $0 script
 
 umask 022
-PATH=/bin:/usr/bin
-export PATH
+export PATH=/bin
 
 # init date from hardware
 clock -s
@@ -29,19 +28,19 @@ then
 	echo -n ' eth'
 	fi
 	
-	ktcp $localip $interface &
 	echo ' ktcp'
+	ktcp $localip $interface &
 	
 	echo -n "Starting network services: "
 	for daemon in telnetd httpd
 	do
 		if test -f /bin/$daemon 
 		then
-			echo -n " $daemon"
-			$daemon &
+			echo -n " $daemon "
+			$daemon || true
 		fi
 	done
-	echo .
+	echo
 
 fi
 

--- a/libc/include/errno.h
+++ b/libc/include/errno.h
@@ -1,4 +1,5 @@
 /* libc errno.h*/
+#include <features.h>
 #include __SYSINC__(errno.h)
 
 extern int errno;

--- a/libc/include/errno.h
+++ b/libc/include/errno.h
@@ -1,7 +1,10 @@
-#pragma once
+/* libc errno.h*/
+#include __SYSINC__(errno.h)
 
+extern int errno;
+
+#if 0
 // From asm-generic/errno-base.h
-
 #define EPERM    1  // Operation not permitted
 #define ENOENT   2	// No such file or directory
 #define EINTR    4  // Interrupted system call
@@ -40,9 +43,6 @@
 #define	EDOM		33	// Math argument out of domain of func
 */
 
-// From ???
-
 #define ENOSYS  38  // Function not implemented
 
-
-extern int errno;
+#endif /* #if 0*/


### PR DESCRIPTION
Fixes `httpd` startup issue brought up in #481. `httpd` will exit if networking not configured or `ktcp` fails to start.

Fixes `tcpdev` network driver bug causing `httpd` to hang when run twice with networking off.

Fix `httpd` to display error message and exit on socket/bind/listen before forking and becoming daemon.

Fix `telnetd` to fork and become daemon if run from command line after socket/bind/listen.

Fix `ktcp` error messages and `rc.sys` to improve network startup display and error messages.

Fix libc `errno.h` to include kernel `errno.h` for access to all kernel generated errno's.