### PR TITLE
[kernel] Rewrite serial interrupt service routine for speed

### DIFF
--- a/elks/arch/i86/drivers/char/serial.c
+++ b/elks/arch/i86/drivers/char/serial.c
@@ -263,7 +263,7 @@ void rs_irq(int irq, struct pt_regs *regs, void *dev_id)
     struct ch_queue *q;
     int i, j, status;
     char *io;
-    unsigned char buf[4];
+    unsigned char buf[10];
 
     i = 0;
     sp = &ports[(int)irq_port[irq - 2]];
@@ -277,9 +277,9 @@ void rs_irq(int irq, struct pt_regs *regs, void *dev_id)
 	//if (status & UART_LSR_DR)			/* Receiver buffer full? */
 	    do {
 		buf[i++] = inb_p(io + UART_RX);		/* Read received data */
-	    } while ((inb_p(io + UART_LSR) & UART_LSR_DR) && i < 4);
+	    } while ((inb_p(io + UART_LSR) & UART_LSR_DR) && i < 10);
 	//}
-    //} while (!(inb_p(io + UART_IIR) & UART_IIR_NO_INT) && i < 4);
+    //} while (!(inb_p(io + UART_IIR) & UART_IIR_NO_INT) && i < 10);
 
     if (status & UART_LSR_OE)
 	printk("serial: data overrun\n");
@@ -360,8 +360,12 @@ static int rs_open(struct tty *tty)
     /* Flush input fifo */
     flush_input_fifo(port);
 
-    /* enable FIFO with 1 byte trigger */
-    //outb_p(UART_FCR_ENABLE_FIFO, port->io + UART_FCR);
+#define UART_FCR_ENABLE_FIFO14	(UART_FCR_ENABLE_FIFO | 0xC0)
+#define UART_FCR_ENABLE_FIFO8	(UART_FCR_ENABLE_FIFO | 0x80)
+#define UART_FCR_ENABLE_FIFO4	(UART_FCR_ENABLE_FIFO | 0x40)
+    /* enable FIFO with 8 byte trigger */
+    //if ((port->flags & SERF_TYPE) > ST_16450)
+	//outb_p(UART_FCR_ENABLE_FIFO8, port->io + UART_FCR);
 
     inb_p(port->io + UART_IIR);
     inb_p(port->io + UART_MSR);

--- a/elks/arch/i86/drivers/char/serial.c
+++ b/elks/arch/i86/drivers/char/serial.c
@@ -215,17 +215,15 @@ void rs_irq(int irq, struct pt_regs *regs, void *dev_id)
     sp = &ports[(int)irq_port[irq - 2]];
     io = sp->io;
 
-    clr_irq();
     /* read from uart into temp buffer with interrupts off*/
     do {
-	status = inb_p(io + UART_LSR);
-	if (status & UART_LSR_DR) {			/* Receiver buffer full? */
+	//status = inb_p(io + UART_LSR);
+	//if (status & UART_LSR_DR) {			/* Receiver buffer full? */
 	    do {
 		buf[i++] = inb_p(io + UART_RX);		/* Read received data */
 	    } while ((inb_p(io + UART_LSR) & UART_LSR_DR) && i < 4);
-	}
+	//}
     } while (!(inb_p(io + UART_IIR) & UART_IIR_NO_INT) && i < 4);
-    set_irq();
 
     /* then process received chars*/
     q = &sp->tty->inq;

--- a/elkscmd/rootfs_template/etc/inittab
+++ b/elkscmd/rootfs_template/etc/inittab
@@ -10,7 +10,7 @@ si::sysinit:/etc/rc.d/rc.sys
 
 #ud::once:/sbin/update
 
-1:2345:respawn:/bin/getty /dev/tty1
-#s0:2345:respawn:/bin/getty /dev/ttyS0 9600
+#1:2345:respawn:/bin/getty /dev/tty1
+s0:2345:respawn:/bin/getty /dev/ttyS0 9600
 #2:2345:respawn:/bin/getty /dev/tty2
 #3:2345:respawn:/bin/getty /dev/tty3

--- a/elkscmd/rootfs_template/etc/inittab
+++ b/elkscmd/rootfs_template/etc/inittab
@@ -10,7 +10,7 @@ si::sysinit:/etc/rc.d/rc.sys
 
 #ud::once:/sbin/update
 
-#1:2345:respawn:/bin/getty /dev/tty1
-s0:2345:respawn:/bin/getty /dev/ttyS0 9600
+1:2345:respawn:/bin/getty /dev/tty1
+#s0:2345:respawn:/bin/getty /dev/ttyS0 9600
 #2:2345:respawn:/bin/getty /dev/tty2
 #3:2345:respawn:/bin/getty /dev/tty3


### PR DESCRIPTION
I'm unable to test this on real hardware right now. Testing with QEMU shows much less character loss, but still having some. @Mellvik, if you could test whether this runs on your hardware when you have time, that would be much appreciated. Should it not work, the "#if 1" can be changed to "#if 0" to get the old routine back.

This work should also help #454.

The revised interrupt routine quickly reads from the UART with interrupts off, into a small buffer. Afterwards with interrupts enabled, the characters are inserted into the tty queue and waiting processes are woken up. The previous routine did the queue insertion and wakeup for each character received, while the chip still may have had the interrupt ID or data ready bits set.