### PR TITLE
[kernel] Add bda4 device to build. Compress boot messages to one screen

### DIFF
--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -62,6 +62,7 @@ static void add_partition(register struct gendisk *hd,
     hdp->start_sect = start;
     hdp->nr_sects = size;
     print_minor_name(hd, minor);
+	printk("(%ld,%ld) ", start, size);
 }
 
 static int is_extended_partition(register struct partition *p)
@@ -244,7 +245,7 @@ void check_partition(register struct gendisk *hd, kdev_t dev)
     sector_t first_sector;
 
     if (first_time)
-	printk("Partition check:\n");
+	printk("Partitions:");
     first_time = 0;
     first_sector = hd->part[MINOR(dev)].start_sect;
 
@@ -259,7 +260,6 @@ void check_partition(register struct gendisk *hd, kdev_t dev)
     }
 #endif
 
-    printk(" ");
     print_minor_name(hd, MINOR(dev));
 
 #ifdef CONFIG_MSDOS_PARTITION
@@ -267,7 +267,7 @@ void check_partition(register struct gendisk *hd, kdev_t dev)
 	return;
 #endif
 
-    printk(" unknown partition table\n");
+    printk(" none.\n");
 }
 #endif
 

--- a/elks/arch/i86/drivers/char/serial.c
+++ b/elks/arch/i86/drivers/char/serial.c
@@ -364,10 +364,9 @@ int rs_init(void)
     } while (++sp < &ports[NR_SERIAL]);
 
     sp = ports;
-    printk("Serial driver version 0.02\n");
     do {
 	if (sp->tty != NULL) {
-	    printk("ttyS%d at 0x%x (irq = %d) is a%s\n", ttyno,
+	    printk("ttyS%d at 0x%x, irq %d is a%s\n", ttyno,
 		       sp->io, sp->irq, serial_type[sp->flags & 0x3]);
 	}
 	sp++;

--- a/elks/arch/i86/mm/init.c
+++ b/elks/arch/i86/mm/init.c
@@ -5,6 +5,7 @@
 
 #include <linuxmt/types.h>
 #include <linuxmt/kernel.h>
+#include <linuxmt/utsname.h>
 #include <linuxmt/config.h>
 
 #include <arch/system.h>
@@ -31,26 +32,25 @@ __u16 kernel_cs, kernel_ds;
 
 void mm_stat(seg_t start, seg_t end)
 {
-    register char *pi;
+    register int i;
     register char *cp;
 
-    pi = (char *)0x30;
+    i = 0x30;
     cp = proc_name;
     do {
-	*cp++ = setupb((int)pi++);
+	*cp++ = setupb(i++);
 
 #ifndef CONFIG_ARCH_SIBO
-
-	if(pi == (char *) 0x40) {
-	    printk("PC/%cT class machine, %s CPU\n%uK base RAM",
+	if (i == 0x40) {
+	    printk("PC/%cT class machine, %s CPU, %uK base RAM",
 		    arch_cpu > 5 ? 'A' : 'X', proc_name, setupw(0x2a));
 	    cp = proc_name;
-	    pi = (char *) 0x50;
+	    i = 0x50;
 	}
 
 #endif
 
-    } while ((int)pi <
+    } while (i <
 #ifndef CONFIG_ARCH_SIBO
 			0x5D);
 #else
@@ -69,9 +69,10 @@ void mm_stat(seg_t start, seg_t end)
 
 #endif
 
-    printk(".\nELKS kernel (%u text + %u data + %u bss + %u heap)\n"
-	   "Kernel text at %x:0000, data at %x:0000\n"
-	   "%u K of memory for user processes.\n",
+    printk(".\nELKS kernel %s (%u text + %u data + %u bss + %u heap)\n"
+	   "Kernel text at %x:0000, data at %x:0000, "
+	   "%uK for user processes.\n",
+	   system_utsname.release,
 	   (unsigned)_endtext, (unsigned)_enddata,
 	   (unsigned)_endbss - (unsigned)_enddata,
 	   1 + ~ (unsigned) _endbss,

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -4,7 +4,6 @@
 #include <linuxmt/sched.h>
 #include <linuxmt/types.h>
 #include <linuxmt/fcntl.h>
-#include <linuxmt/utsname.h>
 
 #include <arch/system.h>
 
@@ -49,7 +48,6 @@ void start_kernel(void)
     fs_init();
 
     mm_stat(base, end);
-    printk("ELKS version %s\n", system_utsname.release);
 
     kfork_proc(init_task);
     wake_up_process(&task[1]);

--- a/elkscmd/rootfs_template/etc/rc.d/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sys
@@ -20,7 +20,7 @@ ttybaud=4800
 
 if test -f /bin/ktcp
 then
-	echo -n 'Starting network process:'
+	echo -n 'Starting networking:'
 	if test "$interface" != "/dev/eth" 
 	then stty $ttybaud < $interface
 	echo -n ' stty slip'
@@ -31,7 +31,6 @@ then
 	echo ' ktcp'
 	ktcp $localip $interface &
 	
-	echo -n "Starting network services: "
 	for daemon in telnetd httpd
 	do
 		if test -f /bin/$daemon 
@@ -40,7 +39,6 @@ then
 			$daemon || true
 		fi
 	done
-	echo
 
 fi
 
@@ -51,5 +49,5 @@ if test -f /etc/motd
 then
     cat /etc/motd
 fi
-date
 
+date

--- a/image/Make.devices
+++ b/image/Make.devices
@@ -31,13 +31,35 @@ devices:
 #	$(MKDEV) /dev/kmsg c 1 11
 #	$(MKDEV) /dev/oldmem c 1 12
 
-
 ##############################################################################
 # RAM disks.
 
 	$(MKDEV) /dev/ram b 1 0 8
 	$(MKDEV) /dev/ramdisk b 1 1
 #	$MKSET   0 7  $(MKDEV) /dev/ram b 1
+
+##############################################################################
+# BIOS devices.
+# BIOS hard disks.
+# Limit to 4 primary partitions per disk (MBR).
+
+	$(MKDEV) /dev/bda  b 3 0
+	$(MKDEV) /dev/bda1 b 3 1
+	$(MKDEV) /dev/bda2 b 3 2
+	$(MKDEV) /dev/bda3 b 3 3
+	$(MKDEV) /dev/bda4 b 3 4
+	$(MKDEV) /dev/bdb  b 3 64
+	$(MKDEV) /dev/bdb1 b 3 65
+	$(MKDEV) /dev/bdb2 b 3 66
+	$(MKDEV) /dev/bdb3 b 3 67
+	$(MKDEV) /dev/bdb4 b 3 68
+#	$MKSET   0 15 $(MKDEV) /dev/bda b 3	# Currently
+#	$MKSET  64 15 $(MKDEV) /dev/bdb b 3	# Currently
+
+# BIOS Floppy diskettes.
+
+	$(MKDEV) /dev/fd0	b 3 128
+	$(MKDEV) /dev/fd1	b 3 192
 
 ##############################################################################
 # Pseudo-TTY master devices. 
@@ -65,14 +87,6 @@ devices:
 #	$MKSET 208 15 $(MKDEV) /dev/ptyc x 2
 #	$MKSET 224 15 $(MKDEV) /dev/ptyd x 2
 #	$MKSET 240 15 $(MKDEV) /dev/ptye x 2
-
-##############################################################################
-# Floppy diskettes. Only the auto-detect nodes are listed.
-
-	$(MKDEV) /dev/fd0	b 3 128 	# Currently.
-	$(MKDEV) /dev/fd1	b 3 192 	# Currently.
-
-#	$MKSET   0 3  $(MKDEV) /dev/fd b 2	# Ought to be.
 
 ##############################################################################
 # Pseudo-TTY slave devices. 
@@ -211,24 +225,6 @@ devices:
 
 #	$MKSET   0 63 $(MKDEV) /dev/xda b 13
 #	$MKSET  64 63 $(MKDEV) /dev/xdb b 13
-
-##############################################################################
-# BIOS hard disks.
-# Limit to 4 primary partitions per disk (MBR).
-
-	$(MKDEV) /dev/bda b 3  0    # Currently.
-	$(MKDEV) /dev/bda b 3  0 4  # Currently.
-	$(MKDEV) /dev/bdb b 3 64    # Currently.
-	$(MKDEV) /dev/bdb b 3 64 4  # Currently.
-#	$MKSET   0 15 $(MKDEV) /dev/bda b 3	# Currently
-#	$MKSET  64 15 $(MKDEV) /dev/bdb b 3	# Currently
-#	$MKSET 128 15 $(MKDEV) /dev/bdc b 3	# Currently
-#	$MKSET 192 15 $(MKDEV) /dev/bdd b 3	# Currently
-
-#	$MKSET   0 63 $(MKDEV) /dev/bda b 14	# Ought to be
-#	$MKSET  64 63 $(MKDEV) /dev/bdb b 14	# Ought to be
-#	$MKSET 128 63 $(MKDEV) /dev/bdc b 14	# Ought to be
-#	$MKSET 192 63 $(MKDEV) /dev/bdd b 14	# Ought to be
 
 ##############################################################################
 # Joysticks. These are not yet supported.


### PR DESCRIPTION
Support 4 partitions on MBR hard drives.

Removes `/dev/bda0` (duplicate of `/dev/bda`). Add `/dev/bda4` to image.
Same for `/dev/bdb0` and `/dev/bdb4`. (Second hard drive).
Show partition start sector and num sectors  at boot.
Replace 'unknown partition table' message with 'none.' at boot for flat HD images.

Tighten up boot messages to enable reading all kernel messages from setup to login on one screen, to help see what's going on at boot time. (Shown is boot from floppy with MBR-partitioned hard drive as second drive).

<img width="832" alt="Screen Shot 2020-03-24 at 11 24 57 PM" src="https://user-images.githubusercontent.com/11985637/77505140-f156d100-6e27-11ea-8f19-36195f68b5b3.png">
