### PR TITLE
Bugfixes in init.c, more.c + expanded termcap

### DIFF
--- a/elkscmd/file_utils/more.c
+++ b/elkscmd/file_utils/more.c
@@ -25,8 +25,9 @@ int more_wait(int fout, char *msg)
 
 	if (tcgetattr(1, &termios) >= 0) {
 		struct termios termios2;
+		tcgetattr(1, &termios2);
 		termios2.c_lflag &= ~ICANON;
-		termios2.c_cc[VMIN] = 0;
+		termios2.c_cc[VMIN] = 1;
 		tcsetattr(1, TCSAFLUSH, &termios2);
 	}
 	read(1, buf, sizeof(buf));
@@ -45,7 +46,7 @@ int more_wait(int fout, char *msg)
 		return 1;
 	case 'Q':
 	case 'q':
-		write(1, "        \r", 9);
+		write(1, "          \r", 11);
 		close(fd);
 		return -1;
 	}

--- a/elkscmd/misc_utils/time.c
+++ b/elkscmd/misc_utils/time.c
@@ -13,8 +13,8 @@ static void printt(char * s, long se, long us)
 	long mins, secs;
 
 	if (se == -1 ) {		/* microsecs only */
-		if (us < 1000)		/* round up to 1/1000 second*/
-			us = 1000;
+		if (us < 1000L)		/* round up to 1/1000 second*/
+			us = 1000L;
 
 		mins = us / 60000000L;
 		if (mins)
@@ -24,9 +24,9 @@ static void printt(char * s, long se, long us)
 		if (secs)
 			us -= secs * 1000000L;
 	} else {
-		mins = se / 60;
+		mins = se / 60L;
 		secs = se;
-		if (mins) secs -= se * 60;
+		if (mins) secs -= se * 60L;
 	}
 	us /= 1000L;
 
@@ -69,8 +69,8 @@ int main(int argc, char **argv)
 	after.tv_sec -= before.tv_sec;
 	after.tv_usec -= before.tv_usec;
         if (after.tv_usec < 0)
-                after.tv_sec--, after.tv_usec += 1000000;
-	if (after.tv_usec > 500000) after.tv_sec++;
+                after.tv_sec--, after.tv_usec += 1000000L;
+	if (after.tv_usec > 500000L) after.tv_sec++;
 	fprintf(stderr, "\n");
 	printt("real", after.tv_sec, after.tv_usec);
 	//printt("user", -1, end.tms_cutime - start.tms_cutime);

--- a/elkscmd/misc_utils/time.c
+++ b/elkscmd/misc_utils/time.c
@@ -8,34 +8,45 @@
 #include <sys/times.h>
 #include <sys/wait.h>
 
-static void printt(char *s, long a)
+static void printt(char * s, long se, long us)
 {
 	long mins, secs;
 
-	if (a < 1000)			/* round up to 1/1000 second*/
-		a = 1000;
+	if (se == -1 ) {		/* microsecs only */
+		if (us < 1000)		/* round up to 1/1000 second*/
+			us = 1000;
 
-	mins = a / 60000000L;
-	if (mins)
-		a %= mins * 60000000L;
+		mins = us / 60000000L;
+		if (mins)
+			us -= mins * 60000000L;
 
-	secs = a / 1000000L;
-	if (secs)
-		a %= secs * 1000000L;
+		secs = us / 1000000L;
+		if (secs)
+			us -= secs * 1000000L;
+	} else {
+		mins = se / 60;
+		secs = se;
+		if (mins) secs -= se * 60;
+	}
+	us /= 1000L;
 
-	fprintf(stderr, "%s\t%lum%lu.%03lus\n", s, mins, secs, a / 1000L);
+	fprintf(stderr, "%s\t%lum%lu.%03lus\n", s, mins, secs, us);
+	
 }
+
 
 int main(int argc, char **argv)
 {
 	int status, p;
 	struct tms end, start;
+	struct timeval before, after;
 
 	if(argc <= 1) {
 		fprintf(stderr, "Usage: time <program ...>\n");
 		exit(0);
 	}
 
+	gettimeofday(&before, NULL);
 	times(&start);
 	p = fork();
 	if(p == -1) {
@@ -54,8 +65,15 @@ int main(int argc, char **argv)
 	if((status&0377) != 0)
 		fprintf(stderr,"Command terminated abnormally.\n");
 	times(&end);
-
+	gettimeofday(&after, NULL);
+	after.tv_sec -= before.tv_sec;
+	after.tv_usec -= before.tv_usec;
+        if (after.tv_usec < 0)
+                after.tv_sec--, after.tv_usec += 1000000;
+	if (after.tv_usec > 500000) after.tv_sec++;
 	fprintf(stderr, "\n");
-	printt("real", end.tms_cutime - start.tms_cutime);
+	printt("real", after.tv_sec, after.tv_usec);
+	//printt("user", -1, end.tms_cutime - start.tms_cutime);
+	printt("sys", -1, end.tms_cstime - start.tms_cstime);
 	exit(status>>8);
 }

--- a/elkscmd/rootfs_template/etc/termcap
+++ b/elkscmd/rootfs_template/etc/termcap
@@ -4,10 +4,11 @@ elks|vt52|vt-52|ELKS VT-52 console:\
 	:le=\ED:nd=\EC:sr=\EM:ta=^I:up=\EA:
 
 ansi|vt100|vt-100|ELKS ANSI (VT-100) console:\
-	:al=\E[L:AL=\E[%dL:bl=^G:bs:co#80:it#8:li#25:cd=\E[J:ce=\E[K\
+	:al=\E[L:bl=^G:bs:co#80:it#8:li#25:
 	:cd=\E[J:ce=\E[K:cl=\E[H\E[2J:cm=\E[%i%d;%dH:do=\E[B:ho=\E[H:\
-	:kd=\E[B:kl=\E[D:kr=\E[C:ku=\E[A:dl=\E[M:DL=\E[%dM:\
-	:kh=\E[H:kH=\E[F:kP=\E[5~:kN=\E[6~:dc=\E[P:DC=\E[%dP:\
+	:kd=\E[B:kl=\E[D:kr=\E[C:ku=\E[A:\
+	:kh=\E[H:kH=\E[F:kP=\E[5~:kN=\E[6~:dc=\E[P:\
+	:AL=\E[%dL:dl=\E[M:DL=\E[%dM:DC=\E[%dP:\
 	:le=\E[D:nd=\E[C:ta=^I:up=\E[A:se=\E[m:so=\E[7m:sr=\E[L:
 
 ansi77|ANSI 3.64 standard 1977 version:\

--- a/elkscmd/rootfs_template/etc/termcap
+++ b/elkscmd/rootfs_template/etc/termcap
@@ -4,10 +4,10 @@ elks|vt52|vt-52|ELKS VT-52 console:\
 	:le=\ED:nd=\EC:sr=\EM:ta=^I:up=\EA:
 
 ansi|vt100|vt-100|ELKS ANSI (VT-100) console:\
-	:al=\E[L:am:bl=^G:bs:co#80:it#8:li#25:\
+	:al=\E[L:AL=\E[%dL:bl=^G:bs:co#80:it#8:li#25:cd=\E[J:ce=\E[K\
 	:cd=\E[J:ce=\E[K:cl=\E[H\E[2J:cm=\E[%i%d;%dH:do=\E[B:ho=\E[H:\
-	:kd=\E[B:kl=\E[D:kr=\E[C:ku=\E[A:\
-	:kh=\E[H:kH=\E[F:kP=\E[5~:kN=\E[6~:\
+	:kd=\E[B:kl=\E[D:kr=\E[C:ku=\E[A:dl=\E[M:DL=\E[%dM:\
+	:kh=\E[H:kH=\E[F:kP=\E[5~:kN=\E[6~:dc=\E[P:DC=\E[%dP:\
 	:le=\E[D:nd=\E[C:ta=^I:up=\E[A:se=\E[m:so=\E[7m:sr=\E[L:
 
 ansi77|ANSI 3.64 standard 1977 version:\

--- a/elkscmd/rootfs_template/etc/termcap
+++ b/elkscmd/rootfs_template/etc/termcap
@@ -4,12 +4,12 @@ elks|vt52|vt-52|ELKS VT-52 console:\
 	:le=\ED:nd=\EC:sr=\EM:ta=^I:up=\EA:
 
 ansi|vt100|vt-100|ELKS ANSI (VT-100) console:\
-	:al=\E[L:bl=^G:bs:co#80:it#8:li#25:
-	:cd=\E[J:ce=\E[K:cl=\E[H\E[2J:cm=\E[%i%d;%dH:do=\E[B:ho=\E[H:\
-	:kd=\E[B:kl=\E[D:kr=\E[C:ku=\E[A:\
-	:kh=\E[H:kH=\E[F:kP=\E[5~:kN=\E[6~:dc=\E[P:\
-	:AL=\E[%dL:dl=\E[M:DL=\E[%dM:DC=\E[%dP:\
-	:le=\E[D:nd=\E[C:ta=^I:up=\E[A:se=\E[m:so=\E[7m:sr=\E[L:
+        :al=\E[L:bl=^G:bs:co#80:it#8:li#25:\
+        :cd=\E[J:ce=\E[K:cl=\E[H\E[2J:cm=\E[%i%d;%dH:do=\E[B:ho=\E[H:\
+        :kd=\E[B:kl=\E[D:kr=\E[C:ku=\E[A:\
+        :kh=\E[H:kH=\E[F:kP=\E[5~:kN=\E[6~:dc=\E[P:\
+        :le=\E[D:nd=\E[C:ta=^I:up=\E[A:se=\E[m:so=\E[7m:sr=\E[L:\
+        :ic=\E[@:IC=\E[%d@:AL=\E[%dL:dl=\E[M:DL=\E[%dM:DC=\E[%dP:
 
 ansi77|ANSI 3.64 standard 1977 version:\
 	:am:bs:co#80:it#8:li#24:mi:\

--- a/elkscmd/sys_utils/init.c
+++ b/elkscmd/sys_utils/init.c
@@ -157,38 +157,6 @@ void parseLine(const char* line, void func())
 void scanFile(void func())
 {
 	char buf[BUFSIZE+1];
-
-#if 0
-	int f, left;
-	char *line, *next;
-
-	f = open(INITTAB, O_RDONLY);
-	if (f < 0) fatalmsg("Missing %s\r\n", INITTAB);
-	left = read(f, buf, BUFSIZE);
-	buf[left] = 0;
-	line = strtok(buf, "\n");
-	next = strtok(NULL, "\n");
-
-	while (1) {
-		if (!next) {
-			if (line == buf) goto out;
-			if (left) memmove(buf, line, left);
-			left += read(f, buf+left, BUFSIZE-left);
-			buf[left] = 0;
-			line = strtok(buf, "\n");
-			next = strtok(NULL, "\n");
-		}
-		else {
-			parseLine(line, func);
-
-			left -= next-line;
-			line = next;
-			next = strtok(NULL, "\n");
-		}
-	}
-out:
-	close(f);
-#else /*0*/
 	FILE *fp;
 
 	fp = fopen(INITTAB, "r");
@@ -200,7 +168,6 @@ out:
 		parseLine(buf, func);
 	}
 	fclose(fp);
-#endif
 }
 
 /* returns a pointer to the child or NULL */

--- a/elkscmd/sys_utils/init.c
+++ b/elkscmd/sys_utils/init.c
@@ -156,13 +156,14 @@ void parseLine(const char* line, void func())
 
 void scanFile(void func())
 {
+	char buf[BUFSIZE+1];
+
+#if 0
 	int f, left;
 	char *line, *next;
-	char buf[BUFSIZE+1];
 
 	f = open(INITTAB, O_RDONLY);
 	if (f < 0) fatalmsg("Missing %s\r\n", INITTAB);
-
 	left = read(f, buf, BUFSIZE);
 	buf[left] = 0;
 	line = strtok(buf, "\n");
@@ -187,6 +188,19 @@ void scanFile(void func())
 	}
 out:
 	close(f);
+#else /*0*/
+	FILE *fp;
+
+	fp = fopen(INITTAB, "r");
+	if (!fp) fatalmsg("Missing %s\r\n", INITTAB);
+
+	while (fgets(buf, BUFSIZE, fp)) {
+		if (buf[strlen(buf)-1] == '\n')
+			buf[strlen(buf)-1] = '\0';
+		parseLine(buf, func);
+	}
+	fclose(fp);
+#endif
 }
 
 /* returns a pointer to the child or NULL */


### PR DESCRIPTION
- init() failed to read the last line of inittab, rewrote the scanFile function (kept the old code for review in #if 0)
- more() didn't wait for input, set VMIN to 1 and fixed uninitialized terms struct.
- added insert line(s), delete line(s), delete character(s) to ansi termcap entry, tested in VB and on serial.