### PR TITLE
Add declaration for reboot() in elksemu

### DIFF
--- a/config/Menuconfig
+++ b/config/Menuconfig
@@ -1378,7 +1378,7 @@ then
 
 	 * End of ELKS kernel configuration.
 	 *
-	 * You may now run \`make\` to build.
+	 * You may now run \`make clean\` and \`make\` to build.
 
 .EOM
 else

--- a/elksemu/elks.h
+++ b/elksemu/elks.h
@@ -128,3 +128,5 @@ extern volatile struct elks_cpu_s elks_cpu;
 void db_printf(const char *, ...);
 int elks_syscall(void);
 void minix_syscall(void);
+
+int reboot(int magic1, int magic2, int magic3);

--- a/elksemu/elks_sys.c
+++ b/elksemu/elks_sys.c
@@ -21,7 +21,6 @@
 #include <sys/ioctl.h>
 #include <dirent.h>
 #include <sys/time.h>
-#include <linux/reboot.h>
 #include "elks.h" 
 
 #include "efile.h"


### PR DESCRIPTION
The missing declaration caused a warning when compiling ELKS. 

Added `make clean` to final message in Menuconfig also.