### PR TITLE
[kernel] Add customizable IRQ and I/O ports for all drivers

### DIFF
--- a/elks/arch/i86/drivers/block/directhd.c
+++ b/elks/arch/i86/drivers/block/directhd.c
@@ -58,7 +58,7 @@ static struct file_operations directhd_fops = {
 /* what is this good for ? */
 static int access_count[4] = { 0, };
 
-static int io_ports[2] = { 0x1f0, 0x170 };
+static int io_ports[2] = { HD1_PORT, HD2_PORT };
 
 static int directhd_initialized = 0;
 

--- a/elks/arch/i86/drivers/block/floppy.c
+++ b/elks/arch/i86/drivers/block/floppy.c
@@ -54,11 +54,12 @@
  * removed volatile and fixed function definitions
  */
 
+#ifdef CONFIG_BLK_DEV_FD
+
 #define TRP_TIMER
 #define TRP_SIG
 
 #define REALLY_SLOW_IO
-#define FLOPPY_IRQ 6
 #define FLOPPY_DMA 2
 
 #include <linuxmt/config.h>
@@ -77,15 +78,6 @@
 #include <arch/io.h>
 #include <arch/segment.h>
 
-#ifdef CONFIG_BLK_DEV_FD
-#if 1
-/* Hack until this code works */
-void floppy_init(void)
-{
-/* Do nothing */
-}
-
-#else
 
 #define FLOPPYDISK
 #define MAJOR_NR FLOPPY_MAJOR
@@ -1450,7 +1442,5 @@ void floppy_init(void)
 	reset_floppy();
     }
 }
-
-#endif
 
 #endif

--- a/elks/arch/i86/drivers/char/serial.c
+++ b/elks/arch/i86/drivers/char/serial.c
@@ -10,6 +10,7 @@
 #include <linuxmt/termios.h>
 #include <linuxmt/debug.h>
 #include <arch/io.h>
+#include <arch/ports.h>
 
 #define NEW		1	/* set =0 for old driver code if needed*/
 #define FIFO		0	/* set =1 to enable new FIFO code for testing*/
@@ -54,10 +55,10 @@ struct serial_info {
 #define MAX_RX_BUFFER_SIZE 16
 
 static struct serial_info ports[NR_SERIAL] = {
-    {(char *)0x3f8, 4, 0, DEFAULT_LCR, DEFAULT_MCR, 0, 0, NULL},
-    {(char *)0x2f8, 3, 0, DEFAULT_LCR, DEFAULT_MCR, 0, 0, NULL},
-    {(char *)0x3e8, 5, 0, DEFAULT_LCR, DEFAULT_MCR, 0, 0, NULL},
-    {(char *)0x2e8, 2, 0, DEFAULT_LCR, DEFAULT_MCR, 0, 0, NULL},
+    {(char *)COM1_PORT, COM1_IRQ, 0, DEFAULT_LCR, DEFAULT_MCR, 0, 0, NULL},
+    {(char *)COM2_PORT, COM2_IRQ, 0, DEFAULT_LCR, DEFAULT_MCR, 0, 0, NULL},
+    {(char *)COM3_PORT, COM3_IRQ, 0, DEFAULT_LCR, DEFAULT_MCR, 0, 0, NULL},
+    {(char *)COM4_PORT, COM4_IRQ, 0, DEFAULT_LCR, DEFAULT_MCR, 0, 0, NULL},
 };
 
 static char irq_port[NR_SERIAL] = { 3, 1, 0, 2 };

--- a/elks/arch/i86/drivers/char/xt_key.c
+++ b/elks/arch/i86/drivers/char/xt_key.c
@@ -28,6 +28,7 @@
 #include <linuxmt/ntty.h>
 
 #include <arch/io.h>
+#include <arch/ports.h>
 #include <arch/keyboard.h>
 
 #ifdef CONFIG_CONSOLE_DIRECT
@@ -126,7 +127,7 @@ void xtk_init(void)
 {
     /* Set off the initial keyboard interrupt handler */
 
-    if (request_irq(1, keyboard_irq, NULL))
+    if (request_irq(KBD_IRQ, keyboard_irq, NULL))
 	panic("Unable to get keyboard");
 }
 

--- a/elks/arch/i86/drivers/net/ne2k.h
+++ b/elks/arch/i86/drivers/net/ne2k.h
@@ -1,11 +1,7 @@
 #ifndef NE2K_H
 #define NE2K_H
 
-
-// Default in QEMU
-
-#define NE2K_IRQ 9
-
+#include <arch/ports.h>
 
 // NE2K status
 

--- a/elks/arch/i86/kernel/irq.c
+++ b/elks/arch/i86/kernel/irq.c
@@ -24,6 +24,7 @@
 
 #include <arch/io.h>
 #include <arch/irq.h>
+#include <arch/ports.h>
 
 /* Enable 80386 Traps */
 /*#define ENABLE_TRAPS */
@@ -226,7 +227,7 @@ void init_IRQ(void)
     irqtab_init();			/* Store DS */
 
     /* Set off the initial timer interrupt handler */
-    if (request_irq(0, timer_tick,NULL))
+    if (request_irq(TIMER_IRQ, timer_tick, NULL))
 	panic("Unable to get timer");
 
     /* Re-start the timer only after irq is set */

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -1,5 +1,6 @@
 #include <linuxmt/config.h>
 #include <arch/asm-offsets.h>
+#include <arch/ports.h>
 
 	.code16
 
@@ -22,33 +23,90 @@ ds_kernel:
 	.word	0
 #endif
 
-#ifdef CONFIG_CONSOLE_DIRECT
-#define MCD 0x2
+/* build MINT mask based on required interrupts in arch/ports.h*/
+#ifdef CONFIG_NEED_IRQ0
+#define M0	0x01
 #else
-#define MCD 0
+#define M0	0
 #endif
-#ifdef CONFIG_CHAR_DEV_RS
-#define MRS 0x18
+#ifdef CONFIG_NEED_IRQ1
+#define M1	0x02
 #else
-#define MRS 0
+#define M1	0
 #endif
-#ifdef CONFIG_BLK_DEV_HD
-#define MHD 0xC020
+#ifdef CONFIG_NEED_IRQ2
+#define M2	0x04
 #else
-#define MHD 0
+#define M2	0
 #endif
-#ifdef CONFIG_BLK_DEV_FD
-#define MFD 0x40
+#ifdef CONFIG_NEED_IRQ3
+#define M3	0x08
 #else
-#define MFD 0
+#define M3	0
 #endif
-#ifdef CONFIG_ETH_NE2K
-#define METH 0x200
+#ifdef CONFIG_NEED_IRQ4
+#define M4	0x10
 #else
-#define METH 0
+#define M4	0
+#endif
+#ifdef CONFIG_NEED_IRQ5
+#define M5	0x20
+#else
+#define M5	0
+#endif
+#ifdef CONFIG_NEED_IRQ6
+#define M6	0x40
+#else
+#define M6	0
+#endif
+#ifdef CONFIG_NEED_IRQ7
+#define M7	0x80
+#else
+#define M7	0
+#endif
+#ifdef CONFIG_NEED_IRQ8
+#define M8	0x100
+#else
+#define M8	0
+#endif
+#ifdef CONFIG_NEED_IRQ9
+#define M9	0x200
+#else
+#define M9	0
+#endif
+#ifdef CONFIG_NEED_IRQ10
+#define M10	0x400
+#else
+#define M10	0
+#endif
+#ifdef CONFIG_NEED_IRQ11
+#define M11	0x800
+#else
+#define M11	0
+#endif
+#ifdef CONFIG_NEED_IRQ12
+#define M12	0x1000
+#else
+#define M12	0
+#endif
+#ifdef CONFIG_NEED_IRQ13
+#define M13	0x2000
+#else
+#define M13	0
+#endif
+#ifdef CONFIG_NEED_IRQ14
+#define M14	0x4000
+#else
+#define M14	0
+#endif
+#ifdef CONFIG_NEED_IRQ15
+#define M15	0x8000
+#else
+#define M15	0
 #endif
 
-#define MINT (1 | MCD | MRS | MHD | MFD | METH)
+/* took awhile to generate this...*/
+#define MINT (M0|M1|M2|M3|M4|M5|M6|M7|M8|M9|M10|M11|M12|M13|M14|M15)
 
 	.global	irqtab_init
 irqtab_init:
@@ -77,7 +135,7 @@ irqtab_init:
 	mov	%ax,%es:_stashed_irq0_l+2
 
 	mov	$MINT,%cx
-	mov	$_irq0,%ax
+	mov	$_irqtable,%ax
 init_tab1:
 	shr	$1,%cx
 	jnc	init_tab2
@@ -106,71 +164,88 @@ init_tab3:
 // Instead, the address pushed in the stack will be used to get
 // the interrupt number.
 
+_irqtable:
+#ifdef CONFIG_NEED_IRQ0
 _irq0:			// Timer
 	call	_irqit
 	.byte	0
-#ifdef CONFIG_CONSOLE_DIRECT
+#endif
+#ifdef CONFIG_NEED_IRQ1
 _irq1:			// Keyboard
 	call	_irqit
 	.byte	1
 #endif
-#if 0
+#ifdef CONFIG_NEED_IRQ2
 _irq2:			// Cascade
 	call	_irqit
 	.byte	2
 #endif
-#ifdef CONFIG_CHAR_DEV_RS
+#ifdef CONFIG_NEED_IRQ3
 _irq3:			// COM2
 	call	_irqit
 	.byte	3
+#endif
+#ifdef CONFIG_NEED_IRQ4
 _irq4:			// COM1
 	call	_irqit
 	.byte	4
 #endif
-#ifdef CONFIG_BLK_DEV_HD
+#ifdef CONFIG_NEED_IRQ5
 _irq5:			// XT HD
 	call	_irqit
 	.byte	5
 #endif
-#ifdef CONFIG_BLK_DEV_FD
+#ifdef CONFIG_NEED_IRQ6
 _irq6:			// Floppy
 	call	_irqit
 	.byte	6
 #endif
-#if 0
+#ifdef CONFIG_NEED_IRQ7
 _irq7:			// Lp1
 	call	_irqit
 	.byte	7
-!
-!	AT interrupts
-!
+#endif
+
+//
+//	AT interrupts
+//
+
+#ifdef CONFIG_NEED_IRQ8
 _irq8:			// RTC
 	call	_irqit
 	.byte	8
 #endif
-#ifdef CONFIG_ETH_NE2K
+#ifdef CONFIG_NEED_IRQ9
 _irq9:			// Ethernet device
 	call	_irqit
 	.byte	9
 #endif
-#if 0
+#ifdef CONFIG_NEED_IRQ10
 _irq10:			// USB
 	call	_irqit
 	.byte	10
+#endif
+#ifdef CONFIG_NEED_IRQ11
 _irq11:			// Sound
 	call	_irqit
 	.byte	11
+#endif
+#ifdef CONFIG_NEED_IRQ12
 _irq12:			// Mouse
 	call	_irqit
 	.byte	12
+#endif
+#ifdef CONFIG_NEED_IRQ13
 _irq13:			// Math coproc.
 	call	_irqit
 	.byte	13
 #endif
-#ifdef CONFIG_BLK_DEV_HD
+#ifdef CONFIG_NEED_IRQ14
 _irq14:			// AT HD ide primary
 	call	_irqit
 	.byte	14
+#endif
+#ifdef CONFIG_NEED_IRQ15
 _irq15:			// AT HD ide secondary
 	call	_irqit
 	.byte	15

--- a/elks/arch/i86/kernel/timer.c
+++ b/elks/arch/i86/kernel/timer.c
@@ -5,6 +5,7 @@
 
 #include <arch/io.h>
 #include <arch/irq.h>
+#include <arch/ports.h>
 
 /*
  *	Timer tick routine
@@ -33,9 +34,6 @@ extern void keyboard_irq(int, struct pt_regs *, void *);
  *  hypothetical exact reference frequency for the timer is 39375000/33 Hz.
  *  The macros use scaled fixed point arithmetic for greater accuracy.
  */
-
-#define TIMER_CMDS_PORT ((void *) 0x43) 	/* command port */
-#define TIMER_DATA_PORT ((void *) 0x40) 	/* data port    */
 
 #define TIMER_MODE0 0x30   /* timer 0, binary count, mode 0, lsb/msb */
 #define TIMER_MODE2 0x34   /* timer 0, binary count, mode 2, lsb/msb */
@@ -79,9 +77,9 @@ void enable_timer_tick(void)
 {
 #ifndef CONFIG_ARCH_SIBO
     /* set the clock frequency */
-    outb (TIMER_MODE2, TIMER_CMDS_PORT);
-    outb (TIMER_LO_BYTE, TIMER_DATA_PORT);	/* LSB */
-    outb (TIMER_HI_BYTE, TIMER_DATA_PORT);	/* MSB */
+    outb (TIMER_MODE2, (void*)TIMER_CMDS_PORT);
+    outb (TIMER_LO_BYTE, (void*)TIMER_DATA_PORT);	/* LSB */
+    outb (TIMER_HI_BYTE, (void*)TIMER_DATA_PORT);	/* MSB */
 
 #else
 
@@ -95,8 +93,8 @@ void enable_timer_tick(void)
 void stop_timer(void)
 {
 #ifndef CONFIG_ARCH_SIBO
-    outb (TIMER_MODE0, TIMER_CMDS_PORT);
-    outb (0, TIMER_DATA_PORT);
-    outb (0, TIMER_DATA_PORT);
+    outb (TIMER_MODE0, (void*)TIMER_CMDS_PORT);
+    outb (0, (void*)TIMER_DATA_PORT);
+    outb (0, (void*)TIMER_DATA_PORT);
 #endif
 }

--- a/elks/include/arch/keyboard.h
+++ b/elks/include/arch/keyboard.h
@@ -11,7 +11,4 @@ extern int psiongetchar(void);
 
 #endif
 
-#define KBD_IO	0x60
-#define KBD_CTL	0x61
-
 #endif

--- a/elks/include/arch/ports.h
+++ b/elks/include/arch/ports.h
@@ -1,0 +1,111 @@
+/*
+ * ELKS I/O port and IRQ mappings
+ *
+ * PC IRQ default mappings (* = possible conflicting uses)
+ *
+ *  IRQ	ELKS Device         Config Option           Status
+ *  0   Timer                                       Required
+ *  1   Keyboard            CONFIG_CONSOLE_DIRECT   Optional
+ *  2*  Cascade -> 9 AT, Unused on XT               Optional on XT, not available on AT
+ *  3   Com2 (/dev/ttyS1)   CONFIG_CHAR_DEV_RS      Optional
+ *  4   Com1 (/dev/ttyS0)   CONFIG_CHAR_DEV_RS      Optional
+ *  5*  Unused
+ *  5*  Com3 (/devb/ttyS2)  CONFIG_CHAR_DEV_RS      Optional
+ *  5*  HW IDE hard drive   CONFIG_BLK_DEV_HD       Driver doesn't work
+ *  6*  Unused
+ *  6*  HW floppy drive     CONFIG_BLK_DEV_FD       Driver doesn't compile
+ *  7   Unused (LPT)
+ *  8   Unused (RTC)
+ *  9   NE2K (/dev/eth)     CONFIG_ETH_NE2K         Optional
+ * 10   Unused (USB)                                Turned off
+ * 11   Unused (Sound)                              Turned off
+ * 12   Unused (Mouse)                              Turned off
+ * 13   Unused (Math coproc.)                       Turned off
+ * 14*  AT HD IDE (/dev/hda) CONFIG_BLK_DEV_HD      Driver doesn't work
+ * 15*  AT HD IDE (/dev/hdb) CONFIG_BLK_DEV_HD      Driver doesn't work
+ *
+ * Edit settings below to change port address or IRQ:
+ *   #define CONFIG_NEED_IRQx to map interrupt vector to ELKS
+ *   Change I/O port and driver IRQ number to match your hardware
+ */
+
+#define CONFIG_NEED_IRQ0		/* Timer, required*/
+
+#ifdef CONFIG_CONSOLE_DIRECT
+#define CONFIG_NEED_IRQ1
+#endif
+
+/* unused*/
+//#define CONFIG_NEED_IRQ2		/* only available on XT, slave PIC on AT*/
+
+#ifdef CONFIG_CHAR_DEV_RS
+#define CONFIG_NEED_IRQ4		/* COM1*/
+#define CONFIG_NEED_IRQ3		/* COM2*/
+#define CONFIG_NEED_IRQ5		/* COM3*/
+//#define CONFIG_NEED_IRQ2		/* COM4, XT only*/
+#endif
+
+/* unused*/
+//#define CONFIG_NEED_IRQ6
+//#define CONFIG_NEED_IRQ7
+//#define CONFIG_NEED_IRQ8
+
+#ifdef CONFIG_ETH_NE2K
+#define CONFIG_NEED_IRQ9
+#endif
+
+/* unused*/
+//#define CONFIG_NEED_IRQ10
+//#define CONFIG_NEED_IRQ11
+//#define CONFIG_NEED_IRQ12
+//#define CONFIG_NEED_IRQ13
+
+/* obsolete - driver won't compile*/
+#ifdef CONFIG_BLK_DEV_FD
+#define CONFIG_NEED_IRQ6
+#endif
+
+/* obsolete - driver doesn't work*/
+#ifdef CONFIG_BLK_DEV_HD
+#define CONFIG_NEED_IRQ5
+#define CONFIG_NEED_IRQ14
+#define CONFIG_NEED_IRQ15
+#endif
+
+/* timer, timer.c*/
+#define TIMER_CMDS_PORT 0x43		/* command port */
+#define TIMER_DATA_PORT 0x40		/* data port    */
+#define TIMER_IRQ	0		/* can't change*/
+
+/* keyboard, xt_kbd.c*/
+#define KBD_IO		0x60
+#define KBD_CTL		0x61
+#define KBD_IRQ		1
+
+/* serial, serial.c*/
+#define COM1_PORT	0x3f8
+#define COM1_IRQ	4		/* unregistered unless COM1_PORT found*/
+
+#define COM2_PORT	0x2f8
+#define COM2_IRQ	3		/* unregistered unless COM2_PORT found*/
+
+#define COM3_PORT	0x3e8
+#define COM3_IRQ	5		/* unregistered unless COM3_PORT found*/
+
+#define COM4_PORT	0x2e8
+#define COM4_IRQ	2		/* unregistered unless COM4_PORT found*/
+
+/* ne2k, eth-main.c*/
+#define io_ne2k_command 0x0300		/* FIXME needs to be included in ne2k-mac.s*/
+#define NE2K_IRQ	9
+
+
+/* obsolete - experimental IDE hard drive, directhd.c (broken)*/
+#define HD1_PORT	0x1f0
+#define HD2_PORT	0x170
+#define HD_IRQ		5		/* missing request_irq call*/
+#define HD1_AT_IRQ	14		/* missing request_irq call*/
+#define HD2_AT_IRQ	15		/* missing request_irq call*/
+
+/* obsoleete - experimental floppy drive, floppy.c (won't compile)*/
+#define FLOPPY_IRQ	6		/* missing request_irq call*/


### PR DESCRIPTION
Allows programmatic customization of all IRQ \#'s and port addresses for all drivers that use interrupts by editing a single new file, 'elks/include/arch/ports.h'. 

Requested in #372. 

This change should allow customization of all hardware device port numbers and IRQs.
After working through this, there are quite a few available IRQs available for use. See ports.h for details. Here is the top of that file:
```
/*
 * ELKS I/O port and IRQ mappings
 *
 * PC IRQ default mappings (* = possible conflicting uses)
 *
 *  IRQ ELKS Device         Config Option           Status
 *  0   Timer                                       Required
 *  1   Keyboard            CONFIG_CONSOLE_DIRECT   Optional
 *  2*  Cascade -> 9 AT, Unused on XT               Optional on XT, not available on AT
 *  3   Com2 (/dev/ttyS1)   CONFIG_CHAR_DEV_RS      Optional
 *  4   Com1 (/dev/ttyS0)   CONFIG_CHAR_DEV_RS      Optional
 *  5*  Unused
 *  5*  Com3 (/devb/ttyS2)  CONFIG_CHAR_DEV_RS      Optional
 *  5*  HW IDE hard drive   CONFIG_BLK_DEV_HD       Driver doesn't work
 *  6*  Unused
 *  6*  HW floppy drive     CONFIG_BLK_DEV_FD       Driver doesn't compile
 *  7   Unused (LPT)
 *  8   Unused (RTC)
 *  9   NE2K (/dev/eth)     CONFIG_ETH_NE2K         Optional
 * 10   Unused (USB)                                Turned off
 * 11   Unused (Sound)                              Turned off
 * 12   Unused (Mouse)                              Turned off
 * 13   Unused (Math coproc.)                       Turned off
 * 14*  AT HD IDE (/dev/hda) CONFIG_BLK_DEV_HD      Driver doesn't work
 * 15*  AT HD IDE (/dev/hdb) CONFIG_BLK_DEV_HD      Driver doesn't work
 *
 * Edit settings below to change port address or IRQ:
 *   #define CONFIG_NEED_IRQx to map interrupt vector to ELKS
 *   Change I/O port and driver IRQ number to match your hardware
 */
```

Not completed: 
- The NE2K network driver needs more modifications to 'elks/arch/i86/drivers/net/ne2k-mac.s' to access port ranges by adding to a base port, rather than using set constants.
- Customization is through editing ports.h only, not by `menuconfig`.