### PR TITLE
Fix many warnings in ktcp

### DIFF
--- a/elkscmd/ktcp/arp.c
+++ b/elkscmd/ktcp/arp.c
@@ -20,6 +20,7 @@
 #include "ip.h"
 #include "arp.h"
 
+static int tcpdevfd;
 
 /* ARP operations */
 /* as big endian values */

--- a/elkscmd/ktcp/arp.c
+++ b/elkscmd/ktcp/arp.c
@@ -17,10 +17,10 @@
 #include <linuxmt/arpa/inet.h>
 
 #include "deveth.h"
+#include "tcp.h"
+#include "tcpdev.h"
 #include "ip.h"
 #include "arp.h"
-
-static int tcpdevfd;
 
 /* ARP operations */
 /* as big endian values */

--- a/elkscmd/ktcp/arp.h
+++ b/elkscmd/ktcp/arp.h
@@ -33,6 +33,6 @@ void arp_cache_add (ipaddr_t ip_addr, eth_addr_t * eth_addr);
 int arp_cache_get (ipaddr_t ip_addr, eth_addr_t * eth_addr);
 
 void arp_proc (char * packet, int size);
-
+int arp_request(ipaddr_t ipaddress);
 
 #endif /* !ARP_H */

--- a/elkscmd/ktcp/deveth.c
+++ b/elkscmd/ktcp/deveth.c
@@ -19,7 +19,9 @@
 #include <arch/ioctl.h>
 
 #include "config.h"
+#include "tcp.h"
 #include "deveth.h"
+#include "ip.h"
 #include "tcpdev.h"
 #include "arp.h"
 

--- a/elkscmd/ktcp/icmp.c
+++ b/elkscmd/ktcp/icmp.c
@@ -13,8 +13,8 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include "slip.h"
-#include "icmp.h"
 #include "ip.h"
+#include "icmp.h"
 #include <linuxmt/arpa/inet.h>
 
 int icmp_init(void)

--- a/elkscmd/ktcp/icmp.h
+++ b/elkscmd/ktcp/icmp.h
@@ -3,4 +3,7 @@
 
 #define PROTO_ICMP	1
 
-#endif
+int icmp_init(void);
+void icmp_process(struct iphdr_s *iph, char *packet);
+
+#endif /* !ICMP_H */

--- a/elkscmd/ktcp/ip.c
+++ b/elkscmd/ktcp/ip.c
@@ -13,16 +13,19 @@
  * TODO : IP fragmentation and reassemply of fragmented IP packets
  */
 
+#include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 
 #include "ip.h"
 #include "icmp.h"
+#include "slip.h"
 #include "tcp.h"
 #include "tcpdev.h"
 #include <linuxmt/arpa/inet.h>
 #include "deveth.h"
+#include "arp.h"
 
 #if 0
 #define IP_VERSION(s)	((s)->version_ihl>>4&0xf)
@@ -123,7 +126,8 @@ void ip_print(struct iphdr_s *head)
 void ip_recvpacket(char *packet,int size)
 {
     struct iphdr_s *iphdr;
-    __u8 *addr, *data;
+    __u8 *data;
+    //__u8 *addr;
 
     iphdr = (struct iphdr_s *)packet;
 
@@ -172,8 +176,8 @@ void ip_sendpacket(char *packet,int len,struct addr_pair *apair)
 {
     struct iphdr_s *iph = (struct iphdr_s *)&ipbuf;
     __u16 tlen;
-    __u8 *addr;
-    ipaddr_t tmpaddress;
+    //__u8 *addr;
+    //ipaddr_t tmpaddress;
     char llbuf[15];
     struct ip_ll *ipll = (struct ip_ll *)&llbuf;
 

--- a/elkscmd/ktcp/ip.h
+++ b/elkscmd/ktcp/ip.h
@@ -52,8 +52,6 @@ struct ip_ll
          __u16 ll_type_len;	/* 0x800 big endian for IP */
 };
 
-/* static int tcpdevfd; */
-
 int ip_init(void);
 void ip_recvpacket(char *packet, int size);
 void ip_sendpacket(char *packet, int len, struct addr_pair *apair);

--- a/elkscmd/ktcp/ip.h
+++ b/elkscmd/ktcp/ip.h
@@ -52,6 +52,10 @@ struct ip_ll
          __u16 ll_type_len;	/* 0x800 big endian for IP */
 };
 
-static int tcpdevfd;
+/* static int tcpdevfd; */
 
-#endif
+int ip_init(void);
+void ip_recvpacket(char *packet, int size);
+void ip_sendpacket(char *packet, int len, struct addr_pair *apair);
+
+#endif /* !IP_H */

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -38,7 +38,7 @@ char deveth[] = "/dev/eth";
 
 extern int tcp_timeruse;
 
-static int tcpdevfd;
+int tcpdevfd;
 static int intfd;
 
 unsigned long int in_aton(const char *str)

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -17,13 +17,16 @@
 #include <string.h>
 
 #include "slip.h"
+#include "tcp.h"
 #include "tcpdev.h"
+#include "tcp_output.h"
 #include "timer.h"
 #include <linuxmt/arpa/inet.h>
 #include "ip.h"
-#include "tcp.h"
+#include "icmp.h"
 #include "netconf.h"
 #include "deveth.h"
+#include "arp.h"
 
 #ifdef DEBUG
 #define debug	printf
@@ -35,7 +38,7 @@ char deveth[] = "/dev/eth";
 
 extern int tcp_timeruse;
 
-//static int tcpdevfd; /* defined in ip.h */
+static int tcpdevfd;
 static int intfd;
 
 unsigned long int in_aton(const char *str)
@@ -99,7 +102,7 @@ void ktcp_run(void)
 
 int main(int argc,char **argv)
 {
-    __u8 * addr;
+    //__u8 * addr;
     int daemon = 0;
     speed_t baudrate = 0;
     char *progname = argv[0];

--- a/elkscmd/ktcp/netconf.c
+++ b/elkscmd/ktcp/netconf.c
@@ -12,6 +12,7 @@
 #include "config.h"
 #include <linuxmt/arpa/inet.h>
 #include "tcp.h"
+#include "tcp_cb.h"
 #include "tcpdev.h"
 #include "netconf.h"
 

--- a/elkscmd/ktcp/netconf.h
+++ b/elkscmd/ktcp/netconf.h
@@ -30,4 +30,4 @@ void netconf_init();
 void netconf_send();
 void netconf_request();
 
-#endif
+#endif /* !NETCONF_H */

--- a/elkscmd/ktcp/slip.c
+++ b/elkscmd/ktcp/slip.c
@@ -18,6 +18,7 @@
 #include <unistd.h>
 #include <linuxmt/termios.h>
 
+#include "ip.h"
 #include "slip.h"
 #include "vjhc.h"
 
@@ -238,7 +239,7 @@ void slip_process(void)
 
 void send_char(__u8 ch)
 {
-    int i = write(devfd, &ch, 1);
+    /* int i = */ write(devfd, &ch, 1);
 
 #if 0
     if (i <= 0)

--- a/elkscmd/ktcp/slip.h
+++ b/elkscmd/ktcp/slip.h
@@ -3,4 +3,8 @@
 
 #define SLIP_MTU   1064
 
+void slip_process(void);
+int slip_init(char *fdev, speed_t baudrate);
+void slip_send(char *packet, int len);
+
 #endif

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -272,7 +272,7 @@ void tcp_synrecv(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 
     if (h->flags & TF_RST)
 	cb->state = TS_LISTEN;		/* FIXME: not valid any more */
-    else if ((!h->flags) & TF_ACK)
+    else if ((h->flags & TF_ACK) == 0)
 	printf("NO ACK IN SYNRECV\n");
     else {
 	cb->state = TS_ESTABLISHED;

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -272,7 +272,7 @@ void tcp_synrecv(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 
     if (h->flags & TF_RST)
 	cb->state = TS_LISTEN;		/* FIXME: not valid any more */
-    else if (!h->flags & TF_ACK)
+    else if ((!h->flags) & TF_ACK)
 	printf("NO ACK IN SYNRECV\n");
     else {
 	cb->state = TS_ESTABLISHED;

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -8,6 +8,7 @@
  *	2 of the License, or (at your option) any later version.
  */
 
+#include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -17,6 +18,9 @@
 #include "slip.h"
 #include "ip.h"
 #include "tcp.h"
+#include "tcp_cb.h"
+#include "tcpdev.h"
+#include "tcp_output.h"
 #include "timer.h"
 #include <linuxmt/arpa/inet.h>
 
@@ -49,7 +53,7 @@ void tcp_print(struct iptcp_s *head)
 
 int tcp_init(void)
 {
-    struct tcpcb_list_s *n;
+    //struct tcpcb_list_s *n;
 
     tcpcb_init();
     cbs_in_time_wait = 0;
@@ -388,7 +392,7 @@ void tcp_process(struct iphdr_s *iph)
     struct tcphdr_s *tcph;
     struct tcpcb_list_s *cbnode;
     struct tcpcb_s *cb;
-    __u16 tmp;
+    //__u16 tmp;
 
     tcph = (struct tcphdr_s *)(((char *)iph) + 4 * IP_IHL(iph));
     iptcp.iph = iph;

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -158,4 +158,10 @@ void tcp_output();
 
 unsigned long int in_aton(const char *str);
 
-#endif
+void tcp_update(void);
+int tcp_init(void);
+void tcp_process(struct iphdr_s *iph);
+void tcp_connect(struct tcpcb_s *cb);
+void tcp_send_fin(struct tcpcb_s *cb);
+
+#endif /* !TCP_H */

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -9,9 +9,14 @@
  *	2 of the License, or (at your option) any later version.
  */
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "config.h"
 #include "tcp.h"
 #include "tcpdev.h"
+#include "tcp_output.h"
 
 static struct tcpcb_list_s	*tcpcbs;
 int cbs_in_time_wait, cbs_in_user_timeout;
@@ -229,7 +234,7 @@ void tcpcb_push_data(void)
 }
 
 /* There must be free space greater-equal than len */
-int tcpcb_buf_write(struct tcpcb_s *cb, __u8 *data, __u16 len)
+void tcpcb_buf_write(struct tcpcb_s *cb, __u8 *data, __u16 len)
 {
     int tail;
     register int i;
@@ -241,7 +246,7 @@ int tcpcb_buf_write(struct tcpcb_s *cb, __u8 *data, __u16 len)
 }
 
 /* same here */
-int tcpcb_buf_read(struct tcpcb_s *cb, __u8 *data, __u16 len)
+void tcpcb_buf_read(struct tcpcb_s *cb, __u8 *data, __u16 len)
 {
     register int head = cb->buf_head, i;
 

--- a/elkscmd/ktcp/tcp_cb.h
+++ b/elkscmd/ktcp/tcp_cb.h
@@ -1,0 +1,15 @@
+#ifndef TCP_CB_H
+#define TCP_CB_H
+
+void tcpcb_init(void);
+struct tcpcb_list_s *tcpcb_clone(struct tcpcb_s *cb);
+void tcpcb_buf_read(struct tcpcb_s *cb, __u8 *data, __u16 len);
+void tcpcb_buf_write(struct tcpcb_s *cb, __u8 *data, __u16 len);
+void tcpcb_expire_timeouts(void);
+void tcpcb_push_data(void);
+struct tcpcb_list_s *tcpcb_check_port(__u16 lport);
+struct tcpcb_list_s *tcpcb_find_unaccepted(__u16 sock);
+void tcpcb_rmv_all_unaccepted(struct tcpcb_s *cb);
+struct tcpcb_s *tcpcb_getbynum(int num);
+
+#endif

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -9,6 +9,9 @@
  *	2 of the License, or (at your option) any later version.
  */
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -267,7 +270,7 @@ void tcp_reoutput(struct tcp_retrans_list_s *n)
     ip_sendpacket(n->tcph, n->len, &n->apair);
 }
 
-int tcp_retrans(void)
+void tcp_retrans(void)
 {
     struct tcp_retrans_list_s *n;
     int datalen, rtt;
@@ -314,8 +317,8 @@ void tcp_output(struct tcpcb_s *cb)
     struct addr_pair apair;
     __u16 len;
     __u8 *options, header_len, option_len;
-    __u8 addr[4], *addr2;
-    __u32 temp;
+    //__u8 addr[4], *addr2;
+    //__u32 temp;
 
     th->sport = htons(cb->localport);
     th->dport = htons(cb->remport);

--- a/elkscmd/ktcp/tcp_output.h
+++ b/elkscmd/ktcp/tcp_output.h
@@ -1,0 +1,7 @@
+#ifndef TCP_OUTPUT_H
+#define TCP_OUTPUT_H
+
+void tcp_retrans(void);
+void rmv_all_retrans(struct tcpcb_list_s *lcb);
+
+#endif

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -29,14 +29,14 @@
 #include "tcpdev.h"
 #include "netconf.h"
 
-static int tcpdevfd;
-
 static unsigned char sbuf[TCPDEV_BUFSIZE];
 
 extern int cbs_in_user_timeout;
 
 int tcpdev_init(char *fdev)
 {
+    int tcpdevfd;
+
     tcpdevfd = open(fdev, O_NONBLOCK | O_RDWR);
     if (tcpdevfd < 0)
 	printf("ktcp: failed to open tcpdev device %s\n",fdev);

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -23,13 +23,15 @@
 #include <linuxmt/errno.h>
 
 #include <linuxmt/arpa/inet.h>
+#include "ip.h"
 #include "tcp.h"
+#include "tcp_cb.h"
 #include "tcpdev.h"
 #include "netconf.h"
 
-static unsigned char sbuf[TCPDEV_BUFSIZE];
-
 static int tcpdevfd;
+
+static unsigned char sbuf[TCPDEV_BUFSIZE];
 
 extern int cbs_in_user_timeout;
 

--- a/elkscmd/ktcp/tcpdev.h
+++ b/elkscmd/ktcp/tcpdev.h
@@ -6,6 +6,8 @@
 #define MAX_ADDR_LEN    7
 #define IFNAMSIZ        16
 
+extern int tcpdevfd;
+
 struct net_device
  {
     char name[ IFNAMSIZ ];	/* name of the device */

--- a/elkscmd/ktcp/tcpdev.h
+++ b/elkscmd/ktcp/tcpdev.h
@@ -59,4 +59,11 @@ struct net_device *dev; /* global */
 
   #define IFF_ECHO        0x40000         /* echo sent packets            */
 
-#endif
+void tcpdev_process(void);
+int tcpdev_init(char *fdev);
+void retval_to_sock(__u16 sock, short int r);
+void tcpdev_checkread(struct tcpcb_s *cb);
+void tcpdev_sock_state(struct tcpcb_s *cb, int state);
+void tcpdev_checkaccept(struct tcpcb_s *cb);
+
+#endif /* !TCPDEV_H */

--- a/elkscmd/ktcp/timer.c
+++ b/elkscmd/ktcp/timer.c
@@ -8,7 +8,7 @@
  *	2 of the License, or (at your option) any later version.
  */
 
-#include <time.h>
+#include <sys/time.h>
 
 #include "timer.h"
 

--- a/elkscmd/ktcp/timer.h
+++ b/elkscmd/ktcp/timer.h
@@ -13,4 +13,6 @@ typedef	__u32 timeq_t;
 
 extern timeq_t Now;
 
+timeq_t timer_get_time(void);
+
 #endif


### PR DESCRIPTION
Fix many "implicit declaration" and "unused variable" warnings in ktcp.

Comment out unused variables. Add new headers. Reorder the inclusion
of some headers. Declare tcpdevfd in files that use it and remove it
from ip.h. Make some functions that return nothing void.

Compiles. Untested. If it did work, it should probably be tested by
someone who has the setup to do so before merging.