### PR TITLE
[cmds] Fix ps, sash, tail, elvis, wait

### DIFF
--- a/elkscmd/minix3/tail.c
+++ b/elkscmd/minix3/tail.c
@@ -66,7 +66,7 @@ extern int optind;
  * but we'll specify it here just in case it's been left out.
  */
 #ifndef LINE_MAX
-#define LINE_MAX 2048		/* minimum acceptable lower bound */
+#define LINE_MAX 128		/* minimum acceptable lower bound */
 #endif
 
 /* Magic numbers suggested or required by Posix specification */

--- a/elkscmd/sash/sash.c
+++ b/elkscmd/sash/sash.c
@@ -276,13 +276,15 @@ int main(int argc, char **argv)
 	init_hist();
 #endif /* CMD_HISTORY */
 
-	if (argc > 1) {
-		readfile(argv[1]);
-	} else {
-		readfile(NULL);
+	if (argc > 2 && !strcmp(argv[1], "-c")) {
+		command(argv[2]);
 	}
-	exit(0);
+	else if (argc > 1)
+		readfile(argv[1]);
+	else
+		readfile(NULL);
 
+	exit(0);
 }
 
 

--- a/libc/system/wait.c
+++ b/libc/system/wait.c
@@ -1,8 +1,16 @@
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <errno.h>
 
 pid_t
 wait(int * status)
 {
-   return wait4(-1, status, 0, (void*)0);
+	int ret;
+
+	/* for compatibility, loop while EINTR return*/
+	do {
+		ret = wait4(-1, status, 0, (void*)0);
+	} while (ret == -1 && errno == EINTR);
+
+	return ret;
 }


### PR DESCRIPTION
Fixes all items mentioned in #608.

Fixes `ps`, problem was DSEG was deallocated. Thus, there is no reliable way to print command arguments, as segment is discarded. Output truncated after CSEG/DSEG displayed as 0.

Fixes `elvis` to properly display ":!cmd" output. Turns out this was related to the `wait` system call returning -EINTR, rather than a process id. Thus, control returned to elvis prior to the command output being displayed, and by that time elvis had reset raw terminal mode.

Fixes libc `wait` to retry on EINTR, to be compatible with Linux. This fixed the elvis problem, and has the side effect of the kernel `wait` waking up `init` to process zombie entries, so `ps` is unlikely to show zombie processes, even though it is also fixed.

Adds -c option to `sash`. Traced raw mode behavior in `ash` and determined not to be the problem. Added `sash -c` to fully test above wait() fix.

Fixes `tail` by allocating 1280 bytes rather than 20k bytes. Seems to work well but needs further testing.

