### PR TITLE
[kernel] Fix Minix filesystem rmdir on large directories

### DIFF
--- a/elks/fs/minix/namei.c
+++ b/elks/fs/minix/namei.c
@@ -359,9 +359,9 @@ static int empty_dir(register struct inode *inode)
 	if (!offset) {
 	    unmap_brelse(bh);
 	    bh = minix_bread(inode, (__u16)(bo >> BLOCK_SIZE_BITS), 0);
-	    if (!bh) {
+	    if (!bh)
 		continue;
-	    }
+	    map_buffer(bh);
 	}
 	de = (struct minix_dir_entry *) (bh->b_data + offset);
 	if (de->inode) {

--- a/elks/fs/namei.c
+++ b/elks/fs/namei.c
@@ -475,7 +475,7 @@ int sys_mkdir(char *pathname, int mode)
 #endif
 }
 
-int __do_rmthing(char *pathname, size_t offst)
+int do_rmthing(char *pathname, size_t offst)
 {
     register struct inode *dirp;
     register struct inode_operations *iop;
@@ -511,13 +511,13 @@ int __do_rmthing(char *pathname, size_t offst)
 
 int sys_rmdir(char *pathname)
 {
-    return __do_rmthing(pathname, offsetof(struct inode_operations,rmdir));
+    return do_rmthing(pathname, offsetof(struct inode_operations,rmdir));
 }
 
 int sys_unlink(char *pathname)
 {
-    debug_file("UNLINK '%s'\n", get_userspace_filename(pathname));
-    return __do_rmthing(pathname, offsetof(struct inode_operations,unlink));
+    debug_file("UNLINK '%t'\n", pathname);
+    return do_rmthing(pathname, offsetof(struct inode_operations,unlink));
 }
 
 int sys_symlink(char *oldname, char *pathname)
@@ -537,8 +537,7 @@ int sys_link(char *oldname, char *pathname)
     struct inode *oldinode;
     int error;
 
-    debug_file("LINK '%s' ", get_userspace_filename(oldname));
-    debug_file("'%s'\n", get_userspace_filename(pathname));
+    debug_file("LINK '%t' '%t'\n", oldname, pathname);
     error = namei(oldname, &oldinode, 0, 0);
     if (!error)
 	error = do_mknod(pathname, offsetof(struct inode_operations,link), (int)oldinode, 0);

--- a/elks/fs/open.c
+++ b/elks/fs/open.c
@@ -344,17 +344,6 @@ int sys_fchown(unsigned int fd, uid_t user, gid_t group)
 	    : do_chown(filp->f_inode, user, group));
 }
 
-#if DEBUG_FILE
-char *get_userspace_filename(char *filename)
-{
-	static char name[32];
-
-	memcpy_fromfs(name, filename, sizeof(name));
-	name[sizeof(name)-1] = 0;
-	return name;
-}
-#endif
-
 /*
  * Note that while the flag value (low two bits) for sys_open means:
  *	00 - read-only
@@ -380,7 +369,7 @@ int sys_open(char *filename, int flags, int mode)
     if ((mode_t)((flags + 1) & O_ACCMODE)) flag++;
     if (flag & (O_TRUNC | O_CREAT)) flag |= FMODE_WRITE;
 
-    debug_file("OPEN '%s' flags 0x%x\n", get_userspace_filename(filename), flags);
+    debug_file("OPEN '%t' flags 0x%x\n", filename, flags);
     error = open_namei(filename, flag, mode, &inode, NULL);
     if (!error) {
 	pinode = inode;

--- a/elks/include/linuxmt/debug.h
+++ b/elks/include/linuxmt/debug.h
@@ -50,7 +50,6 @@
 
 #if DEBUG_FILE
 #define debug_file	printk
-extern char *get_userspace_filename(char *filename);
 #else
 #define debug_file(...)
 #endif
@@ -112,7 +111,7 @@ extern char *get_userspace_filename(char *filename);
 
 #else
 
-#define debug(a)
+#define debug(a,...)
 #define debug1(a,b)
 #define debug2(a,b,c)
 #define debug3(a,b,c,d)

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -140,9 +140,9 @@ struct buffer_head {
 
 #ifdef CONFIG_FS_EXTERNAL_BUFFER
     unsigned char		b_offset;	/* Offset into L2 allocation block */
-    unsigned int		b_mapcount;	/* Used for the new L2 buffer cache scheme */
+    int				b_mapcount;	/* count of L2 buffer mapped into L1 */
     unsigned int		b_ds;		/* L2 buffer data segment */
-    unsigned char		b_num;		/* Buffer number, not really needed */
+    unsigned char		b_num;		/* Buffer number, for debugging */
 #endif
 
 };


### PR DESCRIPTION
Fixes unreported problem of `rmdir` sometimes not working on Minix filesystems. Fixed in elks/fs/minix/namei.c.

Rewrote buffer debug code to trace down problem. Symptoms showed up in unmap_buffer with incorrect buffer mapcount. Only occurred when directory size was > 1024 bytes.

Clean up elks/fs/buffer.c and added comments for better understanding.
Clean up earlier debug code in elks/fs/open.c and elks/fs/namei.c.

<img width="832" alt="unmap_buffer bug" src="https://user-images.githubusercontent.com/11985637/80334358-d64ff600-8805-11ea-8074-2215bcd35184.png">
