### PR TITLE
[cmds] Minor bugfixes in sash, /bin/ls

### DIFF
--- a/elkscmd/file_utils/ls.c
+++ b/elkscmd/file_utils/ls.c
@@ -413,7 +413,7 @@ int not_dotdir(char *name)
 int main(int argc, char **argv)
 {
     char  *cp;
-    char  *name;
+    char  *name = argv[0];
     int  flags, recursive, is_dir;
     struct stat statbuf;
     static char *def[] = {".", 0};
@@ -529,7 +529,7 @@ int main(int argc, char **argv)
     return EXIT_SUCCESS;
 
 usage:
-    fprintf(stderr, "usage: %s [-aAdFilrR1] [file1] [file2] ...\n", argv[0]);
+    fprintf(stderr, "usage: %s [-aAdFilrR1] [file1] [file2] ...\n", name);
     fprintf(stderr, "  -a: list all files (including '.' and '..')\n");
     fprintf(stderr, "  -A: list hidden files too\n");
     fprintf(stderr, "  -d: list directory entries instead of contents (not implemented)\n");

--- a/elkscmd/sash/cmds.c
+++ b/elkscmd/sash/cmds.c
@@ -728,7 +728,7 @@ do_setenv(argc, argv)
 		strcat(buf, argv[2]);
 	}
 	if (putenv(buf)) 
-		fprintf(stderr, "usage: setenv VAR=value - value is optional, '=' is required.\n");
+		perror("setenv");
 
 }
 #endif /* CMD_SETENV */


### PR DESCRIPTION
sash: Fixed printenv error message to use perror()

/bin/ls: Usage() listed the erroneous argument as program name.