### PR TITLE
[cmds] Fix shell line editing to work on serial & cleanups

### DIFF
--- a/elkscmd/ash/input.c
+++ b/elkscmd/ash/input.c
@@ -219,16 +219,14 @@ preadbuffer() {
 	p = parsenextc = parsefile->buf;
 	prompt = r_use_prompt;
 	r_use_prompt = NULL;
-    line = linenoise(prompt);
+	line = linenoise(prompt);
 	if (line == NULL) {
                 parsenleft = EOF_NLEFT;
                 return PEOF;
 	}
-	printf("\r"); /* or next prompt is not printed at left border */
-    fflush(stdout);
-    linenoiseHistoryAdd(line); /* Add to the history. */
 	strcpy(p, line);
-    linenoiseFree(line); /* The returned line has to be freed */
+	linenoiseHistoryAdd(line); /* Add to the history. */
+	linenoiseFree(line); /* The returned line has to be freed */
 	i = strlen(p);
 	p[i++] = '\n';
     } else {

--- a/elkscmd/ash/shell.h
+++ b/elkscmd/ash/shell.h
@@ -72,7 +72,7 @@
 #define USEGETPW  0
 #define ATTY	  0
 #define READLINE  0
-#define LINENOISE 0
+#define LINENOISE 1
 /* #define BSD */
 #define POSIX	  1
 #define DEBUG	  0


### PR DESCRIPTION
Fixes and cleanups for @georgp24's line editing and history contribution to `sh`.

Thanks @georgp24, your contribution from the linenoise project enhances the usability of the standard shell greatly!

Fixes from the original contribution #536 include:
Stop ^C from exiting shell (from @georgp24 ).
Stop various other errors from exiting shell.
Make it work on serial port (required removing ECHONL and standardizing output).
Fix internal getenv (allows setting TERM=dumb to bypass linenoise, and setting of other terminal types in .profile).
Add HISTORY_SAVE option to remove space when history isn't saved to a file.
Turned MULTILINE off.
Various cleanups.

Shell line editing and history are set back to default ON with this commit.

Still need the implementation of either TIOCGWINSZ `ioctl` or ESC [6n in ELKS ansi console in order to know the screen width. For now, 80 is assumed. 