### PR TITLE
Fixes for rm, open.c, putenv.c

### DIFF
--- a/elks/fs/open.c
+++ b/elks/fs/open.c
@@ -175,20 +175,21 @@ int sys_access(char *filename, int mode)
     register __ptask currentp = current;
     uid_t old_euid;
     gid_t old_egid;
-    int res;
+    int error;
 
     if (mode != (mode & S_IRWXO))	/* where's F_OK, X_OK, W_OK, R_OK? */
-	res = -EINVAL;
+	error = -EINVAL;
     else {
 	old_euid = currentp->euid;
 	old_egid = currentp->egid;
 	currentp->euid = currentp->uid;
 	currentp->egid = currentp->gid;
-	res = namei(filename, &inode, 0, mode);
+	error = namei(filename, &inode, 0, mode);
+	if (!error) iput(inode);
 	currentp->euid = old_euid;
 	currentp->egid = old_egid;
     }
-    return res;
+    return error;
 }
 
 int sys_chdir(char *filename)

--- a/elkscmd/file_utils/rm.c
+++ b/elkscmd/file_utils/rm.c
@@ -1,10 +1,133 @@
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <getopt.h>
+#include <dirent.h>
 
-char *basename(char *name)
-{
+static 	int	errcode;
+static	int	usage(char *);
+static	void	rm();
+static 	int	yes();
+static	int 	dotname();
+
+int
+main(int argc, char **argv) {
+	int force=0, recurse = 0, interact =0 ;
+	char *arg;
+
+	if (argc < 2)
+		return(usage(argv[0]));
+	errcode = 0;
+
+        while(argc>1 && argv[1][0]=='-') {
+                arg = *++argv;
+                argc--;
+
+                /*
+                 *  all files following a single '-' are considered file names
+                 */
+                if (*(arg+1) == '\0') break;
+
+                while(*++arg != '\0')
+                        switch(*arg) {
+                        case 'f':
+                                force++;
+                                break;
+                        case 'i':
+                                interact++;
+                                break;
+                        case 'r':
+                                recurse++;
+                                break;
+                        default:
+                                return(usage(*argv));
+                        }
+        }
+        while(--argc > 0) {
+                if(!strcmp(*++argv, "..")) {
+                        fprintf(stderr, "rm: cannot remove `..'\n");
+                        continue;
+                }
+                rm(*argv, force, recurse, interact, 0);
+        }
+
+        return(errcode);
+}
+
+int usage(char * a) {
+	fprintf(stderr, "usage: %s [-rfi] file1 [file2] ...\n", a);
+	return(1);
+}
+
+void
+rm(char *arg, int fflg, int rflg, int iflg, int level) {
+        struct stat buf;
+        struct dirent *dp;
+        DIR *dirp;
+        char name[BUFSIZ];
+
+        if(lstat(arg, &buf)) {
+                if (fflg==0) {
+                        printf("rm: %s nonexistent\n", arg);
+                        ++errcode;
+                }
+                return;
+        }
+        if ((buf.st_mode&S_IFMT) == S_IFDIR) {
+                if(rflg) {
+                        if (access(arg, 02) < 0) {
+                                if (fflg==0)
+                                        printf("rm: %s not changed\n", arg);
+                                errcode++;
+                                return;
+                        }
+                        if(iflg && level!=0) {
+                                printf("rm: remove directory %s? ", arg);
+                                if(!yes())
+                                        return;
+                        }
+                        if((dirp = opendir(arg)) == NULL) {
+                                printf("rm: cannot read %s?\n", arg);
+                                return(1);
+                        }
+                        while((dp = readdir(dirp)) != NULL) {
+                                if(dp->d_ino != 0 && !dotname(dp->d_name)) {
+                                        sprintf(name, "%s/%s", arg, dp->d_name);
+                                        rm(name, fflg, rflg, iflg, level+1);
+                                }
+                        }
+                        closedir(dirp);
+                        if (dotname(arg))
+                                return;
+                        if (rmdir(arg) < 0) {
+                                fprintf(stderr, "rm: ");
+                                perror(arg);
+                                errcode++;
+                        }
+                        return;
+                }
+                fprintf(stderr, "rm: %s is a directory\n", arg);
+                ++errcode;
+                return;
+        }
+
+        if(iflg) {
+                printf("rm: remove %s? ", arg);
+                if(!yes())
+                        return;
+        } else if(!fflg) {
+                if ((buf.st_mode&S_IFMT) != S_IFLNK && access(arg, 02) < 0) {
+                        printf("rm: override protection %o for %s? ", buf.st_mode&0777, arg);
+                        if(!yes())
+                                return;
+                }
+        }
+        if (unlink(arg) && (fflg==0 || iflg)) {
+                fprintf(stderr, "rm: %s not removed\n", arg);
+                ++errcode;
+        }
 	char *base;
 	
 	base = strrchr(name, '/');
@@ -12,31 +135,25 @@ char *basename(char *name)
 }
                                 
 
-int main(int argc, char **argv)
-{
-	int i;	/*, recurse = 0, interact =0 */
-	struct stat sbuf;
+int
+dotname(char *s) {
+        if ((s[0] == '.')) {
+                if (s[1] == '.')
+                        if (s[2] == '\0')
+                                return(1);
+                        else
+                                return(0);
+                else if(s[1] == '\0')
+                        return(1);
+        }
+	return(0);
+}
 
-	if (argc < 2) goto usage;
+int yes(void) {
+        int i, b;
 
-/*	if (((argv[1][0] == '-') && (argv[1][1] == 'r')) || ((argv[2][0] == '-') && (argv[2][1] == 'r'))) 
-		recurse = 1;
-	
-        if (((argv[1][0] == '-') && (argv[1][1] == 'i')) || ((argv[2][0] == '-') && (argv[2][1] == 'i')))
-		interact = 1;        
- */	
-	for (i = /*recurse+interact+*/1; i < argc; i++) {
-		if (argv[i][0] != '-') {	
-
-			if (!lstat(argv[i],&sbuf)) {
-				if (unlink(argv[i]))
-					fprintf(stderr,"rm: could not remove %s\n", argv[i]);
-			} else fprintf(stderr, "rm: %s not found\n", argv[i]);
-		}
-	}
-	return 0;
-
-usage:
-	fprintf(stderr, "usage: %s file1 [file2] ...\n", argv[0]);
-	return 1;
+        i = b = getchar();
+        while(b != '\n' && b != EOF)
+                b = getchar();
+        return(i == 'y');
 }

--- a/elkscmd/rootfs_template/etc/profile
+++ b/elkscmd/rootfs_template/etc/profile
@@ -1,0 +1,1 @@
+export TEST="this is a placeholder"

--- a/elkscmd/rootfs_template/etc/sashrc
+++ b/elkscmd/rootfs_template/etc/sashrc
@@ -1,0 +1,4 @@
+# init file for sash
+setenv TZ GMT
+setenv HISTORY 30
+setenv HISTPAGE 20

--- a/libc/misc/putenv.c
+++ b/libc/misc/putenv.c
@@ -1,56 +1,95 @@
-/* Copyright (C) 1995,1996 Robert de Bath <rdebath@cix.compulink.co.uk>
- * This file is part of the Linux-8086 C library and is distributed
+/* 
+ * Written by Gregory Haerr for the ELKS project, published
  * under the GNU Library General Public License.
  */
 #include <string.h>
 #include <stdlib.h>
 #include <malloc.h>
+#include <errno.h>
 
 extern char ** environ;
-#define ADD_NUM 4
 
+/*
+ * Put or delete a string from the global process environment
+ *
+ * 'NAME=value'	adds environment variable name with value
+ * 'NAME'	deletes environent variable if exists
+ */
 int
 putenv(var)
 char * var;
 {
-static char ** mall_env = 0;
-static int extras = 0;
-   char **p, **d;
-   char * r;
-   int len;
+	char **	env;
+	int	envp_count;
+	int	envp_len;
+	int	namelen;
+	char *	heap_bytes;
+	char **	newenv;
+	char **	nextarg;
+	char *	nextstr;
+	char *	rp;
 
-   r = strchr(var, '=');
-   if( r == 0 )  len = strlen(var);
-   else          len = r-var;
+	/* figure environment variable name length*/
+	if ( (rp = strchr(var, '=')) == NULL)
+		namelen = strlen(var);
+	else namelen = rp - var;
 
-   for(p=environ; *p; p++)
-   {
-      if( memcmp(var, *p, len) == 0 && (*p)[len] == '=' )
-      {
-         while ((p[0] = p[1])) p++;
-         extras++;
-         break;
-      }
-   }
-   if( r == 0 ) return 0;
-   if( extras <= 0 )	/* Need more space */
-   {
-      d = malloc((p-environ+1+ADD_NUM)*sizeof(char*));
-      if( d == 0 ) return -1;
+	/* count environment bytes*/
+again:
+	envp_len = 0;
+	env = environ;
+	while (*env) {
+		/* check for variable in current environment*/
+		if (ENVNAME(var, *env, namelen)) {
 
-      memcpy((void*) d, (void*) environ, (p-environ+1)*sizeof(char*));
-      p = d + (p-environ);
-      extras=ADD_NUM;
+			/* match, delete it and copy remaining up*/
+			while ( (env[0] = env[1]) != NULL)
+				++env;
 
-      if( mall_env ) free(mall_env);
-      environ = d;
-      mall_env = d;
-   }
-   *p++ = var;
-   *p = '\0';
-   extras--;
+			/* if requested to delete, we're done*/
+			if (rp == NULL)
+				return 0;
 
-   return 0;
+			goto again;
+		}
+		envp_len += strlen(*env++) + 1;
+	}
+
+	envp_len += strlen(var) + 1;		/* new environment variable*/
+	envp_count = env - environ + 2;		/* + 1 for NULL terminator*/
+						/* + 1 for newly added var*/
+
+	/* compute new environment allocation size*/
+	heap_bytes = envp_count * sizeof(char *) + envp_len;
+
+	/* allocate new environment*/
+	if ( (newenv = malloc(heap_bytes)) == NULL) {
+		errno = ENOMEM;
+		return -1;
+	}
+
+	/* build new environment*/
+	nextarg = newenv;
+	nextstr = &newenv[envp_count];
+	env = environ;
+	while (*env) {
+		*nextarg++ = nextstr;
+		strcpy(nextstr, *env);
+		nextstr += strlen(nextstr) + 1;
+		++env;
+	}
+
+	/* add new variable*/
+	strcpy(nextstr, var);
+	*nextarg++ = nextstr;
+	*nextarg = NULL;
+
+	/* free previous environment*/
+	if (putenv_environ)
+		free(putenv_environ);
+
+	/* set new global environment*/
+	environ = putenv_environ = newenv;
+	return 0;
 }
-
 

--- a/libc/misc/putenv.c
+++ b/libc/misc/putenv.c
@@ -7,7 +7,14 @@
 #include <malloc.h>
 #include <errno.h>
 
-extern char ** environ;
+/* macro for matching environment name in string*/
+#define ENVNAME(var,buf,len)    (memcmp(var,buf,len) == 0 && (buf)[len] == '=')
+
+/* external data*/
+extern char **  environ;                /* process global environment*/
+
+/* local data*/
+static char **  putenv_environ = NULL;  /* ptr to any environment we allocated*/
 
 /*
  * Put or delete a string from the global process environment


### PR DESCRIPTION
putenv() turned out to be totally broken: Added one line to the environment, the replaced that line for every subsequent call.

rm(1) now supports recursive, directory, forced and interactive removal.

open.c (access system call): Bug in sys_access() that left the inode busy after checking access. Fix from @ghaerr.