### PR TITLE
[serial] Read data until no interrupt flag

### DIFF
--- a/elks/arch/i86/drivers/char/serial.c
+++ b/elks/arch/i86/drivers/char/serial.c
@@ -223,9 +223,9 @@ void rs_irq(int irq, struct pt_regs *regs, void *dev_id)
 	//if (status & UART_LSR_DR)			/* Receiver buffer full? */
 	    do {
 		buf[i++] = inb_p(io + UART_RX);		/* Read received data */
-	    } while ((inb_p(io + UART_LSR) & UART_LSR_DR) && i < MAX_RX_BUFFER_SIZE);
+	    //} while ((inb_p(io + UART_LSR) & UART_LSR_DR) && i < MAX_RX_BUFFER_SIZE);
 	//}
-    //} while (!(inb_p(io + UART_IIR) & UART_IIR_NO_INT) && i < MAX_RX_BUFFER_SIZE);
+    } while (!(inb_p(io + UART_IIR) & UART_IIR_NO_INT) && i < MAX_RX_BUFFER_SIZE);
 
     if (status & UART_LSR_OE)
 	printk("serial: data overrun\n");


### PR DESCRIPTION
Hello @pawosm-arm,

This PR causes serial data to be read in the interrupt handler until the hardware interrupt flag is reset, rather than the previous way which reads data until the read data available bit is reset. I would like you to test with this code compiled in the kernel, and see whether the mouse still locks up your system.

From reading the MINIX 2.0.4 serial driver code (https://github.com/chenshuo/old-minix/blob/master/src/kernel/rs232.c), it is mentioned that some chips lock up if this is not done. (see the serial interrupt routine rs232_handler()).

@Mellvik, this should not affect the FIFO operation, but I am unable to test that. I am assuming that the FIFO hardware continues to assert the interrupt pending flag in the IID while FIFO data is available. If not, then this would have the effect of only reading one character per interrupt.

