### PR TITLE
[kernel] Dynamically allocate TTY input/output queues

### DIFF
--- a/elks/arch/i86/drivers/char/dircon.c
+++ b/elks/arch/i86/drivers/char/dircon.c
@@ -559,12 +559,14 @@ static int Console_write(register struct tty *tty)
 
 static void Console_release(struct tty *tty)
 {
-/* Do nothing */
+    tty_freeq(tty);
 }
 
 static int Console_open(register struct tty *tty)
 {
-    return (tty->minor >= NumConsoles) ? -ENODEV : 0;
+    if (tty->minor >= NumConsoles)
+	return -ENODEV;
+    return tty_allocq(tty, INQ_SIZE, OUTQ_SIZE);
 }
 
 struct tty_ops dircon_ops = {

--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -309,9 +309,9 @@ again:
 		if (!icanon && vtime) {
 		    if (jiffies < timeout) {
 			schedule();
-			if (!vmin)
-			    goto again;		/* VMIN = 0 don't reset timer*/
-			else {
+			goto again;		/* don't reset timer*/
+		    } else {
+			if (vmin && (i == 0)) {
 			    nonblock = 1;
 			    continue;		/* VMIN > 0 reset timer*/
 			}
@@ -342,6 +342,9 @@ again:
 
 		if (ch == tty->termios.c_cc[VEOF])
 		    break;
+	    } else {
+		if (vtime && vmin)	/* start timeout after first character*/
+		    nonblock = 1;
 	    }
 	    put_user_char(ch, (void *)(data++));
 	    tty_echo(tty, ch);

--- a/elks/arch/i86/drivers/char/pty.c
+++ b/elks/arch/i86/drivers/char/pty.c
@@ -115,11 +115,21 @@ size_t pty_write (struct inode *inode, struct file *file, char *data, size_t len
 	return count;
 }
 
-int ttyp_write(register struct tty *tty)
+static int ttyp_write(register struct tty *tty)
 {
     if (tty->outq.len == tty->outq.size)
 	interruptible_sleep_on(&tty->outq.wait);
     return 0;
+}
+
+static int ttyp_open(struct tty *tty)
+{
+    return tty_allocq(tty, RSINQ_SIZE, RSOUTQ_SIZE);
+}
+
+static void ttyp_release(struct tty *tty)
+{
+    tty_freeq(tty);
 }
 
 /*@-type@*/
@@ -142,11 +152,11 @@ static struct file_operations pty_fops = {
 };
 
 struct tty_ops ttyp_ops = {
-    ttynull_openrelease,	/* None of these really need to do anything */
-    ttynull_openrelease,
+    ttyp_open,
+    ttyp_release,
     ttyp_write,
     NULL,
-    NULL,
+    NULL			/* ioctl*/
 };
 
 /*@+type@*/

--- a/elks/arch/i86/kernel/timer.c
+++ b/elks/arch/i86/kernel/timer.c
@@ -18,7 +18,7 @@
  *        8254 timers. - Thomas McWilliams  <tmwo@users.sourceforge.net>
  */
 
-jiff_t jiffies = 0;
+volatile jiff_t jiffies = 0;
 
 extern void do_timer(struct pt_regs *);
 extern void keyboard_irq(int, struct pt_regs *, void *);

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -121,7 +121,7 @@ typedef struct task_struct __task, *__ptask;
 
 extern __task task[MAX_TASKS];
 
-extern jiff_t jiffies;
+extern volatile jiff_t jiffies;	/* ticks updated by the timer interrupt*/
 extern __ptask current;		/* next; */
 extern int need_resched;
 

--- a/elks/kernel/time.c
+++ b/elks/kernel/time.c
@@ -38,9 +38,6 @@
 /* this is the structure holding the base time (in UTC, of course) */
 struct timeval xtime;
 
-/* ticks updated by the timer interrupt, to be added to the base time */
-extern jiff_t jiffies;
-
 /* timezone in effect */
 static struct timezone xzone;
 

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -81,6 +81,7 @@ sys_utils/meminfo				:sysutil				:1440k
 sys_utils/mouse					:sysutil				:1440k
 sys_utils/passwd				:sysutil				:1440k
 sys_utils/poweroff				:sysutil			:720k
+sys_utils/sercat				:sysutil				:1440k
 sys_utils/who					:sysutil				:1440k
 sys_utils/unreal16				:sysutil				:1440k
 sh_utils/basename				:be-shutil			:720k

--- a/elkscmd/sys_utils/.gitignore
+++ b/elkscmd/sys_utils/.gitignore
@@ -14,6 +14,7 @@ passwd
 poweroff
 ps
 reboot
+sercat
 shutdown
 umount
 unreal16

--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -32,6 +32,7 @@ PRGS = \
 	clock \
 	unreal16 \
 	mouse \
+	sercat \
 	# EOL
 
 init: init.o
@@ -90,6 +91,9 @@ chmem: chmem.o
 
 mouse: mouse.o
 	$(LD) $(LDFLAGS) -o mouse mouse.o $(LDLIBS)
+
+sercat: sercat.o
+	$(LD) $(LDFLAGS) -o sercat sercat.o $(LDLIBS)
 
 unreal16: unreal16.o
 	$(LD) -melks-libc -mcmodel=small -c unreal16.S -o unreal16.o

--- a/elkscmd/sys_utils/sercat.c
+++ b/elkscmd/sys_utils/sercat.c
@@ -36,7 +36,7 @@ void copyfile(int ifd, int ofd)
 	while ((n = read(ifd, readbuf, BUF_SIZE)) > 0) {
 		if (n == 1 && readbuf[0] == CTRL_D)
 			return;
-		if (verbose) fprintf(stderr, "%d bytes read\n", n);
+		if (verbose) fprintf(stderr, " %d bytes read\n", n);
 		write(ofd, readbuf, n);
 	}
 	if (n < 0) perror("read");
@@ -60,8 +60,8 @@ int main(int argc, char **argv)
 		new = org;
 		new.c_lflag &= ~(ECHO | ECHOE | ECHONL);
 		new.c_lflag &= ~ICANON;
-		new.c_cc[VMIN] = 1;				/* min bytes to read if VTIME = 0*/
-		new.c_cc[VTIME] = 0;			/* intercharacter timeout if VMIN > 0, timeout if VMIN = 0*/
+		new.c_cc[VMIN] = 255;			/* min bytes to read if VTIME = 0*/
+		new.c_cc[VTIME] = 1;			/* intercharacter timeout if VMIN > 0, timeout if VMIN = 0*/
 		//new.c_cflag = B19200 | CS8;
         //new.c_cflag |= CRTSCTS;
 		tcsetattr(fd, TCSAFLUSH, &new);

--- a/elkscmd/sys_utils/sercat.c
+++ b/elkscmd/sys_utils/sercat.c
@@ -1,0 +1,76 @@
+/*
+ * sercat.c - serial cat (for testing)
+ *
+ *	sercat [-v] [serial device] [> file]
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <termios.h>
+#include <signal.h>
+
+#define DEFAULT_PORT "/dev/ttyS0"
+#define BUF_SIZE 4096
+#define CTRL_D	04
+
+int verbose = 0;
+int fd;
+char readbuf[BUF_SIZE];
+struct termios org, new;
+
+void sig_handler(int sig)
+{
+	fprintf(stderr, "Interrupt\n");
+	tcsetattr(fd, TCSAFLUSH, &org);
+	close(fd);
+	exit(1);
+}
+
+void copyfile(int ifd, int ofd)
+{
+	int n;
+
+	while ((n = read(ifd, readbuf, BUF_SIZE)) > 0) {
+		if (n == 1 && readbuf[0] == CTRL_D)
+			return;
+		if (verbose) fprintf(stderr, "%d bytes read\n", n);
+		write(ofd, readbuf, n);
+	}
+	if (n < 0) perror("read");
+}
+
+int main(int argc, char **argv)
+{
+	if (argc > 1 && !strcmp(argv[1], "-v")) {
+		verbose = 1;
+		argc--;
+		argv++;
+	}
+	if (argc > 1) {
+		if ((fd = open(argv[1], O_RDONLY|O_EXCL)) < 0) {
+			perror(argv[1]);
+			return 1;
+		}
+	} else fd = STDIN_FILENO;
+
+	if (tcgetattr(fd, &org) >= 0) {
+		new = org;
+		new.c_lflag &= ~(ECHO | ECHOE | ECHONL);
+		new.c_lflag &= ~ICANON;
+		new.c_cc[VMIN] = 1;				/* min bytes to read if VTIME = 0*/
+		new.c_cc[VTIME] = 0;			/* intercharacter timeout if VMIN > 0, timeout if VMIN = 0*/
+		//new.c_cflag = B19200 | CS8;
+        //new.c_cflag |= CRTSCTS;
+		tcsetattr(fd, TCSAFLUSH, &new);
+	} else fprintf(stderr, "Can't set termios\n");
+	signal(SIGINT, sig_handler);
+
+	copyfile(fd, STDOUT_FILENO);
+
+	tcsetattr(fd, TCSAFLUSH, &org);
+	close(fd);
+	return 0;
+}


### PR DESCRIPTION
Allocate TTY input and output character queues dynamically [EDIT: allocated on open].
That allows different-sized queues based on hardware/tty device.

Console TTY and PTY input queues reduced from 512 to 128 bytes. All output queues 64 bytes.

Serial TTY input queue increased from 512 to 1200 bytes (= SLIP MTU + 136 for `ktcp`). This should stop the data loss on SLIP packets, and improve data-loss problems reported in #515.

Add `sercat` test program to help @Mellvik's throughput and data-loss testing in #515.
Usage: `sercat [-v] [serial device] [ > file]`. On serial login port, use `sercat > file`. From console, use `sercat -v /dev/ttyS0 > file`, then send file across serial line. ^D to quit.

After testing with `sercat`, I've realized that the VMIN/VTIME termios settings are not working properly. Subsequent PR will provide a fix, which will improve overall serial performance for high-speed serial input data. The current implementation requires VMIN=1 and will not wait with timeout for a larger packet size (e.g. =1024) to be received before returning.


