### PR TITLE
[cmds] Cleanup termios handling in various applications

### DIFF
--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -197,8 +197,11 @@ void tty_release(struct inode *inode, struct file *file)
 
     /* don't release pgrp for /dev/tty, only real tty*/
     if (current->pid == rtty->pgrp) {
-	debug_tty("TTY release pgrp %d, sending SIGHUP\n", current->pid);
-	kill_pg(rtty->pgrp, SIGHUP, 1);
+	debug_tty("TTY release pgrp %d\n", current->pid);
+	if ((int)rtty->termios.c_cflag & HUPCL) {	/* warning truncated to 16 bits*/
+		debug_tty("TTY sending SIGHUP\n", current->pid);
+		kill_pg(rtty->pgrp, SIGHUP, 1);
+	}
 	rtty->pgrp = 0;
     }
     rtty->flags &= ~TTY_OPEN;

--- a/elkscmd/ktcp/slip.c
+++ b/elkscmd/ktcp/slip.c
@@ -102,13 +102,13 @@ int slip_init(char *fdev, speed_t baudrate)
     /* Setup the tty
      */
     ioctl(devfd, TCGETS, &tios);
-    tios.c_lflag &= ~(ICANON|ECHO|ECHOE);
+    tios.c_lflag &= ~(ISIG | ICANON | ECHO | ECHOE);
     tios.c_oflag &= ~ONLCR;
     if (baud)
 	tios.c_cflag = baud;
     tios.c_cflag |= CS8 | CREAD;
-    tios.c_cflag |= CLOCAL;
-    /*tios.c_cflag |= CRTSCTS;*/
+    tios.c_cflag |= CLOCAL;	/* ignore modem control lines*/
+    //tios.c_cflag |= CRTSCTS;	/* hw flow control*/
     tios.c_cc[VMIN] = 255;	/* try for max 255 byte reads*/
     tios.c_cc[VTIME] = 1;	/* 100ms intercharacter timeout*/
     ioctl(devfd, TCSETS, &tios);

--- a/elkscmd/nano-X/drivers/mou_ser.c
+++ b/elkscmd/nano-X/drivers/mou_ser.c
@@ -21,6 +21,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <string.h>
 #include "../device.h"
 
 #define TERMIOS		1	/* set to use termios serial port control*/
@@ -169,7 +170,7 @@ MOU_Open(MOUSEDEVICE *pmd)
 	termios.c_lflag &= ~(ECHO | ECHONL | ICANON | IEXTEN | ISIG);
 	termios.c_iflag &= ~(ICRNL | INPCK | ISTRIP | IXON | BRKINT | IGNBRK);
 	termios.c_cflag &= ~(CSIZE | PARENB);
-	termios.c_cflag |= CS8;
+	termios.c_cflag |= CS8 | CREAD;
 	termios.c_cc[VMIN] = 0;
 	termios.c_cc[VTIME] = 0;
 	if(tcsetattr(mouse_fd, TCSAFLUSH, &termios) < 0)

--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -11,7 +11,7 @@ include $(BASEDIR)/Make.rules
 ###############################################################################
 
 # clock enabled and has direct I/O port access
-# knl removed as useless
+# knl, insmod removed as useless
 # exitemu disabled because it calls INT directly to DOSEMU
 PRGS = \
 	init \

--- a/elkscmd/sys_utils/getty.c
+++ b/elkscmd/sys_utils/getty.c
@@ -262,9 +262,10 @@ int main(int argc, char **argv)
         termios.c_oflag &= ~XTABS;
         if (baud)
             termios.c_cflag = baud;
-        termios.c_cflag |= CS8 | CLOCAL | HUPCL;
-        /*termios.c_cflag |= CRTSCTS;*/
-        termios.c_cflag &= ~(PARENB | CREAD);
+        termios.c_cflag &= ~PARENB;
+        termios.c_cflag |= CS8 | CREAD | HUPCL;
+        termios.c_cflag |= CLOCAL;			/* ignore modem control lines*/
+        //termios.c_cflag |= CRTSCTS;		/* hw flow control*/
         termios.c_cc[VMIN] = 1;
         termios.c_cc[VTIME] = 0;
         tcsetattr(STDIN_FILENO, TCSAFLUSH, &termios);

--- a/elkscmd/sys_utils/sercat.c
+++ b/elkscmd/sys_utils/sercat.c
@@ -58,12 +58,10 @@ int main(int argc, char **argv)
 
 	if (tcgetattr(fd, &org) >= 0) {
 		new = org;
-		new.c_lflag &= ~(ECHO | ECHOE | ECHONL);
-		new.c_lflag &= ~ICANON;
+		new.c_lflag &= ~(ICANON | ISIG | ECHO | ECHOE | ECHONL);
+		new.c_cflag |= CS8 | CREAD;
 		new.c_cc[VMIN] = 255;			/* min bytes to read if VTIME = 0*/
 		new.c_cc[VTIME] = 1;			/* intercharacter timeout if VMIN > 0, timeout if VMIN = 0*/
-		//new.c_cflag = B19200 | CS8;
-        //new.c_cflag |= CRTSCTS;
 		tcsetattr(fd, TCSAFLUSH, &new);
 	} else fprintf(stderr, "Can't set termios\n");
 	signal(SIGINT, sig_handler);

--- a/libc/termios/cfmakeraw.c
+++ b/libc/termios/cfmakeraw.c
@@ -21,7 +21,7 @@ cfmakeraw(struct termios *t)
 	t->c_cc[VTIME] = 1;
 	/* clear some bits with &= ~(bits), set others with |= */
 	t->c_cflag &= ~(CSIZE | PARENB | CSTOPB);
-	t->c_cflag |= (CS8 | HUPCL | CREAD);
+	t->c_cflag |= (CS8 | CREAD);
 	t->c_iflag &= ~(IGNBRK | BRKINT | PARMRK | INPCK | ISTRIP);
 	t->c_iflag &= ~(INLCR | IGNCR | ICRNL | IXON | IXOFF);
 	t->c_iflag |= (BRKINT | IGNPAR);


### PR DESCRIPTION
Cleanup ISIG, CFREAD, CLOCAL and CRTSCTS termios handling in `ktcp` (slip), `mouse`, `sercat`, `miniterm` and Nano-X. Various applications did not turn off ISIG which could cause program aborts or other unwanted kernel actions on received characters matching termios special handling characters.

Cleanup `miniterm`, decrease stack requirements.

Only send SIGHUP on tty close when HUPCL set. (only set by `getty`).

This is the final preparation for slip serial line handling for testing, and using CRTSCTS to turn on hardware flow control when implemented.