### PR TITLE
[cmds] fix ps tty display

### DIFF
--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <fcntl.h>
 #include <string.h>
 
 #include "slip.h"
@@ -156,10 +157,14 @@ usage:
 
     /* become daemon now that tcpdev_inuse race condition over*/
     if (daemon) {
+	int fd;
 	if (fork())
 	    exit(0);
 	close(0);
-	//close(1);		//FIXME required for printf output in -b
+	/* redirect messages to console*/
+	fd = open("/dev/console", O_WRONLY);
+	dup2(fd, 1);		/* required for printf output*/
+	dup2(fd, 2);
     }
 
     arp_init ();


### PR DESCRIPTION
This fixes  `ps` apparently not displaying tty correctly for tty1. Turns out this was not a `ps` bug, but rather `ktcp` kept open file descriptors 1 and 2 for debugging output, and thus held on to the controlling terminal when run at sys.rc time. Since tty's can only have one controlling process group, the subsequent /bin/sh run on tty1 didn't have a controlling tty.

Now, `ktcp` closes its stdout/stderr and opens /dev/console, which fixes the problem. This has the nice side-effect of having ktcp debug information sent to the console which can be redirected with the console command.

Thanks @Mellvik for noticing this!