### PR TITLE
Bugfixes in sash, libc/putenv.

### DIFF
--- a/elkscmd/sash/cmd_history.c
+++ b/elkscmd/sash/cmd_history.c
@@ -32,13 +32,16 @@ init_hist() {
                 if (histcnt > HISTMAX)
                         histcnt = HISTMAX;
         }
+	if (!histcnt) return;
         histbuf = malloc(histcnt * sizeof(char*));
         if (!histbuf) {
                 fprintf(stderr, "No history buffer, history turned off\n");
                 histcnt = 0;
-        }
-        while (k < histcnt)     /* initialize history list */
-                histbuf[k++] = NULL;
+        } else {
+        	while (k < histcnt)     /* initialize history list */
+                	histbuf[k++] = NULL;
+	}
+	return;
 }
 
 
@@ -92,7 +95,7 @@ cmd_search(char * pat) {
 	for (i = 0; i < histcnt; i++) {
 		idx = map_ind(-i);
 		if ((found = strstr(histbuf[idx], pat)))
-			return(found);
+			return(histbuf[idx]);
 	}
 	return(NULL);
 }
@@ -202,10 +205,14 @@ fixbuf(char *cmd, char *prev, char *pos, char *cm) {
 
 	char buf[CMDBUF];
 
-	strcpy(buf, cmd);
-	strcat(buf, prev);
-	strcat(buf, pos);
-	strcpy(cm, buf);
+	if ((strlen(cmd) + strlen(prev) + strlen(pos)) > (CMDBUF -1)) 
+		fprintf(stderr, "Buffer overflow in command history \n");
+	else {
+		strcpy(buf, cmd);
+		strcat(buf, prev);
+		strcat(buf, pos);
+		strcpy(cm, buf);
+	}
 	return;
 }
 

--- a/elkscmd/sash/cmds.c
+++ b/elkscmd/sash/cmds.c
@@ -727,7 +727,9 @@ do_setenv(argc, argv)
 		strcat(buf, "=");
 		strcat(buf, argv[2]);
 	}
-	putenv(buf);
+	if (putenv(buf)) 
+		fprintf(stderr, "usage: setenv VAR=value - value is optional, '=' is required.\n");
+
 }
 #endif /* CMD_SETENV */
 

--- a/elkscmd/sash/sash.c
+++ b/elkscmd/sash/sash.c
@@ -255,6 +255,14 @@ int main(int argc, char **argv)
 	else cp = argv[0];
 	isbinshell = !strcmp(cp, "sh");
 
+#ifdef CMD_SOURCE
+	sourcecfg("/etc", CFGFILE);
+
+	cp = getenv("HOME");
+	if (cp)
+		sourcecfg(cp, "." CFGFILE);
+#endif
+
 #ifdef CMD_PROMPT
 	if ((prompt = malloc(3)) == 0)
 #endif
@@ -268,23 +276,13 @@ int main(int argc, char **argv)
 	init_hist();
 #endif /* CMD_HISTORY */
 
-#ifdef CMD_SOURCE
-	sourcecfg("/etc", CFGFILE);
-
-	cp = getenv("HOME");
-	if (cp)
-		sourcecfg(cp, "." CFGFILE);
-
 	if (argc > 1) {
 		readfile(argv[1]);
 	} else {
 		readfile(NULL);
 	}
-#else
-	readfile(NULL);
-#endif
-
 	exit(0);
+
 }
 
 

--- a/libc/misc/putenv.c
+++ b/libc/misc/putenv.c
@@ -63,7 +63,7 @@ again:
 	}
 
 	if (rp == NULL) {	/* missing '=' - reject */
-		errno = 22;
+		errno = EINVAL;
 		return -1;
 	}
 	envp_len += strlen(var) + 1;		/* new environment variable*/

--- a/libc/misc/putenv.c
+++ b/libc/misc/putenv.c
@@ -62,6 +62,10 @@ again:
 		envp_len += strlen(*env++) + 1;
 	}
 
+	if (rp == NULL) {	/* missing '=' - reject */
+		errno = 22;
+		return -1;
+	}
 	envp_len += strlen(var) + 1;		/* new environment variable*/
 	envp_count = env - environ + 2;		/* + 1 for NULL terminator*/
 						/* + 1 for newly added var*/


### PR DESCRIPTION
- process sash startupfile(s) (set environment variables etc.) before initializing history and running scripts.
- fixed bug in history command search and added check for buffer overflow.
- setting environment variable HISTORY to zero now REALLY turns off history in sash.
- fixed bug in libc/putenv.c that allowed environment variables w/o value to be added to the environment, multiple times.