### PR TITLE
[cmds] Update fdisk for ELKS, also compiles and execute on host OS

### DIFF
--- a/elkscmd/rootfs_template/etc/inittab
+++ b/elkscmd/rootfs_template/etc/inittab
@@ -12,5 +12,5 @@ si::sysinit:/etc/rc.d/rc.sys
 
 1:2345:respawn:/bin/getty /dev/tty1
 #2:2345:respawn:/bin/getty /dev/ttyS0 9600
-#1:2345:respawn:/bin/getty /dev/tty2
+#2:2345:respawn:/bin/getty /dev/tty2
 #3:2345:respawn:/bin/getty /dev/tty3

--- a/elkscmd/sys_utils/getpass.c
+++ b/elkscmd/sys_utils/getpass.c
@@ -9,6 +9,7 @@
 
 #include <pwd.h>
 #include <stdio.h>
+#include <string.h>
 #include <unistd.h>
 #include <termios.h>
 
@@ -23,7 +24,6 @@ char *getpass(char *prompt)
     struct termio old, new;
 #endif
     int reset_terminal;
-    int n;
 
     /* grab our input device */
     in = fopen("/dev/tty", "r");


### PR DESCRIPTION
Update `fdisk` to use ELKS structures and defines rather than numeric offsets in source code.

Compiles outside of ELKS for use in inspecting and creating/changing MBR boot bocks. (Not installed as a tool yet, needs a new name).

Other minor fixes.