### PR TITLE
[kernel][cmds] Port 'kilo' color screen editor, fix/enhance ANSI console

### DIFF
--- a/elks/arch/i86/drivers/char/xt_key.c
+++ b/elks/arch/i86/drivers/char/xt_key.c
@@ -282,8 +282,23 @@ void keyboard_irq(int irq, struct pt_regs *regs, void *dev_id)
 	if (ModeState & CTRL && !(ModeState & ALT))	/* Changed to support CTRL-ALT */
 	    keyp_E0 = (char *)(((int) keyp_E0) & 0x1F); /* CTRL-.. */	/*[ keyp ]*/
 	    
-	if (((int)keyp_E0) == '\r')	/*[ keyp ]*/
-	    keyp_E0 = (char *) '\n';	/*[ keyp ]*/
+#ifdef CONFIG_EMUL_ANSI
+	code = mode = 0;
+	switch ((unsigned int)keyp_E0) {
+	case 0xb7: code = 'H'; break;			/* home*/
+	case 0xb1: code = 'F'; break;			/* end*/
+	case 0xb9: code = '5'; mode = '~'; break;	/* page up*/
+	case 0xb3: code = '6'; mode = '~'; break;	/* page dn*/
+	}
+	if (code) {
+	    AddQueue(ESC);
+	    AddQueue('[');
+	    AddQueue(code);
+	    if (mode)
+		AddQueue(mode);
+	    return;
+	}
+#endif
 	//printk("keyp_E0:%X\n",keyp_E0);    
 	AddQueue((unsigned char) keyp_E0);
     }

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -55,7 +55,7 @@ sh_utils/true			:boot	:be-shutil
 sh_utils/echo			:boot	:be-shutil
 file_utils/cat			:boot	:be-fileutil
 file_utils/chgrp				:be-fileutil		:720k
-file_utils/chmod				:be-fileutil		:720k
+file_utils/chmod				:be-fileutil	:360k
 file_utils/chown				:be-fileutil		:720k
 file_utils/cmp					:be-fileutil			:1440k
 file_utils/cp					:be-fileutil	:360k
@@ -89,7 +89,7 @@ sh_utils/dirname				:be-shutil			:720k
 sh_utils/false					:be-shutil				:1440k
 sh_utils/logname				:shutil					:1440k
 sh_utils/mesg					:shutil					:1440k
-sh_utils/stty					:shutil				:720k
+sh_utils/stty					:shutil			:360k
 sh_utils/printenv				:shutil			:360k
 sh_utils/pwd					:shutil			:360k
 sh_utils/tr						:shutil				:720k
@@ -98,12 +98,13 @@ sh_utils/whoami					:shutil					:1440k
 sh_utils/xargs					:shutil					:1440k
 sh_utils/yes					:shutil				:720k
 misc_utils/miniterm				:miscutil			:720k
-misc_utils/tar					:miscutil			:720k
-misc_utils/od					:miscutil			:720k
-misc_utils/hd					:miscutil			:720k
+misc_utils/tar					:miscutil				:1440k
+misc_utils/od					:miscutil				:1440k
+misc_utils/hd					:miscutil		:360k
 misc_utils/time					:miscutil			:720k
+misc_utils/kilo					:miscutil		:360k
 misc_utils/ed					:be-miscutil		:720k
-elvis/elvis	::bin/vi			:elvis			:360k
+elvis/elvis	::bin/vi			:elvis				:720k
 minix1/banner					:minix1					:1440k
 minix1/decomp16					:minix1					:1440k
 minix1/fgrep					:minix1					:1440k

--- a/elkscmd/ash/linenoise_elks.c
+++ b/elkscmd/ash/linenoise_elks.c
@@ -204,8 +204,7 @@ enum KEY_ACTION{
 	CTRL_U = 21,        /* Ctrl+u */
 	CTRL_W = 23,        /* Ctrl+w */
 	ESC = 27,           /* Escape */
-	BACKSPACE =  127,   /* Backspace */
-	LINEFEED = 10       /* Linefeed */
+	BACKSPACE =  127    /* Backspace */
 };
 
 static void linenoiseAtExit(void);
@@ -917,7 +916,6 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
 
         switch((unsigned int)c) {
         case ENTER:    /* enter */
-        case LINEFEED:
             history_len--;
             free(history[history_len]);
             if (mlmode) linenoiseEditMoveEnd(&l);
@@ -966,7 +964,8 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
         case CTRL_N:    /* ctrl-n */
             linenoiseEditHistoryNext(&l, LINENOISE_HISTORY_NEXT);
             break;
-            /* Extended key sequences. */
+            /* ELKS extended key sequences. */
+#if 0 /* handled with ANSI sequences*/
         case 0xb7: /* Home */
             linenoiseEditMoveHome(&l);
             break;
@@ -987,6 +986,7 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
         case 0xb3: /* Page down */
             linenoiseEditHistoryNext(&l, LINENOISE_HISTORY_NEXT);
             break;
+#endif
         case 0x8c: /* + Num keypad */
             linenoiseEditInsert(&l,'+');
             break;
@@ -1009,6 +1009,12 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
                         switch(seq[1]) {
                         case '3': /* Delete key. */
                             linenoiseEditDelete(&l);
+                            break;
+                        case '5': /* Page up */
+                            linenoiseEditHistoryNext(&l, LINENOISE_HISTORY_PREV);
+                            break;
+                        case '6': /* Page dn */
+                            linenoiseEditHistoryNext(&l, LINENOISE_HISTORY_NEXT);
                             break;
                         }
                     }

--- a/elkscmd/busyelks/cmd/sed.c
+++ b/elkscmd/busyelks/cmd/sed.c
@@ -238,7 +238,7 @@ _PROTOTYPE(static void command, (sedcmd *ipc));
 _PROTOTYPE(static void openfile, (char *file));
 _PROTOTYPE(static void get, (void));
 _PROTOTYPE(static void initget, (void));
-_PROTOTYPE(static char *getline, (char *buf));
+_PROTOTYPE(static char *ourgetline, (char *buf));
 _PROTOTYPE(static int Memcmp, (char *a, char *b, int count));
 _PROTOTYPE(static void readout, (void));
 
@@ -956,7 +956,7 @@ void sed_execute()
   for (;;) {
 
 	/* Get next line to filter */
-	if ((execp = getline(linebuf)) == BAD) return;
+	if ((execp = ourgetline(linebuf)) == BAD) return;
 	spend = execp;
 	anysub = FALSE;
 
@@ -1422,7 +1422,7 @@ sedcmd *ipc;
       case NCMD:		/* read next line into pattern space */
 	if (!nflag) puts(linebuf);	/* flush out the current line */
 	if (aptr > appends) readout();	/* do pending a, r commands */
-	if ((execp = getline(linebuf)) == BAD) {
+	if ((execp = ourgetline(linebuf)) == BAD) {
 		delete = TRUE;
 		break;
 	}
@@ -1433,7 +1433,7 @@ sedcmd *ipc;
       case CNCMD:		/* append next line to pattern space */
 	if (aptr > appends) readout();
 	*spend++ = '\n';
-	if ((execp = getline(spend)) == BAD) {
+	if ((execp = ourgetline(spend)) == BAD) {
 		*--spend = 0;
 		break;
 	}
@@ -1542,7 +1542,7 @@ static void initget()
   get();
 }
 
-static char *getline(buf)
+static char *ourgetline(buf)
 /* Get next line of text to be edited, return pointer to end */
 register char *buf;		/* where to send the input */
 {

--- a/elkscmd/busyelks/cmd/uniq.c
+++ b/elkscmd/busyelks/cmd/uniq.c
@@ -31,7 +31,7 @@ int equal();
 void show();
 int uniq();
 void uniq_usage();
-int getline();
+int ourgetline();
 
 FILE *xfopen(fn, mode)
 char *fn, *mode;
@@ -150,13 +150,13 @@ int uniq()
 
   /* Setup */
   prevline = buf1;
-  if (getline(prevline, 1024) < 0) return(0);
+  if (ourgetline(prevline, 1024) < 0) return(0);
   seen = 1;
   nowline = buf2;
 
   /* Get nowline and compare if not equal, dump prevline and swap
    * pointers else continue, bumping seen count */
-  while (getline(nowline, 1024) > 0) {
+  while (ourgetline(nowline, 1024) > 0) {
 	if (!equal(prevline, nowline)) {
 		show(prevline, seen);
 		seen = 1;
@@ -175,7 +175,7 @@ void uniq_usage()
   fprintf(stderr, "Usage: uniq [-udc] [+n] [-n] [input [output]]\n");
 }
 
-int getline(buf, count)
+int ourgetline(buf, count)
 char *buf;
 int count;
 {

--- a/elkscmd/levee/extern.h
+++ b/elkscmd/levee/extern.h
@@ -194,7 +194,7 @@ cmdtype movemap[];
 extern findstates findCP();
 extern exec_type editcore();
 extern char line(), peekc(), readchar();
-extern bool getline();
+extern bool ourgetline();
 extern char *findparse(),*makepat();
 extern bool putfile();
 extern bool doyank(), deletion(), putback();

--- a/elkscmd/levee/main.c
+++ b/elkscmd/levee/main.c
@@ -248,7 +248,7 @@ exec_type emode;
     mode=emode;
     do {
 	prompt(FALSE,":");
-	if (getline(instring))
+	if (ourgetline(instring))
 	    exec(instring, &mode, &noquit);
 	indirect = FALSE;
 	if (mode == E_VISUAL && zotscreen && noquit) {	/*ask for more*/

--- a/elkscmd/levee/misc.c
+++ b/elkscmd/levee/misc.c
@@ -20,7 +20,7 @@
 #include "extern.h"
 
 bool PROC
-getline(str)
+ourgetline(str)
  char *str;
 {
     int len;
@@ -30,7 +30,7 @@ getline(str)
     str[len] = 0;
     strput(CE);
     return (flag == EOL);
-} /* getline */
+} /* ourgetline */
 
 
 char PROC

--- a/elkscmd/levee/move.c
+++ b/elkscmd/levee/move.c
@@ -153,7 +153,7 @@ cmdtype cmd;
 	clrprompt();
 	if (cmd == PATT_FWD || cmd == PATT_BACK) {
 	    printch(tsearch = instring[0] = chars[cmd-PATT_FWD]);
-	    if (!getline(&instring[1]))
+	    if (!ourgetline(&instring[1]))
 		return ESCAPED;	/* needs to skip later tests */
 	}
 	else {

--- a/elkscmd/levee/proto.h
+++ b/elkscmd/levee/proto.h
@@ -71,7 +71,7 @@ int  PROC fseekeol(int  origin);
 int  PROC gcount(void);
 int  PROC getKey(void);
 int  PROC getcontext(char  c,int  begline);
-int  PROC getline(char  *str);
+int  PROC ourgetline(char  *str);
 int  PROC initialize(int  count,char  * *args);
 int  PROC inputf(char  *fname,int  newbuf);
 int  PROC insert_to_undo(struct  undostack *u,int  start,int  size);

--- a/elkscmd/minix1/uniq.c
+++ b/elkscmd/minix1/uniq.c
@@ -27,7 +27,7 @@ static int chars = 0;
 /* The meat of the whole affair */
 static char *nowline, *prevline, buf1[1024], buf2[1024];
 
-static int getline(char *buf, int count);
+static int ourgetline(char *buf, int count);
 
 static FILE *xfopen(const char *fn, const char *mode)
 {
@@ -84,13 +84,13 @@ static int uniq(void)
 
   /* Setup */
   prevline = buf1;
-  if (getline(prevline, 1024) < 0) return(0);
+  if (ourgetline(prevline, 1024) < 0) return(0);
   seen = 1;
   nowline = buf2;
 
   /* Get nowline and compare if not equal, dump prevline and swap
    * pointers else continue, bumping seen count */
-  while (getline(nowline, 1024) > 0) {
+  while (ourgetline(nowline, 1024) > 0) {
 	if (!equal(prevline, nowline)) {
 		show(prevline, seen);
 		seen = 1;
@@ -105,7 +105,7 @@ static int uniq(void)
 }
 
 
-static int getline(char *buf, int count)
+static int ourgetline(char *buf, int count)
 {
   int c;
   int ct = 0;

--- a/elkscmd/minix3/sed.c
+++ b/elkscmd/minix3/sed.c
@@ -237,7 +237,7 @@ _PROTOTYPE(static void command, (sedcmd *ipc));
 _PROTOTYPE(static void openfile, (char *file));
 _PROTOTYPE(static void get, (void));
 _PROTOTYPE(static void initget, (void));
-_PROTOTYPE(static char *getline, (char *buf));
+_PROTOTYPE(static char *ourgetline, (char *buf));
 _PROTOTYPE(static int Memcmp, (char *a, char *b, int count));
 _PROTOTYPE(static void readout, (void));
 
@@ -964,7 +964,7 @@ void execute()
   for (;;) {
 
 	/* Get next line to filter */
-	if ((execp = getline(linebuf)) == BAD) return;
+	if ((execp = ourgetline(linebuf)) == BAD) return;
 	spend = execp;
 	anysub = FALSE;
 
@@ -1430,7 +1430,7 @@ sedcmd *ipc;
       case NCMD:		/* read next line into pattern space */
 	if (!nflag) puts(linebuf);	/* flush out the current line */
 	if (aptr > appends) readout();	/* do pending a, r commands */
-	if ((execp = getline(linebuf)) == BAD) {
+	if ((execp = ourgetline(linebuf)) == BAD) {
 		delete = TRUE;
 		break;
 	}
@@ -1441,7 +1441,7 @@ sedcmd *ipc;
       case CNCMD:		/* append next line to pattern space */
 	if (aptr > appends) readout();
 	*spend++ = '\n';
-	if ((execp = getline(spend)) == BAD) {
+	if ((execp = ourgetline(spend)) == BAD) {
 		*--spend = 0;
 		break;
 	}
@@ -1550,7 +1550,7 @@ static void initget()
   get();
 }
 
-static char *getline(buf)
+static char *ourgetline(buf)
 /* Get next line of text to be edited, return pointer to end */
 register char *buf;		/* where to send the input */
 {

--- a/elkscmd/misc_utils/.gitignore
+++ b/elkscmd/misc_utils/.gitignore
@@ -6,5 +6,6 @@ tar
 od
 hd
 time
+kilo
 uncompress
 zcat

--- a/elkscmd/misc_utils/Makefile
+++ b/elkscmd/misc_utils/Makefile
@@ -14,7 +14,7 @@ HOST_CFLAGS = -O2
 ###############################################################################
 
 #TODO: fix compress uncompress zcat lpfilter disabled
-PRGS = tar miniterm ed od hd time
+PRGS = tar miniterm ed od hd time kilo
 
 #PRGS_HOST=compress.host
 
@@ -34,6 +34,9 @@ hd: hd.o
 
 time: time.o
 	$(LD) $(LDFLAGS) -o time time.o $(LDLIBS)
+
+kilo: kilo.o
+	$(LD) $(LDFLAGS) -maout-chmem=0xfff0 -o kilo kilo.o $(LDLIBS)
 
 compress: compress.o
 	$(LD) $(LDFLAGS) -o compress compress.o $(LDLIBS)

--- a/elkscmd/misc_utils/kilo.c
+++ b/elkscmd/misc_utils/kilo.c
@@ -123,7 +123,7 @@ enum KEY_ACTION{
         CTRL_S = 19,        /* Ctrl-s */
         CTRL_U = 21,        /* Ctrl-u */
         ESC = 27,           /* Escape */
-        BACKSPACE =  127,   /* Backspace */
+        DELETE =  127,      /* Delete */
         /* The following are just soft codes, not really reported by the
          * terminal directly. */
         ARROW_LEFT = 1000,
@@ -163,12 +163,14 @@ void editorSetStatusMessage(const char *fmt, ...);
 /* C / C++ */
 char *C_HL_extensions[] = {".c",".cpp",NULL};
 char *C_HL_keywords[] = {
-        /* A few C / C++ keywords */
-        "switch","if","while","for","break","continue","return","else",
-        "struct","union","typedef","static","enum","class","register",
+        /* C keywords */
+        "auto","break","case","continue","default","do","else","enum",
+        "extern","for","goto","if","register","return","sizeof","static",
+        "struct","switch","typedef","union","volatile","while",
+
         /* C types */
         "int|","long|","double|","float|","char|","unsigned|","signed|",
-        "void|",NULL
+		"void|","short|","auto|","const|",NULL
 };
 
 /* Here we define an array of syntax highlights by extensions, keywords,
@@ -1019,7 +1021,7 @@ void editorFind(int fd) {
         editorRefreshScreen();
 
         int c = editorReadKey(fd);
-        if (c == DEL_KEY || c == CTRL_H || c == BACKSPACE) {
+        if (c == DEL_KEY || c == CTRL_H || c == DELETE) {
             if (qlen != 0) query[--qlen] = '\0';
             last_match = -1;
         } else if (c == ESC || c == ENTER) {
@@ -1206,9 +1208,12 @@ void editorProcessKeypress(int fd) {
     case CTRL_F:
         editorFind(fd);
         break;
-    case BACKSPACE:     /* Backspace */
     case CTRL_H:        /* Ctrl-h */
+        editorDelChar();
+		break;
+    case DELETE:        /* Delete */
     case DEL_KEY:
+		editorMoveCursor(ARROW_RIGHT);
         editorDelChar();
         break;
     case PAGE_UP:

--- a/elkscmd/misc_utils/kilo.c
+++ b/elkscmd/misc_utils/kilo.c
@@ -1,0 +1,1301 @@
+/* Kilo -- A very simple editor in less than 1-kilo lines of code (as counted
+ *         by "cloc"). Does not depend on libcurses, directly emits VT100
+ *         escapes on the terminal.
+ *
+ * -----------------------------------------------------------------------
+ *
+ * Copyright (C) 2016 Salvatore Sanfilippo <antirez at gmail dot com>
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define KILO_VERSION "0.0.1"
+
+#define _BSD_SOURCE
+#define _GNU_SOURCE
+#define _DEFAULT_SOURCE
+
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <termios.h>
+#include <time.h>
+#include <unistd.h>
+
+/* Syntax highlight types */
+#define HL_NORMAL 0
+#define HL_NONPRINT 1
+#define HL_COMMENT 2   /* Single line comment. */
+#define HL_MLCOMMENT 3 /* Multi-line comment. */
+#define HL_KEYWORD1 4
+#define HL_KEYWORD2 5
+#define HL_STRING 6
+#define HL_NUMBER 7
+#define HL_MATCH 8      /* Search match. */
+
+#define HL_HIGHLIGHT_STRINGS (1<<0)
+#define HL_HIGHLIGHT_NUMBERS (1<<1)
+
+struct editorSyntax {
+    char **filematch;
+    char **keywords;
+    char singleline_comment_start[2];
+    char multiline_comment_start[3];
+    char multiline_comment_end[3];
+    int flags;
+};
+
+/* This structure represents a single line of the file we are editing. */
+typedef struct erow {
+    int idx;            /* Row index in the file, zero-based. */
+    int size;           /* Size of the row, excluding the null term. */
+    int rsize;          /* Size of the rendered row. */
+    char *chars;        /* Row content. */
+    char *render;       /* Row content "rendered" for screen (for TABs). */
+    unsigned char *hl;  /* Syntax highlight type for each character in render.*/
+    int hl_oc;          /* Row had open comment at end in last syntax highlight
+                           check. */
+} erow;
+
+typedef struct hlcolor {
+    int r,g,b;
+} hlcolor;
+
+struct editorConfig {
+    int cx,cy;  /* Cursor x and y position in characters */
+    int rowoff;     /* Offset of row displayed. */
+    int coloff;     /* Offset of column displayed. */
+    int screenrows; /* Number of rows that we can show */
+    int screencols; /* Number of cols that we can show */
+    int numrows;    /* Number of rows */
+    int rawmode;    /* Is terminal raw mode enabled? */
+    erow *row;      /* Rows */
+    int dirty;      /* File modified but not saved. */
+    char *filename; /* Currently open filename */
+    char statusmsg[80];
+    time_t statusmsg_time;
+    struct editorSyntax *syntax;    /* Current syntax highlight, or NULL. */
+};
+
+static struct editorConfig E;
+
+enum KEY_ACTION{
+        KEY_NULL = 0,       /* NULL */
+        CTRL_C = 3,         /* Ctrl-c */
+        CTRL_D = 4,         /* Ctrl-d */
+        CTRL_F = 6,         /* Ctrl-f */
+        CTRL_H = 8,         /* Ctrl-h */
+        TAB = 9,            /* Tab */
+        CTRL_L = 12,        /* Ctrl+l */
+        ENTER = 13,         /* Enter */
+        CTRL_Q = 17,        /* Ctrl-q */
+        CTRL_S = 19,        /* Ctrl-s */
+        CTRL_U = 21,        /* Ctrl-u */
+        ESC = 27,           /* Escape */
+        BACKSPACE =  127,   /* Backspace */
+        /* The following are just soft codes, not really reported by the
+         * terminal directly. */
+        ARROW_LEFT = 1000,
+        ARROW_RIGHT,
+        ARROW_UP,
+        ARROW_DOWN,
+        DEL_KEY,
+        HOME_KEY,
+        END_KEY,
+        PAGE_UP,
+        PAGE_DOWN
+};
+
+void editorSetStatusMessage(const char *fmt, ...);
+
+/* =========================== Syntax highlights DB =========================
+ *
+ * In order to add a new syntax, define two arrays with a list of file name
+ * matches and keywords. The file name matches are used in order to match
+ * a given syntax with a given file name: if a match pattern starts with a
+ * dot, it is matched as the last past of the filename, for example ".c".
+ * Otherwise the pattern is just searched inside the filenme, like "Makefile").
+ *
+ * The list of keywords to highlight is just a list of words, however if they
+ * a trailing '|' character is added at the end, they are highlighted in
+ * a different color, so that you can have two different sets of keywords.
+ *
+ * Finally add a stanza in the HLDB global variable with two two arrays
+ * of strings, and a set of flags in order to enable highlighting of
+ * comments and numbers.
+ *
+ * The characters for single and multi line comments must be exactly two
+ * and must be provided as well (see the C language example).
+ *
+ * There is no support to highlight patterns currently. */
+
+/* C / C++ */
+char *C_HL_extensions[] = {".c",".cpp",NULL};
+char *C_HL_keywords[] = {
+        /* A few C / C++ keywords */
+        "switch","if","while","for","break","continue","return","else",
+        "struct","union","typedef","static","enum","class","register",
+        /* C types */
+        "int|","long|","double|","float|","char|","unsigned|","signed|",
+        "void|",NULL
+};
+
+/* Here we define an array of syntax highlights by extensions, keywords,
+ * comments delimiters and flags. */
+struct editorSyntax HLDB[] = {
+    {
+        /* C / C++ */
+        C_HL_extensions,
+        C_HL_keywords,
+        "//","/*","*/",
+        HL_HIGHLIGHT_STRINGS | HL_HIGHLIGHT_NUMBERS
+    }
+};
+
+#define HLDB_ENTRIES (sizeof(HLDB)/sizeof(HLDB[0]))
+
+/* ======================= Low level terminal handling ====================== */
+
+static struct termios orig_termios; /* In order to restore at exit.*/
+
+void disableRawMode(int fd) {
+    /* Don't even check the return value as it's too late. */
+    if (E.rawmode) {
+        tcsetattr(fd,TCSAFLUSH,&orig_termios);
+        E.rawmode = 0;
+    }
+}
+
+/* Called at exit to avoid remaining in raw mode. */
+void editorAtExit(void) {
+    disableRawMode(STDIN_FILENO);
+}
+
+/* Raw mode: 1960 magic shit. */
+int enableRawMode(int fd) {
+    struct termios raw;
+
+    if (E.rawmode) return 0; /* Already enabled. */
+    if (!isatty(STDIN_FILENO)) goto fatal;
+    atexit(editorAtExit);
+    if (tcgetattr(fd,&orig_termios) == -1) goto fatal;
+
+    raw = orig_termios;  /* modify the original mode */
+    /* input modes: no break, no CR to NL, no parity check, no strip char,
+     * no start/stop output control. */
+    raw.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
+    /* output modes - disable post processing */
+    raw.c_oflag &= ~(OPOST);
+    /* control modes - set 8 bit chars */
+    raw.c_cflag |= (CS8);
+    /* local modes - choing off, canonical off, no extended functions,
+     * no signal chars (^Z,^C) */
+    raw.c_lflag &= ~(ECHO | ICANON | IEXTEN | ISIG);
+    /* control chars - set return condition: min number of bytes and timer. */
+    raw.c_cc[VMIN] = 0; /* Timed wait for input. */
+    raw.c_cc[VTIME] = 2; /* 200 ms timeout (unit is tens of second). */
+    //raw.c_cc[VMIN] = 1; /* Wait for each byte. */
+    //raw.c_cc[VTIME] = 0; /* No timeout. */
+
+    /* put terminal in raw mode after flushing */
+    if (tcsetattr(fd,TCSAFLUSH,&raw) < 0) goto fatal;
+    E.rawmode = 1;
+    return 0;
+
+fatal:
+    errno = ENOTTY;
+    return -1;
+}
+
+/* Read a key from the terminal put in raw mode, trying to handle
+ * escape sequences. */
+int editorReadKey(int fd) {
+    int nread;
+    unsigned char c, seq[3];
+    while ((nread = read(fd,&c,1)) == 0);
+    if (nread == -1) exit(1);
+
+    while(1) {
+        switch((unsigned int)c) {
+        case ESC:    /* escape sequence */
+            /* If this is just an ESC, we'll timeout here. */
+            if (read(fd,seq,1) == 0) return ESC;
+            if (read(fd,seq+1,1) == 0) return ESC;
+
+            /* ESC [ sequences. */
+            if (seq[0] == '[') {
+                if (seq[1] >= '0' && seq[1] <= '9') {
+                    /* Extended escape, read additional byte. */
+                    if (read(fd,seq+2,1) == 0) return ESC;
+                    if (seq[2] == '~') {
+                        switch(seq[1]) {
+                        case '3': return DEL_KEY;
+                        case '5': return PAGE_UP;
+                        case '6': return PAGE_DOWN;
+                        }
+                    }
+                } else {
+                    switch(seq[1]) {
+                    case 'A': return ARROW_UP;
+                    case 'B': return ARROW_DOWN;
+                    case 'C': return ARROW_RIGHT;
+                    case 'D': return ARROW_LEFT;
+                    case 'H': return HOME_KEY;
+                    case 'F': return END_KEY;
+                    }
+                }
+            }
+
+            /* ESC O sequences. */
+            else if (seq[0] == 'O') {
+                switch(seq[1]) {
+                case 'H': return HOME_KEY;
+                case 'F': return END_KEY;
+                }
+            }
+            break;
+        default:
+            return c;
+        }
+    }
+}
+
+/* Use the ESC [6n escape sequence to query the horizontal cursor position
+ * and return it. On error -1 is returned, on success the position of the
+ * cursor is stored at *rows and *cols and 0 is returned. */
+int getCursorPosition(int ifd, int ofd, int *rows, int *cols) {
+    char buf[32];
+    unsigned int i = 0;
+
+    /* Report cursor location */
+    if (write(ofd, "\x1b[6n", 4) != 4) return -1;
+
+    /* Read the response: ESC [ rows ; cols R */
+    while (i < sizeof(buf)-1) {
+        if (read(ifd,buf+i,1) != 1) break;
+        if (buf[i] == 'R') break;
+        i++;
+    }
+    buf[i] = '\0';
+
+    /* Parse it. */
+    if (buf[0] != ESC || buf[1] != '[') return -1;
+    if (sscanf(buf+2,"%d;%d",rows,cols) != 2) return -1;
+    return 0;
+}
+
+/* Try to get the number of columns in the current terminal. If the ioctl()
+ * call fails the function will try to query the terminal itself.
+ * Returns 0 on success, -1 on error. */
+int getWindowSize(int ifd, int ofd, int *rows, int *cols) {
+    struct winsize ws;
+
+    if (ioctl(1, TIOCGWINSZ, &ws) == -1 || ws.ws_col == 0) {
+        /* ioctl() failed. Try to query the terminal itself. */
+        int orig_row, orig_col, retval;
+
+        /* Get the initial position so we can restore it later. */
+        retval = getCursorPosition(ifd,ofd,&orig_row,&orig_col);
+        if (retval == -1) goto failed;
+
+        /* Go to right/bottom margin and get position. */
+        if (write(ofd,"\x1b[999C\x1b[999B",12) != 12) goto failed;
+        retval = getCursorPosition(ifd,ofd,rows,cols);
+        if (retval == -1) goto failed;
+
+        /* Restore position. */
+        char seq[32];
+        snprintf(seq,32,"\x1b[%d;%dH",orig_row,orig_col);
+        if (write(ofd,seq,strlen(seq)) == -1) {
+            /* Can't recover... */
+        }
+        return 0;
+    } else {
+        *cols = ws.ws_col;
+        *rows = ws.ws_row;
+        return 0;
+    }
+
+failed:
+    return -1;
+}
+
+/* ====================== Syntax highlight color scheme  ==================== */
+
+int is_separator(int c) {
+    return c == '\0' || isspace(c) || strchr(",.()+-/*=~%[];",c) != NULL;
+}
+
+/* Return true if the specified row last char is part of a multi line comment
+ * that starts at this row or at one before, and does not end at the end
+ * of the row but spawns to the next row. */
+int editorRowHasOpenComment(erow *row) {
+    if (row->hl && row->rsize && row->hl[row->rsize-1] == HL_MLCOMMENT &&
+        (row->rsize < 2 || (row->render[row->rsize-2] != '*' ||
+                            row->render[row->rsize-1] != '/'))) return 1;
+    return 0;
+}
+
+/* Set every byte of row->hl (that corresponds to every character in the line)
+ * to the right syntax highlight type (HL_* defines). */
+void editorUpdateSyntax(erow *row) {
+    row->hl = realloc(row->hl,row->rsize);
+    memset(row->hl,HL_NORMAL,row->rsize);
+
+    if (E.syntax == NULL) return; /* No syntax, everything is HL_NORMAL. */
+
+    int i, prev_sep, in_string, in_comment;
+    char *p;
+    char **keywords = E.syntax->keywords;
+    char *scs = E.syntax->singleline_comment_start;
+    char *mcs = E.syntax->multiline_comment_start;
+    char *mce = E.syntax->multiline_comment_end;
+
+    /* Point to the first non-space char. */
+    p = row->render;
+    i = 0; /* Current char offset */
+    while(*p && isspace(*p)) {
+        p++;
+        i++;
+    }
+    prev_sep = 1; /* Tell the parser if 'i' points to start of word. */
+    in_string = 0; /* Are we inside "" or '' ? */
+    in_comment = 0; /* Are we inside multi-line comment? */
+
+    /* If the previous line has an open comment, this line starts
+     * with an open comment state. */
+    if (row->idx > 0 && editorRowHasOpenComment(&E.row[row->idx-1]))
+        in_comment = 1;
+
+    while(*p) {
+        /* Handle // comments. */
+        if (prev_sep && *p == scs[0] && *(p+1) == scs[1]) {
+            /* From here to end is a comment */
+            memset(row->hl+i,HL_COMMENT,row->size-i);
+            return;
+        }
+
+        /* Handle multi line comments. */
+        if (in_comment) {
+            row->hl[i] = HL_MLCOMMENT;
+            if (*p == mce[0] && *(p+1) == mce[1]) {
+                row->hl[i+1] = HL_MLCOMMENT;
+                p += 2; i += 2;
+                in_comment = 0;
+                prev_sep = 1;
+                continue;
+            } else {
+                prev_sep = 0;
+                p++; i++;
+                continue;
+            }
+        } else if (*p == mcs[0] && *(p+1) == mcs[1]) {
+            row->hl[i] = HL_MLCOMMENT;
+            row->hl[i+1] = HL_MLCOMMENT;
+            p += 2; i += 2;
+            in_comment = 1;
+            prev_sep = 0;
+            continue;
+        }
+
+        /* Handle "" and '' */
+        if (in_string) {
+            row->hl[i] = HL_STRING;
+            if (*p == '\\') {
+                row->hl[i+1] = HL_STRING;
+                p += 2; i += 2;
+                prev_sep = 0;
+                continue;
+            }
+            if (*p == in_string) in_string = 0;
+            p++; i++;
+            continue;
+        } else {
+            if (*p == '"' || *p == '\'') {
+                in_string = *p;
+                row->hl[i] = HL_STRING;
+                p++; i++;
+                prev_sep = 0;
+                continue;
+            }
+        }
+
+        /* Handle non printable chars. */
+        if (!isprint(*p)) {
+            row->hl[i] = HL_NONPRINT;
+            p++; i++;
+            prev_sep = 0;
+            continue;
+        }
+
+        /* Handle numbers */
+        if ((isdigit(*p) && (prev_sep || row->hl[i-1] == HL_NUMBER)) ||
+            (*p == '.' && i >0 && row->hl[i-1] == HL_NUMBER)) {
+            row->hl[i] = HL_NUMBER;
+            p++; i++;
+            prev_sep = 0;
+            continue;
+        }
+
+        /* Handle keywords and lib calls */
+        if (prev_sep) {
+            int j;
+            for (j = 0; keywords[j]; j++) {
+                int klen = strlen(keywords[j]);
+                int kw2 = keywords[j][klen-1] == '|';
+                if (kw2) klen--;
+
+                if (!memcmp(p,keywords[j],klen) &&
+                    is_separator(*(p+klen)))
+                {
+                    /* Keyword */
+                    memset(row->hl+i,kw2 ? HL_KEYWORD2 : HL_KEYWORD1,klen);
+                    p += klen;
+                    i += klen;
+                    break;
+                }
+            }
+            if (keywords[j] != NULL) {
+                prev_sep = 0;
+                continue; /* We had a keyword match */
+            }
+        }
+
+        /* Not special chars */
+        prev_sep = is_separator(*p);
+        p++; i++;
+    }
+
+    /* Propagate syntax change to the next row if the open commen
+     * state changed. This may recursively affect all the following rows
+     * in the file. */
+    int oc = editorRowHasOpenComment(row);
+    if (row->hl_oc != oc && row->idx+1 < E.numrows)
+        editorUpdateSyntax(&E.row[row->idx+1]);
+    row->hl_oc = oc;
+}
+
+/* Maps syntax highlight token types to terminal colors. */
+int editorSyntaxToColor(int hl) {
+    switch(hl) {
+    case HL_COMMENT:
+    case HL_MLCOMMENT: return 36;     /* cyan */
+    case HL_KEYWORD1: return 33;    /* yellow */
+    case HL_KEYWORD2: return 32;    /* green */
+    case HL_STRING: return 35;      /* magenta */
+    case HL_NUMBER: return 31;      /* red */
+    case HL_MATCH: return 34;      /* blu */
+    default: return 37;             /* white */
+    }
+}
+
+/* Select the syntax highlight scheme depending on the filename,
+ * setting it in the global state E.syntax. */
+void editorSelectSyntaxHighlight(char *filename) {
+    for (unsigned int j = 0; j < HLDB_ENTRIES; j++) {
+        struct editorSyntax *s = HLDB+j;
+        unsigned int i = 0;
+        while(s->filematch[i]) {
+            char *p;
+            int patlen = strlen(s->filematch[i]);
+            if ((p = strstr(filename,s->filematch[i])) != NULL) {
+                if (s->filematch[i][0] != '.' || p[patlen] == '\0') {
+                    E.syntax = s;
+                    return;
+                }
+            }
+            i++;
+        }
+    }
+}
+
+/* ======================= Editor rows implementation ======================= */
+
+/* Update the rendered version and the syntax highlight of a row. */
+void editorUpdateRow(erow *row) {
+    int tabs = 0, nonprint = 0, j, idx;
+
+   /* Create a version of the row we can directly print on the screen,
+     * respecting tabs, substituting non printable characters with '?'. */
+    free(row->render);
+    for (j = 0; j < row->size; j++)
+        if (row->chars[j] == TAB) tabs++;
+
+    row->render = malloc(row->size + tabs*8 + nonprint*9 + 1);
+    idx = 0;
+    for (j = 0; j < row->size; j++) {
+        if (row->chars[j] == TAB) {
+            row->render[idx++] = ' ';
+            while((idx+1) % 8 != 0) row->render[idx++] = ' ';
+        } else {
+            row->render[idx++] = row->chars[j];
+        }
+    }
+    row->rsize = idx;
+    row->render[idx] = '\0';
+
+    /* Update the syntax highlighting attributes of the row. */
+    editorUpdateSyntax(row);
+}
+
+/* Insert a row at the specified position, shifting the other rows on the bottom
+ * if required. */
+void editorInsertRow(int at, char *s, size_t len) {
+    if (at > E.numrows) return;
+    E.row = realloc(E.row,sizeof(erow)*(E.numrows+1));
+    if (at != E.numrows) {
+        memmove(E.row+at+1,E.row+at,sizeof(E.row[0])*(E.numrows-at));
+        for (int j = at+1; j <= E.numrows; j++) E.row[j].idx++;
+    }
+    E.row[at].size = len;
+    E.row[at].chars = malloc(len+1);
+    memcpy(E.row[at].chars,s,len+1);
+    E.row[at].hl = NULL;
+    E.row[at].hl_oc = 0;
+    E.row[at].render = NULL;
+    E.row[at].rsize = 0;
+    E.row[at].idx = at;
+    editorUpdateRow(E.row+at);
+    E.numrows++;
+    E.dirty++;
+}
+
+/* Free row's heap allocated stuff. */
+void editorFreeRow(erow *row) {
+    free(row->render);
+    free(row->chars);
+    free(row->hl);
+}
+
+/* Remove the row at the specified position, shifting the remainign on the
+ * top. */
+void editorDelRow(int at) {
+    erow *row;
+
+    if (at >= E.numrows) return;
+    row = E.row+at;
+    editorFreeRow(row);
+    memmove(E.row+at,E.row+at+1,sizeof(E.row[0])*(E.numrows-at-1));
+    for (int j = at; j < E.numrows-1; j++) E.row[j].idx++;
+    E.numrows--;
+    E.dirty++;
+}
+
+/* Turn the editor rows into a single heap-allocated string.
+ * Returns the pointer to the heap-allocated string and populate the
+ * integer pointed by 'buflen' with the size of the string, escluding
+ * the final nulterm. */
+char *editorRowsToString(int *buflen) {
+    char *buf = NULL, *p;
+    int totlen = 0;
+    int j;
+
+    /* Compute count of bytes */
+    for (j = 0; j < E.numrows; j++)
+        totlen += E.row[j].size+1; /* +1 is for "\n" at end of every row */
+    *buflen = totlen;
+    totlen++; /* Also make space for nulterm */
+
+    p = buf = malloc(totlen);
+    for (j = 0; j < E.numrows; j++) {
+        memcpy(p,E.row[j].chars,E.row[j].size);
+        p += E.row[j].size;
+        *p = '\n';
+        p++;
+    }
+    *p = '\0';
+    return buf;
+}
+
+/* Insert a character at the specified position in a row, moving the remaining
+ * chars on the right if needed. */
+void editorRowInsertChar(erow *row, int at, int c) {
+    if (at > row->size) {
+        /* Pad the string with spaces if the insert location is outside the
+         * current length by more than a single character. */
+        int padlen = at-row->size;
+        /* In the next line +2 means: new char and null term. */
+        row->chars = realloc(row->chars,row->size+padlen+2);
+        memset(row->chars+row->size,' ',padlen);
+        row->chars[row->size+padlen+1] = '\0';
+        row->size += padlen+1;
+    } else {
+        /* If we are in the middle of the string just make space for 1 new
+         * char plus the (already existing) null term. */
+        row->chars = realloc(row->chars,row->size+2);
+        memmove(row->chars+at+1,row->chars+at,row->size-at+1);
+        row->size++;
+    }
+    row->chars[at] = c;
+    editorUpdateRow(row);
+    E.dirty++;
+}
+
+/* Append the string 's' at the end of a row */
+void editorRowAppendString(erow *row, char *s, size_t len) {
+    row->chars = realloc(row->chars,row->size+len+1);
+    memcpy(row->chars+row->size,s,len);
+    row->size += len;
+    row->chars[row->size] = '\0';
+    editorUpdateRow(row);
+    E.dirty++;
+}
+
+/* Delete the character at offset 'at' from the specified row. */
+void editorRowDelChar(erow *row, int at) {
+    if (row->size <= at) return;
+    memmove(row->chars+at,row->chars+at+1,row->size-at);
+    editorUpdateRow(row);
+    row->size--;
+    E.dirty++;
+}
+
+/* Insert the specified char at the current prompt position. */
+void editorInsertChar(int c) {
+    int filerow = E.rowoff+E.cy;
+    int filecol = E.coloff+E.cx;
+    erow *row = (filerow >= E.numrows) ? NULL : &E.row[filerow];
+
+    /* If the row where the cursor is currently located does not exist in our
+     * logical representaion of the file, add enough empty rows as needed. */
+    if (!row) {
+        while(E.numrows <= filerow)
+            editorInsertRow(E.numrows,"",0);
+    }
+    row = &E.row[filerow];
+    editorRowInsertChar(row,filecol,c);
+    if (E.cx == E.screencols-1)
+        E.coloff++;
+    else
+        E.cx++;
+    E.dirty++;
+}
+
+/* Inserting a newline is slightly complex as we have to handle inserting a
+ * newline in the middle of a line, splitting the line as needed. */
+void editorInsertNewline(void) {
+    int filerow = E.rowoff+E.cy;
+    int filecol = E.coloff+E.cx;
+    erow *row = (filerow >= E.numrows) ? NULL : &E.row[filerow];
+
+    if (!row) {
+        if (filerow == E.numrows) {
+            editorInsertRow(filerow,"",0);
+            goto fixcursor;
+        }
+        return;
+    }
+    /* If the cursor is over the current line size, we want to conceptually
+     * think it's just over the last character. */
+    if (filecol >= row->size) filecol = row->size;
+    if (filecol == 0) {
+        editorInsertRow(filerow,"",0);
+    } else {
+        /* We are in the middle of a line. Split it between two rows. */
+        editorInsertRow(filerow+1,row->chars+filecol,row->size-filecol);
+        row = &E.row[filerow];
+        row->chars[filecol] = '\0';
+        row->size = filecol;
+        editorUpdateRow(row);
+    }
+fixcursor:
+    if (E.cy == E.screenrows-1) {
+        E.rowoff++;
+    } else {
+        E.cy++;
+    }
+    E.cx = 0;
+    E.coloff = 0;
+}
+
+/* Delete the char at the current prompt position. */
+void editorDelChar() {
+    int filerow = E.rowoff+E.cy;
+    int filecol = E.coloff+E.cx;
+    erow *row = (filerow >= E.numrows) ? NULL : &E.row[filerow];
+
+    if (!row || (filecol == 0 && filerow == 0)) return;
+    if (filecol == 0) {
+        /* Handle the case of column 0, we need to move the current line
+         * on the right of the previous one. */
+        filecol = E.row[filerow-1].size;
+        editorRowAppendString(&E.row[filerow-1],row->chars,row->size);
+        editorDelRow(filerow);
+        row = NULL;
+        if (E.cy == 0)
+            E.rowoff--;
+        else
+            E.cy--;
+        E.cx = filecol;
+        if (E.cx >= E.screencols) {
+            int shift = (E.screencols-E.cx)+1;
+            E.cx -= shift;
+            E.coloff += shift;
+        }
+    } else {
+        editorRowDelChar(row,filecol-1);
+        if (E.cx == 0 && E.coloff)
+            E.coloff--;
+        else
+            E.cx--;
+    }
+    if (row) editorUpdateRow(row);
+    E.dirty++;
+}
+
+/* Load the specified program in the editor memory and returns 0 on success
+ * or 1 on error. */
+int editorOpen(char *filename) {
+    FILE *fp;
+
+    E.dirty = 0;
+    free(E.filename);
+    E.filename = strdup(filename);
+
+    fp = fopen(filename,"r");
+    if (!fp) {
+        if (errno != ENOENT) {
+            perror("Opening file");
+            exit(1);
+        }
+        return 1;
+    }
+
+    char *line = NULL;
+    size_t linecap = 0;
+    ssize_t linelen;
+    while((linelen = getline(&line,&linecap,fp)) != -1) {
+        if (linelen && (line[linelen-1] == '\n' || line[linelen-1] == '\r'))
+            line[--linelen] = '\0';
+        editorInsertRow(E.numrows,line,linelen);
+    }
+    free(line);
+    fclose(fp);
+    E.dirty = 0;
+    return 0;
+}
+
+/* Save the current file on disk. Return 0 on success, 1 on error. */
+int editorSave(void) {
+    int len;
+    char *buf = editorRowsToString(&len);
+    int fd = open(E.filename,O_RDWR|O_CREAT,0644);
+    if (fd == -1) goto writeerr;
+
+#if 0
+    /* Use truncate + a single write(2) call in order to make saving
+     * a bit safer, under the limits of what we can do in a small editor. */
+    if (ftruncate(fd,len) == -1) goto writeerr;
+#endif
+    if (write(fd,buf,len) != len) goto writeerr;
+
+    close(fd);
+    free(buf);
+    E.dirty = 0;
+    editorSetStatusMessage("%d bytes written on disk", len);
+    return 0;
+
+writeerr:
+    free(buf);
+    if (fd != -1) close(fd);
+    editorSetStatusMessage("Can't save! I/O error: %s",strerror(errno));
+    return 1;
+}
+
+/* ============================= Terminal update ============================ */
+
+/* We define a very simple "append buffer" structure, that is an heap
+ * allocated string where we can append to. This is useful in order to
+ * write all the escape sequences in a buffer and flush them to the standard
+ * output in a single call, to avoid flickering effects. */
+struct abuf {
+    char *b;
+    int len;
+};
+
+#define ABUF_INIT {NULL,0}
+
+void abAppend(struct abuf *ab, const char *s, int len) {
+    char *new = realloc(ab->b,ab->len+len);
+
+    if (new == NULL) return;
+    memcpy(new+ab->len,s,len);
+    ab->b = new;
+    ab->len += len;
+}
+
+void abFree(struct abuf *ab) {
+    free(ab->b);
+}
+
+/* This function writes the whole screen using VT100 escape characters
+ * starting from the logical state of the editor in the global state 'E'. */
+void editorRefreshScreen(void) {
+    int y;
+    erow *r;
+    char buf[32];
+    struct abuf ab = ABUF_INIT;
+
+    abAppend(&ab,"\x1b[?25l",6); /* Hide cursor. */
+    abAppend(&ab,"\x1b[H",3); /* Go home. */
+    for (y = 0; y < E.screenrows; y++) {
+        int filerow = E.rowoff+y;
+
+        if (filerow >= E.numrows) {
+            if (E.numrows == 0 && y == E.screenrows/3) {
+                char welcome[80];
+                int welcomelen = snprintf(welcome,sizeof(welcome),
+                    "Kilo editor -- version %s\x1b[0K\r\n", KILO_VERSION);
+                int padding = (E.screencols-welcomelen)/2;
+                if (padding) {
+                    abAppend(&ab,"~",1);
+                    padding--;
+                }
+                while(padding--) abAppend(&ab," ",1);
+                abAppend(&ab,welcome,welcomelen);
+            } else {
+                abAppend(&ab,"~\x1b[0K\r\n",7);
+            }
+            continue;
+        }
+
+        r = &E.row[filerow];
+
+        int len = r->rsize - E.coloff;
+        int current_color = -1;
+        if (len > 0) {
+            if (len > E.screencols) len = E.screencols;
+            char *c = r->render+E.coloff;
+            unsigned char *hl = r->hl+E.coloff;
+            int j;
+            for (j = 0; j < len; j++) {
+                if (hl[j] == HL_NONPRINT) {
+                    char sym;
+                    abAppend(&ab,"\x1b[7m",4);
+                    if (c[j] <= 26)
+                        sym = '@'+c[j];
+                    else
+                        sym = '?';
+                    abAppend(&ab,&sym,1);
+                    abAppend(&ab,"\x1b[0m",4);
+                } else if (hl[j] == HL_NORMAL) {
+                    if (current_color != -1) {
+                        abAppend(&ab,"\x1b[39m",5);
+                        current_color = -1;
+                    }
+                    abAppend(&ab,c+j,1);
+                } else {
+                    int color = editorSyntaxToColor(hl[j]);
+                    if (color != current_color) {
+                        char buf[16];
+                        int clen = snprintf(buf,sizeof(buf),"\x1b[%dm",color);
+                        current_color = color;
+                        abAppend(&ab,buf,clen);
+                    }
+                    abAppend(&ab,c+j,1);
+                }
+            }
+        }
+        abAppend(&ab,"\x1b[39m",5);
+        abAppend(&ab,"\x1b[0K",4);
+        abAppend(&ab,"\r\n",2);
+    }
+
+    /* Create a two rows status. First row: */
+    abAppend(&ab,"\x1b[0K",4);
+    abAppend(&ab,"\x1b[7m",4);
+    char status[80], rstatus[80];
+    int len = snprintf(status, sizeof(status), "%.20s - %d lines %s",
+        E.filename, E.numrows, E.dirty ? "(modified)" : "");
+    int rlen = snprintf(rstatus, sizeof(rstatus),
+        "%d/%d",E.rowoff+E.cy+1,E.numrows);
+    if (len > E.screencols) len = E.screencols;
+    abAppend(&ab,status,len);
+    while(len < E.screencols) {
+        if (E.screencols - len == rlen) {
+            abAppend(&ab,rstatus,rlen);
+            break;
+        } else {
+            abAppend(&ab," ",1);
+            len++;
+        }
+    }
+    abAppend(&ab,"\x1b[0m\r\n",6);
+
+    /* Second row depends on E.statusmsg and the status message update time. */
+    abAppend(&ab,"\x1b[0K",4);
+    int msglen = strlen(E.statusmsg);
+    if (msglen && time(NULL)-E.statusmsg_time < 5)
+        abAppend(&ab,E.statusmsg,msglen <= E.screencols ? msglen : E.screencols);
+
+    /* Put cursor at its current position. Note that the horizontal position
+     * at which the cursor is displayed may be different compared to 'E.cx'
+     * because of TABs. */
+    int j;
+    int cx = 1;
+    int filerow = E.rowoff+E.cy;
+    erow *row = (filerow >= E.numrows) ? NULL : &E.row[filerow];
+    if (row) {
+        for (j = E.coloff; j < (E.cx+E.coloff); j++) {
+            if (j < row->size && row->chars[j] == TAB) cx += 7-((cx)%8);
+            cx++;
+        }
+    }
+    snprintf(buf,sizeof(buf),"\x1b[%d;%dH",E.cy+1,cx);
+    abAppend(&ab,buf,strlen(buf));
+    abAppend(&ab,"\x1b[?25h",6); /* Show cursor. */
+    write(STDOUT_FILENO,ab.b,ab.len);
+    abFree(&ab);
+}
+
+/* Set an editor status message for the second line of the status, at the
+ * end of the screen. */
+void editorSetStatusMessage(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap,fmt);
+    vsnprintf(E.statusmsg,sizeof(E.statusmsg),fmt,ap);
+    va_end(ap);
+    E.statusmsg_time = time(NULL);
+}
+
+/* =============================== Find mode ================================ */
+
+#define KILO_QUERY_LEN 256
+
+void editorFind(int fd) {
+    char query[KILO_QUERY_LEN+1] = {0};
+    int qlen = 0;
+    int last_match = -1; /* Last line where a match was found. -1 for none. */
+    int find_next = 0; /* if 1 search next, if -1 search prev. */
+    int saved_hl_line = -1;  /* No saved HL */
+    char *saved_hl = NULL;
+
+#define FIND_RESTORE_HL do { \
+    if (saved_hl) { \
+        memcpy(E.row[saved_hl_line].hl,saved_hl, E.row[saved_hl_line].rsize); \
+        free(saved_hl); \
+        saved_hl = NULL; \
+    } \
+} while (0)
+
+    /* Save the cursor position in order to restore it later. */
+    int saved_cx = E.cx, saved_cy = E.cy;
+    int saved_coloff = E.coloff, saved_rowoff = E.rowoff;
+
+    while(1) {
+        editorSetStatusMessage(
+            "Search: %s (Use ESC/Arrows/Enter)", query);
+        editorRefreshScreen();
+
+        int c = editorReadKey(fd);
+        if (c == DEL_KEY || c == CTRL_H || c == BACKSPACE) {
+            if (qlen != 0) query[--qlen] = '\0';
+            last_match = -1;
+        } else if (c == ESC || c == ENTER) {
+            if (c == ESC) {
+                E.cx = saved_cx; E.cy = saved_cy;
+                E.coloff = saved_coloff; E.rowoff = saved_rowoff;
+            }
+            FIND_RESTORE_HL;
+            editorSetStatusMessage("");
+            return;
+        } else if (c == ARROW_RIGHT || c == ARROW_DOWN) {
+            find_next = 1;
+        } else if (c == ARROW_LEFT || c == ARROW_UP) {
+            find_next = -1;
+        } else if (isprint(c)) {
+            if (qlen < KILO_QUERY_LEN) {
+                query[qlen++] = c;
+                query[qlen] = '\0';
+                last_match = -1;
+            }
+        }
+
+        /* Search occurrence. */
+        if (last_match == -1) find_next = 1;
+        if (find_next) {
+            char *match = NULL;
+            int match_offset = 0;
+            int i, current = last_match;
+
+            for (i = 0; i < E.numrows; i++) {
+                current += find_next;
+                if (current == -1) current = E.numrows-1;
+                else if (current == E.numrows) current = 0;
+                match = strstr(E.row[current].render,query);
+                if (match) {
+                    match_offset = match-E.row[current].render;
+                    break;
+                }
+            }
+            find_next = 0;
+
+            /* Highlight */
+            FIND_RESTORE_HL;
+
+            if (match) {
+                erow *row = &E.row[current];
+                last_match = current;
+                if (row->hl) {
+                    saved_hl_line = current;
+                    saved_hl = malloc(row->rsize);
+                    memcpy(saved_hl,row->hl,row->rsize);
+                    memset(row->hl+match_offset,HL_MATCH,qlen);
+                }
+                E.cy = 0;
+                E.cx = match_offset;
+                E.rowoff = current;
+                E.coloff = 0;
+                /* Scroll horizontally as needed. */
+                if (E.cx > E.screencols) {
+                    int diff = E.cx - E.screencols;
+                    E.cx -= diff;
+                    E.coloff += diff;
+                }
+            }
+        }
+    }
+}
+
+/* ========================= Editor events handling  ======================== */
+
+/* Handle cursor position change because arrow keys were pressed. */
+void editorMoveCursor(int key) {
+    int filerow = E.rowoff+E.cy;
+    int filecol = E.coloff+E.cx;
+    int rowlen;
+    erow *row = (filerow >= E.numrows) ? NULL : &E.row[filerow];
+
+    switch(key) {
+    case ARROW_LEFT:
+        if (E.cx == 0) {
+            if (E.coloff) {
+                E.coloff--;
+            } else {
+                if (filerow > 0) {
+                    E.cy--;
+                    E.cx = E.row[filerow-1].size;
+                    if (E.cx > E.screencols-1) {
+                        E.coloff = E.cx-E.screencols+1;
+                        E.cx = E.screencols-1;
+                    }
+                }
+            }
+        } else {
+            E.cx -= 1;
+        }
+        break;
+    case ARROW_RIGHT:
+        if (row && filecol < row->size) {
+            if (E.cx == E.screencols-1) {
+                E.coloff++;
+            } else {
+                E.cx += 1;
+            }
+        } else if (row && filecol == row->size) {
+            E.cx = 0;
+            E.coloff = 0;
+            if (E.cy == E.screenrows-1) {
+                E.rowoff++;
+            } else {
+                E.cy += 1;
+            }
+        }
+        break;
+    case ARROW_UP:
+        if (E.cy == 0) {
+            if (E.rowoff) E.rowoff--;
+        } else {
+            E.cy -= 1;
+        }
+        break;
+    case ARROW_DOWN:
+        if (filerow < E.numrows) {
+            if (E.cy == E.screenrows-1) {
+                E.rowoff++;
+            } else {
+                E.cy += 1;
+            }
+        }
+        break;
+    }
+    /* Fix cx if the current line has not enough chars. */
+    filerow = E.rowoff+E.cy;
+    filecol = E.coloff+E.cx;
+    row = (filerow >= E.numrows) ? NULL : &E.row[filerow];
+    rowlen = row ? row->size : 0;
+    if (filecol > rowlen) {
+        E.cx -= filecol-rowlen;
+        if (E.cx < 0) {
+            E.coloff += E.cx;
+            E.cx = 0;
+        }
+    }
+}
+
+/* Process events arriving from the standard input, which is, the user
+ * is typing stuff on the terminal. */
+#define KILO_QUIT_TIMES 3
+void editorProcessKeypress(int fd) {
+    /* When the file is modified, requires Ctrl-q to be pressed N times
+     * before actually quitting. */
+    static int quit_times = KILO_QUIT_TIMES;
+	int times;
+
+    int c = editorReadKey(fd);
+    switch(c) {
+    case ENTER:         /* Enter */
+        editorInsertNewline();
+        break;
+    case CTRL_C:        /* Ctrl-c */
+        /* We ignore ctrl-c, it can't be so simple to lose the changes
+         * to the edited file. */
+        break;
+    case CTRL_Q:        /* Ctrl-q */
+        /* Quit if the file was already saved. */
+        if (E.dirty && quit_times) {
+            editorSetStatusMessage("WARNING!!! File has unsaved changes. "
+                "Press Ctrl-Q %d more times to quit.", quit_times);
+            quit_times--;
+            return;
+        } else {
+                /* move cursor below editor before quitting */
+                char buf[32];
+                struct abuf ab = ABUF_INIT;
+                snprintf(buf,sizeof(buf),"\x1b[39m\x1b[%d;%dH\r\n\x1b[K",E.screenrows+1,1); //numrows
+                abAppend(&ab,buf,strlen(buf));
+                write(STDOUT_FILENO,ab.b,ab.len);
+                abFree(&ab);
+                exit(0);
+        }
+        break;
+    case CTRL_S:        /* Ctrl-s */
+        editorSave();
+        break;
+    case CTRL_F:
+        editorFind(fd);
+        break;
+    case BACKSPACE:     /* Backspace */
+    case CTRL_H:        /* Ctrl-h */
+    case DEL_KEY:
+        editorDelChar();
+        break;
+    case PAGE_UP:
+    case PAGE_DOWN:
+        if (c == PAGE_UP && E.cy != 0)
+            E.cy = 0;
+        else if (c == PAGE_DOWN && E.cy != E.screenrows-1)
+            E.cy = E.screenrows-1;
+        times = E.screenrows;
+        while(times--)
+            editorMoveCursor(c == PAGE_UP ? ARROW_UP: ARROW_DOWN);
+        break;
+    case HOME_KEY:
+	    E.cx = 0;
+        break;
+    case END_KEY:
+        E.cx = E.row[E.rowoff+E.cy].size;
+        break;
+    case ARROW_UP:
+    case ARROW_DOWN:
+    case ARROW_LEFT:
+    case ARROW_RIGHT:
+        editorMoveCursor(c);
+        break;
+    case CTRL_L: /* ctrl+l, clear screen */
+        /* Just refresht the line as side effect. */
+        break;
+    case ESC:
+        /* Nothing to do for ESC in this mode. */
+        break;
+    default:
+        editorInsertChar(c);
+        break;
+    }
+
+    quit_times = KILO_QUIT_TIMES; /* Reset it to the original value. */
+}
+
+int editorFileWasModified(void) {
+    return E.dirty;
+}
+
+void updateWindowSize(void) {
+    if (getWindowSize(STDIN_FILENO,STDOUT_FILENO,
+                      &E.screenrows,&E.screencols) == -1) {
+        perror("Unable to query the screen for size (columns / rows)");
+        exit(1);
+    }
+    E.screenrows -= 2; /* Get room for status bar. */
+}
+
+void handleSigWinCh(int unused __attribute__((unused))) {
+    updateWindowSize();
+    if (E.cy > E.screenrows) E.cy = E.screenrows - 1;
+    if (E.cx > E.screencols) E.cx = E.screencols - 1;
+    editorRefreshScreen();
+}
+
+void initEditor(void) {
+    E.cx = 0;
+    E.cy = 0;
+    E.rowoff = 0;
+    E.coloff = 0;
+    E.numrows = 0;
+    E.row = NULL;
+    E.dirty = 0;
+    E.filename = NULL;
+    E.syntax = NULL;
+    updateWindowSize();
+    signal(SIGWINCH, handleSigWinCh);
+}
+
+int main(int argc, char **argv) {
+    if (argc != 2) {
+        fprintf(stderr,"Usage: kilo <filename>\n");
+        exit(1);
+    }
+
+    initEditor();
+    editorSelectSyntaxHighlight(argv[1]);
+    editorOpen(argv[1]);
+    enableRawMode(STDIN_FILENO);
+    editorSetStatusMessage(
+        "HELP: Ctrl-S = save | Ctrl-Q = quit | Ctrl-F = find");
+    while(1) {
+        editorRefreshScreen();
+        editorProcessKeypress(STDIN_FILENO);
+    }
+    return 0;
+}

--- a/elkscmd/rootfs_template/etc/termcap
+++ b/elkscmd/rootfs_template/etc/termcap
@@ -7,6 +7,7 @@ ansi|vt100|vt-100|ELKS ANSI (VT-100) console:\
 	:al=\E[L:am:bl=^G:bs:co#80:it#8:li#25:\
 	:cd=\E[J:ce=\E[K:cl=\E[H\E[2J:cm=\E[%i%d;%dH:do=\E[B:ho=\E[H:\
 	:kd=\E[B:kl=\E[D:kr=\E[C:ku=\E[A:\
+	:kh=\E[H:kH=\E[F:kP=\E[5~:kN=\E[6~:\
 	:le=\E[D:nd=\E[C:ta=^I:up=\E[A:se=\E[m:so=\E[7m:sr=\E[L:
 
 ansi77|ANSI 3.64 standard 1977 version:\

--- a/image/Makefile
+++ b/image/Makefile
@@ -27,13 +27,13 @@ all: $(TARGETS)
 image:
 	$(MAKE) -f Make.image "CONFIG=$(TOPDIR)/.config"
 
-images: images-minix hd32-minix images-fat images-mbr
+images: images-minix images-mbr images-fat
 
 images-minix: fd360-minix fd720-minix fd1440-minix fd2880-minix hd32-minix
 
-images-fat: fd360-fat fd720-fat fd1440-fat fd2880-fat hd32-fat
+images-fat: fd360-fat fd720-fat fd1440-fat fd2880-fat hd32-fat hd32mbr-fat
 
-images-mbr: hd32mbr-minix hd32mbr-fat
+images-mbr: hd32mbr-minix
 
 fd360-minix:
 	echo CONFIG_APPS_360K=y		> Config

--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -113,6 +113,11 @@ extern int fclose __P((FILE*));
 extern int fflush __P((FILE*));
 extern char *fgets __P((char*, size_t, FILE*));
 
+ssize_t getdelim(char **__restrict lineptr, size_t *__restrict n,
+		int delimiter, register FILE *__restrict stream);
+ssize_t getline(char **__restrict lineptr, size_t *__restrict n,
+		FILE *__restrict stream);
+
 extern FILE *fopen __P((char*, char*));
 extern FILE *fdopen __P((int, char*));
 extern FILE *freopen  __P((char*, char*, FILE*));

--- a/libc/include/sys/types.h
+++ b/libc/include/sys/types.h
@@ -1,3 +1,6 @@
 #include <features.h>
 #include <stddef.h>
 #include __SYSINC__(types.h)
+
+typedef int intptr_t;
+typedef intptr_t ssize_t;

--- a/libc/include/unistd.h
+++ b/libc/include/unistd.h
@@ -5,9 +5,6 @@
 #include <sys/types.h>
 #include <sys/select.h>
 
-typedef int intptr_t;
-typedef intptr_t ssize_t;
-
 #define STDIN_FILENO 0
 #define STDOUT_FILENO 1
 #define STDERR_FILENO 2

--- a/libc/stdio/Makefile
+++ b/libc/stdio/Makefile
@@ -25,6 +25,8 @@ OBJS = \
 	ftell.o \
 	fwrite.o \
 	puts.o \
+	getdelim.o \
+	getline.o \
 	gets.o \
 	printf.o \
 	putchar.o \

--- a/libc/stdio/getdelim.c
+++ b/libc/stdio/getdelim.c
@@ -1,0 +1,74 @@
+/* Copyright (C) 2004       Manuel Novoa III    <mjn3@codepoet.org>
+ * ported to ELKS by Greg Haerr 15 Apr 2020
+ *
+ * GNU Library General Public License (LGPL) version 2 or later.
+ *
+ * Dedicated to Toni.  See uClibc/DEDICATION.mjn3 for details.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <errno.h>
+
+/* Note: There is a defect in this function.  (size_t vs ssize_t). */
+
+/* glibc function --
+ * Return -1 if error or EOF prior to any chars read.
+ * Return number of chars read (including possible delimiter but not
+ *   the terminating nul) otherwise.
+ *
+ * NOTE: If we need to allocate a buffer, we do so prior to attempting
+ * a reading.  So space may be allocated even if initially at EOF.
+ */
+
+#define GETDELIM_GROWBY		64
+
+ssize_t getdelim(char **__restrict lineptr, size_t *__restrict n,
+				   int delimiter, register FILE *__restrict stream)
+{
+	register char *buf;
+	ssize_t pos = -1;
+	int c;
+
+	if (!lineptr || !n || !stream) {
+		errno = -EINVAL;
+	} else {
+		if (!(buf = *lineptr)) { /* If passed NULL for buffer, */
+			*n = 0;		/* ignore value passed and treat size as 0. */
+		}
+
+		/* Within the loop, pos is actually the current buffer index + 2,
+		 * because we want to make sure we have enough space to store
+		 * an additional char plus a nul terminator.
+		 */
+		pos = 1;
+
+		do {
+			if (pos >= *n) {
+				if (!(buf = realloc(buf, *n + GETDELIM_GROWBY))) {
+					pos = -1;
+					break;
+				}
+				*n += GETDELIM_GROWBY;
+				*lineptr = buf;
+			}
+
+			if ((c = fgetc(stream)) != EOF) {
+				buf[++pos - 2] = c;
+				if (c != delimiter) {
+					continue;
+				}
+			}
+
+			/* We're done, so correct pos back to being the current index. */
+			if ((pos -= 2) >= 0) {
+				buf[++pos] = 0;
+			}
+			break;
+
+		} while (1);
+	}
+
+	return pos;
+}

--- a/libc/stdio/getline.c
+++ b/libc/stdio/getline.c
@@ -1,0 +1,14 @@
+/* Copyright (C) 2004       Manuel Novoa III    <mjn3@codepoet.org>
+ *
+ * GNU Library General Public License (LGPL) version 2 or later.
+ *
+ * Dedicated to Toni.  See uClibc/DEDICATION.mjn3 for details.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+
+ssize_t getline(char **__restrict lineptr, size_t *__restrict n, FILE *__restrict stream)
+{
+	return getdelim(lineptr, n, '\n', stream);
+}


### PR DESCRIPTION
Port small (16k) nano-like `kilo` color screen editor to ELKS. Runs on console and serial port with terminal emulator. From https://github.com/antirez/kilo (same author as 'linenoise' shell line editor).

Fix ANSI color display on console. (ESC [ 30-47 m ] )
Fix ANSI delayed column 80 auto-wrap on console.
Fix low-level keyboard CR -> LF conversion bug.
Send ANSI escape sequences for console Home, End, PgUp, PgDn keys.
Add /etc/termcap entries for above keys to allow `vi` to use them.
Add `getline` and `getdelim` stdio libc routines.

![kilo](https://user-images.githubusercontent.com/11985637/79419279-61f69680-7f6b-11ea-9bb2-bd5ef516c66a.png)

