### PR TITLE
[kernel] Last compiler warning cleanup for kernel and libc, other cleanup

### DIFF
--- a/elks/arch/i86/drivers/block/init.c
+++ b/elks/arch/i86/drivers/block/init.c
@@ -26,6 +26,7 @@
 #include <linuxmt/string.h>
 
 #include <arch/system.h>
+#include <arch/segment.h>
 
 extern void rd_load();
 extern void chr_dev_init();

--- a/elks/arch/i86/drivers/char/dircon.c
+++ b/elks/arch/i86/drivers/char/dircon.c
@@ -146,7 +146,8 @@ static void ScrollUp(register Console * C, int y)
 
     vp = (__u16 *)((__u16)(y * Width) << 1);
     if ((unsigned int)y < MaxRow)
-	fmemcpyb(vp, (seg_t) C->vseg, vp + Width, (seg_t) C->vseg, (MaxRow - y)*(Width << 1));
+	fmemcpyb((byte_t *)vp, (seg_t) C->vseg,
+		(byte_t *)(vp + Width), (seg_t) C->vseg, (MaxRow - y)*(Width << 1));
     ClearRange(C, 0, MaxRow, MaxCol, MaxRow);
 }
 
@@ -157,8 +158,9 @@ static void ScrollDown(register Console * C, int y)
     int yy = MaxRow + 1;
 
     vp = (__u16 *)((__u16)(yy * Width) << 1);
-    while (--y > y) {
-	fmemcpyb(vp, (seg_t) C->vseg, vp - Width, (seg_t) C->vseg, (Width << 1));
+    while (--yy > y) {
+	fmemcpyb((byte_t *)vp, (seg_t) C->vseg,
+		(byte_t *)(vp - Width), (seg_t) C->vseg, (Width << 1));
 	vp -= Width;
     }
     ClearRange(C, 0, y, MaxCol, y);
@@ -168,22 +170,22 @@ static void ScrollDown(register Console * C, int y)
 #if defined (CONFIG_EMUL_VT52) || defined (CONFIG_EMUL_ANSI)
 static void Console_gotoxy(register Console * C, int x, int y)
 {
-    register char *xp = (char *)x;
+    register int xp = x;
 
-    C->cx = ((((int) xp) >= MaxCol) ? MaxCol : ((((int)xp) < 0) ? 0 : (int)xp));
-    xp = (char *)y;
-    C->cy = ((((int) xp) >= MaxRow) ? MaxRow : ((((int)xp) < 0) ? 0 : (int)xp));
+    C->cx = (xp >= MaxCol) ? MaxCol : (xp < 0) ? 0 : xp;
+    xp = y;
+    C->cy = (xp >= MaxRow) ? MaxRow : (xp < 0) ? 0 : xp;
 }
 #endif
 
 #ifdef CONFIG_EMUL_ANSI
 static int parm1(register unsigned char *buf)
 {
-    register char *np;
+    int n;
 
-    if (!(np = (char *) atoi((char *) buf)))
-	np = 1;
-    return np;
+    if (!(n = atoi((char *)buf)))
+	n = 1;
+    return n;
 }
 
 static int parm2(register unsigned char *buf)
@@ -540,7 +542,7 @@ struct tty_ops dircon_ops = {
 void init_console(void)
 {
     register Console *C;
-    register char *pi;
+    register int i;
     unsigned PageSizeW;
     unsigned VideoSeg;
 
@@ -560,14 +562,14 @@ void init_console(void)
     C = Con;
     Visible = C;
 
-    for (pi = 0; ((unsigned int)pi) < NumConsoles; pi++) {
+    for (i = 0; i < NumConsoles; i++) {
 	C->cx = C->cy = 0;
-	if (!pi) {
+	if (!i) {
 	    C->cx = peekb(0x50, 0x40);
 	    C->cy = peekb(0x51, 0x40);
 	}
 	C->fsm = std_char;
-	C->basepage = (int)pi * PageSizeW;
+	C->basepage = i * PageSizeW;
 	C->vseg = VideoSeg + (C->basepage >> 3);
 	C->attr = A_DEFAULT;
 

--- a/elks/arch/i86/drivers/char/lp.c
+++ b/elks/arch/i86/drivers/char/lp.c
@@ -104,7 +104,7 @@ static int lp_char_polled(char c, unsigned int target)
 
 #if 0
 
-	if (!status & LP_SELECTED)) { /* printer offline */
+	if (!(status & LP_SELECTED)) { /* printer offline */
 	    printk("lp%d: printer offline\n", target);
 	    return 0;
 	}

--- a/elks/arch/i86/drivers/char/lp.c
+++ b/elks/arch/i86/drivers/char/lp.c
@@ -89,22 +89,22 @@ static int lp_char_polled(char c, unsigned int target)
 #endif
 
     {
-	register char *statusp;
+	int status;
 
 	/* safety checks */
-	statusp = (char *) LP_STATUS(lpp);
+	status = LP_STATUS(lpp);
 
 	/* safety checks, note that LP_ERROR and LP_SELECTED
 	 * are inverted signals */
 
-	if (((int)statusp) & LP_OUTOFPAPER) { /* printer out of paper */
+	if (status & LP_OUTOFPAPER) { /* printer out of paper */
 	    printk("lp%d: out of paper\n", target);
 	    return 0;
 	}
 
 #if 0
 
-	if (!(((int)statusp) & LP_SELECTED)) { /* printer offline */
+	if (!status & LP_SELECTED)) { /* printer offline */
 	    printk("lp%d: printer offline\n", target);
 	    return 0;
 	}
@@ -113,7 +113,7 @@ static int lp_char_polled(char c, unsigned int target)
 
 	wait = LP_CHAR_WAIT + 1;
 
-	while (!(((int)(statusp = (char *)LP_STATUS(lpp))) & LP_SELECTED))
+	while (!((status = LP_STATUS(lpp)) & LP_SELECTED))
 	    /* while not ready do busy loop */
 	    {
 		if (!--wait) {
@@ -129,7 +129,7 @@ static int lp_char_polled(char c, unsigned int target)
 	    }
 #endif
 
-	if (!(((int)statusp) & LP_ERROR)) { /* printer error */
+	if (!(status & LP_ERROR)) { /* printer error */
 	    printk("lp%d: printer error\n", target);
 	    return 0;
 	}
@@ -159,7 +159,7 @@ static int lp_char_polled(char c, unsigned int target)
     return 1;
 }
 
-static size_t lp_write(struct inode *inode, struct file *file, char *buf, int count)
+static size_t lp_write(struct inode *inode, struct file *file, char *buf, size_t count)
 {
     register char *chrsp;
 
@@ -183,11 +183,8 @@ static size_t lp_write(struct inode *inode, struct file *file, char *buf, int co
 static int lp_open(struct inode *inode, struct file *file)
 {
     register struct lp_info *lpp;
-    register char *statusp;
+    short status;
     unsigned short int target;
-#if 0
-    short int status;
-#endif
 
     target = MINOR(inode->i_rdev);
 
@@ -197,14 +194,14 @@ static int lp_open(struct inode *inode, struct file *file)
     lpp = &ports[port_order[target]];
 #endif
 
-    statusp = (char *)((short int)(lpp->flags));
+    status = lpp->flags;
 
-    if (!(((short int)statusp) & LP_EXIST)) { /* if LP_EXIST flag not set */
+    if (!(status & LP_EXIST)) { /* if LP_EXIST flag not set */
 	debug1("lp: device lp%d doesn't exist\n", target);
 	return -ENODEV;
     }
 
-    if (((short int)statusp) & LP_BUSY) { /* if LP_BUSY flag set */
+    if (status & LP_BUSY) { /* if LP_BUSY flag set */
 	debug1("lp: device lp%d busy\n", target);
 	return -EBUSY;
     }

--- a/elks/arch/i86/drivers/char/mem.c
+++ b/elks/arch/i86/drivers/char/mem.c
@@ -76,13 +76,13 @@ int null_lseek(struct inode *inode, struct file *filp,
     return 0;
 }
 
-size_t null_read(struct inode *inode, struct file *filp, char *data, int len)
+size_t null_read(struct inode *inode, struct file *filp, char *data, size_t len)
 {
     debugmem("null_read()\n");
     return 0;
 }
 
-size_t null_write(struct inode *inode, struct file *filp, char *data, int len)
+size_t null_write(struct inode *inode, struct file *filp, char *data, size_t len)
 {
     debugmem1("null write: ignoring %d bytes!\n", len);
     return (size_t)len;
@@ -91,14 +91,14 @@ size_t null_write(struct inode *inode, struct file *filp, char *data, int len)
 /*
  * /dev/full code
  */
-size_t full_read(struct inode *inode, struct file *filp, char *data, int len)
+size_t full_read(struct inode *inode, struct file *filp, char *data, size_t len)
 {
     debugmem("full_read()\n");
     filp->f_pos += len;
     return len;
 }
 
-size_t full_write(struct inode *inode, struct file *filp, char *data, int len)
+size_t full_write(struct inode *inode, struct file *filp, char *data, size_t len)
 {
     debugmem1("full_write: objecting to %d bytes!\n", len);
     return -ENOSPC;
@@ -107,10 +107,10 @@ size_t full_write(struct inode *inode, struct file *filp, char *data, int len)
 /*
  * /dev/zero code
  */
-size_t zero_read(struct inode *inode, struct file *filp, char *data, int len)
+size_t zero_read(struct inode *inode, struct file *filp, char *data, size_t len)
 {
     debugmem("zero_read()\n");
-    fmemsetb(data, current->t_regs.ds, 0, (word_t) len);
+    fmemsetb((word_t)data, current->t_regs.ds, 0, (word_t) len);
     filp->f_pos += len;
     return (size_t)len;
 }
@@ -133,7 +133,7 @@ size_t kmem_read(struct inode *inode, register struct file *filp,
     debugmem("[k]mem_read()\n");
     sseg = split_seg_off(&soff, filp->f_pos);
     debugmem3("Reading %u %p %p.\n", len, sseg, soff);
-    fmemcpyb(data, current->t_regs.ds, soff, sseg, (word_t) len);
+    fmemcpyb((byte_t *)data, current->t_regs.ds, (byte_t *)soff, sseg, (word_t) len);
     filp->f_pos += len;
     return (size_t) len;
 }
@@ -147,7 +147,7 @@ size_t kmem_write(struct inode *inode, register struct file *filp,
 
     dseg = split_seg_off(&doff, filp->f_pos);
     debugmem2("Writing to %d:%d\n", dseg, doff);
-    fmemcpyb(doff, dseg, data, current->t_regs.ds, (word_t) len);
+    fmemcpyb((byte_t *)doff, dseg, (byte_t *)data, current->t_regs.ds, (word_t) len);
     filp->f_pos += len;
     return len;
 }

--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -216,7 +216,7 @@ void tty_echo(register struct tty *tty, unsigned char ch)
  *
  */
 
-size_t tty_write(struct inode *inode, struct file *file, char *data, int len)
+size_t tty_write(struct inode *inode, struct file *file, char *data, size_t len)
 {
     register struct tty *tty = determine_tty(inode->i_rdev);
     int i, s;
@@ -236,7 +236,7 @@ size_t tty_write(struct inode *inode, struct file *file, char *data, int len)
     return i;
 }
 
-size_t tty_read(struct inode *inode, struct file *file, char *data, int len)
+size_t tty_read(struct inode *inode, struct file *file, char *data, size_t len)
 {
     register struct tty *tty = determine_tty(inode->i_rdev);
     int i = 0;

--- a/elks/arch/i86/drivers/char/pty.c
+++ b/elks/arch/i86/drivers/char/pty.c
@@ -77,7 +77,7 @@ int pty_select (struct inode *inode, struct file *file, int sel_type)
 	return res;
 }
 
-size_t pty_read (struct inode *inode, struct file *file, char *data, int len)
+size_t pty_read (struct inode *inode, struct file *file, char *data, size_t len)
 {
 	int count = 0;
 	int err;
@@ -100,7 +100,7 @@ size_t pty_read (struct inode *inode, struct file *file, char *data, int len)
 	return count;
 }
 
-size_t pty_write (struct inode *inode, struct file *file, char *data, int len)
+size_t pty_write (struct inode *inode, struct file *file, char *data, size_t len)
 {
 	int count = 0;
 	int err;

--- a/elks/arch/i86/drivers/char/serial.c
+++ b/elks/arch/i86/drivers/char/serial.c
@@ -96,28 +96,28 @@ static void flush_input_fifo(register struct serial_info *sp)
 static int rs_probe(register struct serial_info *sp)
 {
     int status1, status2;
-    register char *scratch;
+    unsigned char scratch;
 
     inb(sp->io + UART_IER);
     outb_p(0, sp->io + UART_IER);
-    scratch = (char *)inb_p(sp->io + UART_IER);
-    outb_p((unsigned char)scratch, sp->io + UART_IER);
-    if ((unsigned char)scratch)
+    scratch = inb_p(sp->io + UART_IER);
+    outb_p(scratch, sp->io + UART_IER);
+    if (scratch)
 	return -1;
 
     /* this code is weird, IMO */
-    scratch = (char *)inb_p(sp->io + UART_LCR);
-    outb_p((unsigned char)scratch | UART_LCR_DLAB, sp->io + UART_LCR);
+    scratch = inb_p(sp->io + UART_LCR);
+    outb_p(scratch | UART_LCR_DLAB, sp->io + UART_LCR);
     outb_p(0, sp->io + UART_EFR);
-    outb_p((unsigned char)scratch, sp->io + UART_LCR);
+    outb_p(scratch, sp->io + UART_LCR);
 
     outb_p(UART_FCR_ENABLE_FIFO, sp->io + UART_FCR);
 
     /* upper two bits of IIR define UART type, but according to both RB's
      * intlist and HelpPC this code is wrong, see comments marked with [*]
      */
-    scratch = (char *)(inb_p(sp->io + UART_IIR) >> 6);
-    switch ((unsigned char)scratch) {
+    scratch = inb_p(sp->io + UART_IIR) >> 6;
+    switch (scratch) {
     case 0:
 	sp->flags = (unsigned char) (SERF_EXIST | ST_16450);
 	break;
@@ -133,13 +133,13 @@ static int rs_probe(register struct serial_info *sp)
     }
 
     /* 8250 UART if scratch register isn't present */
-    if (!(unsigned char)scratch) {
-	scratch = (char *)inb_p(sp->io + UART_SCR);
+    if (!scratch) {
+	scratch = inb_p(sp->io + UART_SCR);
 	outb_p(0xA5, sp->io + UART_SCR);
 	status1 = inb_p(sp->io + UART_SCR);
 	outb_p(0x5A, sp->io + UART_SCR);
 	status2 = inb_p(sp->io + UART_SCR);
-	outb_p((unsigned char)scratch, sp->io + UART_SCR);
+	outb_p(scratch, sp->io + UART_SCR);
 	if ((status1 != 0xA5) || (status2 != 0x5A))
 	    sp->flags = (unsigned char) (SERF_EXIST | ST_8250);
     }
@@ -220,17 +220,17 @@ static void receive_chars(register struct serial_info *sp)
 void rs_irq(int irq, struct pt_regs *regs, void *dev_id)
 {
     register struct serial_info *sp;
-    register char *statusp;
+    int status;
 
 
     debug1("SERIAL: Interrupt %d received.\n", irq);
     sp = &ports[(int)irq_port[irq - 2]];
     do {
-	statusp = (char *)inb_p(sp->io + UART_LSR);
-	if ((int)statusp & UART_LSR_DR)		/* Receiver buffer full? */
+	status = inb_p(sp->io + UART_LSR);
+	if (status & UART_LSR_DR)		/* Receiver buffer full? */
 	    receive_chars(sp);
 #if 0
-	if (((int)statusp) & UART_LSR_THRE)	/* Transmitter buffer empty? */
+	if (status & UART_LSR_THRE)		/* Transmitter buffer empty? */
 	    transmit_chars(sp);
 #endif
     } while (!(inb_p(sp->io + UART_IIR) & UART_IIR_NO_INT));

--- a/elks/arch/i86/mm/user.c
+++ b/elks/arch/i86/mm/user.c
@@ -68,7 +68,7 @@ void put_user_char(unsigned char dv, void *dp)
 
 unsigned short int get_user(void *dv)
 {
-    return peekw(dv, current->t_regs.ds);
+    return peekw((word_t)dv, current->t_regs.ds);
 }
 
 void put_user(unsigned short int dv, void *dp)

--- a/elks/arch/i86/tools/mkbootloader.c
+++ b/elks/arch/i86/tools/mkbootloader.c
@@ -280,7 +280,7 @@ int main(int argcnt, char **arg)
 		    for (i = check.start; i < check.end; i++)
 			l += rom[i] & 0xff;
 		    rom[check.end] = -l;
-		    printf("[%02hhx @%05x]\n", rom[check.end] & 0xff,
+		    printf("[%02hhx @%05x]\n", (unsigned char)(rom[check.end] & 0xff),
 			   check.end);
 		    if ((unsigned char) rom[check.start + 2] < 3)
 			printf

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -190,7 +190,7 @@ int sys_execve(char *filename, char *sptr, size_t slen)
 	? (__pptr)base_data
 	: currentp->t_endseg) - slen;
     currentp->t_regs.sp = (__u16)(currentp->t_begstack);
-    fmemcpyb(currentp->t_begstack, seg_data->base, (word_t) sptr, ds, (word_t) slen);
+    fmemcpyb((byte_t *)currentp->t_begstack, seg_data->base, (byte_t *)sptr, ds, (word_t) slen);
 
     /* From this point, the old code and data segments are not needed anymore */
 

--- a/elks/fs/minix/inode.c
+++ b/elks/fs/minix/inode.c
@@ -288,8 +288,7 @@ static unsigned short map_iblock(struct inode *inode, block_t i,
     return *b_zone;
 }
 
-unsigned short _minix_bmap(register struct inode *inode,
-			   unsigned short block, int create)
+unsigned short _minix_bmap(register struct inode *inode, block_t block, int create)
 {
     register char *i;
 
@@ -331,8 +330,7 @@ unsigned short _minix_bmap(register struct inode *inode,
     return (unsigned short)i;
 }
 
-struct buffer_head *minix_getblk(register struct inode *inode,
-				 unsigned short block, int create)
+struct buffer_head *minix_getblk(register struct inode *inode, block_t block, int create)
 {
     unsigned short blknum;
 

--- a/elks/fs/minix/namei.c
+++ b/elks/fs/minix/namei.c
@@ -335,7 +335,7 @@ int minix_mkdir(register struct inode *dir, char *name, size_t len, int mode)
 static int empty_dir(register struct inode *inode)
 {
     unsigned short offset;
-    register struct buffer_head *bh;
+    register struct buffer_head *bh = NULL;
     struct minix_dir_entry *de;
     unsigned short dirsize;
     __u32 bo;

--- a/elks/fs/minix/symlink.c
+++ b/elks/fs/minix/symlink.c
@@ -64,7 +64,7 @@ static int minix_follow_link(struct inode *dir,
 }
 
 static int minix_readlink(register struct inode *inode,
-			  char *buffer, int buflen)
+			  char *buffer, size_t buflen)
 {
     register struct buffer_head *bh;
     size_t len;

--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -18,7 +18,7 @@
 #include <linuxmt/mm.h>
 #include <linuxmt/debug.h>
 
-static int msdos_dir_read(struct inode *dir, struct file *filp, char *buf, int count)
+static size_t msdos_dir_read(struct inode *dir, struct file *filp, char *buf, size_t count)
 {
     return -EISDIR;
 }

--- a/elks/fs/msdos/fat.c
+++ b/elks/fs/msdos/fat.c
@@ -18,11 +18,14 @@ static struct fat_cache *fat_cache,cache[FAT_CACHE];
 
 long fat_access(register struct super_block *sb,long this,long new_value)
 {
-	struct buffer_head *bh,*bh2,*c_bh,*c_bh2;
+	struct buffer_head *bh,*bh2;
 	unsigned char *p_first,*p_last;
-	void *data,*data2,*c_data,*c_data2;
-	long first,last,next,copy;
+	void *data,*data2;
+	long first,last,next;
 	int fatsz = MSDOS_SB(sb)->fat_bits;
+	//long copy;
+	//void *c_data, *c_data2;
+	//struct buffer_head *c_bh, *c_bh2;
 
 #ifndef FAT_BITS_32
 	if (fatsz == 32)

--- a/elks/fs/msdos/file.c
+++ b/elks/fs/msdos/file.c
@@ -20,9 +20,9 @@
 
 #define MIN(a,b) (((a) < (b)) ? (a) : (b))
 
-static int msdos_file_read(struct inode *inode,struct file *filp,char *buf,
+static size_t msdos_file_read(struct inode *inode,struct file *filp,char *buf,
     size_t count);
-static int msdos_file_write(struct inode *inode,struct file *filp,char *buf,
+static size_t msdos_file_write(struct inode *inode,struct file *filp,char *buf,
     size_t count);
 
 
@@ -61,7 +61,7 @@ struct inode_operations msdos_file_inode_operations_no_bmap = {
 };
 
 
-static int msdos_file_read(register struct inode *inode,register struct file *filp,
+static size_t msdos_file_read(register struct inode *inode,register struct file *filp,
 	char *buf,size_t count)
 {
 	char *start;
@@ -96,7 +96,7 @@ static int msdos_file_read(register struct inode *inode,register struct file *fi
 }
 
 
-static int msdos_file_write(register struct inode *inode,register struct file *filp,char *buf,
+static size_t msdos_file_write(register struct inode *inode,register struct file *filp,char *buf,
     size_t count)
 {
 	long sector;

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -26,7 +26,7 @@ struct buffer_head *msdos_sread(int dev,long sector,void **start)
 }
 
 
-static struct wait_queue *creation_wait = NULL;
+static struct wait_queue creation_wait;
 static int creation_lock = 0;
 
 

--- a/elks/fs/msdos/namei.c
+++ b/elks/fs/msdos/namei.c
@@ -20,7 +20,7 @@ unsigned char get_fs_byte(const void *dv)
 {
     unsigned char retv;
 
-    memcpy_fromfs(&retv,dv,1);
+    memcpy_fromfs(&retv,(void *)dv,1);
     return retv;
 }
 
@@ -112,7 +112,7 @@ static int msdos_find_long(struct inode *dir, const char *name, int len,
 
 }
 
-int msdos_lookup(register struct inode *dir,const char *name,int len,
+int msdos_lookup(register struct inode *dir,char *name,size_t len,
     register struct inode **result)
 {
 	ino_t ino;

--- a/elks/include/linuxmt/debug.h
+++ b/elks/include/linuxmt/debug.h
@@ -30,9 +30,10 @@
 #define DEBUG_BLK	0		/* block i/o*/
 #define DEBUG_FAT	0		/* FAT filesystem*/
 #define DEBUG_FILE	0		/* sys open and file i/o*/
+#define DEBUG_NET	0		/* networking*/
 #define DEBUG_SIG	0		/* signals*/
 #define DEBUG_SUP	0		/* superblock, mount, umount*/
-#define DEBUG_TTY	0		/* wait, exit*/
+#define DEBUG_TTY	0		/* tty driver*/
 #define DEBUG_WAIT	0		/* wait, exit*/
 
 #if DEBUG_BLK
@@ -51,6 +52,12 @@
 #define debug_file	printk
 #else
 #define debug_file(...)
+#endif
+
+#if DEBUG_NET
+#define debug_net	printk
+#else
+#define debug_net(...)
 #endif
 
 #if DEBUG_SIG

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -359,7 +359,7 @@ struct inode_operations {
     int 			(*follow_link) ();
 
 #ifdef USE_GETBLK
-    struct buffer_head *	(*getblk) ();
+    struct buffer_head *	(*getblk) (struct inode *, block_t, int);
 #endif
 
     void			(*truncate) ();

--- a/elks/include/linuxmt/msdos_fs.h
+++ b/elks/include/linuxmt/msdos_fs.h
@@ -153,7 +153,7 @@ long get_cluster(struct inode *inode,long cluster);
 
 /* namei.c */
 
-extern int msdos_lookup(struct inode *dir,const char *name,int len,
+extern int msdos_lookup(struct inode *dir,char *name,size_t len,
 	struct inode **result);
 extern int msdos_create(struct inode *dir,const char *name,int len,int mode,
 	struct inode **result);

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -113,6 +113,9 @@ struct task_struct {
 
 /*@-namechecks@*/
 
+#define DEPRECATED
+//#define DEPRECATED	__attribute__ ((deprecated))
+
 /* We use typedefs to avoid using struct foobar (*) */
 typedef struct task_struct __task, *__ptask;
 
@@ -137,8 +140,8 @@ extern void wait_clear(struct wait_queue *);
 
 // This old style sleep is unsafe
 // Use wait_event instead
-extern void sleep_on(struct wait_queue *) __attribute__ ((deprecated));
-extern void interruptible_sleep_on(struct wait_queue *)__attribute__ ((deprecated));
+extern void sleep_on(struct wait_queue *) DEPRECATED;
+extern void interruptible_sleep_on(struct wait_queue *) DEPRECATED;
 
 /*@-namechecks@*/
 
@@ -149,8 +152,8 @@ extern void _wake_up(struct wait_queue *,unsigned short int);
 // These old style semaphore functions are unsafe
 // Use count_t for reference counting
 // Use lock_t for object locking
-extern void down (short int *) __attribute__ ((deprecated));
-extern void up (short int *) __attribute__ ((deprecated));
+extern void down (short int *)  DEPRECATED;
+extern void up (short int *)  DEPRECATED;
 
 extern void wake_up_process(struct task_struct *);
 

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -18,6 +18,7 @@
 #include <linuxmt/fcntl.h>
 #include <linuxmt/net.h>
 #include <linuxmt/tcpdev.h>
+#include <linuxmt/debug.h>
 
 #include "af_inet.h"
 
@@ -55,7 +56,7 @@ extern char tcpdev_inuse;
 
 static int inet_create(struct socket *sock, int protocol)
 {
-    debug1("inet_create(sock: 0x%x)\n", sock);
+    debug_net("NET inet_create(sock: 0x%x) tcpdev %d\n", sock, tcpdev_inuse);
 
     if (protocol != 0 || !tcpdev_inuse)
         return -EINVAL;
@@ -74,7 +75,7 @@ static int inet_release(struct socket *sock, struct socket *peer)
     register struct tdb_release *cmd;
     int ret;
 
-    debug1("inet_release(sock: 0x%x)\n", sock);
+    debug_net("NET inet_release(sock: 0x%x) tcpdev %d\n", sock, tcpdev_inuse);
 	if (!tcpdev_inuse)
 		return -EINVAL;
     cmd = (struct tdb_release *)get_tdout_buf();

--- a/elks/net/socket.c
+++ b/elks/net/socket.c
@@ -23,6 +23,7 @@
 #include <linuxmt/sched.h>
 #include <linuxmt/fcntl.h>
 #include <linuxmt/stat.h>
+#include <linuxmt/debug.h>
 
 #include <arch/segment.h>
 
@@ -633,6 +634,7 @@ int sys_socket(int family, int type, int protocol)
 	sock_release(sock);
 	return fd;
     }
+    debug_net("SOCK success\n");
 
     if ((fd = get_fd(SOCK_INODE(sock))) < 0) {
 	sock_release(sock);

--- a/elkscmd/ash/Makefile
+++ b/elkscmd/ash/Makefile
@@ -8,6 +8,7 @@ BASEDIR = ..
 include $(BASEDIR)/Make.defs
 
 LOCALFLAGS = -DSHELL -I. -D_MINIX -D_POSIX_SOURCE -Dlint
+LOCALFLAGS += -Wno-implicit-int
 
 ###############################################################################
 #

--- a/elkscmd/ash/cd.c
+++ b/elkscmd/ash/cd.c
@@ -54,6 +54,7 @@ static char sccsid[] = "@(#)cd.c	5.2 (Berkeley) 3/13/91";
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <errno.h>
+#include <unistd.h>
 
 
 #ifdef __STDC__

--- a/elkscmd/ash/error.c
+++ b/elkscmd/ash/error.c
@@ -49,6 +49,8 @@ static char sccsid[] = "@(#)error.c	5.1 (Berkeley) 3/7/91";
 #include "error.h"
 #include <sys/types.h>
 #include <signal.h>
+#include <stdlib.h>
+#include <unistd.h>
 #ifdef __STDC__
 #include "stdarg.h"
 #else

--- a/elkscmd/ash/eval.c
+++ b/elkscmd/ash/eval.c
@@ -62,6 +62,7 @@ static char sccsid[] = "@(#)eval.c	5.3 (Berkeley) 4/12/91";
 #include "mystring.h"
 #include <sys/types.h>
 #include <signal.h>
+#include <unistd.h>
 #include "debug.h"
 
 

--- a/elkscmd/ash/exec.c
+++ b/elkscmd/ash/exec.c
@@ -69,6 +69,7 @@ static char sccsid[] = "@(#)exec.c	5.2 (Berkeley) 3/13/91";
 #include <fcntl.h>
 #include <errno.h>
 #include <limits.h>
+#include <unistd.h>
 
 
 #define CMDTABLESIZE 31		/* should be prime */

--- a/elkscmd/ash/expand.c
+++ b/elkscmd/ash/expand.c
@@ -62,6 +62,7 @@ static char sccsid[] = "@(#)expand.c	5.1 (Berkeley) 3/7/91";
 #include <sys/stat.h>
 #include <errno.h>
 #include <dirent.h>
+#include <unistd.h>
 #if USEGETPW
 #include <pwd.h>
 #endif

--- a/elkscmd/ash/input.c
+++ b/elkscmd/ash/input.c
@@ -44,14 +44,17 @@ static char sccsid[] = "@(#)input.c	5.4 (Berkeley) 7/1/91";
 
 #include <sys/types.h>
 #include <stdio.h>	/* defines BUFSIZ */
+#include <string.h>
 #include "shell.h"
 #include <fcntl.h>
 #include <errno.h>
+#include <unistd.h>
 #include "syntax.h"
 #include "input.h"
 #include "output.h"
 #include "memalloc.h"
 #include "error.h"
+#include "redir.h"
 
 #define EOF_NLEFT -99		/* value of parsenleft when EOF pushed back */
 
@@ -92,8 +95,6 @@ STATIC void pushfile(void);
 #else
 STATIC void pushfile();
 #endif
-
-
 
 #ifdef mkinit
 INCLUDE "input.h"

--- a/elkscmd/ash/jobs.c
+++ b/elkscmd/ash/jobs.c
@@ -61,6 +61,7 @@ static char sccsid[] = "@(#)jobs.c	5.1 (Berkeley) 3/7/91";
 #include <fcntl.h>
 #include <signal.h>
 #include <errno.h>
+#include <unistd.h>
 #ifdef BSD
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -79,13 +80,13 @@ MKINIT short backgndpid = -1;	/* pid of last background process */
 #if JOBS
 int initialpgrp;		/* pgrp of shell on invocation */
 short curjob;			/* current job */
+STATIC void restartjob(struct job *);
+STATIC int procrunning(int);
 #endif
 
 #ifdef __STDC__
-STATIC void restartjob(struct job *);
 STATIC struct job *getjob(char *);
 STATIC void freejob(struct job *);
-STATIC int procrunning(int);
 STATIC int dowait(int, struct job *);
 STATIC int waitproc(int, int *);
 STATIC char *commandtext(union node *);
@@ -439,6 +440,7 @@ currentjob:
 		}
 	}
 	error("No such job: %s", name);
+	return NULL;
 }
 
 

--- a/elkscmd/ash/mail.c
+++ b/elkscmd/ash/mail.c
@@ -48,6 +48,8 @@ static char sccsid[] = "@(#)mail.c	5.1 (Berkeley) 3/7/91";
 #include "output.h"
 #include "memalloc.h"
 #include "error.h"
+#include <unistd.h>
+#include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 

--- a/elkscmd/ash/main.c
+++ b/elkscmd/ash/main.c
@@ -47,6 +47,7 @@ static char sccsid[] = "@(#)main.c	5.2 (Berkeley) 3/13/91";
 #include <sys/types.h>
 #include <signal.h>
 #include <fcntl.h>
+#include <stdlib.h>
 #include "shell.h"
 #include "main.h"
 #include "mail.h"
@@ -81,10 +82,8 @@ extern int etext();
 
 #ifdef __STDC__
 STATIC void read_profile(char *);
-char *getenv(char *);
 #else
 STATIC void read_profile();
-char *getenv();
 #endif
 
 

--- a/elkscmd/ash/memalloc.c
+++ b/elkscmd/ash/memalloc.c
@@ -38,6 +38,8 @@
 static char sccsid[] = "@(#)memalloc.c	5.2 (Berkeley) 3/13/91";
 #endif /* not lint */
 
+#include <unistd.h>
+#include <stdlib.h>
 #include "shell.h"
 #include "output.h"
 #include "memalloc.h"

--- a/elkscmd/ash/miscbltin.c
+++ b/elkscmd/ash/miscbltin.c
@@ -42,6 +42,9 @@ static char sccsid[] = "@(#)miscbltin.c	5.2 (Berkeley) 3/13/91";
  * Miscelaneous builtins.
  */
 
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/stat.h>
 #include "shell.h"
 #include "options.h"
 #include "var.h"

--- a/elkscmd/ash/mksyntax.c
+++ b/elkscmd/ash/mksyntax.c
@@ -222,7 +222,7 @@ void digit_convert(void)
 		for (p = digit ; *p && *p != i ; p++);
 		if (*p == '\0')
 			p = digit;
-		fprintf(cfile, "      %d,\n", p - digit);
+		fprintf(cfile, "      %ld,\n", (long)(p - digit));
 	}
 	fputs("};\n", cfile);
 }

--- a/elkscmd/ash/options.c
+++ b/elkscmd/ash/options.c
@@ -38,6 +38,7 @@
 static char sccsid[] = "@(#)options.c	5.2 (Berkeley) 3/13/91";
 #endif /* not lint */
 
+#include <unistd.h>
 #include "shell.h"
 #define DEFINE_OPTIONS
 #include "options.h"

--- a/elkscmd/ash/output.c
+++ b/elkscmd/ash/output.c
@@ -50,6 +50,8 @@ static char sccsid[] = "@(#)output.c	5.1 (Berkeley) 3/7/91";
  */
 
 #include <stdio.h>	/* defines BUFSIZ */
+#include <string.h>
+#include <unistd.h>
 #include "shell.h"
 #include "syntax.h"
 #include "output.h"

--- a/elkscmd/ash/redir.c
+++ b/elkscmd/ash/redir.c
@@ -56,6 +56,9 @@ static char sccsid[] = "@(#)redir.c	5.1 (Berkeley) 3/7/91";
 #include <fcntl.h>
 #include <errno.h>
 #include <limits.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
 
 
 #define EMPTY -2		/* marks an unused slot in redirtab */

--- a/elkscmd/ash/trap.c
+++ b/elkscmd/ash/trap.c
@@ -38,6 +38,7 @@
 static char sccsid[] = "@(#)trap.c	5.2 (Berkeley) 4/12/91";
 #endif /* not lint */
 
+#include <unistd.h>
 #include "shell.h"
 #include "main.h"
 #include "nodes.h"	/* for other headers */

--- a/elkscmd/ash/var.c
+++ b/elkscmd/ash/var.c
@@ -42,6 +42,7 @@ static char sccsid[] = "@(#)var.c	5.3 (Berkeley) 4/12/91";
  * Shell variables.
  */
 
+#include <unistd.h>
 #include "shell.h"
 #include "output.h"
 #include "expand.h"

--- a/elkscmd/inet/httpd/httpd.c
+++ b/elkscmd/inet/httpd/httpd.c
@@ -192,7 +192,8 @@ char** argv;
 	dup2(ret, 0);
 	dup2(ret, 1);
 	dup2(ret, 2);
-	close(ret);
+	if (ret > 2)
+		close(ret);
 	setsid();
 
 	while (1){

--- a/elkscmd/inet/telnetd/telnetd.c
+++ b/elkscmd/inet/telnetd/telnetd.c
@@ -204,6 +204,7 @@ int main(int argc, char *argv[]) {
   addr_in.sin_port = htons(23);
   if (bind(sockfd, (struct sockaddr*)&addr_in, sizeof(addr_in)) == -1) {
     perror("bind error");
+	close(sockfd);
     exit(-1);
   }
 
@@ -219,7 +220,8 @@ int main(int argc, char *argv[]) {
 	dup2(ret, 0);
 	dup2(ret, 1);
 	dup2(ret, 2);
-	close(ret);
+	if (ret > 2)
+		close(ret);
 
 	while (1) {
 		connectionfd = accept (sockfd, (struct sockaddr *) NULL, NULL);

--- a/elkscmd/rootfs_template/etc/rc.d/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sys
@@ -51,4 +51,3 @@ then
 fi
 
 date
-reboot

--- a/elkscmd/rootfs_template/etc/rc.d/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sys
@@ -51,3 +51,4 @@ then
 fi
 
 date
+reboot

--- a/libc/include/string.h
+++ b/libc/include/string.h
@@ -42,7 +42,7 @@ extern char * strerror __P ((int));
 /* Other common BSD functions */
 extern int strcasecmp __P ((char*, char*));
 extern int strncasecmp __P ((char*, char*, size_t));
-char *strpbrk __P ((char *, char *));
+char *strpbrk __P ((const char *, const char *));
 char *strsep __P ((char **, char *));
 
 char * strstr (const char *, const char *);

--- a/libc/string/strpbrk.c
+++ b/libc/string/strpbrk.c
@@ -7,9 +7,7 @@
 
 /* This uses strchr, strchr should be in assembler */
 
-char *strpbrk(str, set)
-register char *str;
-char *set;
+char *strpbrk(const char *str, const char *set)
 {
   while (*str != '\0')
     if (strchr(set, *str) == 0)

--- a/libc/string/strrchr.c
+++ b/libc/string/strrchr.c
@@ -6,12 +6,12 @@ strrchr (const char * s, int c)
    register const char * prev = 0;
    register const char * p = s;
    /* For null it's just like strlen */
-   if( c == '\0' ) return p+strlen(p);
+   if( c == '\0' ) return (char *)p+strlen(p);
 
    /* everything else just step along the string. */
    while( (p=strchr(p, c)) != 0 )
    {
       prev = p; p++;
    }
-   return prev;
+   return (char *)prev;
 }

--- a/qemu.sh
+++ b/qemu.sh
@@ -15,6 +15,8 @@ IMAGE="-fda image/fd1440.bin"
 #IMAGE="-fda image/fd720.bin"
 #IMAGE="-fda image/fd360.bin"
 #IMAGE="-hda image/hd.bin"
+#IMAGE="-boot order=a -fda image/fd1440.bin \
+	-drive file=image/hd32-minix.bin,format=raw,if=ide"
 
 # FAT package manager build
 #IMAGE="-fda image/fd360-fat.bin"


### PR DESCRIPTION
Eliminates all kernel and libc compiler warnings, except those that need careful attention and testing to fix.

Lots of minor fixes, including BCC-register-optimizations of using `register char *` then casting with `(int)`. I suspect this generated better BCC code, but is terrible use of C with `gcc`.

While reading compiler warnings for elimination, the following bugs were found and fixed:
Direct console driver ANSI insert line broken (affects `vi`).
`mkdir` on Minix FS buffer release bug on non-empty directory.
BIOS HD partition start sector and numsectors truncated when > 65535.

In order to reduce kernel compiler warning output, the various semaphore operators tagged as `deprecated` are temporarily turned off using 'DEPRECATED' define (@mfld-fr: one line change in 'sched.h' to turn them back on when you're ready to replace them).
 
Other minor changes:
BIOS floppy and hard disk driver always uses `bioshd:` for kernel messages, instead of `doshd:` and `hd:`.
Libc `const` decls added in some string functions (more to do, but stopping at compiler warnings).
Added many missing include files for libc functions in `ash`.
Added `debug_net` debugging macro that allowed tracing down networking application startup race condition over `tcpdev_inuse` kernel variable. The race condition is fixed in the next PR.

With kernel and libc warnings down to a bare minimum, it should be easier to track down bugs in new code, and fix remaining issues using the remaining warnings. 

A huge amount of compiler warnings remain for ELKS applications, far too many to tackle easily.