### PR TITLE
[ktcp] Basic fixes to enable network testing

### DIFF
--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -30,7 +30,7 @@ struct msdos_devdir_entry devnods[DEVDIR_SIZE] = {
     { "ttyS0",	S_IFCHR | 0644, MKDEV(4, 64)},
     { "ttyS1",	S_IFCHR | 0644, MKDEV(4, 65)},
     { "ttyS2",	S_IFCHR | 0644, MKDEV(4, 66)},
-    { "console",S_IFCHR | 0644, MKDEV(4, 254)},
+    { "console",S_IFCHR | 0600, MKDEV(4, 254)},
     { "tty",	S_IFCHR | 0666, MKDEV(4, 255) },
 };
 #endif

--- a/elkscmd/inet/httpd/sample_index.html
+++ b/elkscmd/inet/httpd/sample_index.html
@@ -5,7 +5,7 @@
 <B><BIG>It worked!!</BIG></B>
 <P>
 If you can see this page the web server worked.<br>
-Visit <a href="https://github.com/elks-org/elks">https://github.com/elks-org/elks</a>
+Visit <a href="https://github.com/jbruchon/elks">https://github.com/jbruchon/elks</a>
 </p>
 </CENTER>
 </BODY>

--- a/elkscmd/ktcp/Makefile
+++ b/elkscmd/ktcp/Makefile
@@ -14,7 +14,7 @@ OBJS		= $(CFILES:.c=.o)
 all:	ktcp
 
 ktcp:	$(OBJS)
-	$(LD) $(LDFLAGS) -maout-chmem=0x3000 -o ktcp $(OBJS) $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-chmem=0x4000 -o ktcp $(OBJS) $(LDLIBS)
 
 lint:
 	@for FILE in *.c ; do \

--- a/elkscmd/ktcp/arp.c
+++ b/elkscmd/ktcp/arp.c
@@ -13,6 +13,7 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
 
 #include <linuxmt/arpa/inet.h>
 
@@ -176,7 +177,10 @@ selectagain:
     FD_SET(tcpdevfd, &fdset);
     i = select(tcpdevfd + 1, &fdset, NULL, NULL, NULL);
     if (i < 0) {
-	//if (errno == EINTR) goto selectagain;
+	if (errno == EINTR) {
+		fprintf(stderr, "arp: select EINTR\n");
+		goto selectagain;
+	}
 	perror("select");
 	return -1;
     }

--- a/elkscmd/ktcp/ip.h
+++ b/elkscmd/ktcp/ip.h
@@ -52,6 +52,6 @@ struct ip_ll
          __u16 ll_type_len;	/* 0x800 big endian for IP */
 };
 
-static int tcpdevfd;
+extern int tcpdevfd;
 
 #endif

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -35,7 +35,6 @@ char deveth[] = "/dev/eth";
 
 extern int tcp_timeruse;
 
-//static int tcpdevfd; /* defined in ip.h */
 static int intfd;
 
 unsigned long int in_aton(const char *str)
@@ -160,7 +159,7 @@ usage:
 	if (fork())
 	    exit(0);
 	close(0);
-	close(1);
+	//close(1);		//FIXME required for printf output in -b
     }
 
     arp_init ();

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -8,7 +8,7 @@
 #include "ip.h"
 #include <linuxmt/arpa/inet.h>
 
-/* #define DEBUG */
+//#define DEBUG
 
 #define PROTO_TCP	0x06
 

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -29,16 +29,16 @@
 
 static unsigned char sbuf[TCPDEV_BUFSIZE];
 
-static int tcpdevfd;
+int tcpdevfd;
 
 extern int cbs_in_user_timeout;
 
 int tcpdev_init(char *fdev)
 {
-    tcpdevfd = open(fdev, O_NONBLOCK | O_RDWR);
-    if (tcpdevfd < 0)
+    int fd  = open(fdev, O_NONBLOCK | O_RDWR);
+    if (fd < 0)
 	printf("ktcp: failed to open tcpdev device %s\n",fdev);
-    return tcpdevfd;
+    return fd;
 }
 
 void retval_to_sock(__u16 sock,short int r)

--- a/elkscmd/ktcp/vjhc.c
+++ b/elkscmd/ktcp/vjhc.c
@@ -46,6 +46,7 @@ Created:	Nov 11, 1993 by Philip Homburg <philip@cs.vu.nl>
  * the variable 'opt_d' doesn't exist, presumably because this was
  * ported from something else that provided it. */
 #ifdef DEBUGHC
+//int opt_d = 1;
 #define DBG(a) a
 #else
 #define DBG(a)


### PR DESCRIPTION
Fix 'static int tcpdevfd' problem.
Increase `ktcp` heap/stack memory to 16k.
Allow printf debug output in -b mode.
Various small fixes.

These fixes should enable using the current source head for continued testing of networking, without patching. Any testing of slip or ethernet would be greatly appreciated. Setting DEBUG in tcp.h will provide more information.