### PR TITLE
[shell] Enhance shell autocomplete to operate identical to BASH

### DIFF
--- a/elkscmd/ash/autocomplete.c
+++ b/elkscmd/ash/autocomplete.c
@@ -1,116 +1,116 @@
 /*
- * This implements the autocompletion callback (or TAB completion) for Linenoise
- * see the shell.txt file in the Documentation/text directory for details
+ * This implements the autocompletion callback (or TAB completion) for ash/linenoise.
+ * Autocompletion operates identically to BASH shell. Greg Haerr 17 Apr 2020
  */
 
 #include "shell.h"
 
-#if LINENOISE
-
+#if LINENOISE		/* entire file if LINENOISE=0 in shell.h*/
 #include <dirent.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <stdio.h>
 #include <string.h>
 #include "linenoise.h"
 
-void completion(const char *buf, linenoiseCompletions *lc) {
-/* completion callback for ELKS */
+void completion(const char *buf, linenoiseCompletions *lc)
+{
+	char *arg, *file;
+	DIR *fp;
+	struct dirent *dp;
+	int count;
+	char dir[128];
+	char line[128];
+	char result[128];
+	char lastentry[128];
 
-int files_found=0;
-char path[1024]=""; 
-char resultstring[100]="";
-char startchars[100]="";
-char matchterm[100]="";
-char blank[]=" ";
-char* sptr=NULL;
-int dirs =0;
-int exes = 0;
-int stds = 0;
-int firstcharpos =0; //zero based!
+	strcpy(line, buf);
 
-struct stat file_attribute;
+	/* get active argument*/
+	arg = rindex(line, ' ');
+	if (arg)
+		++arg;
+	else arg = line;
 
+	/* parse directory and filename portion*/
+	file = rindex(arg, '/');
+	if (file) {
+		char c = *++file;
+		*file = 0;
+		strcpy(dir, arg);
+		*file = c;
+	}
+	else {
+		file = arg;
+		strcpy(dir, (arg == line)? "/bin": ".");
+	}
 
-   if (strncmp(buf, "cd ",3) == 0) {
-        //look for directories
-       dirs=1;
-       if (strncmp(buf, "cd /",4) == 0){
-            //search in root for directories
-            sprintf(path,"/");
-            sprintf(startchars,"cd /");
-            sprintf(matchterm,"%s",buf+4);
-        } else {
-            //search in current directory for directories
-            sprintf(path,".");
-            sprintf(startchars,"cd ");
-            sprintf(matchterm,"%s",buf+3);
-        }
-   } else if ((strlen(buf) > 1) && (strncmp(buf, "./",2)) == 0){
-       //search for executables in current directory
-       exes = 1;
-       sprintf(path,".");
-       sprintf(startchars,"./");
-       sprintf(matchterm,"%s",buf+2);
-   } else if (strpbrk(buf,blank) != NULL) { 
-       // search for file to use with ls, cat, vi, ed, type etc.
-       // in the current directory
-       stds=1;
-       sprintf(path,".");
-       firstcharpos=strpbrk(buf,blank)- buf+1;
-       sprintf(matchterm,"%s",buf+firstcharpos);
-       sprintf(startchars,"%s",buf);
-       startchars[firstcharpos]=0x00;
-   } else {
-       //search for executable in /bin
-       exes=1; //no need and will not list outside currdir
-       sprintf(path,"/bin");
-       sprintf(matchterm,"%s",buf);
-   }
-   
-   DIR *dirp=opendir(path);
-   
-   struct dirent entry;
-   struct dirent *dp=&entry;
-   
-   printf("\n\r"); //print files in new line
-   
-   while(dp = readdir(dirp))
-   {
-      if((strncmp(matchterm, dp->d_name,strlen(matchterm))) == 0)
-      {
-          if (dirs ==1) {
-              stat(dp->d_name, &file_attribute);
-              if ((file_attribute.st_mode & S_IFDIR)==0) continue; //is no directory
-              if (strcmp(dp->d_name,".") == 0) continue; //add no '.' to directories
-          }
-          if (stds ==1) {
-              stat(dp->d_name, &file_attribute);
-              if ((file_attribute.st_mode & S_IXUSR)!=0) continue; //show no executable files
-              if ((file_attribute.st_mode & S_IFDIR)!=0) continue; //show no directories
-          }
-          if (exes ==1) {
-                stat(dp->d_name, &file_attribute);
-                if (strcmp(startchars,"./") == 0) { //workaround, st_mode may need path to filename
-                    if ((file_attribute.st_mode & S_IXUSR)==0) continue; //is no executable file
-                }
-                if ((file_attribute.st_mode & S_IFDIR)!=0) continue; //show no directories
-          }
+	fp = opendir(dir);
+	if (!fp)
+		return;
 
-          if (files_found != 0) printf("%s, ",resultstring);   //do not print a single file found
-          sprintf(resultstring,"%s%s",startchars,dp->d_name); //cannot pass pointer to linenoiseAddCompletion          
-          linenoiseAddCompletion(lc,resultstring);           
-          files_found++;
-          if (files_found >500) break; //limit
-      }
-   }
-   if (files_found > 1) {
-       printf("%s ",resultstring); //the last one - do not print single match
-       printf("(%d Files found)\n", files_found);
-       }
-   
-   closedir(dirp); //now dp no longer available!
+	/* first pass, count matches*/
+	count = 0;
+	while ((dp = readdir(fp)) != NULL) {
+		if (!strncmp(file, dp->d_name, strlen(file))) {
+			if ((file[0] == '.') || (strcmp(dp->d_name, ".") && strcmp(dp->d_name, ".."))) {
+				strcpy(result, buf);
+				strcpy(&result[strlen(result)-strlen(file)], dp->d_name);
 
-   return;
+				strcpy(lastentry, dp->d_name);
+				count++;
+			}
+		}
+	}
+	closedir(fp);
 
+	if (count == 0)
+		return;
+	if (count == 1) {
+		struct stat st;
+		char path[128];
+
+		sprintf(path, "%s/%s", dir, lastentry);
+		if (!stat(path, &st)) {
+			if (S_ISDIR(st.st_mode))
+				strcat(result, "/");
+			if (S_ISREG(st.st_mode))
+				strcat(result, " ");
+		}
+		linenoiseAddCompletion(lc, result);
+		return;
+	}
+
+	/* display matches if more than one*/
+	linenoiseAddCompletion(lc, buf);
+	count = 0;
+	fp = opendir(dir);
+	while ((dp = readdir(fp)) != NULL) {
+		if (!strncmp(file, dp->d_name, strlen(file))) {
+			struct stat st;
+			char path[128];
+
+			if ((file[0] == '.') || (strcmp(dp->d_name, ".") && strcmp(dp->d_name, ".."))) {
+				strcpy(result, buf);
+				strcpy(&result[strlen(result)-strlen(file)], dp->d_name);
+				linenoiseAddCompletion(lc, result);
+
+				strcpy(result, dp->d_name);
+				sprintf(path, "%s/%s", dir, dp->d_name);
+				if (!stat(path, &st) && S_ISDIR(st.st_mode))
+					strcat(result, "/");
+
+				if ((count & 3) == 0)
+					printf("\r\n");
+				printf("%-16s", result);
+				count++;
+			}
+		}
+	}
+	if (count)
+		printf("\r\n");
+	fflush(stdout);
+	closedir(fp);
 }
-#endif
+
+#endif /* LINENOISE entire file*/

--- a/elkscmd/misc_utils/.gitignore
+++ b/elkscmd/misc_utils/.gitignore
@@ -7,5 +7,6 @@ od
 hd
 time
 kilo
+tty
 uncompress
 zcat


### PR DESCRIPTION
Enhance TAB completion in `sh` to operate very closely to BASH autocomplete.

Thanks again to @georgp24 for bringing the lightweight `linenoise` library to ELKS.

Command line editing and TAB completion make using ELKS `sh` as easy to use as `bash`, and in a lot less space.