### PR TITLE
[kernel][cmds] Fix buggy getpass() causing login to run out of memory

### DIFF
--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -131,8 +131,9 @@ void tty_release(struct inode *inode, struct file *file)
 	return;
 
     debug_tty("TTY close pid %d\n", current->pid);
-    if (current->pid == rtty->pgrp) {
-	debug_tty("TTY release pgrp %d\n", current->pid);
+    /* don't release pgrp for /dev/tty, only real tty*/
+    if (current->pid == rtty->pgrp && MINOR(inode->i_rdev) != 255) {
+	debug_tty("TTY release pgrp %d, sending SIGHUP\n", current->pid);
 	kill_pg(rtty->pgrp, SIGHUP, 1);
 	rtty->pgrp = 0;
     }

--- a/elkscmd/sys_utils/getpass.c
+++ b/elkscmd/sys_utils/getpass.c
@@ -75,6 +75,9 @@ char *getpass(char *prompt)
 #endif
     }
 
+    if (in != stdin)
+	fclose(in);
+
     /* return a pointer to our result string */
     return result;
 }


### PR DESCRIPTION
Fixes /bin/login running out of memory after successive failed logins.

Function `getpass()` opens `/dev/tty` to read password, but didn't close it, causing login to run out of memory from `fopen` mallocs.

Fixing it exposed problem with `/dev/tty` implementation sending SIGHUP on process group close, killing login (only happens at init/getty/login time). Changed SIGHUP to only be sent on process group close of underlying real tty device (e.g. `/dev/tty1`).