### PR TITLE
[cmds] Fix grep

### DIFF
--- a/elkscmd/APPS
+++ b/elkscmd/APPS
@@ -31,9 +31,9 @@ CONFIG_APP_COREUTILS	core_utils/		Core utilities, Installed in /bin. Sources mov
 											cat, date, env
 										Move from sys_utils: clock, getty, init, login, mount, umount
 										Move from file_utils:
-											cat, chgrp, chmod, chown, cp, dd, grep, ln, mkdir, mknod,
+											cat, chgrp, chmod, chown, cp, dd, ln, mkdir, mknod,
 											more, mv, rm, rmdir, sync, touch
-										Move from minix1:
+										Move from minix1: grep
 										Move from minix2: env
 										Move from minix3: 
 										Move from misc_utils: ed, tar
@@ -55,8 +55,9 @@ CONFIG_APP_SYS_UTILS	sys_utils/		System utilities from various origins.
 
 CONFIG_APP_FILE_UTILS	file_utils/		File utilities from Alistair Riddoch.
 										Rewritten from GNU fileutils 3.14 and sash.
-										Installs in /bin: cat, chgrp, chmod, chown, cmp, cp, dd, grep,
+										Installs in /bin: cat, chgrp, chmod, chown, cmp, cp, dd,
 										l, ln, ls, mkdir, mkfifo, mknod, more, mv, rm, rmdir, sync, touch
+										Not installed: grep (broken)
 
 CONFIG_APP_DISK_UTILS	disk_utils/		Disk utilities from early 1990s.
 										Installs in /bin: fdisk, fsck, mkfs, partype, ramdisk
@@ -66,9 +67,8 @@ CONFIG_APP_MISC_UTILS	misc_utils/		Miscellaneous utilities from various sources,
 										Not installed: compress, uncompress, zcat
 
 CONFIG_APP_MINIX1		minix1/			MINIX utilities, part 1.
-										Installs in /bin: banner, cksum, cut, decomp16, du, fgrep,
+										Installs in /bin: banner, cksum, cut, decomp16, du, fgrep, grep,
 											proto, sum, uniq, wc
-										Not installed: grep (duplicated in file_utils)
 
 CONFIG_APP_MINIX2		minix2/			MINIX utilities, part 2.
 										Installs in /bin: env, lp, pwdauth, synctree, tget

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -60,7 +60,6 @@ file_utils/chown				:be-fileutil		:720k
 file_utils/cmp					:be-fileutil			:1440k
 file_utils/cp					:be-fileutil	:360k
 file_utils/dd					:be-fileutil			:1440k
-file_utils/grep					:fileutil		:360k
 file_utils/mkdir				:fileutil		:360k
 file_utils/mknod				:fileutil				:1440k
 file_utils/mkfifo				:fileutil				:1440k
@@ -111,7 +110,7 @@ elvis/elvis	::bin/vi			:elvis				:720k
 minix1/banner					:minix1					:1440k
 minix1/decomp16					:minix1					:1440k
 minix1/fgrep					:minix1					:1440k
-#minix1/grep					:minix1			:360k
+minix1/grep					:minix1			:360k
 minix1/sum						:minix1					:1440k
 minix1/uniq						:minix1				:720k
 minix1/wc						:minix1					:1440k

--- a/elkscmd/file_utils/Makefile
+++ b/elkscmd/file_utils/Makefile
@@ -10,7 +10,8 @@ include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
-PRGS = grep ln ls mkdir mkfifo mknod more mv rm rmdir sync touch \
+# note: grep broken, replaced with minix1/grep
+PRGS = ln ls mkdir mkfifo mknod more mv rm rmdir sync touch \
 	cat chgrp chmod chown cmp cp dd
 
 all: $(PRGS)

--- a/elkscmd/minix1/Makefile
+++ b/elkscmd/minix1/Makefile
@@ -12,8 +12,7 @@ include $(BASEDIR)/Make.rules
 
 LOCALFLAGS=-D_POSIX_SOURCE
 
-# TODO: grep removed for now, duplicated in file_utils
-PRGS = banner decomp16 fgrep proto sum uniq wc cksum cut du
+PRGS = banner decomp16 fgrep grep proto sum uniq wc cksum cut du
 
 all: $(PRGS)
 


### PR DESCRIPTION
I noticed that `grep` from file_utils is totally broken: `ls -l / | grep home` produces nothing.

Replaced with duplicate grep from elkscmd/minix1/.