### PR TITLE
[init] Stop init respawns if getty exits quickly

### DIFF
--- a/elkscmd/rootfs_template/etc/inittab
+++ b/elkscmd/rootfs_template/etc/inittab
@@ -11,6 +11,6 @@ si::sysinit:/etc/rc.d/rc.sys
 #ud::once:/sbin/update
 
 1:2345:respawn:/bin/getty /dev/tty1
-#s0:2345:respawn:/bin/getty /dev/ttyS0 9600
+s0:2345:respawn:/bin/getty /dev/ttyS0 9600
 #2:2345:respawn:/bin/getty /dev/tty2
 #3:2345:respawn:/bin/getty /dev/tty3


### PR DESCRIPTION
Modify `init` to stop continual 'respawn' processing of a command in /etc/inittab if process exits within 3 seconds of starting. No current way of automatically restarting, but that shouldn't be a problem.

Fixes issue mentioned in #515.

Modify /etc/inittab to défault running `getty` onto /dev/tty1 and /dev/ttyS0.
ELKS now boots fine from serial or console and allows access from serial or console with no /etc/inittab modifications.

Tested on QEMU with serial port setup and disabled.

@Mellvik, please test. I was able to fix the problem where `getty` was cycling, but am not able to see `init` hang. Perhaps they are the same thing.