### PR TITLE
[cmds] Enhance ps and meminfo with heap and size info

### DIFF
--- a/elks/arch/i86/drivers/block/rd.c
+++ b/elks/arch/i86/drivers/block/rd.c
@@ -226,7 +226,7 @@ static int rd_ioctl(register struct inode *inode, struct file *file,
 		else
 		    size = SEG_SIZE;
 
-		rd_segment[j].seg_desc = seg_alloc (size);
+		rd_segment[j].seg_desc = seg_alloc (size, SEG_FLAG_RAMDSK);
 		if (rd_segment[j].seg_desc == 0) {
 		    rd_dealloc(target);
 		    return -ENOMEM;

--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -108,9 +108,9 @@ struct tty *determine_tty(dev_t dev)
 
 int tty_allocq(struct tty *tty, int insize, int outsize)
 {
-    if ((tty->inq_buf = heap_alloc(insize, 0)) == NULL)
+    if ((tty->inq_buf = heap_alloc(insize, HEAP_TAG_TTY)) == NULL)
 	return -ENOMEM;
-    if ((tty->outq_buf = heap_alloc(outsize, 0)) == NULL) {
+    if ((tty->outq_buf = heap_alloc(outsize, HEAP_TAG_TTY)) == NULL) {
 	heap_free(tty->inq_buf);
 	return -ENOMEM;
     }

--- a/elks/arch/i86/kernel/system.c
+++ b/elks/arch/i86/kernel/system.c
@@ -43,12 +43,13 @@ void setup_arch(seg_t *start, seg_t *end)
     *end = (basmem)<<6;
 #endif
 
-	/* Now insert local heap at end of kernel data segment */
+	/* Heap allocations at even addresses, helps debugging*/
+	unsigned int endbss = (unsigned int)(_endbss + 1) & ~1;
 
-	heap_add (_endbss, 1 + ~ (unsigned) _endbss);
+	/* Now insert local heap at end of kernel data segment */
+	heap_add ((void *)endbss, 1 + ~endbss);
 
 	/* Misc */
-
     ROOT_DEV = setupw(0x1fc);
 
     arch_cpu = setupb(0x20);

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -191,7 +191,7 @@ unsigned int mm_get_usage(int type, int used)
 	segment_s * seg = _seg_first;
 	if (!_seg_first) return 0;
 
-	word_t res = 0;
+	long res = 0;
 
 	if (type == MM_MEM) {
 		while (1) {
@@ -199,14 +199,14 @@ unsigned int mm_get_usage(int type, int used)
 				seg->base, seg->size, seg->flags, seg->ref_count);*/
 
 			if ((seg->flags & SEG_FLAG_USED) == used)
-				res += seg->size >> 6;
+				res += seg->size;
 
 			seg = structof (seg->node.next, segment_s, node);
 			if (seg == _seg_first) break;
 		}
 	}
 
-	return res;
+	return ((res + 31) >> 6);		/* floor, not ceiling, so average return*/
 }
 
 

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -14,8 +14,6 @@
 #define MIN_STACK_SIZE 0x1000	/* 4k min stack above heap*/
 
 // TODO: reduce size
-// TODO: convert to tag
-#define SEG_FLAG_USED 0x0001
 
 // Segment descriptor
 
@@ -205,11 +203,11 @@ unsigned int mm_get_usage(int type, int used)
 
 			seg = structof (seg->node.next, segment_s, node);
 			if (seg == _seg_first) break;
-			}
 		}
+	}
 
 	return res;
-		}
+}
 
 
 // User data segment functions
@@ -222,7 +220,7 @@ int sys_brk(__pptr newbrk)
 		current->pid, newbrk, currentp->t_enddata, currentp->t_endbrk,
 		currentp->t_regs.sp - currentp->t_endbrk,
 		currentp->t_regs.sp, currentp->t_endseg,
-		mm_get_usage(MM_MEM, 1), mm_get_usage(MM_MEM, 0));*/
+		mm_get_usage(MM_MEM, SEG_FLAG_USED), mm_get_usage(MM_MEM, 0));*/
 
     if (newbrk < currentp->t_enddata)
         return -ENOMEM;

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -54,7 +54,7 @@ static int seg_split (segment_s * s1, segext_t size0)
 
 // Get free segment
 
-static segment_s * seg_free_get (segext_t size0)
+static segment_s * seg_free_get (segext_t size0, word_t type)
 {
 	segment_s * best_seg  = 0;
 	segext_t best_size = 0xFFFF;
@@ -84,7 +84,7 @@ static segment_s * seg_free_get (segext_t size0)
 		if (err)
 			printk ("seg:cannot split:heap full");
 
-		best_seg->flags = SEG_FLAG_USED;
+		best_seg->flags = SEG_FLAG_USED | type;
 		best_seg->ref_count = 1;
 	}
 
@@ -126,11 +126,11 @@ static void seg_merge_right (segment_s * seg)
 
 // Allocate segment
 
-segment_s * seg_alloc (segext_t size)
+segment_s * seg_alloc (segext_t size, word_t type)
 {
 	segment_s * seg = 0;
 	//lock_wait (&_seg_lock);
-	seg = seg_free_get (size);
+	seg = seg_free_get (size, type);
 	//unlock_event (&_seg_lock);
 	return seg;
 }
@@ -176,7 +176,7 @@ void seg_put (segment_s * seg)
 
 segment_s * seg_dup (segment_s * src)
 {
-	segment_s * dst = seg_free_get (src->size);
+	segment_s * dst = seg_free_get (src->size, src->flags);
 	if (dst)
 		fmemcpyb (NULL, dst->base, 0, src->base, src->size << 4);
 

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -104,6 +104,7 @@ void buffer_init(void)
 	// TODO: allocate buffer one by one in global memory
 	// TODO: release on kernel shutdown ?
 	segment_s * seg = seg_alloc (NR_BUFFERS << (BLOCK_SIZE_BITS - 4));
+	seg->flags |= SEG_FLAG_EXTBUF;
     _buf_ds = seg->base;
     unsigned int i = NR_MAPBUFS;
     do {

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -103,8 +103,7 @@ void buffer_init(void)
 #ifdef CONFIG_FS_EXTERNAL_BUFFER
 	// TODO: allocate buffer one by one in global memory
 	// TODO: release on kernel shutdown ?
-	segment_s * seg = seg_alloc (NR_BUFFERS << (BLOCK_SIZE_BITS - 4));
-	seg->flags |= SEG_FLAG_EXTBUF;
+	segment_s * seg = seg_alloc (NR_BUFFERS << (BLOCK_SIZE_BITS - 4), SEG_FLAG_EXTBUF);
     _buf_ds = seg->base;
     unsigned int i = NR_MAPBUFS;
     do {

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -154,6 +154,7 @@ int sys_execve(char *filename, char *sptr, size_t slen)
 	retval = -ENOMEM;
 	seg_code = seg_alloc((segext_t) ((mh.tseg + 15) >> 4));
 	if (!seg_code) goto error_exec3;
+	seg_code->flags |= SEG_FLAG_CSEG;
 	currentp->t_regs.ds = seg_code->base;  // segment used by read()
 	retval = filp->f_op->read(inode, filp, 0, (size_t)mh.tseg);
 	if (retval != (int)mh.tseg) {
@@ -165,12 +166,12 @@ int sys_execve(char *filename, char *sptr, size_t slen)
 	seg_get (seg_code);
 	filp->f_pos += mh.tseg;
     }
-
     debug1("EXEC: Allocating %lu bytes for data segment\n", len);
 
     retval = -ENOMEM;
     seg_data = seg_alloc ((segext_t) (len >> 4));
     if (!seg_data) goto error_exec4;
+    seg_data->flags |= SEG_FLAG_DSEG;
 
     debug2("EXEC: Malloc succeeded - cs=%x ds=%x\n", seg_code->base, seg_data->base);
 

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -152,9 +152,8 @@ int sys_execve(char *filename, char *sptr, size_t slen)
      */
     if (!seg_code) {
 	retval = -ENOMEM;
-	seg_code = seg_alloc((segext_t) ((mh.tseg + 15) >> 4));
+	seg_code = seg_alloc((segext_t) ((mh.tseg + 15) >> 4), SEG_FLAG_CSEG);
 	if (!seg_code) goto error_exec3;
-	seg_code->flags |= SEG_FLAG_CSEG;
 	currentp->t_regs.ds = seg_code->base;  // segment used by read()
 	retval = filp->f_op->read(inode, filp, 0, (size_t)mh.tseg);
 	if (retval != (int)mh.tseg) {
@@ -169,9 +168,8 @@ int sys_execve(char *filename, char *sptr, size_t slen)
     debug1("EXEC: Allocating %lu bytes for data segment\n", len);
 
     retval = -ENOMEM;
-    seg_data = seg_alloc ((segext_t) (len >> 4));
+    seg_data = seg_alloc ((segext_t) (len >> 4), SEG_FLAG_DSEG);
     if (!seg_data) goto error_exec4;
-    seg_data->flags |= SEG_FLAG_DSEG;
 
     debug2("EXEC: Malloc succeeded - cs=%x ds=%x\n", seg_code->base, seg_data->base);
 

--- a/elks/include/linuxmt/heap.h
+++ b/elks/include/linuxmt/heap.h
@@ -10,14 +10,17 @@
 
 // Heap block header
 
-#define HEAP_TAG_USED 0x80
+#define HEAP_TAG_USED    0x80
+#define HEAP_TAG_TYPE    0x0F
 #define HEAP_TAG_SEG     0x01
 #define HEAP_TAG_STRING  0x02
+#define HEAP_TAG_TTY     0x03
 
 struct heap {
 	list_s node;
 	word_t size;
 	byte_t tag;
+	byte_t unused;
 };
 
 typedef struct heap heap_s;
@@ -30,5 +33,5 @@ void heap_free (void * data);
 void heap_add (void * data, word_t size);
 
 #ifdef HEAP_DEBUG
-void heap_iterate (int (* cb) (heap_s * h));
+void heap_iterate (void (* cb) (heap_s * h));
 #endif /* HEAP_DEBUG */

--- a/elks/include/linuxmt/mem.h
+++ b/elks/include/linuxmt/mem.h
@@ -14,6 +14,7 @@
 #define MEM_GETTASK	4
 #define MEM_GETDS	5
 #define MEM_GETCS	6
+#define MEM_GETHEAP	7
 
 struct mem_usage {
 	unsigned int free_memory;

--- a/elks/include/linuxmt/mm.h
+++ b/elks/include/linuxmt/mm.h
@@ -20,6 +20,7 @@ typedef struct segment segment_s;
 #define SEG_FLAG_CSEG	0x0001
 #define SEG_FLAG_DSEG	0x0002
 #define SEG_FLAG_EXTBUF	0x0003
+#define SEG_FLAG_RAMDSK	0x0004
 
 #ifdef __KERNEL__
 
@@ -61,7 +62,7 @@ extern int verified_memcpy_fromfs(void *,void *,size_t);
 
 void mm_init (seg_t, seg_t);
 
-segment_s * seg_alloc (segext_t);
+segment_s * seg_alloc (segext_t, word_t);
 void seg_free (segment_s *);
 
 segment_s * seg_get (segment_s *);

--- a/elks/include/linuxmt/mm.h
+++ b/elks/include/linuxmt/mm.h
@@ -1,20 +1,8 @@
 #ifndef __LINUXMT_MM_H
 #define __LINUXMT_MM_H
 
-#include <linuxmt/sched.h>
-#include <linuxmt/errno.h>
-#include <linuxmt/kernel.h>
-#include <linuxmt/string.h>
+#include <linuxmt/types.h>
 #include <linuxmt/list.h>
-
-extern unsigned long high_memory;
-
-#ifdef __KERNEL__
-
-#define VERIFY_READ 0
-#define VERIFY_WRITE 1
-
-#define MM_MEM	0
 
 struct segment {
 	list_s    node;
@@ -25,6 +13,25 @@ struct segment {
 };
 
 typedef struct segment segment_s;
+
+// TODO: convert to tag
+#define SEG_FLAG_USED	0x0080
+#define SEG_FLAG_TYPE	0x000F
+#define SEG_FLAG_CSEG	0x0001
+#define SEG_FLAG_DSEG	0x0002
+#define SEG_FLAG_EXTBUF	0x0003
+
+#ifdef __KERNEL__
+
+#include <linuxmt/sched.h>
+#include <linuxmt/errno.h>
+#include <linuxmt/kernel.h>
+#include <linuxmt/string.h>
+
+#define VERIFY_READ 0
+#define VERIFY_WRITE 1
+
+#define MM_MEM	0
 
 #include <linuxmt/memory.h>
 

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -30,12 +30,6 @@
 #include <linuxmt/mm.h>
 #include <stdarg.h>
 
-#ifdef __BCC__
-#define REGISTER register
-#else
-#define REGISTER
-#endif
-
 /*
  *	Just to make it work for now
  */
@@ -130,7 +124,7 @@ static void vprintk(register char *fmt, va_list p)
 {
     unsigned long v;
     int width, zero;
-    char c;
+    int c;
     register char *tmp;
 
     while ((c = *fmt++)) {
@@ -181,8 +175,8 @@ static void vprintk(register char *fmt, va_list p)
 	    case 's':
 	    case 't':
 		tmp = va_arg(p, char*);
-		while ((zero = (int)(c == 's' ? *tmp : (char)get_user_char(tmp)))) {
-		    kputchar((char)zero);
+		while ((zero = (c == 's' ? *tmp : get_user_char(tmp)))) {
+		    kputchar(zero);
 		    tmp++;
 		    width--;
 		}
@@ -201,7 +195,7 @@ static void vprintk(register char *fmt, va_list p)
 
 void printk(char *fmt, ...)
 {
-    REGISTER va_list p;
+    va_list p;
 
     va_start(p, fmt);
     vprintk(fmt, p);

--- a/elks/lib/heap.c
+++ b/elks/lib/heap.c
@@ -12,7 +12,7 @@
 // TODO: regroup in one structure
 
 static lock_t _heap_lock;
-static heap_s * _heap_first;
+heap_s * _heap_first;
 // TODO: free block list
 //static heap_s * _heap_free;
 
@@ -152,7 +152,7 @@ void heap_add (void * data, word_t size)
 
 #ifdef HEAP_DEBUG
 
-void heap_iterate (int (* cb) (heap_s *))
+void heap_iterate (void (* cb) (heap_s *))
 {
 	if (!_heap_first) return;
 	heap_s * h = _heap_first;

--- a/elkscmd/sys_utils/meminfo.c
+++ b/elkscmd/sys_utils/meminfo.c
@@ -49,7 +49,7 @@ void dump_heap(int fd)
 	word_t total_size = 0;
 	long total_segsize = 0;
 	static char *heaptype[] = { "free", "SEG ", "STR ", "TTY " };
-	static char *segtype[] = { "free", "CSEG", "DSEG", "BUF " };
+	static char *segtype[] = { "free", "CSEG", "DSEG", "BUF ", "RDSK" };
 
 	if (!h)
 		return;

--- a/elkscmd/sys_utils/meminfo.c
+++ b/elkscmd/sys_utils/meminfo.c
@@ -63,7 +63,7 @@ void dump_heap(int fd)
 		word_t flags, ref_count;
 
 		printf("  %4x   %s %5d", mem, heaptype[tag], size);
-		total_size += size;
+		total_size += size + sizeof(heap_s);
 
 		switch (tag) {
 		case HEAP_TAG_SEG:
@@ -98,9 +98,11 @@ int main(int argc, char **argv)
 
 	dump_heap(fd);
 
-	if (!ioctl(fd, MEM_GETUSAGE, &mu))
+	if (!ioctl(fd, MEM_GETUSAGE, &mu)) {
+		/* note MEM_GETUSAGE amounts are floors, so total may display less by 1k than actual*/
 		printf("  Memory usage %4dKB total, %4dKB used, %4dKB free\n",
 			mu.used_memory + mu.free_memory, mu.used_memory, mu.free_memory);
+	}
 
 	return 0;
 }

--- a/elkscmd/sys_utils/meminfo.c
+++ b/elkscmd/sys_utils/meminfo.c
@@ -4,32 +4,103 @@
  * Copyright (c) 2002 Harry Kalogirou
  * harkal@gmx.net
  *
+ * Enhanced by Greg Haerr 24 Apr 2020
+ *
  * This file may be distributed under the terms of the GNU General Public
  * License v2, or at your option any later version.
  */
-
-#include <stdio.h>
+#include <linuxmt/types.h>
+#include <linuxmt/mm.h>
 #include <linuxmt/mem.h>
+#include <linuxmt/heap.h>
+#include <stdio.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/ioctl.h>
 
-int main(argc, argv)
-int argc;
-char ** argv;
+#define LINEARADDRESS(off, seg)		((off_t) (((off_t)seg << 4) + off))
+
+unsigned int ds;
+unsigned int heap_first;
+
+int memread(int fd, word_t off, word_t seg, void *buf, int size)
 {
-    struct mem_usage mu;
-    int fd;
+	if (lseek(fd, LINEARADDRESS(off, seg), SEEK_SET) == -1)
+		return 0;
 
-    if ((fd = open("/dev/kmem", O_RDONLY)) < 0) {
-	perror("meminfo");
-	exit(1);
-    }
-    if (ioctl(fd, MEM_GETUSAGE, &mu))
-	perror("meminfo");
+	if (read(fd, buf, size) != size)
+		return 0;
 
-    printf("memory usage : %4dKB total, %4dKB used, %4dKB free\n",
-		mu.used_memory + mu.free_memory, mu.used_memory,
-		mu.free_memory);
+	return 1;
+}
 
-    return 0;
+word_t getword(int fd, word_t off, word_t seg)
+{
+	word_t word;
+
+	if (!memread(fd, off, seg, &word, sizeof(word)))
+		return 0;
+	return word;
+}
+
+void dump_heap(int fd)
+{
+	word_t h = heap_first;
+	word_t total_size = 0;
+	long total_segsize = 0;
+	static char *heaptype[] = { "free", "SEG ", "STR ", "TTY " };
+	static char *segtype[] = { "free", "CSEG", "DSEG", "BUF " };
+
+	if (!h)
+		return;
+	printf("  HEAP   TYPE  SIZE    SEG   TYPE    SIZE  CNT\n");
+	do {
+		word_t size = getword(fd, h + offsetof(heap_s, size), ds);
+		byte_t tag = getword(fd, h + offsetof(heap_s, tag), ds) & HEAP_TAG_TYPE;
+		word_t mem = h + sizeof(heap_s);
+		seg_t segbase;
+		segext_t segsize;
+		word_t flags, ref_count;
+
+		printf("  %4x   %s %5d", mem, heaptype[tag], size);
+		total_size += size;
+
+		switch (tag) {
+		case HEAP_TAG_SEG:
+			segbase = getword(fd, mem + offsetof(segment_s, base), ds);
+			segsize = getword(fd, mem + offsetof(segment_s, size), ds);
+			flags = getword(fd, mem + offsetof(segment_s, flags), ds);
+			ref_count = getword(fd, mem + offsetof(segment_s, ref_count), ds);
+			printf("   %4x   %s %7ld %4d", segbase, segtype[flags & 0x0F], (long)segsize << 4, ref_count);
+			total_segsize += (long)segsize << 4;
+			break;
+		}
+
+		printf("\n");
+		h = getword(fd, (word_t)h + offsetof(heap_s, node) + offsetof(list_s, next), ds);
+	} while (h != heap_first);
+	printf("  Total heap  %5d     Total mem %7ld\n", total_size, total_segsize);
+}
+
+int main(int argc, char **argv)
+{
+	int fd;
+	struct mem_usage mu;
+
+	if ((fd = open("/dev/kmem", O_RDONLY)) < 0) {
+		perror("meminfo");
+		return 1;
+	}
+	if (ioctl(fd, MEM_GETDS, &ds) || ioctl(fd, MEM_GETHEAP, &heap_first)) {
+		perror("meminfo");
+		return 1;
+	}
+
+	dump_heap(fd);
+
+	if (!ioctl(fd, MEM_GETUSAGE, &mu))
+		printf("  Memory usage %4dKB total, %4dKB used, %4dKB free\n",
+			mu.used_memory + mu.free_memory, mu.used_memory, mu.free_memory);
+
+	return 0;
 }


### PR DESCRIPTION
`ps` and `meminfo` enhanced with information useful for understanding ELKS.

Add process heap usage, free heap, and total size to `ps` display for better understanding of memory limits. 'INODE' changed to 'CSEG'.

Add kernel local heap and main memory segment display to `meminfo`.

Example output:
```
ELKS 0.3.0

login: root
# ps
  PID   GRP  TTY USER STAT CSEG  HEAP   FREE   SIZE COMMAND
    1     0      root    S 2e36  4096  12228  29872 /bin/init 
   10    10    1 root    S 40c3     0  16275  30416 /bin/getty /dev/tty1 
   11    11   S0 root    S 4830  2191  13916  79728 -/bin/sh 
   12    11   S0 root    R 3d1c  1025  14046  29696 ps 
# meminfo
  HEAP   TYPE  SIZE    SEG   TYPE    SIZE  CNT
  dde2   SEG     12   1e36   BUF    65536    1
  ddf6   SEG     12   2e36   CSEG    6816    1
  de0a   SEG     12   2fe0   DSEG   23056    1
  de1e   SEG     12   3581   free   31152    0
  de32   SEG     12   3d1c   CSEG    3840    1
  de46   SEG     12   40c3   CSEG    6608    1
  de5a   TTY    128
  dee2   TTY     64
  df2a   SEG     12   4260   DSEG   23808    1
  df3e   SEG     12   4830   CSEG   48576    1
  df52   TTY   1200
  e40a   TTY     64
  e452   SEG     12   540c   DSEG   31152    1
  e466   SEG     12   3e0c   free   11120    0
  e47a   SEG     12   5ba7   DSEG   23152    1
  e48e   SEG     12   614e   free  255776    0
  e4a2   free  7006
  Total heap   8606     Total mem  530592
  Memory usage  512KB total,  223KB used,  289KB free
# 
```


