### PR TITLE
[boot] [kernel] allow boot from hd partitions above first 32 MiB

### DIFF
--- a/bootblocks/boot_sect.S
+++ b/bootblocks/boot_sect.S
@@ -32,14 +32,16 @@
 
 // Macro to restore the original (i.e. BIOS's) Diskette Drive Parameter Table
 //
-// Note: this clobbers BX and DS, and resets SP!  Use it only upon an error
+// Note: this may clobber BX and DS, and reset SP!  Use it only upon an error
 // or just before handing over to /linux
 .macro RESTORE_DDPT
+#ifdef FAST_READ
 	mov $-8,%sp
 	pop %bx
 	pop %ds
 	popw (%bx)
 	popw 2(%bx)
+#endif
 .endm
 
 	.code16
@@ -67,12 +69,17 @@ entry1:
 #endif
 
 	// instructions through _next0 not needed for floppy, only MBR boot
+	cld
 	cmp $0x4c65,%ax			// coming from ELKS MBR?
 	jnz _next0
-	mov 8(%si),%bx			// get MBR start sector from partion table at DS:SI
-	xor %ax,%ax				// save in sect_offset
-	mov %ax,%ds
-	mov %bx,BOOTADDR+sect_offset
+	mov 8(%si),%ax			// get MBR start sector from partion table at DS:SI
+	mov 10(%si),%si
+	push %cs
+	pop %es
+	mov $BOOTADDR+sect_offset,%di
+	stosw
+	xchg %ax,%si
+	stosw
 _next0:
 
 	// Get the memory size
@@ -97,10 +104,10 @@ _next0:
 	mov %di,%ds
 	mov $BOOTADDR,%si
 	mov $256,%cx  // 256 words = 512 B
-	cld
 	rep
 	movsw
 
+#ifdef FAST_READ
 	// Copy the current BIOS floppy parameter table
 	// so that we could modify it locally
 	//
@@ -129,6 +136,7 @@ _next0:
 	mov %cx,%ds    // CX = 0
 	popw (%bx)
 	mov %es,2(%bx)
+#endif
 
 	// Rebase CS DS to work in the 64K segment
 
@@ -151,10 +159,12 @@ _next1:
 	mov $msg_boot,%bx
 	call _puts
 
+#ifdef FAST_READ
 	// Set sector count in floppy parameter table
 
 	mov sect_max,%al
 	mov %al,floppy_table + 4
+#endif
 
 #ifndef BOOT_FAT
 	// Load the second sector of the boot block
@@ -274,7 +284,6 @@ _disk_read:
 	mov $5,%bh
 	push %bp
 	mov %sp,%bp
-	add sect_offset,%ax
 	push %ax
 	push %dx
 	push %cx
@@ -295,6 +304,8 @@ dr_loop:
 	mulb head_max
 	xchg %ax,%bx
 	xor %dx,%dx
+	add sect_offset,%ax
+	adc sect_offset+2,%dx
 	div %bx
 	mov %al,%ch      // CH = low 8 bits of physical cylinder number
 	ror %ah
@@ -491,6 +502,7 @@ binfile:
 	mov drive_num,%dl
 	xor %dh,%dh
 	mov sect_offset,%cx
+	mov sect_offset+2,%bx
 	mov $LOADSEG,%ax
 	mov %ax,%ds
 
@@ -521,6 +533,7 @@ boot_it:
 .endif
 	mov %dx,root_dev
 	mov %cx,part_offset  // save sector offset of booted partition
+	mov %bx,part_offset+2
 
 	RESTORE_DDPT
 
@@ -542,8 +555,10 @@ msg_error:
 msg_reboot:
 	.asciz "Press key\r\n"
 
+#ifndef BOOT_FAT
 sect_offset:
-	.word 0
+	.long 0
+#endif
 
 	.global last_code
 last_code:

--- a/bootblocks/boot_sect_fat.h
+++ b/bootblocks/boot_sect_fat.h
@@ -117,6 +117,7 @@ bpb_num_heads:				// Number of heads
 head_max:
 	.word FAT_NUM_HEADS
 bpb_hidd_sec:				// Hidden sectors
+sect_offset:
 	.long 0
 bpb_tot_sec_32:				// Total number of sectors, 32-bit
 .if FAT_TOT_SEC > 0xffff
@@ -202,6 +203,7 @@ bpb_fil_sys_type:			// Filesystem type (8 bytes)
 	push %bx
 	call disk_read
 	mov sect_offset,%cx
+	mov sect_offset+2,%si
 
 	// Check for ELKS magic number
 	mov $elks_magic,%di
@@ -233,6 +235,7 @@ boot_it:
 .endif
 	mov %ax,root_dev
 	mov %cx,part_offset  // save sector offset of booted partition
+	mov %si,part_offset+2
 	ljmp $ELKS_INITSEG+0x20,$0
 
 kernel_name:

--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -75,7 +75,7 @@
 !			0x94, no. of sectors/track, 2 bytes
 !			0x96, no. of cylinders, 2 bytes
 !	...
-!	0x1e4:	part_offset, 2 bytes. Sector offset of booted MBR partition
+!	0x1e2:	part_offset, 4 bytes. Sector offset of booted MBR partition
 !	0x1e6:	elks_magic, 2 bytes
 !	0x1ef:	SETUPSEG
 !	0x1f1:	SETUPSECS, 1 byte

--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -80,8 +80,11 @@ static void add_partition(struct gendisk *hd, unsigned short int minor,
     }
 
     /* save boot partition # based on start offset*/
-    if ((int)start == setupw(0x1e4))
-	boot_partition = minor;
+    if (ROOT_DEV == (0x80 | minor >> hd->minor_shift)) {
+	sector_t boot_start = setupw(0x1e2) | (sector_t) setupw(0x1e4) << 16;
+	if (start == boot_start)
+	    boot_partition = minor;
+    }
 }
 
 static int is_extended_partition(register struct partition *p)

--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -79,7 +79,14 @@ static void add_partition(struct gendisk *hd, unsigned short int minor,
 	return;
     }
 
-    /* save boot partition # based on start offset*/
+    /*
+     * Save boot partition # based on start offset.  This is needed if
+     * ROOT_DEV is still a BIOS drive number at this point (see init.c), and
+     * if we have not yet figured out which partition is the boot partition.
+     *
+     * If the root device is already fully known, i.e. ROOT_DEV is already
+     * a device number, then we do not really need boot_partition.
+     */
     if (ROOT_DEV == (0x80 | minor >> hd->minor_shift)) {
 	sector_t boot_start = setupw(0x1e2) | (sector_t) setupw(0x1e4) << 16;
 	if (start == boot_start)

--- a/include/linuxmt/boot.h
+++ b/include/linuxmt/boot.h
@@ -43,7 +43,7 @@
    Fields which are specific to ELKS are indicated below.  */
 
 #if defined __ASSEMBLER__ && !defined BOOTSEG
-part_offset =	0x1e4		/* sector offset of booted partition*/
+part_offset	=	0x1e2		/* sector offset of booted partition*/
 elks_magic	=	0x1e6		/* should read "ELKS" (45 4c 4b 53) */
 setup_sects	=	0x1f1
 root_flags	=	0x1f2


### PR DESCRIPTION
I also disabled the code for modifying the DDPT when the bootloader only does sector-by-sector reads (i.e. for the FAT bootloader).  This frees up some code space.