### PR TITLE
Sash history fix

### DIFF
--- a/elkscmd/file_utils/more.c
+++ b/elkscmd/file_utils/more.c
@@ -62,21 +62,20 @@ int cat_file(int m_in, int m_out) {
 	}
 	return (m_stat);
 } 
- 
 
 int main(int argc, char **argv)
 {
 	int	cin, multi, mw;
-	char	*name;
-	char	ch;
+	char	*name, ch, next[80];
 	int	line;
 	int	col;
-	char 	next[80];
+	char 	*divider = "\n::::::::::::::\n";
 
-	cin = open("/dev/tty", O_RDONLY); 
-					   /* should do error checking, */
-					   /* but will not be used unless stdout */
-					   /* is a tty. */
+#if 0 /* temp fix */
+	if ((cin = open("/dev/tty", O_RDONLY)) < 0) 
+		fputs("Open /dev/tty failed, exiting\n", stderr); 
+#endif /* 0 */
+	cin = 2; /*temporary --- using stderr */
 	multi = (argc >= 3); 		/* multiple input files */
 	do {
 		line = 1;
@@ -90,14 +89,14 @@ int main(int argc, char **argv)
 				return 1;
 			}
 			if (multi) {	/* if more than one file, print name */
-				puts("::::::::::::::");
-				puts(name);
-				puts("::::::::::::::");
+				fputs(&divider[1], stdout);
+				fputs(name, stdout);
+				fputs(divider, stdout);
 				fflush(stdout);
 				line += 3;
 			}
 		} else 
-			fd = 0;
+			fd = 0;		/* use stdin */
 		if (!isatty(1)) {	/* output is not terminal, just copy */
 			if (cat_file(fd, 1) < 0) {
 				perror("more :");

--- a/elkscmd/sash/cmd_history.c
+++ b/elkscmd/sash/cmd_history.c
@@ -110,7 +110,7 @@ cmd_edit(char *cm, char *edit, char *dst) {
                 *pmid = '\0';
 		if ((pend = strchr((pmid+1), (int)delim))) /* third caret */
 			*pend = '\0';	/* supporting blanks at the end of the subst */
-                fprintf(stderr, "subst: %s --%s--\n", cm, (char *)(pmid+1));
+                /*fprintf(stderr, "subst: %s --%s--\n", cm, (char *)(pmid+1));*/
                 if (!(psub = strstr(cm, edit))) {
                         fprintf(stderr, "substitution failed\n");
                 } else {

--- a/elkscmd/sash/cmd_history.c
+++ b/elkscmd/sash/cmd_history.c
@@ -93,11 +93,13 @@ cmd_get(int idx) { /* return the selected command from the history buffer */
 char *
 cmd_edit(char *cm, char *edit, char *dst) {
         char delim = *edit;
-        char *pmid, *psub, *tmp;
+        char *pmid, *psub, *pend, *tmp;
+	int len;
 
         if (!cm)
                 return("\0");   /* got null string */
-        if (!(tmp = malloc(CMDBUF + 2 + strlen(edit)))) {
+	len = CMDBUF + 2 + strlen(edit);
+        if (!(tmp = malloc(len))) {
                 printf("Malloc error in substitute.\n");
                 return(NULL);
         }
@@ -106,15 +108,16 @@ cmd_edit(char *cm, char *edit, char *dst) {
         *tmp = '\0';
         if ((pmid = strchr(++edit, (int) delim))) {
                 *pmid = '\0';
-                /*fprintf(stderr, "subst: %s -- %s\n", cm, edit);*/
+		if ((pend = strchr((pmid+1), (int)delim))) /* third caret */
+			*pend = '\0';	/* supporting blanks at the end of the subst */
+                fprintf(stderr, "subst: %s --%s--\n", cm, (char *)(pmid+1));
                 if (!(psub = strstr(cm, edit))) {
                         fprintf(stderr, "substitution failed\n");
                 } else {
                         strncpy(tmp, cm, (int)(psub - cm));
 			tmp[(int)(psub - cm)] = '\0';
                         strcat(tmp, ++pmid);
-                        strcat(tmp, (char *)(psub+strlen(edit)));
-                        /* warning - buffer oveflow possible in *tmp */
+                        strncat(tmp, (char *)(psub+strlen(edit)), len - strlen(tmp) -1);
                 }
         }
         strcpy(dst, tmp);

--- a/elkscmd/sash/sash.c
+++ b/elkscmd/sash/sash.c
@@ -215,7 +215,7 @@ static	ALIAS	*findalias();
 #endif
 
 #ifdef CMD_HISTORY
-static  void	init_hist();
+extern  void	init_hist();
 extern	int	history();
 extern	int	histcnt;
 #endif
@@ -327,7 +327,7 @@ readfile(name)
 
 	while (TRUE) {
 		fflush(stdout);
-		showprompt();
+		if (ttyflag) showprompt();
 
 #ifdef CMD_SOURCE
 		if (intflag && !ttyflag && (fp != stdin)) {
@@ -354,7 +354,7 @@ readfile(name)
 		buf[cc] = '\0';
 		if (strlen(buf) < 1) continue; 	/* blank line */
 #ifdef CMD_HISTORY
-		if (histcnt && history(buf))
+		if ((fp == stdin) && histcnt && history(buf))
 				continue;	
 
 #endif


### PR DESCRIPTION
Added 'lost' fixes to sash.c - read startup files correctly.

Cleanup in sash/cmd_history.c, added 3rd caret in history editing, enabling substitutions to have trailing blanks: ^this^that  ^ (shell command line processing removes trailing blanks which makes this necessary).

Temporary fix to more(1) to work on serial lines. /dev/tty apparently  some work.
