### PR TITLE
[kernel][cmds] Fix lots of serial port issues

### DIFF
--- a/elks/kernel/sys.c
+++ b/elks/kernel/sys.c
@@ -313,7 +313,7 @@ int sys_setsid(void)
 
     if (currentp->session == currentp->pid)
 	return -EPERM;
-    debug_sig("SETSID pgrp %d\n", currentp->pid);
+    debug_tty("SETSID pgrp %d\n", currentp->pid);
     currentp->session = currentp->pgrp = currentp->pid;
     currentp->tty = NULL;
 

--- a/elkscmd/elvis/curses.c
+++ b/elkscmd/elvis/curses.c
@@ -516,7 +516,7 @@ int getsize(signo)
 #if OSK
 		write(2, "\l", 1);
 #endif
-		endwin();
+		//endwin();
 		exit(2);
 	}
 

--- a/elkscmd/misc_utils/.gitignore
+++ b/elkscmd/misc_utils/.gitignore
@@ -4,6 +4,7 @@ compress.host
 ed
 tar
 od
+hd
 time
 uncompress
 zcat

--- a/elkscmd/rootfs_template/etc/inittab
+++ b/elkscmd/rootfs_template/etc/inittab
@@ -11,6 +11,6 @@ si::sysinit:/etc/rc.d/rc.sys
 #ud::once:/sbin/update
 
 1:2345:respawn:/bin/getty /dev/tty1
-#2:2345:respawn:/bin/getty /dev/ttyS0 9600
+#s0:2345:respawn:/bin/getty /dev/ttyS0 9600
 #2:2345:respawn:/bin/getty /dev/tty2
 #3:2345:respawn:/bin/getty /dev/tty3

--- a/elkscmd/sys_utils/getty.c
+++ b/elkscmd/sys_utils/getty.c
@@ -46,13 +46,20 @@
 #include <termios.h>
 #include <stdarg.h>
 #include <errno.h>
+#include <autoconf.h>		/* get CONFIG_CONSOLE_SERIAL*/
 
-#define DEBUG		0			/* set =1 for debug messages*/
+#define DEBUG		0	/* set =1 for debug messages*/
+
+/* debug messages go here*/
+#ifdef CONFIG_CONSOLE_SERIAL
+#define CONSOLE       "/dev/ttyS0"
+#else
+#define CONSOLE       "/dev/tty1"
+#endif
 
 #define LOGIN		"/bin/login"
 #define HOSTFILE	"/etc/HOSTNAME"
 #define ISSUE		"/etc/issue"
-#define CONSOLE		"/dev/tty1"
 
 /* For those requiring a super-small getty, the following define cuts out
  * all of the extra functionality regarding the /etc/issue code sequences.
@@ -231,7 +238,7 @@ int main(int argc, char **argv)
     }
 
     /* allow execution outside of init*/
-    if (getppid() > 1) {
+    if (getppid() != 1) {
 	int tty = open(argv[1], O_RDWR);
 	if (tty < 0) {
 		consolemsg("cannot open terminal %s\n", argv[1]);
@@ -377,7 +384,7 @@ int main(int argc, char **argv)
         termios.c_cc[VMIN] = 0;
         termios.c_cc[VTIME] = 0;
         tcsetattr(STDIN_FILENO, TCSAFLUSH, &termios);
-    }
+    } else debug("tcgetattr(0) failed\n");
 
     for (;;) {
 	state("login: ");

--- a/qemu.sh
+++ b/qemu.sh
@@ -54,6 +54,11 @@ KEYBOARD=
 SERIAL="-chardev pty,id=chardev1 -device isa-serial,chardev=chardev1,id=serial1"
 #SERIAL="-chardev msmouse,id=chardev1 -device isa-serial,chardev=chardev1,id=serial1"
 
+# Uncomment this to route ELKS /dev/ttyS0 to host terminal
+#CONSOLE="-serial stdio"
+# Hides qemu window also
+#CONSOLE="-serial stdio -nographic"
+
 # Host forwarding for networking
 # No forwarding: only outgoing from ELKS to host
 # HOSTFWD="-net user"
@@ -71,6 +76,6 @@ HOSTFWD="-net user"
 
 # Configure QEMU as pure ISA system
 
-$QEMU -nodefaults -name ELKS -machine isapc -cpu 486,tsc -m 1M \
+exec $QEMU $CONSOLE -nodefaults -name ELKS -machine isapc -cpu 486,tsc -m 1M \
 $KEYBOARD $QDISPLAY -vga std -rtc base=utc $SERIAL \
 -net nic,model=ne2k_isa $HOSTFWD $NETDUMP $IMAGE $DISK2 $@


### PR DESCRIPTION
This PR fixes lots of issues in the kernel serial driver and `/bin/init`, fixing all problems found in #515.

ELKS can be configured with 'CONFIG_CONSOLE_SERIAL' and have the kernel boot and display all messages to /dev/ttyS0, and have `init` and `getty` automatically configured to run on the serial console. (The ttyS0 line still needs to be uncommented in `/etc/inittab`, but could be left enabled as multiple getty lines now function).

Detailed changes:
Serial driver:
   -  /dev/tty now works with serial port as controlling tty.
   -  Don't call sub driver open/close on /dev/tty open/close.
   -  Add use count to serial driver, don't re-init hardware on additional open/close calls.
   -  Remove exclusive use for serial port.
   -  Fix ioctl so `vi` works.
   - Add `qemu.sh` CONSOLE option to redirect all /dev/ttyS0 output to terminal.

/bin/init:
   - Fix major /etc/inittab parsing bug which resulted in multiple getty's running in background.
   - Improve debug messages to display on readable single lines.
   - Redirect init and getty debug messages to serial port if serial console configured.

/bin/more:
   -  Remove /dev/tty use, allow single keystroke for Space, N, Q, fix to allow piped output.
