### PR TITLE
Fix a fair amount of Elvis warnings

### DIFF
--- a/elkscmd/elvis/blk.c
+++ b/elkscmd/elvis/blk.c
@@ -13,6 +13,9 @@
  */
 
 #include "config.h"
+
+#include <unistd.h>
+
 #include "vi.h"
 
 #ifndef NBUFS

--- a/elkscmd/elvis/cmd1.c
+++ b/elkscmd/elvis/cmd1.c
@@ -13,9 +13,17 @@
  */
 
 #include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
 #include <ctype.h>
+
 #include "vi.h"
 #include "regexp.h"
+#include "tmp.h"
+#include "system.h"
 
 #if MSDOS
 #define	DATE __DATE__
@@ -270,7 +278,7 @@ void cmd_shell(frommark, tomark, cmd, bang, extra)
 	suspend_curses();
 	if (frommark == 0L)
 	{
-		system(extra);
+		elvis_system(extra);
 	}
 	else /* pipe lines from the file through the command */
 	{
@@ -1244,7 +1252,7 @@ void cmd_make(frommark, tomark, cmd, bang, extra)
 
 	/* run the command, with curses temporarily disabled */
 	suspend_curses();
-	system(buf.c);
+	elvis_system(buf.c);
 	resume_curses(mode == MODE_EX);
 	if (mode == MODE_COLON)
 		mode = MODE_VI;

--- a/elkscmd/elvis/cmd2.c
+++ b/elkscmd/elvis/cmd2.c
@@ -10,10 +10,20 @@
 
 /* This file contains some of the commands - mostly ones that change text */
 
-#include <ctype.h>
 #include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <ctype.h>
+
 #include "vi.h"
 #include "regexp.h"
+#include "tio.h"
+#include "system.h"
+#include "ex.h"
+
 #if TOS
 # include <stat.h>
 #else

--- a/elkscmd/elvis/config.h
+++ b/elkscmd/elvis/config.h
@@ -178,13 +178,6 @@ extern char *strchr();
 # define uchar		unsigned char
 #endif
 
-/* Some compilers prefer to have malloc declared as returning a (void *) */
-#if BSD
-extern void *malloc();
-#else
-extern char *malloc();
-#endif
-
 /* Most compilers could benefit from using the "register" storage class */
 #if 1
 #define REG	register

--- a/elkscmd/elvis/ctags.c
+++ b/elkscmd/elvis/ctags.c
@@ -44,9 +44,14 @@
  * a line number or a slash-delimited search string.
  */
 
+#include "config.h"
+
 #include <ctype.h>
 #include <stdio.h>
-#include "config.h"
+#include <stdlib.h>
+#include <string.h>
+
+void ctags(FILE *fp, char *name, FILE *refs);
 
 #define REFS	"refs"
 
@@ -156,11 +161,15 @@ main(argc, argv)
 }
 
 
-/* this function finds all tags in a given file */
-ctags(fp, name, refs)
-	FILE	*fp;		/* stream of the file to scan */
-	char	*name;		/* name of the file being scanned */
-	FILE	*refs;		/* NULL, or where to write refs lines */
+/*
+ * This function finds all tags in a given file
+ *
+ * fp    stream of the file to scan
+ * name  name of the file being scanned
+ * refs  NULL, or where to write refs lines
+ */
+
+void ctags(FILE *fp, char *name, FILE *refs)
 {
 	int	context;	/* context - either EXPECTFN, ARGS, or BODY */
 	long	lnum;		/* line number */

--- a/elkscmd/elvis/curses.c
+++ b/elkscmd/elvis/curses.c
@@ -15,8 +15,15 @@
  */
 
 #include "config.h"
-#include "vi.h"
+
+#include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
+#include <string.h>
+#include <sys/ioctl.h>
+
+#include "vi.h"
+#include "curses.h"
 
 #if ANY_UNIX
 # if UNIXV
@@ -533,13 +540,15 @@ static int getWindowSize(int ifd, int ofd, int *rows, int *cols)
         return 0;
 }
 
-/* This function gets the window size.  It uses the TIOCGWINSZ ioctl call if
- * your system has it, or tgetnum("li") and tgetnum("co") if it doesn't.
- * This function is called once during initialization, and thereafter it is
- * called whenever the SIGWINCH signal is sent to this process.
+/*
+ * This function gets the window size. It uses the TIOCGWINSZ ioctl
+ * call if your system has it, or tgetnum("li") and tgetnum("co") if
+ * it doesn't. This function is called once during initialization,
+ * and thereafter it is called whenever the SIGWINCH signal is sent
+ * to this process.
  */
-int getsize(signo)
-	int	signo;
+
+int getsize(int signo)
 {
 	int	lines;
 	int	cols;

--- a/elkscmd/elvis/curses.h
+++ b/elkscmd/elvis/curses.h
@@ -10,10 +10,9 @@
 
 /* This is the header file for a small, fast, fake curses package */
 
-/* termcap stuff */
-extern char	*tgoto();
-extern char	*tgetstr();
-extern void	tputs();
+#include "tinytcap.h"
+
+extern int getsize(int signo);
 
 #if MSDOS
 /* BIOS interface used instead of termcap for MS-DOS */

--- a/elkscmd/elvis/cut.c
+++ b/elkscmd/elvis/cut.c
@@ -12,6 +12,9 @@
 
 #include "config.h"
 #include "vi.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
 #if TURBOC
 #include <process.h>		/* needed for getpid */
 #endif

--- a/elkscmd/elvis/ex.c
+++ b/elkscmd/elvis/ex.c
@@ -11,8 +11,11 @@
 /* This file contains the code for reading ex commands. */
 
 #include "config.h"
+#include <unistd.h>
+#include <string.h>
 #include <ctype.h>
 #include "vi.h"
+#include "tio.h"
 
 #ifndef isascii
 # define isascii(c) !((c)&~0x7f)

--- a/elkscmd/elvis/ex.h
+++ b/elkscmd/elvis/ex.h
@@ -1,0 +1,2 @@
+extern int
+doexrc (char *filename);

--- a/elkscmd/elvis/input.c
+++ b/elkscmd/elvis/input.c
@@ -8,14 +8,18 @@
  */
 
 
-/* This file contains the input() function, which implements vi's INPUT mode.
- * It also contains the code that supports digraphs.
+/* This file contains the input() function, which implements vi's
+ * INPUT mode. It also contains the code that supports digraphs.
  */
 
-#include <ctype.h>
 #include "config.h"
-#include "vi.h"
 
+#include <unistd.h>
+#include <ctype.h>
+
+#include "vi.h"
+#include "tio.h"
+#include "redraw.h"
 
 #ifndef NO_DIGRAPH
 static struct _DIG

--- a/elkscmd/elvis/main.c
+++ b/elkscmd/elvis/main.c
@@ -11,9 +11,17 @@
 /* This file contains the main() function of vi */
 
 #include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
 #include <signal.h>
 #include <setjmp.h>
+
 #include "vi.h"
+#include "ex.h"
+#include "tmp.h"
 
 extern		trapint(); /* defined below */
 extern char	*getenv();
@@ -25,9 +33,7 @@ static init_digraphs();
 
 /*---------------------------------------------------------------------*/
 
-void main(argc, argv)
-	int	argc;
-	REG char	*argv[];
+int main(int argc, REG char *argv[])
 {
 	int	i;
 	char	*cmd = (char *)0;
@@ -330,7 +336,7 @@ void main(argc, argv)
 	refresh();
 	endwin();
 
-	exit(0);
+	return 0;
 	/*NOTREACHED*/
 }
 

--- a/elkscmd/elvis/misc.c
+++ b/elkscmd/elvis/misc.c
@@ -11,6 +11,9 @@
 /* This file contains functions which didn't seem happy anywhere else */
 
 #include "config.h"
+
+#include <string.h>
+
 #include "vi.h"
 
 

--- a/elkscmd/elvis/modify.c
+++ b/elkscmd/elvis/modify.c
@@ -7,6 +7,9 @@
  */
 
 #include "config.h"
+
+#include <string.h>
+
 #include "vi.h"
 
 #ifdef DEBUG

--- a/elkscmd/elvis/move2.c
+++ b/elkscmd/elvis/move2.c
@@ -11,6 +11,9 @@
 /* This function contains the movement functions that perform RE searching */
 
 #include "config.h"
+
+#include <stdlib.h>
+
 #include "vi.h"
 #include "regexp.h"
 

--- a/elkscmd/elvis/move4.c
+++ b/elkscmd/elvis/move4.c
@@ -12,6 +12,7 @@
 
 #include "config.h"
 #include "vi.h"
+#include "tio.h"
 
 /* This moves the cursor to a particular row on the screen */
 /*ARGSUSED*/

--- a/elkscmd/elvis/opts.c
+++ b/elkscmd/elvis/opts.c
@@ -13,6 +13,11 @@
  */
 
 #include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "vi.h"
 #ifndef NULL
 #define NULL (char *)0

--- a/elkscmd/elvis/redraw.c
+++ b/elkscmd/elvis/redraw.c
@@ -18,6 +18,9 @@
  */
 
 #include "config.h"
+
+#include <unistd.h>
+
 #include "vi.h"
 
 /* This variable contains the line number that smartdrawtext() knows best */

--- a/elkscmd/elvis/redraw.h
+++ b/elkscmd/elvis/redraw.h
@@ -1,0 +1,2 @@
+extern int
+idx2col (MARK curs, REG char *text, int inputting);

--- a/elkscmd/elvis/ref.c
+++ b/elkscmd/elvis/ref.c
@@ -11,6 +11,11 @@
 /* This program looks up the declarations of library functions. */
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int lookinfor (char *filename, char *func);
+int desired (char *line, char *word);
 
 /* This is the list of files that are searched. */
 #ifdef OSK
@@ -57,10 +62,15 @@ main(argc, argv)
 }
 
 
-/* This function checks a single file for the function.  Returns 1 if found */
-int lookinfor(filename, func)
-	char	*filename;	/* name of file to look in */
-	char	*func;		/* name of function to look for */
+/*
+ * This function checks a single file for the function. Returns 1 if
+ * found.
+ *
+ * filename  name of file to look in
+ * func      name of function to look for
+ */
+
+int lookinfor(char *filename, char *func)
 {
 	FILE	*fp;	/* stream used to access the database */
 	char	linebuf[300];
@@ -102,11 +112,15 @@ int lookinfor(filename, func)
 }
 
 
-/* This function checks to see if a given line is the first line of the */
-/* entry the user wants to see.  If it is, return non-0 else return 0   */
-desired(line, word)
-	char	*line;	/* the line buffer */
-	char	*word;	/* the string it should contain */
+/*
+ * This function checks to see if a given line is the first line of the
+ * entry the user wants to see. If it is, return non-0 or else return 0.
+ *
+ * line	 the line buffer
+ * word  the string it should contain
+ */
+
+int desired(char *line, char *word)
 {
 	static	wlen = -1;/* length of the "word" variable's value */
 	register char *scan;

--- a/elkscmd/elvis/refont.c
+++ b/elkscmd/elvis/refont.c
@@ -24,8 +24,14 @@
  *	-F	output a formfeed character between files
  */
 
-#include <stdio.h>
 #include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+void usage(void);
+void refont(FILE *fp);
 
 /* the program name, for diagnostics */
 char	*progname;
@@ -39,9 +45,7 @@ int infmt = 0;
 /* do we insert formfeeds between input files? */
 int add_form_feed = 0;
 
-main(argc, argv)
-	int	argc;	/* number of command-line args */
-	char	**argv;	/* values of the command line args */
+int main(int argc, char **argv)
 {
 	FILE	*fp;
 	int	i, j;
@@ -117,10 +121,10 @@ main(argc, argv)
 		}
 	}
 
-	exit(retcode);
+	return retcode;
 }
 
-usage()
+void usage(void)
 {
 	fputs("usage: ", stderr);
 	fputs(progname, stderr);
@@ -130,8 +134,8 @@ usage()
 
 /* This function does the refont thing to a single file */
 /* I apologize for the length of this function.  It is gross. */
-refont(fp)
-	FILE	*fp;
+
+void refont(FILE *fp)
 {
 	char	textbuf[1025];	/* chars of a line of text */
 	char	fontbuf[1025];	/* fonts of chars in fontbuf */

--- a/elkscmd/elvis/regexp.c
+++ b/elkscmd/elvis/regexp.c
@@ -29,9 +29,13 @@
  * That right, this file contains TWO versions of the code.
  */
 
+#include "config.h"
+
+#include <stdlib.h>
+#include <string.h>
 #include <setjmp.h>
 #include <ctype.h>
-#include "config.h"
+
 #include "vi.h"
 #include "regexp.h"
 

--- a/elkscmd/elvis/regsub.c
+++ b/elkscmd/elvis/regsub.c
@@ -6,6 +6,8 @@
 
 #include <ctype.h>
 #include "config.h"
+#include <stdlib.h>
+#include <string.h>
 #include "vi.h"
 #include "regexp.h"
 

--- a/elkscmd/elvis/system.c
+++ b/elkscmd/elvis/system.c
@@ -21,18 +21,28 @@
  */
 
 #include "config.h"
-#include "vi.h"
-#include <signal.h>
+
 #include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <signal.h>
+#include <sys/wait.h>
+
+#include "vi.h"
+
 extern char	**environ;
 
 #if ANY_UNIX
 
-/* This is a new version of the system() function.  The only difference
- * between this one and the library one is: this one uses the o_shell option.
+/* This is a new version of the system() function. The only difference
+ * between this one and the library one is: this one uses the o_shell
+ * option.
+ *
+ * cmd  a command to run
  */
-int system(cmd)
-	char	*cmd;	/* a command to run */
+
+int elvis_system(char *cmd)
 {
 	int	status;	/* exit status of the command */
 

--- a/elkscmd/elvis/system.h
+++ b/elkscmd/elvis/system.h
@@ -1,0 +1,5 @@
+extern int
+elvis_system (char *cmd);
+
+extern int
+filter (MARK from, MARK to, char *cmd);

--- a/elkscmd/elvis/tinytcap.c
+++ b/elkscmd/elvis/tinytcap.c
@@ -28,11 +28,13 @@ static int	nansi;
 # define VAL3(v,a,n)	(n)
 #endif
 
+/*
+ * bp    buffer for storing the entry -- ignored
+ * name  name of the entry
+ */
 
 /*ARGSUSED*/
-int tgetent(bp, name)
-	char	*bp;	/* buffer for storing the entry -- ignored */
-	char	*name;	/* name of the entry */
+int tgetent(char *bp, char *name)
 {
 #if MSDOS
 	nansi = strcmp(name, "ansi");
@@ -40,8 +42,7 @@ int tgetent(bp, name)
 	return 1;
 }
 
-int tgetnum(id)
-	char	*id;
+int tgetnum(char *id)
 {
 	switch (CAP(id))
 	{
@@ -53,8 +54,7 @@ int tgetnum(id)
 	}
 }
 
-int tgetflag(id)
-	char	*id;
+int tgetflag(char *id)
 {
 	switch (CAP(id))
 	{
@@ -67,10 +67,12 @@ int tgetflag(id)
 	}
 }
 
+/*
+ * bp  pointer to pointer to buffer - ignored
+ */
+
 /*ARGSUSED*/
-char *tgetstr(id, bp)
-	char	*id;
-	char	**bp;	/* pointer to pointer to buffer - ignored */
+char *tgetstr(char *id, char **bp)
 {
 	switch (CAP(id))
 	{
@@ -122,11 +124,14 @@ char *tgetstr(id, bp)
 	}
 }
 
+/*
+ * cm       cursor movement string -- ignored
+ * destcol  destination column, 0 - 79
+ * destrow  destination row, 0 - 24
+ */
+
 /*ARGSUSED*/
-char *tgoto(cm, destcol, destrow)
-	char	*cm;	/* cursor movement string -- ignored */
-	int	destcol;/* destination column, 0 - 79 */
-	int	destrow;/* destination row, 0 - 24 */
+char *tgoto(char *cm, int destcol, int destrow)
 {
 	static char buf[30];
 
@@ -139,11 +144,14 @@ char *tgoto(cm, destcol, destrow)
 	return buf;
 }
 
+/*
+ * cp      the string to output
+ * affcnt  number of affected lines -- ignored
+ * outfn   the output function
+ */
+
 /*ARGSUSED*/
-void tputs(cp, affcnt, outfn)
-	char	*cp;		/* the string to output */
-	int	affcnt;		/* number of affected lines -- ignored */
-	int	(*outfn)();	/* the output function */
+void tputs(char *cp, int affcnt, int (*outfn)())
 {
 	while (*cp)
 	{

--- a/elkscmd/elvis/tinytcap.h
+++ b/elkscmd/elvis/tinytcap.h
@@ -1,0 +1,17 @@
+extern int
+tgetent(char *bp, char *name);
+
+extern int 
+tgetnum(char *id);
+
+extern int
+tgetflag(char *id);
+
+extern char *
+tgetstr(char *id, char **bp);
+
+extern char *
+tgoto(char *cm, int destcol, int destrow);
+
+extern void
+tputs(char *cp, int affcnt, int (*outfn)());

--- a/elkscmd/elvis/tio.c
+++ b/elkscmd/elvis/tio.c
@@ -11,12 +11,19 @@
 /* This file contains terminal I/O functions */
 
 #include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
 #if BSD || COHERENT
 # include <setjmp.h>
 #endif
 #include <signal.h>
-#include "vi.h"
 
+#include "vi.h"
+#include "tio.h"
+#include "tmp.h"
 
 /* This function reads in a line from the terminal. */
 int vgets(prompt, buf, bsize)

--- a/elkscmd/elvis/tio.h
+++ b/elkscmd/elvis/tio.h
@@ -1,0 +1,5 @@
+extern int
+vgets (char prompt, char *buf, int bsize);
+
+extern int
+getkey (int when);

--- a/elkscmd/elvis/tmp.c
+++ b/elkscmd/elvis/tmp.c
@@ -12,8 +12,16 @@
 
 
 #include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
 #include <ctype.h>
+
 #include "vi.h"
+#include "tmp.h"
+
 #if TOS
 # include <stat.h>
 #else

--- a/elkscmd/elvis/tmp.h
+++ b/elkscmd/elvis/tmp.h
@@ -1,0 +1,11 @@
+extern int
+tmpstart (char *filename);
+
+extern int
+tmpsave (REG char *filename, int bang);
+
+extern int
+tmpabort (int bang);
+
+extern int
+tmpend (int bang);

--- a/elkscmd/elvis/vcmd.c
+++ b/elkscmd/elvis/vcmd.c
@@ -12,7 +12,13 @@
 
 
 #include "config.h"
+
+#include <string.h>
+
 #include "vi.h"
+#include "tio.h"
+#include "system.h"
+
 #if MSDOS
 #include <process.h>
 #include <string.h>
@@ -627,7 +633,7 @@ MARK v_keyword(keyword, m, cnt)
 	waswarn = *o_warn;
 	*o_warn = FALSE;
 	suspend_curses();
-	if (system(cmdline))
+	if (elvis_system(cmdline))
 	{
 		addstr("<<< failed >>>\n");
 	}

--- a/elkscmd/elvis/vi.c
+++ b/elkscmd/elvis/vi.c
@@ -9,10 +9,14 @@
 
 
 #include "config.h"
+
+#include <unistd.h>
+#include <string.h>
 #include <ctype.h>
+
 #include "vi.h"
-
-
+#include "tio.h"
+#include "redraw.h"
 
 /* This array describes what each key does */
 #define NO_FUNC		(MARK (*)())0

--- a/elkscmd/elvis/vi.h
+++ b/elkscmd/elvis/vi.h
@@ -61,19 +61,19 @@ extern int errno;
 
 #define BLKSIZE	1024		/* size of blocks */
 #define MAXBLKS	(BLKSIZE / sizeof(unsigned short))
+
 typedef union
 {
-	char		c[BLKSIZE];	/* for text blocks */
-	unsigned short	n[MAXBLKS];	/* for the header block */
-}
-	BLK;
+  char           c[BLKSIZE]; /* for text blocks      */
+  unsigned short n[MAXBLKS]; /* for the header block */
+} BLK;
 
 /*------------------------------------------------------------------------*/
 /* These are used manipulate BLK buffers.                                 */
 
-extern BLK	hdr;		/* buffer for the header block */
-extern BLK	*blkget();	/* given index into hdr.c[], reads block */
-extern BLK	*blkadd();	/* inserts a new block into hdr.c[] */
+extern BLK hdr;       /* buffer for the header block           */
+extern BLK *blkget(); /* given index into hdr.c[], reads block */
+extern BLK *blkadd(); /* inserts a new block into hdr.c[]      */
 
 /*------------------------------------------------------------------------*/
 /* These are used to keep track of various flags                          */

--- a/elkscmd/elvis/virec.c
+++ b/elkscmd/elvis/virec.c
@@ -11,9 +11,15 @@
 
 
 #include "config.h"
+
 #include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
 #include <ctype.h>
+
 #include "vi.h"
+
 #if TOS
 # include <stat.h>
 #else
@@ -23,6 +29,8 @@
 #  include <sys/stat.h>
 # endif
 #endif
+
+void copytext (int tmpfd, FILE *fp);
 
 extern char	*getenv();
 struct stat	stbuf;
@@ -223,10 +231,13 @@ BreakBreak:;
 }
 
 
-/* This function moves text from the tmp file to the normal file */
-copytext(tmpfd, fp)
-	int	tmpfd;	/* fd of the tmp file */
-	FILE	*fp;	/* the stream to write it to */
+/* This function moves text from the tmp file to the normal file
+ *
+ * tmpfd  fd of the tmp file
+ * fp     the stream to write it to
+ */
+
+void copytext(int tmpfd, FILE *fp)
 {
 	int	i;
 

--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -147,6 +147,8 @@ int vsnprintf (char * sp, size_t, const char * format, va_list ap);
 void perror (const char * s);
 int rename(const char *old, const char *new);
 
+extern char *tmpnam (char *s);
+
 int scanf (const char * format, ...);
 int sscanf (const char * str, const char * format, ...);
 

--- a/libc/misc/tmpnam.c
+++ b/libc/misc/tmpnam.c
@@ -15,8 +15,7 @@
 #define L_tmpnam 20
 #endif 
 
-char *tmpnam(s)
-char *s;
+char *tmpnam(char *s)
 {
     static char ret_val[L_tmpnam];
     static char c1 = 0;


### PR DESCRIPTION
Mostly "implicit declaration" warnings. Add appropriate headers to fix this. Also reformat some function declarations to ANSI C and some comments to fit in 80 columns.

One "implicit declaration" warning that is still left is for "tmpnam" whose declaration is missing in ELKS' headers. Not sure whether this has to go in libc or gcc headers. In Linux it's declared in stdio.h according to the man page.

Elvis still compiles and runs and edits in ELKS.