### PR TITLE
[kernel][stty] Fix stty erase and sane

### DIFF
--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -203,11 +203,12 @@ void tty_echo(register struct tty *tty, unsigned char ch)
 {
     if ((tty->termios.c_lflag & ECHO)
 		|| ((tty->termios.c_lflag & ECHONL) && (ch == '\n'))) {
-	chq_addch(&tty->outq, ch);
-	if ((ch == '\b') && (tty->termios.c_lflag & ECHOE)) {
+	if ((ch == tty->termios.c_cc[VERASE]) && (tty->termios.c_lflag & ECHOE)) {
+	    chq_addch(&tty->outq, '\b');
 	    chq_addch(&tty->outq, ' ');
 	    chq_addch(&tty->outq, '\b');
-	}
+	} else
+	    chq_addch(&tty->outq, ch);
 	tty->ops->write(tty);
     }
 }

--- a/elkscmd/sh_utils/stty.c
+++ b/elkscmd/sh_utils/stty.c
@@ -95,7 +95,7 @@ struct winsize winsize;
 #define PROTO(a) ()
 #endif
 
-void main PROTO(( int argc, char **argv ));
+int main PROTO(( int argc, char **argv ));
 void report PROTO(( int flags ));
 int option PROTO(( char *opt, char *next ));
 int match PROTO(( char *s1, char *s2 ));
@@ -114,7 +114,7 @@ void set_min_tim PROTO(( int option, char *value ));
 #define print_char(c,d,n,a) (do_print_char((unsigned)(c),(unsigned)(d),(n),(a)))
 #define print_num(m,d,n,a) (do_print_num((unsigned)(m),(unsigned)(d),(n),(a)))
 
-void main(argc, argv)
+int main(argc, argv)
 int argc;
 char *argv[];
 {
@@ -886,7 +886,7 @@ char *opt, *next;
 	 */
 	termios.c_iflag= (TINPUT_DEF & ~(IGNPAR|ISTRIP|INPCK))
 		| (termios.c_iflag & (IGNPAR|ISTRIP|INPCK));
-	termios.c_oflag= (TOUTPUT_DEF & ~(XTABS))
+	termios.c_oflag= (TOUTPUT_DEF & ~(XTABS)) | ONLCR
 		| (termios.c_oflag & (XTABS));
 	termios.c_cflag= (TCTRL_DEF & ~(CLOCAL|CSIZE|CSTOPB|PARENB|PARODD))
 		| (termios.c_cflag & (CLOCAL|CSIZE|CSTOPB|PARENB|PARODD));


### PR DESCRIPTION
Fix `stty erase` to work with printable and non-printable erase characters.

Fix `stty sane` to set ONLCR.