### PR TITLE
[kernel] Fix buggy fstat system call

### DIFF
--- a/elks/fs/stat.c
+++ b/elks/fs/stat.c
@@ -108,11 +108,13 @@ int sys_lstat(char *filename, struct stat *statbuf)
 int sys_fstat(unsigned int fd, register struct stat *statbuf)
 {
     struct file *f;
+    int ret;
 
-    return (fd_check(fd, (char *) statbuf, sizeof(struct stat),
-				FMODE_WRITE | FMODE_READ, &f)
-		? cp_stat(f->f_inode, statbuf)
-		: 0);
+    ret = fd_check(fd, (char *) statbuf, sizeof(struct stat),
+				FMODE_WRITE | FMODE_READ, &f);
+    if (!ret)
+	cp_stat(f->f_inode, statbuf);
+    return ret;
 }
 
 int sys_readlink(char *path, char *buf, size_t bufsiz)

--- a/libc/include/unistd.h
+++ b/libc/include/unistd.h
@@ -52,6 +52,7 @@ int _execve(char *fname, char *stk_ptr, int stack_bytes);
 int execvp(char *fname, char **argv);
 void _exit(int status);
 int isatty (int fd);
+char *ttyname(int fd);
 off_t lseek (int fildes, off_t offset, int whence);
 int link(const char *path1, const char *path2);
 int symlink(const char *path1, const char *path2);


### PR DESCRIPTION
Fixes kernel `fstat`, which always returned zero with `struct stat` filled with zeros.

Fixes #543, used in `ttyname`.

Amazing that ELKS applications seemed to work, given how many use this function.

