### PR TITLE
[build] Add 32MB FAT bootable hard disk image to build

### DIFF
--- a/image/Make.defs
+++ b/image/Make.defs
@@ -30,19 +30,20 @@ FD_FAT_BOOT = $(BOOTBLOCKS_DIR)/fat.bin
 MINIX_MKFSOPTS=
 
 # mformat options
-# -f size	image size in kilobytes
+# -f size	image size in kilobytes (up to 2880k only)
+# -s secs	num sectors/track
+# -h heads	num disk heads
+# -t tracks	num disk tracks
+# -c 1		cluster size 1 sector
 # -M 512	software sector size 512 (=physical sector size)
 # -d 2		2 FAT tables
 # -L 9		9 FAT sectors (mformat forces 3 for 360k, 5 for 720k)
 # -r 14		14 root directory sectors
-# -c 1		cluster size 1 sector
 # -R 1		1 reserve sector (boot, may need to reserve 2)
-# -B boot      use passed boot file (not used)
 # -k		only update offsets 11 through 61 in boot block, all else unchanged
 # -N 0		serial number 0
 # -v label	volume label (don't use with first format as uses two directory entries)
-# -C		create image (buggy, leaves nonzero data in image)
-FAT_MKFSOPTS = -f $(TARGET_BLKS) -M 512 -d 2 -L 9 -r 14 -c 1 -k -N 0
+FAT_MKFSOPTS = -f $(TARGET_BLKS) -M 512 -d 2 -L 9 -r 14 -k -N 0 -c 1
 
 # mcopy options
 # -v		verbose
@@ -82,8 +83,8 @@ TARGET_FILE = $(IMG_DIR)/fd2880.bin
 TARGET_BLKS = 2880
 BPB = -B36,2,80
 MINIX_MKFSOPTS = -1 -n14 -i720 -s$(TARGET_BLKS)
-# use cluster size of 2 for 2880 FAT image
-FAT_MKFSOPTS = -f $(TARGET_BLKS) -M 512 -d 2 -L 9 -r 14 -c 2 -k -N 0
+# FAT12 2880k, use cluster size 2
+FAT_MKFSOPTS = -f $(TARGET_BLKS) -M 512 -d 2 -L 9 -r 14 -k -N 0 -c 2
 endif
 
 ifdef CONFIG_IMG_HD
@@ -91,7 +92,9 @@ TARGET_FILE = $(IMG_DIR)/hd.bin
 TARGET_BLKS = $(CONFIG_IMG_BLOCKS)
 BPB = -B$(CONFIG_IMG_SECT),$(CONFIG_IMG_HEAD),$(CONFIG_IMG_CYL)
 MINIX_MKFSOPTS = -1 -n14 -i720 -s$(CONFIG_IMG_BLOCKS)
-FAT_MKFS_OPTS = -s $(CONFIG_IMG_SECT) -h $(CONFIG_IMG_HEAD) -t $(CONFIG_IMG_CYL)
+# FAT16 HD, cluster size 2, autocalc num root directory sectors
+FAT_MKFSOPTS = -s $(CONFIG_IMG_SECT) -h $(CONFIG_IMG_HEAD) -t $(CONFIG_IMG_CYL) \
+					-M 512 -d 2 -k -N 0 -c 2
 endif
 
 ifdef CONFIG_IMG_RAW

--- a/image/Makefile
+++ b/image/Makefile
@@ -28,7 +28,7 @@ images: images-minix hd32-minix images-fat
 
 images-minix: fd360-minix fd720-minix fd1440-minix fd2880-minix hd32-minix
 
-images-fat: fd360-fat fd720-fat fd1440-fat fd2880-fat
+images-fat: fd360-fat fd720-fat fd1440-fat fd2880-fat hd32-fat
 
 fd360-minix:
 	echo CONFIG_APPS_360K=y		> Config
@@ -116,8 +116,19 @@ fd2880-fat:
 	$(MAKE) -f Make.image "CONFIG=$(TOPDIR)/image/Config" NAME=fd2880-fat
 	rm Config
 
-# FAT32 image (fails on mformat currently)
+# FAT32 image
 hd32-fat:
+	echo CONFIG_APPS_2880K=y	> Config
+	echo CONFIG_IMG_HD=y		>> Config
+	echo CONFIG_IMG_BLOCKS=31752 >> Config
+	echo CONFIG_IMG_SECT=63		>> Config
+	echo CONFIG_IMG_HEAD=16		>> Config
+	echo CONFIG_IMG_CYL=63		>> Config
+	echo CONFIG_IMG_FAT=y		>> Config
+	echo CONFIG_IMG_DEV=y		>> Config
+	echo CONFIG_IMG_BOOT=y		>> Config
+	$(MAKE) -f Make.image "CONFIG=$(TOPDIR)/image/Config" NAME=hd32-fat
+	rm Config
 
 # Clean target
 

--- a/qemu.sh
+++ b/qemu.sh
@@ -15,20 +15,22 @@ IMAGE="-fda image/fd1440.bin"
 #IMAGE="-fda image/fd720.bin"
 #IMAGE="-fda image/fd360.bin"
 #IMAGE="-hda image/hd.bin"
-#IMAGE="-boot order=a -fda image/fd1440.bin \
-	-drive file=image/hd32-minix.bin,format=raw,if=ide"
+#IMAGE="-boot order=a -fda image/fd1440.bin -drive file=image/hd32-minix.bin,format=raw,if=ide"
 
 # FAT package manager build
 #IMAGE="-fda image/fd360-fat.bin"
 #IMAGE="-fda image/fd720-fat.bin"
 #IMAGE="-fda image/fd1440-fat.bin"
 #IMAGE="-fda image/fd2880-fat.bin"
+#IMAGE="-hda image/hd32-fat.bin"
+#IMAGE="-hda image/hd32-fat.bin -fda image/fd1440-minix.bin"
 
 # MINIX package manager build
 #IMAGE="-fda image/fd360-minix.bin"
 #IMAGE="-fda image/fd720-minix.bin"
 #IMAGE="-fda image/fd1440-minix.bin"
 #IMAGE="-fda image/fd2880-minix.bin"
+#IMAGE="-hda image/hd32-minix.bin"
 
 # Second disk for mount after boot
 #DISK2="-fdb image/fd360-fat.bin"


### PR DESCRIPTION
Bootable 'flat' FAT hard drives of user-specified size can now be created in ELKS. This sets the stage for creating and booting ELKS MBR-based Minix or FAT images in next step.

Adds capability to select bootable FAT hard drive of config-selected size to build.

Adds bootable 32MB `hd32-fat.bin` to extra images when extra images selected in config.

Added code to recognize and skip non-existent partition tables in sector 0 during bioshd partition scan.

Updated boot message for better clarity during partition scan for both partitioned and non-partitioned disks.




