### PR TITLE
[cmds] Fix time command

### DIFF
--- a/elkscmd/misc_utils/time.c
+++ b/elkscmd/misc_utils/time.c
@@ -49,8 +49,8 @@ int main(int argc, char **argv)
 	}
 	signal(SIGINT, SIG_IGN);
 	signal(SIGQUIT, SIG_IGN);
-	while(wait(&status) != p)
-		times(&start);
+	while (waitpid(p, &status, 0) != p)
+		continue;
 	if((status&0377) != 0)
 		fprintf(stderr,"Command terminated abnormally.\n");
 	times(&end);


### PR DESCRIPTION
Nice catch, @mellvik. The fix to `wait` in #483 required removal of a timer restart in `time` which probably should not have been there in the first place.