### PR TITLE
[kernel] Cleanup, fix geteuid, getppid, implement getgid, getegid

### DIFF
--- a/elks/arch/i86/kernel/syscall.dat
+++ b/elks/arch/i86/kernel/syscall.dat
@@ -65,7 +65,7 @@ times		43	2	- use gettimeofday and libc times instead
 profil		44	4	@
 dup2		+45	2
 setgid		+46	1	 
-getgid		47	1	* this gets both gid and egid
+getgid		+47	1	* this gets both gid and egid
 signal		+48	2	* have put the despatch table in user space.
 getinfo		49	1	@ possible? gets pid,ppid,uid,euid etc
 fcntl		+50	3	!

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -46,7 +46,7 @@ void unlock_creation(void)
 
 int msdos_add_cluster(register struct inode *inode)
 {
-	static struct wait_queue *wait = NULL;
+	static struct wait_queue wait;
 	static int lock = 0;
 	//FIXME: using previous on booted FAT volume with mounted FAT floppy won't work well
 	static long previous = 0; /* works best if one FS is being used */

--- a/elks/kernel/sys.c
+++ b/elks/kernel/sys.c
@@ -32,6 +32,7 @@
 static int C_A_D = 1;
 
 extern void hard_reset_now(void);
+extern void apm_shutdown_now(void);
 extern int sys_kill(sig_t,pid_t);
 
 /*
@@ -125,14 +126,26 @@ int sys_setgid(gid_t gid)
     return 0;
 }
 
-uid_t sys_getuid(void)
+static int twovalues(int retval, int *copyval, int *copyaddr)
 {
-    return current->uid;
+    if (verified_memcpy_tofs(copyaddr, copyval, sizeof(int)) != 0)
+	return -EFAULT;
+    return retval;
 }
 
-pid_t sys_getpid(void)
+uid_t sys_getuid(int *euid)
 {
-    return current->pid;
+    return twovalues(current->uid, (int *)&current->euid, euid);
+}
+
+uid_t sys_getgid(int *egid)
+{
+    return twovalues(current->gid, (int *)&current->egid, egid);
+}
+
+pid_t sys_getpid(int *ppid)
+{
+    return twovalues(current->pid, (int *)&current->ppid, ppid);
 }
 
 unsigned short int sys_umask(unsigned short int mask)

--- a/elkscmd/file_utils/cat.c
+++ b/elkscmd/file_utils/cat.c
@@ -29,27 +29,28 @@ static int dumpfile(int fd)
 
 int main(int argc, char **argv)
 {
-	int i, fd;
+	int i, fd = -1;
 
 	if (argc <= 1) {
-		if (dumpfile(STDIN_FILENO)) goto error_read;
+		if (dumpfile(STDIN_FILENO)) {
+			perror("stdin");
+			return 1;
+		}
 	} else {
 		for (i = 1; i < argc; i++) {
 			errno = 0;
-			fd = open(argv[i], O_RDONLY);
-			if (fd == -1) {
-				goto error_read;
+			if ((fd = open(argv[i], O_RDONLY)) < 0) {
+				perror(argv[i]);
+				return 1;
 			} else {
-				if (dumpfile(fd)) goto error_read;
+				if (dumpfile(fd)) {
+					perror(argv[i]);
+					close(fd);
+					return 1;
+				}
 				close(fd);
 			}
 		}
 	}
 	return 0;
-
-error_read:
-	fprintf(stderr, "%s: %s: %s\n",
-		argv[0], argv[i], strerror(errno));
-	close(fd);
-	return 1;
 }

--- a/elkscmd/rootfs_template/etc/passwd
+++ b/elkscmd/rootfs_template/etc/passwd
@@ -15,9 +15,5 @@ man:*:13:15:Manual pages:/usr/man:
 ftp:*:14:50:FTP User:/home/ftp:/bin/sash
 postmaster:*:14:12:Postmaster:/var/spool/mail:/bin/sash
 nobody:*:99:99:Nobody:/tmp:
-user0::500:500:User 0:/home/user0:/bin/sh
-user1::501:501:User 1:/home/user1:/bin/ash
-user2::502:502:User 2:/home/user2:/bin/sash
-user3::503:503:User 3:/home/user3:/bin/sh
-user4::504:504:User 4:/home/user4:/bin/ash
-user5::505:505:User 5:/home/user5:/bin/sash
+user1::501:501:User 1:/home:/bin/sh
+user2::502:502:User 2:/home:/bin/sash

--- a/libc/include/unistd.h
+++ b/libc/include/unistd.h
@@ -63,18 +63,19 @@ int rmdir(const char *path);
 
 pid_t fork(void);
 pid_t vfork(void);
-pid_t getpid(void);
 pid_t setsid(void);
+pid_t getpid(void);
+pid_t getppid(void);
+uid_t _getpid(int *ppid);
 int getpgrp(void);
-int getppid(void);
 int setpgrp(void);
 
 uid_t getuid (void);
-uid_t _getuid(int *euid);	//FIXME euid return not implemented in kernel
-int getgid(void);
-uid_t _getgid(int *euid);	//FIXME euid return not implemented in kernel
-int getegid(void);
-int geteuid(void);
+uid_t _getuid(int *euid);
+uid_t getgid(void);
+uid_t _getgid(int *egid);
+uid_t getegid(void);
+uid_t geteuid(void);
 
 char * getcwd (char * buf, size_t size);
 void sync(void);

--- a/libc/system/getegid.c
+++ b/libc/system/getegid.c
@@ -1,6 +1,6 @@
 #include <unistd.h>
 
-int
+uid_t
 getegid(void)
 {
    int egid;

--- a/libc/system/geteuid.c
+++ b/libc/system/geteuid.c
@@ -1,6 +1,6 @@
 #include <unistd.h>
 
-int
+uid_t
 geteuid(void)
 {
    int euid;

--- a/libc/system/getgid.c
+++ b/libc/system/getgid.c
@@ -1,7 +1,8 @@
-#ifdef L_getgid
-int getgid(void)
+#include <unistd.h>
+
+uid_t
+getgid(void)
 {
    int egid;
-   return __getgid(&egid);
+   return _getgid(&egid);
 }
-#endif

--- a/libc/system/getpid.c
+++ b/libc/system/getpid.c
@@ -1,9 +1,8 @@
 #include <unistd.h>
 
-extern pid_t _getpid (pid_t *);
-
-pid_t getpid(void)
+pid_t
+getpid(void)
 {
-	pid_t ppid;
+	int ppid;
 	return _getpid (&ppid);
 }

--- a/libc/system/getppid.c
+++ b/libc/system/getppid.c
@@ -1,11 +1,9 @@
-#ifdef L_getppid
 #include <unistd.h>
 
-int
+pid_t
 getppid(void)
 {
    int ppid;
-   __getpid(&ppid);
+   _getpid(&ppid);
    return ppid;
 }
-#endif


### PR DESCRIPTION
Fix kernel `sys_getuid` to return effective uid for libc `geteuid`.
Fix kernel `sys_getpid` to return parent id and fixed libc `getppid`.
Implement `sys_getgid`, returns gid and egid and fixed libc `getgid` and `getegid`.

Rewrote `cat` error reporting (was used to test the above).

Fix minor improper wait structure definition in FAT filesystem.

