### PR TITLE
[kernel][cmds] Enhance kernel, vi and sh on serial ports

### DIFF
--- a/elks/arch/i86/drivers/char/dircon.c
+++ b/elks/arch/i86/drivers/char/dircon.c
@@ -197,6 +197,20 @@ static int parm2(register unsigned char *buf)
     return parm1(buf);
 }
 
+static void itoaQueue(int i)
+{
+   unsigned char a[6];
+   unsigned char *b = a + sizeof(a) - 1;
+
+   *b = 0;
+   do {
+      *--b = '0' + (i % 10);
+      i /= 10;
+   } while (i);
+   while (*b)
+	AddQueue(*b++);
+}
+
 static void AnsiCmd(register Console * C, char c)
 {
     register unsigned char *p;
@@ -297,6 +311,17 @@ static void AnsiCmd(register Console * C, char c)
 	    }
 	    break;
 	}
+    case 'n':
+	if (parm1(C->params) == 6) {		/* device status report*/
+	    //FIXME sequence can be interrupted by kbd input
+	    AddQueue(ESC);
+	    AddQueue('[');
+	    itoaQueue(C->cy+1);
+	    AddQueue(';');
+	    itoaQueue(C->cx+1);
+	    AddQueue('R');
+	}
+	break;
     }
     C->fsm = std_char;
 }

--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -270,12 +270,13 @@ size_t tty_read(struct inode *inode, struct file *file, char *data, size_t len)
     int icanon = tty->termios.c_lflag & ICANON;
     int vtime = tty->termios.c_cc[VTIME];
     int nonblock = (file->f_flags & O_NONBLOCK) || (!icanon && vtime);
-    jiff_t timeout = jiffies + vtime * (HZ / 10);
+    jiff_t timeout;
     int i = 0;
     int ch, k;
 
     if (len > 0) {
 	do {
+	    timeout = jiffies + vtime * (HZ / 10);
 	    if (tty->ops->read) {
 		tty->ops->read(tty);
 		nonblock = 1;
@@ -288,6 +289,7 @@ again:
 			schedule();
 			goto again;
 		    }
+		    ch = 0;	/* return 0 on VTIME timeout*/
 		}
 		if (i == 0)
 		    i = ch;

--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -25,15 +25,32 @@
 #include <linuxmt/init.h>
 #include <linuxmt/debug.h>
 
-/*
- * XXX plac: setting default to B9600 instead of B1200
- */
-struct termios def_vals = { BRKINT|ICRNL,
-    OPOST|ONLCR,
-    (tcflag_t) (B9600 | CS8),
-    (tcflag_t) (ISIG | ICANON | ECHO | ECHOE | ECHONL),
+/* default termios, set at init time, not reset at open*/
+struct termios def_vals = {
+    BRKINT|ICRNL,					/* c_iflag*/
+    OPOST|ONLCR,					/* c_oflag*/
+    (tcflag_t) (B9600 | CS8),				/* c_cflag*/
+    (tcflag_t) (ISIG | ICANON | ECHO | ECHOE),		/* c_lflag*/
+    0,							/* c_line*/
+    { 3,	/* VINTR*/
+    28,		/* VQUIT*/
+    /*127*/ 8,	/* VERASE*/
+    21,		/* VKILL*/
+    4,		/* VEOF*/
+    0,		/* VTIME*/
+    1,		/* VMIN*/
+    0,		/* VSWTC*/
+    17,		/* VSTART*/
+    19,		/* VSTOP*/
+    26,		/* VSUSP*/
+    0,		/* VEOL*/
+    18,		/* VREPRINT*/
+    15,		/* VDISCARD*/
+    23,		/* VWERASE*/
+    22,		/* VLNEXT*/
+    0,		/* VEOL2*/
     0,
-    {3, 28, /*127*/010, 21, 4, 0, 1, 0, 17, 19, 26, 0, 18, 15, 23, 22, 0, 0, 0}
+    0 }
 };
 
 #define TAB_SPACES 8
@@ -250,19 +267,28 @@ size_t tty_write(struct inode *inode, struct file *file, char *data, size_t len)
 size_t tty_read(struct inode *inode, struct file *file, char *data, size_t len)
 {
     register struct tty *tty = determine_tty(inode->i_rdev);
+    int icanon = tty->termios.c_lflag & ICANON;
+    int vtime = tty->termios.c_cc[VTIME];
+    int nonblock = (file->f_flags & O_NONBLOCK) || (!icanon && vtime);
+    jiff_t timeout = jiffies + vtime * (HZ / 10);
     int i = 0;
-    int ch, k, icanon;
-    int nonblock = (file->f_flags & O_NONBLOCK);
+    int ch, k;
 
     if (len > 0) {
-	icanon = tty->termios.c_lflag & ICANON;
 	do {
 	    if (tty->ops->read) {
 		tty->ops->read(tty);
 		nonblock = 1;
 	    }
+again:
 	    ch = chq_wait_rd(&tty->inq, nonblock);
 	    if (ch < 0) {
+		if (!icanon && vtime) {
+		    if (jiffies < timeout) {
+			schedule();
+			goto again;
+		    }
+		}
 		if (i == 0)
 		    i = ch;
 		break;

--- a/elks/include/linuxmt/chqueue.h
+++ b/elks/include/linuxmt/chqueue.h
@@ -14,7 +14,7 @@ extern void chq_init(register struct ch_queue *,unsigned char *,int);
 extern int chq_wait_wr(register struct ch_queue *,int);
 extern void chq_addch(register struct ch_queue *,unsigned char);
 extern int chq_delch(register struct ch_queue *);
-/*extern int chq_peekch(register struct ch_queue *);*/
+extern int chq_peekch(register struct ch_queue *);
 /*extern int chq_full(register struct ch_queue *);*/
 
 extern int chq_wait_rd(register struct ch_queue *,int);

--- a/elkscmd/sys_utils/getty.c
+++ b/elkscmd/sys_utils/getty.c
@@ -270,7 +270,7 @@ int main(int argc, char **argv)
         termios.c_cflag |= CS8 | CLOCAL | HUPCL;
         /*termios.c_cflag |= CRTSCTS;*/
         termios.c_cflag &= ~(PARENB | CREAD);
-        termios.c_cc[VMIN] = 0;
+        termios.c_cc[VMIN] = 1;
         termios.c_cc[VTIME] = 0;
         tcsetattr(STDIN_FILENO, TCSAFLUSH, &termios);
     } else debug("tcgetattr(0) failed\n");


### PR DESCRIPTION
Lots of changes to allow `vi` and `sh` to work on variable-sized serial consoles (using a terminal emulator for access to ELKS /dev/ttyS0). Changing window size while `vi` is running is not supported.

- Add ANSI DSR (device status report) cursor location handler to direct console driver.
- Implement tty/serial VTIME timeout processing for received characters.
- Don't update serial divisor latch unless changed for TCSET `ioctl`.
- Enhance `vi` and `sh` (linenoise) to use DSR sequence to determine console size/width.
- Allows running serial console of any size and proper operation of `vi`, providing terminal emulator implements DSR response (ESC [ 6 n).
- Enhance linenoise to use VTIME timeout when reading DSR response.
- Enhance linenoise to only check console width once.
- Linenoise ^C operation identical to ^U (clear input line).
- Match `getty` line settings to default tty values, ECHONL default off.
- Revise QEMU defaults in serial driver. QEMU has serious serial port emulation problems and continues to drop input characters.

Please test operation of `vi` on real serial port. Hopefully running `vi` multiple times works perfectly when reading DSR response to find window size, unlike QEMU which loses character input data regularly with no overrun or other UART error bit.