### PR TITLE
[kernel] De-duplicate console code, update BIOS console

### DIFF
--- a/elks/arch/i86/drivers/char/bioscon.c
+++ b/elks/arch/i86/drivers/char/bioscon.c
@@ -132,7 +132,7 @@ void xtk_init(void)
  */
 static void kbd_timer(int __data)
 {
-    int dav;
+    int dav, extra = 0;
 #if 0
     static int clk[4] = {0x072D, 0x075C, 0x077C, 0x072F,};
     static int c = 0;
@@ -148,31 +148,35 @@ static void kbd_timer(int __data)
 		Console_set_vc(dav - 0x3B);
 		dav = 0;
 	    }
-	    else if (dav >= 0x3B && dav < 0x45)	/* Function keys */
-		dav = dav - 0x3B + 'a';
-	    else if (dav >= 0x57 && dav < 0x59)
-		dav = dav - 0x57 + 'k';
-	    else if ((dav >= 0x48 && dav <= 0x50) && ((1 << (dav - 0x48) & 0x129))) {
-		/* arrow keys*/
-		switch(dav) {
-		case 0x48: dav = 'A'; break;
-		case 0x50: dav = 'B'; break;
-		case 0x4d: dav = 'C'; break;
-		case 0x4b: dav = 'D'; break;
-		default:   dav = 0;
-		}
-	    }
 	    else if ((dav >= 0x68) && (dav < 0x6B)) {	/* Change VC */
 		Console_set_vc((unsigned)(dav - 0x68));
 		dav = 0;
 	    }
-	    else dav = 0;
+	    else if (dav >= 0x3B && dav < 0x45)	/* Function keys */
+		dav = dav - 0x3B + 'a';
+	    else {
+		switch(dav) {
+		case 0x48: dav = 'A'; break;	/* up*/
+		case 0x50: dav = 'B'; break;	/* down*/
+		case 0x4d: dav = 'C'; break;	/* right*/
+		case 0x4b: dav = 'D'; break;	/* left*/
+		case 0x47: dav = 'H'; break;	/* home*/
+		case 0x4f: dav = 'F'; break;	/* end*/
+		case 0x49: dav = '5'; extra = '~'; break; /* pgup*/
+		case 0x51: dav = '6'; extra = '~'; break; /* pgdn*/
+		default:   dav = 0;
+		}
+	    }
 	    if (dav) {
 		AddQueue(ESC);
 #ifdef CONFIG_EMUL_ANSI
 		AddQueue('[');
 #endif
 		AddQueue(dav);
+#ifdef CONFIG_EMUL_ANSI
+		if (extra)
+		    AddQueue(extra);
+#endif
 	    }
 	}
     }

--- a/elks/arch/i86/drivers/char/console.c
+++ b/elks/arch/i86/drivers/char/console.c
@@ -1,0 +1,403 @@
+/* shared console routines - #include in console drivers*/
+
+static void WriteChar(register Console * C, char c)
+{
+    /* check for graphics lock */
+    while (glock) {
+	if (glock == C)
+	    return;
+	sleep_on(&glock_wait);
+    }
+    C->fsm(C, c);
+}
+
+void Console_conout(dev_t dev, char Ch)
+{
+    Console *C = &Con[MINOR(dev)];
+
+    if (Ch == '\n')
+	WriteChar(C, '\r');
+    WriteChar(C, Ch);
+    PositionCursor(C);
+}
+
+void AddQueue(unsigned char Key)
+{
+	extern struct tty ttys[];
+    register struct tty *ttyp = &ttys[Current_VCminor];
+
+    if (!tty_intcheck(ttyp, Key))
+	chq_addch(&ttyp->inq, Key);
+}
+
+#if defined (CONFIG_EMUL_VT52) || defined (CONFIG_EMUL_ANSI)
+static void Console_gotoxy(register Console * C, int x, int y)
+{
+    register int xp = x;
+
+    C->cx = (xp >= MaxCol) ? MaxCol : (xp < 0) ? 0 : xp;
+    xp = y;
+    C->cy = (xp >= MaxRow) ? MaxRow : (xp < 0) ? 0 : xp;
+    C->XN = 0;
+}
+#endif
+
+#ifdef CONFIG_EMUL_ANSI
+static int parm1(register unsigned char *buf)
+{
+    int n;
+
+    if (!(n = atoi((char *)buf)))
+	n = 1;
+    return n;
+}
+
+static int parm2(register unsigned char *buf)
+{
+    while (*buf != ';' && *buf)
+	buf++;
+    if (*buf)
+	buf++;
+    return parm1(buf);
+}
+
+static void itoaQueue(int i)
+{
+   unsigned char a[6];
+   unsigned char *b = a + sizeof(a) - 1;
+
+   *b = 0;
+   do {
+      *--b = '0' + (i % 10);
+      i /= 10;
+   } while (i);
+   while (*b)
+	AddQueue(*b++);
+}
+
+static void AnsiCmd(register Console * C, char c)
+{
+    int n;
+
+    /* ANSI param gathering and processing */
+    if (C->parmptr < &C->params[MAXPARMS - 1])
+	*C->parmptr++ = (unsigned char) c;
+    if (!isalpha(c)) {
+	return;
+    }
+    *(C->parmptr) = 0;
+
+    switch (c) {
+    case 's':			/* Save the current location */
+	C->savex = C->cx;
+	C->savey = C->cy;
+	break;
+    case 'u':			/* Restore saved location */
+	C->cx = C->savex;
+	C->cy = C->savey;
+	break;
+    case 'A':			/* Move up n lines */
+	C->cy -= parm1(C->params);
+	if (C->cy < 0)
+	    C->cy = 0;
+	break;
+    case 'B':			/* Move down n lines */
+	C->cy += parm1(C->params);
+	if (C->cy > MaxRow)
+	    C->cy = MaxRow;
+	break;
+    case 'C':			/* Move right n characters */
+	C->cx += parm1(C->params);
+	if (C->cx > MaxCol)
+	    C->cx = MaxCol;
+	break;
+    case 'D':			/* Move left n characters */
+	C->cx -= parm1(C->params);
+	if (C->cx < 0)
+	    C->cx = 0;
+	break;
+    case 'H':			/* cursor move */
+	Console_gotoxy(C, parm2(C->params) - 1, parm1(C->params) - 1);
+	break;
+    case 'J':			/* erase */
+	if (parm1(C->params) == 2)
+	    ClearRange(C, 0, 0, MaxCol, MaxRow);
+	break;
+    case 'K':			/* Clear to EOL */
+	ClearRange(C, C->cx, C->cy, MaxCol, C->cy);
+	break;
+    case 'L':			/* insert line */
+	ScrollDown(C, C->cy);
+	break;
+    case 'M':			/* remove line */
+	ScrollUp(C, C->cy);
+	break;
+    case 'm':			/* ansi color */
+	n = atoi((char *)C->params);
+	if (n >= 30 && n <= 37) {
+	    C->attr &= 0xf8;
+	    C->attr |= (n-30) & 0x07;
+	    C->color = C->attr;
+	}
+	else if (n >= 40 && n <= 47) {
+	    C->attr &= 0x8f;
+	    C->attr |= ((n-40) << 4) & 0x70;
+	    C->color = C->attr;
+	}
+	else switch (n) {
+	    case 0:
+		C->attr = C->color;
+		break;
+	    case 1:
+		C->attr |= A_BOLD;
+		break;
+	    case 5:
+		C->attr |= A_BLINK;
+		break;
+	    case 7:
+		n = C->attr;
+		C->attr &= ~(A_DEFAULT | A_REVERSE);
+		C->attr |= ((n >> 4) & 0x07) | ((n << 4) & 0x70);
+		break;
+	    case 8:
+		C->attr = A_BLANK;
+		break;
+	    case 39:
+	    case 49:
+	    default:
+		C->attr = C->color = A_DEFAULT;
+		break;
+	}
+	break;
+    case 'n':
+	if (parm1(C->params) == 6) {		/* device status report*/
+	    //FIXME sequence can be interrupted by kbd input
+	    AddQueue(ESC);
+	    AddQueue('[');
+	    itoaQueue(C->cy+1);
+	    AddQueue(';');
+	    itoaQueue(C->cx+1);
+	    AddQueue('R');
+	}
+	break;
+    }
+    C->fsm = std_char;
+}
+
+/* Escape character processing */
+static void esc_char(register Console * C, char c)
+{
+    /* Parse CSI sequence */
+    C->parmptr = C->params;
+    C->fsm = (c == '[' ? AnsiCmd : std_char);
+}
+#endif
+
+#ifdef CONFIG_EMUL_VT52
+static void esc_Y2(register Console * C, char c)
+{
+    Console_gotoxy(C, c - ' ', C->tmp);
+    C->fsm = std_char;
+}
+
+static void esc_YS(register Console * C, char c)
+{
+    switch(C->tmp) {
+    case 'Y':
+	C->tmp = (unsigned char) (c - ' ');
+	C->fsm = esc_Y2;
+	break;
+    case '/':
+	C->tmp = 'Z';		/* Discard next char */
+	break;
+    case 'Z':
+	C->fsm = std_char;
+    }
+}
+
+/* Escape character processing */
+static void esc_char(register Console * C, char c)
+{
+    /* process single ESC char sequences */
+    C->fsm = std_char;
+    switch (c) {
+    case 'I':			/* linefeed reverse */
+	if (!C->cy) {
+	    ScrollDown(C, 0);
+	    break;
+	}
+    case 'A':			/* up */
+	if (C->cy)
+	    --C->cy;
+	break;
+    case 'B':			/* down */
+	if (C->cy < MaxRow)
+	    ++C->cy;
+	break;
+    case 'C':			/* right */
+	if (C->cx < MaxCol)
+	    ++C->cx;
+	break;
+    case 'D':			/* left */
+	if (C->cx)
+	    --C->cx;
+	break;
+    case 'H':			/* home */
+	C->cx = C->cy = 0;
+	break;
+    case 'J':			/* clear to eoscreen */
+	ClearRange(C, 0, C->cy+1, MaxCol, MaxRow);
+    case 'K':			/* clear to eol */
+	ClearRange(C, C->cx, C->cy, MaxCol, C->cy);
+	break;
+    case 'L':			/* insert line */
+	ScrollDown(C, C->cy);
+	break;
+    case 'M':			/* remove line */
+	ScrollUp(C, C->cy);
+	break;
+    case '/':			/* Remove echo for identify response */
+    case 'Y':			/* cursor move */
+	C->tmp = c;
+	C->fsm = esc_YS;
+	break;
+    case 'Z':			/* identify as VT52 */
+	AddQueue(ESC);
+	AddQueue('/');
+	AddQueue('K');
+    }
+}
+#endif
+
+/* Normal character processing */
+static void std_char(register Console * C, char c)
+{
+    switch(c) {
+    case BEL:
+	bell();
+	break;
+    case '\b':
+	C->XN = 0;
+	if (C->cx > 0) {
+	    --C->cx;
+#ifdef CONFIG_CONSOLE_BIOS
+	    PositionCursor(C);
+#endif
+	    VideoWrite(C, ' ');
+	}
+	break;
+    case '\t':
+	C->cx = (C->cx | 0x07) + 1;
+	goto linewrap;
+    case '\n':
+	C->XN = 0;
+	++C->cy;
+	break;
+    case '\r':
+	C->XN = 0;
+	C->cx = 0;
+	break;
+
+#if defined (CONFIG_EMUL_VT52) || defined (CONFIG_EMUL_ANSI)
+    case ESC:
+	C->fsm = esc_char;
+	break;
+#endif
+
+    default:
+	if (C->XN) {
+	    C->XN = 0;
+	    C->cx = 0;
+	    C->cy++;
+	    if (C->cy > MaxRow) {
+		ScrollUp(C, 0);
+		C->cy = MaxRow;
+	    }
+	}
+#ifdef CONFIG_CONSOLE_BIOS
+	PositionCursor(C);
+#endif
+	VideoWrite(C, c);
+	C->cx++;
+      linewrap:
+	if (C->cx > MaxCol) {
+
+#ifdef CONFIG_EMUL_VT52
+	    C->cx = MaxCol;
+#else
+	    C->XN = 1;
+	    C->cx = MaxCol;
+#endif
+
+	}
+    }
+    if (C->cy > MaxRow) {
+	ScrollUp(C, 0);
+	C->cy = MaxRow;
+    }
+}
+
+static int Console_ioctl(struct tty *tty, int cmd, char *arg)
+{
+    register Console *C = &Con[tty->minor];
+
+    switch (cmd) {
+    case DCGET_GRAPH:
+	if (!glock) {
+	    glock = C;
+	    return 0;
+	}
+	return -EBUSY;
+    case DCREL_GRAPH:
+	if (glock == C) {
+	    glock = NULL;
+	    wake_up(&glock_wait);
+	    return 0;
+	}
+	break;
+    case DCSET_KRAW:
+	if (glock == C) {
+	    kraw = 1;
+	    return 0;
+	}
+	break;
+    case DCREL_KRAW:
+	if ((glock == C) && (kraw == 1)) {
+	    kraw = 0;
+	    return 1;
+	}
+	break;
+    case TCSETS:
+    case TCSETSW:
+    case TCSETSF:
+	return 0;
+    }
+
+    return -EINVAL;
+}
+
+static int Console_write(register struct tty *tty)
+{
+    register Console *C = &Con[tty->minor];
+    int cnt = 0;
+
+    while ((tty->outq.len > 0) && !glock) {
+	WriteChar(C, (char)tty_outproc(tty));
+	cnt++;
+    }
+    if (C == Visible)
+	PositionCursor(C);
+    return cnt;
+}
+
+static void Console_release(struct tty *tty)
+{
+    ttystd_release(tty);
+}
+
+static int Console_open(register struct tty *tty)
+{
+    if (tty->minor >= NumConsoles)
+	return -ENODEV;
+    return ttystd_open(tty);
+}

--- a/elks/arch/i86/drivers/char/dircon.c
+++ b/elks/arch/i86/drivers/char/dircon.c
@@ -30,16 +30,6 @@
 /* Assumes ASCII values. */
 #define isalpha(c) (((unsigned char)(((c) | 0x20) - 'a')) < 26)
 
-#if 0
-/* public interface of dircon.c: */
-
-int Console_write(struct tty *tty);
-void Console_release(struct tty *tty);
-int Console_open(struct tty *tty);
-struct tty_ops dircon_ops;
-void init_console(void);
-#endif
-
 #define A_DEFAULT 	0x07
 #define A_BOLD 		0x08
 #define A_BLINK 	0x80
@@ -62,8 +52,6 @@ typedef struct console Console;
 struct console {
     int cx, cy;			/* cursor position */
     void (*fsm)(register Console *, char);
-    unsigned int vseg;		/* video segment for page */
-    int basepage;		/* start of video ram */
     unsigned char attr;		/* current attribute */
     unsigned char XN;		/* delayed newline on column 80 */
     unsigned char color;	/* fg/bg attr */
@@ -75,6 +63,8 @@ struct console {
     unsigned char *parmptr;	/* ptr to params */
     unsigned char params[MAXPARMS];	/* ANSI params */
 #endif
+    unsigned int vseg;		/* video segment for page */
+    int basepage;		/* start of video ram */
 };
 
 static struct wait_queue glock_wait;
@@ -97,7 +87,6 @@ extern int kraw;
 #endif
 
 static void std_char(register Console *, char);
-extern void AddQueue(unsigned char Key);	/* From xt_key.c */
 
 static void SetDisplayPage(register Console * C)
 {
@@ -167,327 +156,8 @@ static void ScrollDown(register Console * C, int y)
 }
 #endif
 
-#if defined (CONFIG_EMUL_VT52) || defined (CONFIG_EMUL_ANSI)
-static void Console_gotoxy(register Console * C, int x, int y)
-{
-    register int xp = x;
-
-    C->cx = (xp >= MaxCol) ? MaxCol : (xp < 0) ? 0 : xp;
-    xp = y;
-    C->cy = (xp >= MaxRow) ? MaxRow : (xp < 0) ? 0 : xp;
-    C->XN = 0;
-}
-#endif
-
-#ifdef CONFIG_EMUL_ANSI
-static int parm1(register unsigned char *buf)
-{
-    int n;
-
-    if (!(n = atoi((char *)buf)))
-	n = 1;
-    return n;
-}
-
-static int parm2(register unsigned char *buf)
-{
-    while (*buf != ';' && *buf)
-	buf++;
-    if (*buf)
-	buf++;
-    return parm1(buf);
-}
-
-static void itoaQueue(int i)
-{
-   unsigned char a[6];
-   unsigned char *b = a + sizeof(a) - 1;
-
-   *b = 0;
-   do {
-      *--b = '0' + (i % 10);
-      i /= 10;
-   } while (i);
-   while (*b)
-	AddQueue(*b++);
-}
-
-static void AnsiCmd(register Console * C, char c)
-{
-    int n;
-
-    /* ANSI param gathering and processing */
-    if (C->parmptr < &C->params[MAXPARMS - 1])
-	*C->parmptr++ = (unsigned char) c;
-    if (!isalpha(c)) {
-	return;
-    }
-    *(C->parmptr) = 0;
-
-    switch (c) {
-    case 's':			/* Save the current location */
-	C->savex = C->cx;
-	C->savey = C->cy;
-	break;
-    case 'u':			/* Restore saved location */
-	C->cx = C->savex;
-	C->cy = C->savey;
-	break;
-    case 'A':			/* Move up n lines */
-	C->cy -= parm1(C->params);
-	if (C->cy < 0)
-	    C->cy = 0;
-	break;
-    case 'B':			/* Move down n lines */
-	C->cy += parm1(C->params);
-	if (C->cy > MaxRow)
-	    C->cy = MaxRow;
-	break;
-    case 'C':			/* Move right n characters */
-	C->cx += parm1(C->params);
-	if (C->cx > MaxCol)
-	    C->cx = MaxCol;
-	break;
-    case 'D':			/* Move left n characters */
-	C->cx -= parm1(C->params);
-	if (C->cx < 0)
-	    C->cx = 0;
-	break;
-    case 'H':			/* cursor move */
-	Console_gotoxy(C, parm2(C->params) - 1, parm1(C->params) - 1);
-	break;
-    case 'J':			/* erase */
-	if (parm1(C->params) == 2)
-	    ClearRange(C, 0, 0, MaxCol, MaxRow);
-	break;
-    case 'K':			/* Clear to EOL */
-	ClearRange(C, C->cx, C->cy, MaxCol, C->cy);
-	break;
-    case 'L':			/* insert line */
-	ScrollDown(C, C->cy);
-	break;
-    case 'M':			/* remove line */
-	ScrollUp(C, C->cy);
-	break;
-    case 'm':			/* ansi color */
-	n = atoi((char *)C->params);
-	if (n >= 30 && n <= 37) {
-	    C->attr &= 0xf8;
-	    C->attr |= (n-30) & 0x07;
-	    C->color = C->attr;
-	}
-	else if (n >= 40 && n <= 47) {
-	    C->attr &= 0x8f;
-	    C->attr |= ((n-40) << 4) & 0x70;
-	    C->color = C->attr;
-	}
-	else switch (n) {
-	    case 0:
-		C->attr = C->color;
-		break;
-	    case 1:
-		C->attr |= A_BOLD;
-		break;
-	    case 5:
-		C->attr |= A_BLINK;
-		break;
-	    case 7:
-		n = C->attr;
-		C->attr &= ~(A_DEFAULT | A_REVERSE);
-		C->attr |= ((n >> 4) & 0x07) | ((n << 4) & 0x70);
-		break;
-	    case 8:
-		C->attr = A_BLANK;
-		break;
-	    case 39:
-	    case 49:
-	    default:
-		C->attr = C->color = A_DEFAULT;
-		break;
-	}
-	break;
-    case 'n':
-	if (parm1(C->params) == 6) {		/* device status report*/
-	    //FIXME sequence can be interrupted by kbd input
-	    AddQueue(ESC);
-	    AddQueue('[');
-	    itoaQueue(C->cy+1);
-	    AddQueue(';');
-	    itoaQueue(C->cx+1);
-	    AddQueue('R');
-	}
-	break;
-    }
-    C->fsm = std_char;
-}
-
-/* Escape character processing */
-static void esc_char(register Console * C, char c)
-{
-    /* Parse CSI sequence */
-    C->parmptr = C->params;
-    C->fsm = (c == '[' ? AnsiCmd : std_char);
-}
-#endif
-
-#ifdef CONFIG_EMUL_VT52
-static void esc_Y2(register Console * C, char c)
-{
-    Console_gotoxy(C, c - ' ', C->tmp);
-    C->fsm = std_char;
-}
-
-static void esc_YS(register Console * C, char c)
-{
-    switch(C->tmp) {
-    case 'Y':
-	C->tmp = (unsigned char) (c - ' ');
-	C->fsm = esc_Y2;
-	break;
-    case '/':
-	C->tmp = 'Z';		/* Discard next char */
-	break;
-    case 'Z':
-	C->fsm = std_char;
-    }
-}
-
-/* Escape character processing */
-static void esc_char(register Console * C, char c)
-{
-    /* process single ESC char sequences */
-    C->fsm = std_char;
-    switch (c) {
-    case 'I':			/* linefeed reverse */
-	if (!C->cy) {
-	    ScrollDown(C, 0);
-	    break;
-	}
-    case 'A':			/* up */
-	if (C->cy)
-	    --C->cy;
-	break;
-    case 'B':			/* down */
-	if (C->cy < MaxRow)
-	    ++C->cy;
-	break;
-    case 'C':			/* right */
-	if (C->cx < MaxCol)
-	    ++C->cx;
-	break;
-    case 'D':			/* left */
-	if (C->cx)
-	    --C->cx;
-	break;
-    case 'H':			/* home */
-	C->cx = C->cy = 0;
-	break;
-    case 'J':			/* clear to eoscreen */
-	ClearRange(C, 0, C->cy+1, MaxCol, MaxRow);
-    case 'K':			/* clear to eol */
-	ClearRange(C, C->cx, C->cy, MaxCol, C->cy);
-	break;
-    case 'L':			/* insert line */
-	ScrollDown(C, C->cy);
-	break;
-    case 'M':			/* remove line */
-	ScrollUp(C, C->cy);
-	break;
-    case '/':			/* Remove echo for identify response */
-    case 'Y':			/* cursor move */
-	C->tmp = c;
-	C->fsm = esc_YS;
-	break;
-    case 'Z':			/* identify as VT52 */
-	AddQueue(ESC);
-	AddQueue('/');
-	AddQueue('K');
-    }
-}
-#endif
-
-/* Normal character processing */
-static void std_char(register Console * C, char c)
-{
-    switch(c) {
-    case BEL:
-	bell();
-	break;
-    case '\b':
-	C->XN = 0;
-	if (C->cx > 0) {
-	    --C->cx;
-	    VideoWrite(C, ' ');
-	}
-	break;
-    case '\t':
-	C->cx = (C->cx | 0x07) + 1;
-	goto linewrap;
-    case '\n':
-	C->XN = 0;
-	++C->cy;
-	break;
-    case '\r':
-	C->XN = 0;
-	C->cx = 0;
-	break;
-
-#if defined (CONFIG_EMUL_VT52) || defined (CONFIG_EMUL_ANSI)
-    case ESC:
-	C->fsm = esc_char;
-	break;
-#endif
-
-    default:
-	if (C->XN) {
-	    C->XN = 0;
-	    C->cx = 0;
-	    C->cy++;
-	    if (C->cy > MaxRow) {
-		ScrollUp(C, 0);
-		C->cy = MaxRow;
-	    }
-	}
-	VideoWrite(C, c);
-	C->cx++;
-      linewrap:
-	if (C->cx > MaxCol) {
-
-#ifdef CONFIG_EMUL_VT52
-	    C->cx = MaxCol;
-#else
-	    C->XN = 1;
-	    C->cx = MaxCol;
-#endif
-
-	}
-    }
-    if (C->cy > MaxRow) {
-	ScrollUp(C, 0);
-	C->cy = MaxRow;
-    }
-}
-
-static void WriteChar(register Console * C, char c)
-{
-    /* check for graphics lock */
-    while (glock) {
-	if (glock == C)
-	    return;
-	sleep_on(&glock_wait);
-    }
-    C->fsm(C, c);
-}
-
-void Console_conout(dev_t dev, char Ch)
-{
-    Console *C = &Con[MINOR(dev)];
-
-    if (Ch == '\n')
-	WriteChar(C, '\r');
-    WriteChar(C, Ch);
-    PositionCursor(C);
-}
+/* shared console routines*/
+#include "console.c"
 
 /* This also tells the keyboard driver which tty to direct it's output to...
  * CAUTION: It *WILL* break if the console driver doesn't get tty0-X.
@@ -495,80 +165,13 @@ void Console_conout(dev_t dev, char Ch)
 
 void Console_set_vc(unsigned int N)
 {
-    if ((N >= NumConsoles)
-	|| (Visible == &Con[N])
-	|| (glock))
+    if ((N >= NumConsoles) || (Visible == &Con[N]) || glock)
 	return;
     Visible = &Con[N];
 
     SetDisplayPage(Visible);
     PositionCursor(Visible);
     Current_VCminor = (int) N;
-}
-
-static int Console_ioctl(struct tty *tty, int cmd, char *arg)
-{
-    register Console *C = &Con[tty->minor];
-
-    switch (cmd) {
-    case DCGET_GRAPH:
-	if (!glock) {
-	    glock = C;
-	    return 0;
-	}
-	return -EBUSY;
-    case DCREL_GRAPH:
-	if (glock == C) {
-	    glock = NULL;
-	    wake_up(&glock_wait);
-	    return 0;
-	}
-	break;
-    case DCSET_KRAW:
-	if (glock == C) {
-	    kraw = 1;
-	    return 0;
-	}
-	break;
-    case DCREL_KRAW:
-	if ((glock == C) && (kraw == 1)) {
-	    kraw = 0;
-	    return 1;
-	}
-	break;
-    case TCSETS:
-    case TCSETSW:
-    case TCSETSF:
-	return 0;
-    }
-
-    return -EINVAL;
-}
-
-static int Console_write(register struct tty *tty)
-{
-    register Console *C = &Con[tty->minor];
-    int cnt = 0;
-
-    while ((tty->outq.len > 0) && !glock) {
-	WriteChar(C, (char)tty_outproc(tty));
-	cnt++;
-    }
-    if (C == Visible)
-	PositionCursor(C);
-    return cnt;
-}
-
-static void Console_release(struct tty *tty)
-{
-    ttystd_release(tty);
-}
-
-static int Console_open(register struct tty *tty)
-{
-    if (tty->minor >= NumConsoles)
-	return -ENODEV;
-    return ttystd_open(tty);
 }
 
 struct tty_ops dircon_ops = {

--- a/elks/arch/i86/drivers/char/xt_key.c
+++ b/elks/arch/i86/drivers/char/xt_key.c
@@ -34,6 +34,7 @@
 #ifdef CONFIG_CONSOLE_DIRECT
 
 extern struct tty ttys[];
+extern void AddQueue(unsigned char Key);
 
 #define ESC 27
 #define KB_SIZE 64
@@ -106,17 +107,6 @@ static unsigned char *scan_tabs[] = {
     xtkb_scan_caps,	/*mode = 2*/
     xtkb_scan_ctrl_alt,	/*mode = 3*/
 };
-
-/* Ack.  We can't add a character until the queue's ready
- */
-
-void AddQueue(unsigned char Key)
-{
-    register struct tty *ttyp = &ttys[Current_VCminor];
-
-    if (!tty_intcheck(ttyp, Key))
-	chq_addch(&ttyp->inq, Key);
-}
 
 /*************************************************************************
  * Queue for input received but not yet read by the application. SA 1996 *
@@ -223,8 +213,8 @@ void keyboard_irq(int irq, struct pt_regs *regs, void *dev_id)
     /* F11 and F12 function keys need 89 byte table like keys-de.h */
     /* function keys are not posix standard here */
     
-	//if (ModeState & ALT) {	/* AltF1-F3 are console switch*/
-	if (code <= 0x3D) {		/* F1-F3 are console switch*/
+	/* AltF1-F3 are console switch*/
+	if ((ModeState & ALT) || code <= 0x3D) {/* temp console switch on F1-F3*/
 	    Console_set_vc((unsigned) (code - 0x3B));
 	    return;
 	}


### PR DESCRIPTION
Brings BIOS console completely up-to-date with all direct console enhancements by de-duplicating all shared code into a new file console.c. 

BIOS console now operates well with `vi`, `kilo`, `sh` w/linenoise, etc.

Note: Direct and BIOS keyboards operate quite differently, with direct console supporting international keymaps, and is quite a bit faster. Not all function/arrow/special keys are supported with BIOS console. Use of direct console is recommended.

There is no code in ELKS keyboard drivers that operate the keyboard LEDs.