### PR TITLE
[cmds] Ktcp enhancements and various small cleanups

### DIFF
--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -227,8 +227,8 @@ int sys_brk(__pptr newbrk)
 
     if (currentp->t_begstack > currentp->t_endbrk) {	/* Old format? */
         if (newbrk > currentp->t_endseg - MIN_STACK_SIZE) {	/* Yes */
-			printk("sys_brk failed: brk %x > endseg %x\n",
-				newbrk, currentp->t_endseg - MIN_STACK_SIZE);
+			printk("sys_brk(%d) fail: brk %x over by %d bytes\n",
+				currentp->pid, newbrk, newbrk - (currentp->t_endseg - MIN_STACK_SIZE));
             return -ENOMEM;
 		}
     }

--- a/elkscmd/ash/mkinit.c
+++ b/elkscmd/ash/mkinit.c
@@ -343,7 +343,7 @@ void dodecl(char *line1, FILE *fp)
 		if (! amiddecls)
 			addchar('\n', &decls);
 		q = NULL;
-		for (p = line1 + 6 ; *p != '=' && *p != '/' ; p++);
+		for (p = line1 + 6 ; *p != '=' && *p != '/' && *p != '\0'; p++);
 		if (*p == '=') {		/* eliminate initialization */
 			for (q = p ; *q && *q != ';' ; q++);
 			if (*q == '\0')

--- a/elkscmd/inet/telnetd/telnetd.c
+++ b/elkscmd/inet/telnetd/telnetd.c
@@ -25,7 +25,8 @@ static char buf_out [MAX_BUFFER];
 
 static int tfd, tfs;
 pid_t pid;
-char * nargv[2] = {"/bin/sh", NULL};
+//char * nargv[2] = {"/bin/sh", NULL};
+char * nargv[2] = {"/bin/login", NULL};
 
 void sigchild(int signo)
 {
@@ -37,7 +38,6 @@ int term_init()
 {
 	char pty_name[12];
 	int n = 0;
-	int rc;
 	
 	struct termios slave_orig_term_settings; // Saved terminal settings
 	struct termios new_term_settings; // Current terminal settings
@@ -61,7 +61,7 @@ again:
 	}
 	if (pid>0) {
 		// Save the default parameters of the slave side of the PTY - unused yet
-		rc = tcgetattr(tfs, &slave_orig_term_settings);
+		tcgetattr(tfs, &slave_orig_term_settings);
 		new_term_settings = slave_orig_term_settings;
 		// Set raw mode on the slave side of the PTY - not line oriented
 		//cfmakeraw (&new_term_settings);
@@ -222,6 +222,7 @@ int main(int argc, char *argv[]) {
 	dup2(ret, 2);
 	if (ret > 2)
 		close(ret);
+	setsid();
 
 	while (1) {
 		connectionfd = accept (sockfd, (struct sockaddr *) NULL, NULL);

--- a/elkscmd/ktcp/arp.c
+++ b/elkscmd/ktcp/arp.c
@@ -9,7 +9,10 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/select.h>
 #include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
 
 #include <linuxmt/arpa/inet.h>
 
@@ -39,7 +42,7 @@ typedef struct arp_cache_s arp_cache_t;
 static arp_cache_t _arp_cache [ARP_CACHE_MAX];
 
 
-static int arp_cache_init (void)
+static void arp_cache_init (void)
 {
 	memset (_arp_cache, 0, ARP_CACHE_MAX * sizeof (arp_cache_t));
 }
@@ -118,7 +121,6 @@ void arp_reply(char *packet,int size)
 {
     struct arp_addr apair;
     struct arp *arp_r;
-  __u8 *addr;
 
     arp_r = (struct arp *) packet;
 
@@ -146,13 +148,10 @@ void arp_reply(char *packet,int size)
 int arp_request(ipaddr_t ipaddress)
 {
     int i;
-    __u8 *addr;
     fd_set fdset;
     struct arp *arp_r;
     static char packet[sizeof(struct arp)];
     arp_r = (struct arp *)packet;
-
-    addr = &ipaddress;
 
     /* build arp request */
     for (i=0;i<6;i++) arp_r->ll_eth_dest[i]=0xFF; /*broadcast*/

--- a/elkscmd/ktcp/arp.h
+++ b/elkscmd/ktcp/arp.h
@@ -4,14 +4,14 @@
 #include "ip.h"
 
 
-typedef struct arp_addr {
+struct arp_addr {
 	ipaddr_t daddr;		/* IP destination address */
 	ipaddr_t saddr;		/* IP source address */
 	__u8  eth_dest[6]; 	/* MAC destination address */
 	__u8  eth_src[6]; 	/* MAC source address */
 };
 
-typedef struct arp
+struct arp
 {
          __u8  ll_eth_dest[6]; 	/* link layer MAC destination address */
          __u8  ll_eth_src[6]; 	/* link layer MAC source address */

--- a/elkscmd/ktcp/deveth.c
+++ b/elkscmd/ktcp/deveth.c
@@ -9,7 +9,11 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/ioctl.h>
 #include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
 
 #include <linuxmt/limits.h>
 #include <arch/ioctl.h>
@@ -47,10 +51,6 @@ void deveth_printhex(char* packet, int len)
 
 int deveth_init(char *fdev)
 {
-    int i, err;
-    __u8 *addr;
-    char tmpstring[16];
-
     devfd = open(fdev, O_NONBLOCK|O_RDWR);
     if (devfd < 0) {
 	printf("ktcp: failed to open eth device %s\n", fdev);
@@ -68,7 +68,7 @@ int deveth_init(char *fdev)
     }
 
     /*
-    addr = (__u8 *) &eth_local_addr;
+    __u8 addr = (__u8 *) &eth_local_addr;
     printf ("eth_local_addr: %2X.%2X.%2X.%2X.%2X.%2X \n",
         addr [0], addr [1], addr [2], addr [3], addr [4],addr [5]);
     */
@@ -118,8 +118,7 @@ void deveth_process ()
 
 void deveth_send(char *packet, int len)
 {
-    int i;
     //printf("deveth_send:\n");
     //deveth_printhex(packet,len);
-    i = write(devfd, packet, len);
+    write(devfd, packet, len);
 }

--- a/elkscmd/ktcp/ip.h
+++ b/elkscmd/ktcp/ip.h
@@ -45,7 +45,7 @@ ipaddr_t netmask_ip;
 
 __u16	next_port;
 
-typedef struct ip_ll
+struct ip_ll
 {
          __u8  ll_eth_dest[6]; 	/* link layer MAC destination address */
          __u8  ll_eth_src[6]; 	/* link layer MAC source address */

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -14,6 +14,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
 #include <linuxmt/tcpdev.h>
 #include <linuxmt/net.h>
 #include <linuxmt/in.h>
@@ -198,7 +201,6 @@ void tcpdev_read(void)
     struct tcpcb_s *cb;
     struct tdb_return_data *ret_data;
     int data_avail;
-    register int bcc_bug;
     __u16 sock = db->sock;
 
     n = tcpcb_find_by_sock(sock);
@@ -284,7 +286,6 @@ static void tcpdev_write(void)
     struct tdb_write *db = sbuf;
     struct tcpcb_list_s *n;
     struct tcpcb_s *cb;
-    struct tdb_return_data *ret_data;
     __u16  sock = db->sock;
 
     db = sbuf;
@@ -386,7 +387,6 @@ void tcpdev_sock_state(struct tcpcb_s *cb, int state)
 
 void tcpdev_process(void)
 {
-    struct tdb_bind *db;
     int len = read(tcpdevfd, sbuf, TCPDEV_BUFSIZE);
 
     if (len <= 0)

--- a/elkscmd/rootfs_template/etc/rc.d/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sys
@@ -14,23 +14,15 @@ clock -s
 
 #localip=192.168.1.100
 localip=10.0.2.15
-#interface=/dev/ttyS0
 interface=/dev/eth
+#interface=/dev/ttyS0
 ttybaud=4800
 
 if test -f /bin/ktcp
 then
-	echo -n 'Starting networking:'
-	if test "$interface" != "/dev/eth" 
-	then stty $ttybaud < $interface
-	echo -n ' stty slip'
-	else
-	echo -n ' eth'
-	fi
-	
-	echo ' ktcp'
+	echo 'Starting networking: ktcp'
 	# run ktcp as background daemon if successful starting networking
-	if ktcp -b $localip $interface ; then
+	if ktcp -b -s $ttybaud $localip $interface ; then
 		for daemon in telnetd httpd
 		do
 			if test -f /bin/$daemon


### PR DESCRIPTION
Add '-s baudrate' option to `ktcp`, requested in #539. Modified /etc/rc.d/rc.sys, no need to run `stty` separately beforehand anymore.

Set new VMIN/VTIME serial line parameters for `ktcp` slip testing for @pawosm-arm, from #515.

Fixed lots of compiler warnings in ktcp, many more still there.

Add process ID to kernel `sys_brk` process out of memory errmsg, discussed off-topic in #586.

Temporary change to `telnetd` to exec /bin/login rather than /bin/sh for @pawosm-arm testing.

Quick one-line guess/fix to ash/mkinit.c to try to debug the occasional GitHub CI build errors that are seen just after merges/push to GitHub. This is the 'invalid character in file' that is generated and stops the build (see picture). 

![mkinit](https://user-images.githubusercontent.com/11985637/80326265-09d25680-87ed-11ea-91da-a3334f665f06.png)
