### PR TITLE
	add command history to sash(), fix wc()

### DIFF
--- a/elkscmd/minix1/wc.c
+++ b/elkscmd/minix1/wc.c
@@ -73,8 +73,6 @@ int main(int argc, char **argv)
   char *cp;
   int tflag, files;
 
-  if (argc < 2) goto usage;
-
   /* Get flags. */
   files = argc - 1;
   k = 1;

--- a/elkscmd/sash/Makefile
+++ b/elkscmd/sash/Makefile
@@ -12,7 +12,7 @@ include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
-OBJS = sash.o cmds.o cmd_dd.o cmd_ed.o cmd_grep.o cmd_ls.o cmd_tar.o utils.o
+OBJS = sash.o cmds.o cmd_dd.o cmd_ed.o cmd_grep.o cmd_ls.o cmd_tar.o utils.o cmd_history.o
 #LDFLAGS += -maout-chmem=0xc000
 
 all: sash

--- a/elkscmd/sash/cmd_history.c
+++ b/elkscmd/sash/cmd_history.c
@@ -1,0 +1,249 @@
+/*
+ * HS (@mellvik) for the ELKS project - march 2020 
+ * 
+ * implements csh like command history for sash
+ * 
+ */
+
+#include "sash.h"
+#ifdef CMD_HISTORY
+
+#define HISTMAX 200
+#define HISTMIN 20
+static  int     lastcom = -1;   /* index of most recent command */
+static  int     histind = 0;    /* cmd # for history list */
+static  char    **histbuf;      /* array holding commands */
+int     histcnt = HISTMIN;
+static	void	phex(char *);
+static	void	phlist();
+
+/*#define DEBUG*/
+
+void
+init_hist() {
+	int k = 0;
+	char *cp;
+
+        cp = getenv("HISTORY");
+        if (cp) {
+                histcnt = atoi(cp);
+                if (histcnt > HISTMAX)
+                        histcnt = HISTMAX;
+        }
+        histbuf = malloc(histcnt * sizeof(char*));
+        if (!histbuf) {
+                fprintf(stderr, "No history buffer, history turned off\n");
+                histcnt = 0;
+        }
+        while (k < histcnt)     /* initialize history list */
+                histbuf[k++] = NULL;
+}
+
+
+void
+do_history(argc, argv) /* list ccommands in history buffer */
+	int argc;
+        char **argv;
+{
+        int k = 0;
+        int j = lastcom+1;
+
+        while (k < histcnt) {
+                if (histbuf[j])
+                        printf(" %i  %s\n", histind-histcnt+k+1, histbuf[j]);
+                if (++j >= histcnt)
+                        j = 0;  /* wrap around */
+                k++;
+        }
+}
+
+int
+map_ind(int idx) {      /* map history number to index into history buffer */
+        int ind;
+
+        if (idx < 0)
+                ind = histind + idx + 1;        /* turn backw ref into # */
+        else
+                ind = idx;
+        /* check sanity & return NULL if error */
+        if ((ind < 0 ) || (ind > histind) || (ind < (histind - histcnt))) return(-1);
+        ind = lastcom - (histind - ind);
+        if (ind >=0)
+                return(ind);
+        else
+                return(histcnt + ind);
+}
+
+
+char *
+cmd_get(int idx) { /* return the selected command from the history buffer */
+                   /* error processing already done */
+        return(histbuf[map_ind(idx)]);
+}
+
+/* 
+ * Edit the commandline in cm using substitute operation in 'edit', reslt pointed to by dst
+ * syntax: ^old^new<EOL>
+ * Return NULL on error 
+ * TODO: Does not (yet) support multiple occurences of the replacement string
+ * or regexp.
+ */
+char *
+cmd_edit(char *cm, char *edit, char *dst) {
+        char delim = *edit;
+        char *pmid, *psub, *tmp;
+
+        if (!cm)
+                return("\0");   /* got null string */
+        if (!(tmp = malloc(80))) {
+                printf("Malloc error in substitute.\n");
+                return(NULL);
+        }
+        if ((pmid = strchr(++edit, (int) delim))) {
+                *pmid = '\0';
+                /*fprintf(stderr, "subst: %s -- %s\n", cm, edit);*/
+                if (!(psub = strstr(cm, edit))) {
+                        fprintf(stderr, "substitution failed\n");
+                        *tmp = '\0';
+                } else {
+                        strncpy(tmp, cm, (int)(psub - cm));
+                        strcat(tmp, ++pmid);
+                        strcat(tmp, (char *)(psub+strlen(edit)));
+                        /* warning - buffer oveflow possible in *tmp */
+                }
+        }
+        strcpy(dst, tmp);
+        free(tmp);
+        if (*dst == '\0')
+                return(NULL);
+        else
+                return(dst);
+
+}
+
+int
+add_to_history(char *cm) {
+
+        char *p;
+#ifdef DEBUG
+        phex(cm);
+#endif
+        if (++lastcom >= histcnt) lastcom = 0; /* wrap around */
+        p = histbuf[lastcom];
+        /*fprintf(stderr, "%s lastcom %d (%04x) p=%04x ", cm, lastcom, (int)&cm, p);*/
+        if (p) free(p);
+        if ((p = malloc(strlen(cm)+1)))
+                strcpy(p, cm);
+        else {
+                p = NULL;       /* error */
+                fputs("malloc error in history list\n", stderr);
+                return(-1);
+        }
+        histbuf[lastcom] = p;
+        histind++;
+        /*fprintf(stderr, " CMD: %s --- adr: %04x %04x %04x\n", cm, p, histbuf[lastcom]);
+        phlist();*/
+        return(0);
+}
+#ifdef DEBUG
+int dmap_ind(int idx) {
+        int index;      /* debug wrapper for map_ind() */
+        index = map_ind(idx);
+        fprintf(stderr, "map_ind: in %i, out %i\n", idx, index);
+        fflush(stderr);
+        return(index);
+}
+
+void
+phex(char *c) {
+        fprintf(stderr,"len %d |", strlen(c));
+        while (*c)
+                fprintf(stderr, "%2x ", *c++);
+        fprintf(stderr, "\n");
+        fflush(stderr);
+        return;
+}
+
+void
+phlist() {
+        int k = 0;
+        while (k < histcnt) {
+                fprintf(stderr, "%02i %04x %s\n", k, (int)histbuf[k], histbuf[k]);
+                k++;
+        }
+        return;
+}
+#endif
+
+int
+history(char *cmd) {
+        /*
+         * print command history or replace the command line with
+         * the chosen command from the history list, modified by the
+         * request modifier.
+         * Supported: !!, !<number>, !<number>:<modifier>, history (list)
+         */
+        int prev_cmd, h;
+        char hnum[5];
+        char *cm;
+
+        prev_cmd = 0;
+        h = 0;
+        cm = cmd;       /* save pointer for reuse */
+
+        switch (*cmd) {
+        /* todo: Add argument substitution (!$-notation) */
+
+        case '^':
+                /* do substitution */
+                if (!cmd_edit(cmd_get(-1), cmd, cm)) return(1);
+                puts(cm);
+                break;
+
+        case '!':
+                if (isalpha((int)*++cmd)) {
+                        printf("History search not implemented.\n");
+                        return(1);
+                /* TODO: add search in command history here */
+                }
+                if (*cmd == '!')  {
+                        prev_cmd = -1;          /* previous cmd */
+                } else if (isdigit (*cmd) || (*cmd == '-')) {
+                        hnum[h++] = *cmd++;
+                        while (isdigit(*cmd) && h < 4) {  /* cmd # from history */
+                                hnum[h++] = *cmd++;
+                        }
+                        hnum[h] = '\0';
+                        prev_cmd = atoi(hnum);
+                        if (map_ind(prev_cmd) < 0) {
+                                printf("%d: Event not found.\n", prev_cmd);
+                                return(1);
+                        }
+                        fflush(stderr);
+                }
+                if (*++cmd == ':') {    /* the request has a modifier */
+                        switch (*++cmd) {
+                        case 'p':       /* print the selected command and make it current */
+                                        /* TODO: should add the rest of the cmd line (if any) */
+                                        /* to the old cmd line */
+                                strcpy(cm, cmd_get(prev_cmd));
+                                puts(cm);               /* echo */
+                                add_to_history(cm);     /* add to history list */
+                                return(1);                      /* don't execute */
+                        default:
+                                fputs("Illegal history modifier\n", stderr);
+                                return(1); /* nothing to do */
+                        }
+
+                }
+                strcpy(cm, cmd_get(prev_cmd)) ;
+                puts(cm);
+                break;
+        }      
+        add_to_history(cm);
+        return(0);
+}
+
+#endif /* CMD_HISTORY */
+
+/* END CODE */

--- a/elkscmd/sash/config.h
+++ b/elkscmd/sash/config.h
@@ -34,6 +34,7 @@
 #define CMD_TAR       /* 5576 bytes */
 #define CMD_TOUCH     /*  236 bytes */
 #define CMD_UMASK     /*  272  bytes */
+#define CMD_HISTORY
 
 #ifdef CMD_CP
 #define FUNC_COPYFILE

--- a/elkscmd/sash/sash.c
+++ b/elkscmd/sash/sash.c
@@ -86,6 +86,11 @@ static	CMDTAB	cmdtab[] = {
 	1,		MAXARGS,
 #endif
 
+#ifdef CMD_HISTORY
+	"history",	"", 			do_history,
+	1,		1,
+#endif
+
 #ifdef CMD_KILL
 	"kill",	"[-sig] pid ...",	do_kill,
 	2,		MAXARGS,
@@ -209,9 +214,15 @@ static	int	aliascount;
 static	ALIAS	*findalias();
 #endif
 
+#ifdef CMD_HISTORY
+static  void	init_hist();
+extern	int	history();
+extern	int	histcnt;
+#endif
+
 static	BOOL	intcrlf = TRUE;
 static	char	*prompt;
-static BOOL		isbinshell;
+static	BOOL	isbinshell;
 
 #ifdef CMD_SOURCE
 static	FILE	*sourcefiles[MAXSOURCE];
@@ -227,7 +238,6 @@ static	void	showprompt();
 static	BOOL	trybuiltin();
 
 BOOL	intflag;
-
 
 int main(int argc, char **argv)
 {
@@ -252,6 +262,10 @@ int main(int argc, char **argv)
 
 	if (getenv("PATH") == NULL)
 		putenv("PATH=/bin:/usr/bin:/sbin");
+
+#ifdef CMD_HISTORY
+	init_hist();
+#endif /* CMD_HISTORY */
 
 #ifdef CMD_SOURCE
 	cp = getenv("HOME");
@@ -338,7 +352,12 @@ readfile(name)
 		while ((cc > 0) && isblank(buf[cc - 1]))
 			cc--;
 		buf[cc] = '\0';
+		if (strlen(buf) < 1) continue; 	/* blank line */
+#ifdef CMD_HISTORY
+		if (histcnt && history(buf))
+				continue;	
 
+#endif
 		command(buf);
 	}
 
@@ -427,7 +446,6 @@ command(char *cmd)
 
 	if ((*cmd == '\0') || (*cmd == '#') || !makeargs(cmd, &argc, &argv))
 		return;
-
 #ifdef CMD_ALIAS
 	/*
 	 * Search for the command in the alias table.
@@ -479,7 +497,6 @@ command(char *cmd)
 	newargc = argc;
 	newargv = argv;
 #endif
-
 	/*
 	 * Check if the command line has '>', '<', '&' etc that require a full shell.
 	 * If so, then the external program will be run rather than the builtin.
@@ -533,6 +550,9 @@ trybuiltin(int wildargc, char **wildargv, int argc, char **argv)
 #endif
 #ifdef CMD_PROMPT
 	(cmdptr->func == do_prompt) ||
+#endif
+#ifdef CMD_HISTORY
+	(cmdptr->func == do_history) ||
 #endif
 	   0) {
 		(*cmdptr->func)(argc, argv);
@@ -738,7 +758,6 @@ findalias(name)
 	return NULL;
 }
 #endif /* CMD_ALIAS */
-
 
 #ifdef CMD_SOURCE
 void

--- a/elkscmd/sash/sash.h
+++ b/elkscmd/sash/sash.h
@@ -48,7 +48,7 @@ extern	void	do_cp(), do_mv(), do_rm(), do_chmod(), do_mkdir(), do_rmdir();
 extern	void	do_mknod(), do_chown(), do_chgrp(), do_sync(), do_printenv();
 extern	void	do_more(), do_cmp(), do_touch(), do_ls(), do_dd(), do_tar();
 extern	void	do_mount(), do_umount(), do_setenv(), do_pwd(), do_echo();
-extern	void	do_kill(), do_grep(), do_ed();
+extern	void	do_kill(), do_grep(), do_ed(), do_history();
 
 
 extern	char	*buildname();


### PR DESCRIPTION
-	This commit adds basic csh-like command history to sash()
	!!, !-<num>, !<num>, ^x^y command line edit, HISTORY env variable to set the size of the hsitory list (def=20).
	And a 'history' command to list history.
-	TODO: Command search, save history on exit, change history size while runing, copy last argument ('!$') into current line.

Also in this commit: Fix wc() to work without arguments in a pipe.