### PR TITLE
[kernel][cmds] Fix negative PIDs, baud rate on /etc/inittab line

### DIFF
--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -21,7 +21,7 @@ pid_t get_pid(void)
 	if (p->pid == last_pid || p->pgrp == last_pid ||
 	    p->session == last_pid) {
 	  startgp:
-	    if (++last_pid < 0)
+	    if ((int)(++last_pid) < 0)
 		last_pid = 1;
 	    p = &task[0];
 	}

--- a/elkscmd/rootfs_template/etc/inittab
+++ b/elkscmd/rootfs_template/etc/inittab
@@ -11,5 +11,6 @@ si::sysinit:/etc/rc.d/rc.sys
 #ud::once:/sbin/update
 
 1:2345:respawn:/bin/getty /dev/tty1
-#2:2345:respawn:/bin/getty /dev/tty2
+#2:2345:respawn:/bin/getty /dev/ttyS0 9600
+#1:2345:respawn:/bin/getty /dev/tty2
 #3:2345:respawn:/bin/getty /dev/tty3

--- a/elkscmd/sys_utils/getty.c
+++ b/elkscmd/sys_utils/getty.c
@@ -231,7 +231,7 @@ int main(int argc, char **argv)
 
     fd = open(ISSUE, O_RDONLY);
     if (fd >= 0) {
-	put(13);
+	put('\n');
 #ifdef SUPER_SMALL
 	while ((n=read(fd,Buffer,sizeof(Buffer))) > 0)
 	    write(1,Buffer,n);
@@ -247,7 +247,6 @@ int main(int argc, char **argv)
 	    }
 	    switch (ch) {
 		case '\n':
-		    put(' ');
 		    put(ch);
 		    break;
 		case '\\':


### PR DESCRIPTION
Fixes #507.

Kernel no longer allocates negative process IDs.
/bin/init now properly processes lines containing optional baud rate after tty line.
Heavy cleanup of getty.c to enable console debug messages for debugging.

@Mellvik,
As usual, long story on all your findings. Turns out that `/bin/getty` never even got executed with the optional baud rate added after /dev/ttyS0. `/bin/init` was trying to open "/dev/ttyS0 9600" and failed, and immediately tried again until no process slots. After that was fixed, once getty finally ran, it didn't set the passed baud rate. Let me know whether the baud rate is set correctly, but should you need to fix things, that's all handled in getty.c.