### PR TITLE
[libc] Libc header file cleanup

### DIFF
--- a/libc/include/dirent.h
+++ b/libc/include/dirent.h
@@ -28,6 +28,7 @@ typedef int (*__dir_compar_fn_t) __P ((
 extern DIR *opendir __P ((__const char *__name));
 extern int closedir __P ((DIR * __dirp));
 extern struct dirent *readdir __P ((DIR * __dirp));
+extern int _readdir(int fd, struct dirent *buf, int count);
 extern void rewinddir __P ((DIR * __dirp));
 
 extern void seekdir __P ((DIR * __dirp, off_t __pos));

--- a/libc/include/unistd.h
+++ b/libc/include/unistd.h
@@ -48,7 +48,9 @@ int execle(char *fname, char *arg0, ...);
 int execlp(char *fname, char *arg0, ...);
 int execv(char *fname, char **argv);
 int execve(char *fname, char **argv, char **envp);
+int _execve(char *fname, char *stk_ptr, int stack_bytes);
 int execvp(char *fname, char **argv);
+void _exit(int status);
 int isatty (int fd);
 off_t lseek (int fildes, off_t offset, int whence);
 int link(const char *path1, const char *path2);
@@ -63,17 +65,18 @@ pid_t fork(void);
 pid_t vfork(void);
 pid_t getpid(void);
 pid_t setsid(void);
-
-uid_t getuid (void);
-
-char * getcwd (char * buf, size_t size);
-int getegid(void);
-int geteuid(void);
-int getgid(void);
 int getpgrp(void);
 int getppid(void);
 int setpgrp(void);
 
+uid_t getuid (void);
+uid_t _getuid(int *euid);	//FIXME euid return not implemented in kernel
+int getgid(void);
+uid_t _getgid(int *euid);	//FIXME euid return not implemented in kernel
+int getegid(void);
+int geteuid(void);
+
+char * getcwd (char * buf, size_t size);
 void sync(void);
 void usleep(unsigned long useconds);
 

--- a/libc/misc/getopt.c
+++ b/libc/misc/getopt.c
@@ -62,13 +62,14 @@ int getopt(int argc, char **argv, char *opts)
     static int sp = 1;
     register int c;
 
-    if (sp == 1)
+    if (sp == 1) {
 	if (optind >= argc || argv[optind][0] != '-' || argv[optind][1] == '\0')
 	    return EOF;
 	else if (strcmp(argv[optind], "--") == 0) {
 	    optind++;
 	    return EOF;
 	}
+    }
     optopt = c = argv[optind][sp];
     if (c == ':' || (cp = index(opts, c)) == NULL) {
 	ERR(": illegal option -- ", c);

--- a/libc/misc/mktemp.c
+++ b/libc/misc/mktemp.c
@@ -3,10 +3,9 @@
  */
 
 #include <unistd.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <errno.h>
-
-#define namlen
 
 char *mktemp(s)
 char *s;
@@ -16,7 +15,6 @@ char *s;
     static char c2 = 0;
     static char uniq_ch[] = 
 	 "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    struct stat stbuf;
 
     
     if (!s || strlen(s) < 6) {
@@ -31,7 +29,7 @@ char *s;
 	    return 0;
 	}
     }
-    sprintf(ptr, "%04d%c%c", getpid(), uniq_ch[c1], uniq_ch[c2]);
+    sprintf(ptr, "%04d%c%c", getpid(), uniq_ch[(int)c1], uniq_ch[(int)c2]);
 
     return s;
 }

--- a/libc/misc/popen.c
+++ b/libc/misc/popen.c
@@ -1,5 +1,6 @@
-
 #include <stdio.h>
+#include <unistd.h>
+#include <sys/wait.h>
 
 
 FILE * popen(command, rw)
@@ -37,6 +38,6 @@ FILE *fd;
 {
    int waitstat;
    if( fclose(fd) != 0 ) return EOF;
-   wait(&waitstat);
+   return wait(&waitstat);
 }
 

--- a/libc/misc/putenv.c
+++ b/libc/misc/putenv.c
@@ -27,7 +27,7 @@ static int extras = 0;
    {
       if( memcmp(var, *p, len) == 0 && (*p)[len] == '=' )
       {
-         while( p[0] = p[1] ) p++;
+         while ((p[0] = p[1])) p++;
          extras++;
          break;
       }

--- a/libc/misc/system.c
+++ b/libc/misc/system.c
@@ -1,5 +1,7 @@
 #include <stddef.h>
+#include <unistd.h>
 #include <signal.h>
+#include <sys/wait.h>
 
 int
 system(char *command)

--- a/libc/misc/tmpnam.c
+++ b/libc/misc/tmpnam.c
@@ -5,6 +5,7 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <errno.h>
+#include <string.h>
 
 #ifndef P_tmpdir
 #define P_tmpdir "/tmp"
@@ -27,7 +28,7 @@ char *s;
 
     do {
         sprintf(ret_val, "%s/%05d%c%c%c", P_tmpdir, getpid(), 
-	     uniq_ch[c1], uniq_ch[c2], uniq_ch[c3]);
+	     uniq_ch[(int)c1], uniq_ch[(int)c2], uniq_ch[(int)c3]);
         if (++c1 >= 62) {
   	    c1 = 0;
 	    if (++c2 >= 62) {


### PR DESCRIPTION
This commit cleans up most compile-time warnings in libc. 

During cleanup of `_getuid` and `_getgid`, realized that both functions expect kernel to return effective uid or gid in passed 'int *', which is not implemented in kernel. Thus, both `geteuid` and `getegid` are buggy. This commit doesn't fix that.

There doesn't seem to be a way to know whether the 'syscalls.dat' argument count is in fact used by the kernel...