### PR TITLE
Add bda5-8 for partitions, fix miniterm, temp linenoise off

### DIFF
--- a/elkscmd/ash/shell.h
+++ b/elkscmd/ash/shell.h
@@ -72,7 +72,7 @@
 #define USEGETPW  0
 #define ATTY	  0
 #define READLINE  0
-#define LINENOISE 1
+#define LINENOISE 0
 /* #define BSD */
 #define POSIX	  1
 #define DEBUG	  0

--- a/elkscmd/misc_utils/miniterm.c
+++ b/elkscmd/misc_utils/miniterm.c
@@ -433,6 +433,7 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 
+#if later
 	if (ioctl(fd, TIOCMGET, &flags) == -1) {
 		perror(device);
 		exit(1);
@@ -454,6 +455,7 @@ int main(int argc, char **argv)
 		perror(device);
 		exit(1);
 	}
+#endif
 
 	set_raw(0);
 

--- a/image/Make.devices
+++ b/image/Make.devices
@@ -48,6 +48,10 @@ devices:
 	$(MKDEV) /dev/bda2 b 3 2
 	$(MKDEV) /dev/bda3 b 3 3
 	$(MKDEV) /dev/bda4 b 3 4
+	$(MKDEV) /dev/bda5 b 3 5
+	$(MKDEV) /dev/bda6 b 3 6
+	$(MKDEV) /dev/bda7 b 3 7
+	$(MKDEV) /dev/bda8 b 3 8
 	$(MKDEV) /dev/bdb  b 3 32
 	$(MKDEV) /dev/bdb1 b 3 33
 	$(MKDEV) /dev/bdb2 b 3 34


### PR DESCRIPTION
Add /dev/bda5 through /dev/bda8 for mounting extended partitions.

Fix `miniterm` which broke when serial `ioctl` was fixed. It was calling an unimplemented ioctl which was ignored by the previous buggy driver.

Temporarily turn off LINENOISE in `sh` until serial and ^C problems debugged.