### PR TITLE
Fix chgrp and add a clear command.

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -84,6 +84,7 @@ sys_utils/poweroff				:sysutil			:720k
 sys_utils/who					:sysutil				:1440k
 sys_utils/unreal16				:sysutil				:1440k
 sh_utils/basename				:be-shutil			:720k
+sh_utils/clear					:be-shutil		:1440k
 sh_utils/date					:be-shutil		:360k
 sh_utils/dirname				:be-shutil			:720k
 sh_utils/false					:be-shutil				:1440k

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -84,7 +84,7 @@ sys_utils/poweroff				:sysutil			:720k
 sys_utils/who					:sysutil				:1440k
 sys_utils/unreal16				:sysutil				:1440k
 sh_utils/basename				:be-shutil			:720k
-sh_utils/clear					:be-shutil		:1440k
+sh_utils/clear					:shutil		:1440k
 sh_utils/date					:be-shutil		:360k
 sh_utils/dirname				:be-shutil			:720k
 sh_utils/false					:be-shutil				:1440k

--- a/elkscmd/file_utils/Makefile
+++ b/elkscmd/file_utils/Makefile
@@ -19,7 +19,7 @@ cat: cat.o
 	$(LD) $(LDFLAGS) -o cat cat.o $(LDLIBS)
 
 chgrp: chgrp.o
-	$(LD) $(LDFLAGS) -maout-chmem=0xc000 -o chgrp chgrp.o $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-chmem=0x6000 -o chgrp chgrp.o $(LDLIBS)
 
 chmod: chmod.o
 	$(LD) $(LDFLAGS) -o chmod chmod.o $(LDLIBS)

--- a/elkscmd/file_utils/Makefile
+++ b/elkscmd/file_utils/Makefile
@@ -19,7 +19,7 @@ cat: cat.o
 	$(LD) $(LDFLAGS) -o cat cat.o $(LDLIBS)
 
 chgrp: chgrp.o
-	$(LD) $(LDFLAGS) -o chgrp chgrp.o $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-chmem=0xc000 -o chgrp chgrp.o $(LDLIBS)
 
 chmod: chmod.o
 	$(LD) $(LDFLAGS) -o chmod chmod.o $(LDLIBS)

--- a/elkscmd/sh_utils/.gitignore
+++ b/elkscmd/sh_utils/.gitignore
@@ -1,4 +1,5 @@
 basename
+clear
 date
 dirname
 echo

--- a/elkscmd/sh_utils/Makefile
+++ b/elkscmd/sh_utils/Makefile
@@ -11,8 +11,8 @@ include $(BASEDIR)/Make.rules
 ###############################################################################
 
 # TODO: uname write	# Do not compile
-PRGS=basename date dirname echo false printenv pwd true which whoami yes \
-	logname tr xargs mesg stty test
+PRGS=basename clear date dirname echo false printenv pwd true which whoami \
+	yes logname tr xargs mesg stty test
 
 write: write.o ../sys_utils/utent.o
 
@@ -20,6 +20,9 @@ all: $(PRGS)
 
 basename: basename.o
 	$(LD) $(LDFLAGS) -o basename basename.o $(LDLIBS)
+
+clear: clear.o
+	$(LD) $(LDFLAGS) -o clear clear.o $(LDLIBS)
 
 date: date.o
 	$(LD) $(LDFLAGS) -o date date.o $(LDLIBS)

--- a/elkscmd/sh_utils/clear.c
+++ b/elkscmd/sh_utils/clear.c
@@ -1,0 +1,10 @@
+#include <unistd.h>
+
+#define CLEARSEQ "\x1b[H\x1b[2J"
+
+int main(int argc, char *argv[])
+{
+  write(STDOUT_FILENO, CLEARSEQ, 7);
+
+  return 0;
+}


### PR DESCRIPTION
While attempting to edit files with vi as a normal user, I noticed chgrp wasn't working and I guessed this must be the chmem problem. So I added the compiler flag. Not sure if this is the right value for the flag. But now it works.

Before:

![Screenshot_2020-04-19_18-18-55](https://user-images.githubusercontent.com/359383/79698057-9b3e4780-8286-11ea-96c2-76955d4c95ea.png)

After:

![Screenshot_2020-04-19_21-08-01](https://user-images.githubusercontent.com/359383/79698068-a5604600-8286-11ea-9cf8-02cac68a2d0c.png)

Also while I was at it I added a very simple clear command. Linux uses ncurses to do that, I'm guessing because it works with every terminal since the neolithic. But since ELKS doesn't have a curses I guess this may be good enough until then.

![Screenshot_2020-04-19_21-49-22](https://user-images.githubusercontent.com/359383/79698175-68e11a00-8287-11ea-9ffa-e1481cfb62fb.png)