### PR TITLE
Fixed time command, cleanups in sash command history.

### DIFF
--- a/elkscmd/misc_utils/time.c
+++ b/elkscmd/misc_utils/time.c
@@ -8,29 +8,21 @@
 #include <sys/times.h>
 #include <sys/wait.h>
 
-static void printt(char * s, long se, long us)
+static void printt(char * s, long us)
 {
 	long mins, secs;
 
-	if (se == -1 ) {		/* microsecs only */
-		if (us < 1000L)		/* round up to 1/1000 second*/
-			us = 1000L;
+	if (us < 1000L && us > 499L)	/* round up to 1/1000 second*/
+		us = 1000L;
+	mins = us / 60000000L;
+	if (mins)
+		us -= mins * 60000000L;
 
-		mins = us / 60000000L;
-		if (mins)
-			us -= mins * 60000000L;
+	secs = us / 1000000L;
+	if (secs)
+		us -= secs * 1000000L;
 
-		secs = us / 1000000L;
-		if (secs)
-			us -= secs * 1000000L;
-	} else {
-		mins = se / 60L;
-		secs = se;
-		if (mins) secs -= se * 60L;
-	}
-	us /= 1000L;
-
-	fprintf(stderr, "%s\t%lum%lu.%03lus\n", s, mins, secs, us);
+	fprintf(stderr, "%s\t%lum%lu.%03lus\n", s, mins, secs, us/1000);
 	
 }
 
@@ -39,14 +31,12 @@ int main(int argc, char **argv)
 {
 	int status, p;
 	struct tms end, start;
-	struct timeval before, after;
 
 	if(argc <= 1) {
 		fprintf(stderr, "Usage: time <program ...>\n");
 		exit(0);
 	}
 
-	gettimeofday(&before, NULL);
 	times(&start);
 	p = fork();
 	if(p == -1) {
@@ -65,15 +55,7 @@ int main(int argc, char **argv)
 	if((status&0377) != 0)
 		fprintf(stderr,"Command terminated abnormally.\n");
 	times(&end);
-	gettimeofday(&after, NULL);
-	after.tv_sec -= before.tv_sec;
-	after.tv_usec -= before.tv_usec;
-        if (after.tv_usec < 0)
-                after.tv_sec--, after.tv_usec += 1000000L;
-	if (after.tv_usec > 500000L) after.tv_sec++;
 	fprintf(stderr, "\n");
-	printt("real", after.tv_sec, after.tv_usec);
-	//printt("user", -1, end.tms_cutime - start.tms_cutime);
-	printt("sys", -1, end.tms_cstime - start.tms_cstime);
+	printt("Real", end.tms_cstime - start.tms_cstime);
 	exit(status>>8);
 }


### PR DESCRIPTION
time(1) now displays real time (and only real time) correctly. 

sash command history cleanup: compiler warnings, static declarations (and a bug).