### PR TITLE
[net] Workaround for networking startup race condition

### DIFF
--- a/elkscmd/rootfs_template/etc/rc.d/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sys
@@ -29,17 +29,17 @@ then
 	fi
 	
 	echo ' ktcp'
-	ktcp $localip $interface &
-	
-	for daemon in telnetd httpd
-	do
-		if test -f /bin/$daemon 
-		then
-			echo -n " $daemon "
-			$daemon || true
-		fi
-	done
-
+	# run ktcp as background daemon if successful starting networking
+	if ktcp -b $localip $interface ; then
+		for daemon in telnetd httpd
+		do
+			if test -f /bin/$daemon
+			then
+				echo -n " $daemon "
+				$daemon || true
+			fi
+		done
+	fi
 fi
 
 # 


### PR DESCRIPTION
Provides a workaround for application race condition generated by shared access to global kernel variable `tcpdev_inuse` in networking code.

Workaround consists of not starting `ktcp` asynchronously by the shell in the /etc/rc.d/rc.sys networking startup script. Instead, a `-b` option was added to `ktcp` to fork and become a background process AFTER determining whether `/dev/eth` is active, and if not, exiting with an error.

The race condition is that both `/dev/eth` and access to AF_INET sockets are both controlled by whether the kernel global variable `tcpdev_inuse` is true. When `ktcp` started up asynchronously, it opened `/dev/eth` which succeeded, and the kernel set `tcpdev_inuse` to true. Sometimes, before `ktcp` could continue running and later close `/dev/eth` (reseting `tcpdev_inuse` ), it was scheduled out and the shell continued processing of the rc.sys script, which started `telnetd`. `telnetd` would ask to open a socket, which, if `tcpdev_inuse` was true, would erroneously succeed, and then hang further in the kernel socket create code, which stopped the boot.

The workaround to `ktcp` allows it to run in the foreground for backwards compatibility, but should always be run with the `-b` option in system startup to avoid the race condition, as it will return an error and close the tcp device before another command is executed by the shell in rc.sys.

This workaround has the further effect that `telnetd` and `httpd` are not executed if `ktcp` fails, so system startup will be quicker for non-networked kernels.