### PR TITLE
[kernel][init] Add O_EXCL for serial com/mouse, init run levels

### DIFF
--- a/elks/arch/i86/drivers/char/pty.c
+++ b/elks/arch/i86/drivers/char/pty.c
@@ -21,18 +21,16 @@
 int pty_open(struct inode *inode, struct file *file)
 {
     register struct tty *otty;
-    register char *pi;
 
-    pi = 0;
     if (!(otty = determine_tty(inode->i_rdev))) {
 	debug("failed: NODEV\n");
-	pi = (char *)(-ENODEV);
+	return -ENODEV;
     }
-    else if (otty->flags & TTY_OPEN) {
+    if (otty->flags & TTY_OPEN) {
 	debug("failed: BUSY\n");
-	pi = (char *)(-EBUSY);
+	return -EBUSY;
     }
-    return (int)pi;
+    return 0;
 }
 
 void pty_release(struct inode *inode, struct file *file)

--- a/elks/kernel/sys.c
+++ b/elks/kernel/sys.c
@@ -317,10 +317,6 @@ int sys_setsid(void)
     currentp->session = currentp->pgrp = currentp->pid;
     currentp->tty = NULL;
 
-#if 0
-    currentp->tty_old_pgrp = 0;
-#endif
-
     return currentp->pgrp;
 }
 

--- a/elkscmd/misc_utils/miniterm.c
+++ b/elkscmd/misc_utils/miniterm.c
@@ -248,7 +248,7 @@ static int serial_open(const char *device, speed_t baudrate, bool rtscts, struct
 	int fd;
 	speed_t b;
 
-	fd = open(device, O_RDWR | O_NOCTTY | O_NONBLOCK);
+	fd = open(device, O_RDWR | O_EXCL | O_NOCTTY | O_NONBLOCK);
 
 	if (fd == -1)
 		return -1;
@@ -385,7 +385,6 @@ int main(int argc, char **argv)
 	bool escape = false, rtscts = false;
 	bool enable_rts = false, enable_dtr = false;
 	const char *device = "/dev/ttyS0";
-	int flags;
 	bool no_reset = false;
 
 	while ((ch = getopt(argc, argv, "s:SrdRxh")) != -1) {
@@ -434,6 +433,7 @@ int main(int argc, char **argv)
 	}
 
 #if later
+	int flags;
 	if (ioctl(fd, TIOCMGET, &flags) == -1) {
 		perror(device);
 		exit(1);

--- a/elkscmd/nano-X/demos/nterm.c
+++ b/elkscmd/nano-X/demos/nterm.c
@@ -161,6 +161,7 @@ again:
 		return -1;
 	}
 	if (!pid) {
+		putenv("TERM=dumb");
 		close(STDIN_FILENO);
 		close(STDOUT_FILENO);
 		close(STDERR_FILENO);

--- a/elkscmd/nano-X/drivers/mou_ser.c
+++ b/elkscmd/nano-X/drivers/mou_ser.c
@@ -135,7 +135,7 @@ MOU_Open(MOUSEDEVICE *pmd)
 		return -1;
 
 	/* open mouse port*/
-	mouse_fd = open(port, O_NONBLOCK);
+	mouse_fd = open(port, O_EXCL | O_NOCTTY | O_NONBLOCK);
 	if (mouse_fd < 0) {
 		fprintf(stderr,
 			"Error %d opening serial mouse type %s on port %s.\n",

--- a/elkscmd/rootfs_template/etc/inittab
+++ b/elkscmd/rootfs_template/etc/inittab
@@ -10,7 +10,15 @@ si::sysinit:/etc/rc.d/rc.sys
 
 #ud::once:/sbin/update
 
-1:2345:respawn:/bin/getty /dev/tty1
-s0:2345:respawn:/bin/getty /dev/ttyS0 9600
-#2:2345:respawn:/bin/getty /dev/tty2
-#3:2345:respawn:/bin/getty /dev/tty3
+# getty runlevels
+# 1 single user tty1 only
+# 2 single user ttyS0 only
+# 3 multiuser tty1 and ttyS0
+# 4 multiuser serial only (ttyS0,ttyS1)
+# 5 multiuser console only (tty1,tty2,tty3)
+# 6 multiuser console and serial
+t1:1356:respawn:/bin/getty /dev/tty1
+t2:56:respawn:/bin/getty /dev/tty2
+t3:56:respawn:/bin/getty /dev/tty3
+s0:2346:respawn:/bin/getty /dev/ttyS0 9600
+s1:46:respawn:/bin/getty /dev/ttyS1 9600

--- a/elkscmd/sys_utils/mouse.c
+++ b/elkscmd/sys_utils/mouse.c
@@ -96,7 +96,7 @@ open_mouse(void)
 #endif
 
 	/* open mouse port*/
-	mouse_fd = open(MOUSE_DEVICE, O_NONBLOCK);
+	mouse_fd = open(MOUSE_DEVICE, O_EXCL | O_NOCTTY | O_NONBLOCK);
 	if (mouse_fd < 0) {
 		printf("Can't open %s, error %d\n", MOUSE_DEVICE, errno);
  		return -1;
@@ -187,6 +187,7 @@ read_mouse(int *dx, int *dy, int *dz, int *bptr)
 	return 0;
 }
 
+#if MOUSE_PC
 /*
  * Input routine for PC mouse.
  * Returns nonzero when a new mouse state has been completed.
@@ -246,8 +247,9 @@ parsePC(int byte)
 	}
 	return 0;
 }
+#endif
 
-
+#if MOUSE_MICROSOFT
 /*
  * Input routine for Microsoft mouse.
  * Returns nonzero when a new mouse state has been completed.
@@ -281,6 +283,7 @@ parseMS(int byte)
 	}
 	return 0;
 }
+#endif
 
 int main(int argc, char **argv)
 {

--- a/elkscmd/sys_utils/ps.c
+++ b/elkscmd/sys_utils/ps.c
@@ -13,6 +13,7 @@
 #define __KERNEL__
 #include <linuxmt/ntty.h>
 #undef __KERNEL__
+#include <linuxmt/major.h>
 #include <linuxmt/mem.h>
 #include <linuxmt/sched.h>
 #include <stdio.h>
@@ -69,7 +70,7 @@ void process_name(int fd, unsigned int off, unsigned int seg)
 char *devname(unsigned int minor)
 {
 	struct dirent *d;
-	dev_t ttydev = MKDEV(4, minor);
+	dev_t ttydev = MKDEV(TTY_MAJOR, minor);
 	struct stat st;
 	static char dev[] = "/dev";
 	static char name[16]; /* should be MAXNAMLEN but that's overkill */

--- a/image/Make.devices
+++ b/image/Make.devices
@@ -89,18 +89,6 @@ devices:
 #	$MKSET 224 15 $(MKDEV) /dev/ptyd x 2
 #	$MKSET 240 15 $(MKDEV) /dev/ptye x 2
 
-##############################################################################
-# Pseudo-TTY slave devices. 
-
-	$(MKDEV) /dev/ttyp0 c 4 8
-	$(MKDEV) /dev/ttyp1 c 4 9
-	$(MKDEV) /dev/ttyp2 c 4 10
-	$(MKDEV) /dev/ttyp3 c 4 11
-
-##############################################################################
-# CGATEXT
-	$(MKDEV) /dev/cgatext	c 10 0
-
 # These are not yet supported by the ELKS kernel.
 #	$MKSET   0 15 $(MKDEV) /dev/ttyp x 3
 #	$MKSET  16 15 $(MKDEV) /dev/ttyq x 3
@@ -134,12 +122,18 @@ devices:
 #	$MKSET  64 63 $(MKDEV) /dev/hdb b 3	# Ought to be.
 
 ##############################################################################
-# Virtual consoles and serial ports.
+# Virtual consoles, pseudo-tty slaves and serial ports.
 
 	$(MKDEV) /dev/tty1	c 4 0
 	$(MKDEV) /dev/tty2	c 4 1
 	$(MKDEV) /dev/tty3	c 4 2
-	$(MKDEV) /dev/tty4	c 4 3
+
+# Pseudo-TTY slave devices.
+
+	$(MKDEV) /dev/ttyp0 c 4 8
+	$(MKDEV) /dev/ttyp1 c 4 9
+	$(MKDEV) /dev/ttyp2 c 4 10
+	$(MKDEV) /dev/ttyp3 c 4 11
 
 # /dev/tty is minor 255, last of the /dev/ttye range
 
@@ -175,6 +169,10 @@ devices:
 # Ethernet device
 
 	$(MKDEV) /dev/eth c 9 0
+
+##############################################################################
+# CGATEXT
+	$(MKDEV) /dev/cgatext	c 10 0
 
 ##############################################################################
 # SATA / SCSI disks. These are not yet supported.

--- a/libc/system/usleep.c
+++ b/libc/system/usleep.c
@@ -7,8 +7,8 @@ usleep(unsigned long useconds)
 {
         struct timeval timeout;
 
-        timeout.tv_sec	= useconds % 1000000L;
-        timeout.tv_usec	= useconds / 1000000L;
+        timeout.tv_sec	= useconds / 1000000L;
+        timeout.tv_usec	= useconds % 1000000L;
         select(1, NULL, NULL, NULL, &timeout);
 }
 #endif


### PR DESCRIPTION
Fixes various problems brought up in #552.

The O_EXCL (exclusive use) flag is set in `mouse`, `miniterm`, and all nano-X demos (serial mouse driver). This will disallow opening of the serial mouse port when `getty` or another program has also opened it, with an error message.

Added O_NOCTTY processing to prohibit process from gaining a controlling TTY. Both O_NOCTTY and O_EXCL are set on all terminal emulation and mouse port opens.

Fixed ~[6n display in `nxterm`.

Run level processing of '/etc/inittab' added to `init`. This allows multiple configurations of ELKS console and serial getty/logins and run level shell script processing to be changed from the command line, e.g. `init 1`. Run levels are managed in /etc/inittab, following are the current settings (default is run level 3):
```
# getty runlevels
# 1 single user tty1 only
# 2 single user ttyS0 only
# 3 multiuser tty1 and ttyS0
# 4 multiuser serial only (ttyS0,ttyS1)
# 5 multiuser console only (tty1,tty2,tty3)
# 6 multiuser console and serial
t1:1356:respawn:/bin/getty /dev/tty1
t2:56:respawn:/bin/getty /dev/tty2
t3:56:respawn:/bin/getty /dev/tty3
s0:2346:respawn:/bin/getty /dev/ttyS0 9600
s1:46:respawn:/bin/getty /dev/ttyS1 9600
```

Cleaned up/fixed a few small other issues.