### PR TITLE
[cmds] Fix stack overflow in sash grep

### DIFF
--- a/elkscmd/APPS
+++ b/elkscmd/APPS
@@ -57,7 +57,7 @@ CONFIG_APP_FILE_UTILS	file_utils/		File utilities from Alistair Riddoch.
 										Rewritten from GNU fileutils 3.14 and sash.
 										Installs in /bin: cat, chgrp, chmod, chown, cmp, cp, dd,
 										l, ln, ls, mkdir, mkfifo, mknod, more, mv, rm, rmdir, sync, touch
-										Not installed: grep (broken)
+										Not installed: grep
 
 CONFIG_APP_DISK_UTILS	disk_utils/		Disk utilities from early 1990s.
 										Installs in /bin: fdisk, fsck, mkfs, partype, ramdisk

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -110,7 +110,7 @@ elvis/elvis	::bin/vi			:elvis				:720k
 minix1/banner					:minix1					:1440k
 minix1/decomp16					:minix1					:1440k
 minix1/fgrep					:minix1					:1440k
-minix1/grep					:minix1			:360k
+minix1/grep						:minix1			:360k
 minix1/sum						:minix1					:1440k
 minix1/uniq						:minix1				:720k
 minix1/wc						:minix1					:1440k

--- a/elkscmd/file_utils/Makefile
+++ b/elkscmd/file_utils/Makefile
@@ -10,9 +10,9 @@ include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
-# note: grep broken, replaced with minix1/grep
+# note: grep doesn't read stdin, replaced with minix1/grep
 PRGS = ln ls mkdir mkfifo mknod more mv rm rmdir sync touch \
-	cat chgrp chmod chown cmp cp dd
+	cat chgrp chmod chown cmp cp dd grep
 
 all: $(PRGS)
 

--- a/elkscmd/file_utils/grep.c
+++ b/elkscmd/file_utils/grep.c
@@ -13,10 +13,6 @@
 #include <string.h>
 #include <ctype.h>
 
-#define BUF_SIZE 4096
-
-static char buf[BUF_SIZE];
-
 /*
  * See if the specified word is found in the specified string.
  */
@@ -92,6 +88,7 @@ int main(int argc, char **argv)
 	int	ignorecase;
 	int	tellline;
 	long	line;
+	char	buf[BUFSIZ];
 
 	if (argc < 2) goto usage;
 
@@ -136,7 +133,9 @@ int main(int argc, char **argv)
 
 		line = 0;
 
-		while (fgets(buf, BUF_SIZE, fp)) {
+		while (fgets(buf, sizeof(buf), fp)) {
+			line++;
+
 			/* Make sure the data is text and didn't overflow */
 			cp = &buf[strlen(buf) - 1];
 			if (*cp != '\n') goto error_line_length;

--- a/elkscmd/sash/cmd_grep.c
+++ b/elkscmd/sash/cmd_grep.c
@@ -27,7 +27,7 @@ do_grep(argc, argv)
 	BOOL	ignorecase;
 	BOOL	tellline;
 	long	line;
-	char	buf[8192];
+	char	buf[BUFSIZ];
 
 	ignorecase = FALSE;
 	tellline = FALSE;

--- a/elkscmd/sys_utils/ps.c
+++ b/elkscmd/sys_utils/ps.c
@@ -129,7 +129,7 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 
-	printf("  PID   GRP  TTY USER STAT CSEG  HEAP   FREE   SIZE COMMAND\n");
+	printf("  PID   GRP  TTY USER STAT CSEG DSEG  HEAP   FREE   SIZE COMMAND\n");
 	for (j = 1; j < MAX_TASKS; j++) {
 		if (!memread(fd, off + j*sizeof(struct task_struct), ds, &task_table, sizeof(task_table))) {
 			perror("ps");
@@ -163,6 +163,9 @@ int main(int argc, char **argv)
 
 		/* CSEG*/
 		printf("%4x ", getword(fd, (word_t)task_table.mm.seg_code+offsetof(struct segment, base), ds));
+
+		/* DSEG*/
+		printf("%4x ", getword(fd, (word_t)task_table.mm.seg_data+offsetof(struct segment, base), ds));
 
 		/* heap*/
 		printf("%5d ", (word_t)(task_table.t_endbrk - task_table.t_enddata));

--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -62,11 +62,7 @@ struct __stdio_file {
 
 typedef struct __stdio_file FILE;
 
-#ifdef __AS386_16__
-#define BUFSIZ	(256)
-#else
-#define BUFSIZ	(2048)
-#endif
+#define BUFSIZ	(1024)
 
 extern FILE stdin[1];
 extern FILE stdout[1];

--- a/libc/include/unistd.h
+++ b/libc/include/unistd.h
@@ -84,4 +84,10 @@ char * getcwd (char * buf, size_t size);
 void sync(void);
 void usleep(unsigned long useconds);
 
+int getopt(int argc, char * const argv[], const char *opts);
+extern char *optarg;
+extern int optind;
+extern int optopt;
+extern int opterr;
+
 extern char ** environ;

--- a/libc/misc/getopt.c
+++ b/libc/misc/getopt.c
@@ -56,7 +56,7 @@ int optind = 1;
 int optopt;
 char *optarg;
 
-int getopt(int argc, char **argv, char *opts)
+int getopt(int argc, char * const argv[], const char *opts)
 {
     register char *cp;
     static int sp = 1;


### PR DESCRIPTION
Fix stack overflow in internal `sash` grep command (Fixes #595).
Traced down needlessly-large 8K stack allocation in grep, which combined with
a 2.5K heap and overly-large 2K stdio allocation on fopen, caused stack overflow.
ELKS kernel acted normally and caught the stack overflow error, which is
checked during every interrupt, and terminated sash with SIGSEGV.

Various other fixups, found during bug trace:

Match grep 'fgets' buffer size to same as stdio BUFSIZ.
Reduce stdio BUFSIZ from 2048 to 1024.
Add DSEG in `ps` output. (`ps -m` option coming).