### PR TITLE
Proposed support for "medium memory model" programs in ELKS kernel

### DIFF
--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -232,11 +232,11 @@ int sys_brk(__pptr newbrk)
             return -ENOMEM;
 		}
     }
-#ifdef CONFIG_EXEC_ELKS
+#ifdef CONFIG_EXEC_LOW_STACK
     if (newbrk > currentp->t_endseg) {
         return -ENOMEM;
     }
-#endif /* CONFIG_EXEC_ELKS */
+#endif /* CONFIG_EXEC_LOW_STACK */
     currentp->t_endbrk = newbrk;
 
     return 0;

--- a/elks/elks-medium.ld
+++ b/elks/elks-medium.ld
@@ -1,0 +1,35 @@
+OUTPUT_FORMAT(elks)
+ENTRY(_start)
+
+SECTIONS {
+	.text 0 : {
+		CREATE_OBJECT_SYMBOLS
+		*(.text .text.*
+		  /*
+		   * Place the text segments from about half the input
+		   * modules into the near text segment.  Let the rest go
+		   * into .fartext .
+		   */
+		  .fartext.f.*0$ .fartext.f.*2$ .fartext.f.*4$ .fartext.f.*6$)
+		. = ALIGN(0x10);
+	}
+	.fartext 0 : AT(0x10000) {
+		*(.fartext .fartext$ .fartext.*)
+		. = ALIGN(0x10);
+	}
+	.data 0 : AT(0x20000) {
+		*(.nildata .nildata.*)
+		*(.rodata .rodata.*)
+		*(.data .data.*)
+		CONSTRUCTORS
+		. = ALIGN(0x10);
+	}
+	.bss : {
+		*(.bss .bss.*)
+		*(COMMON)
+		. = ALIGN(0x10);
+		ASSERT (. + 0x100 <= 0xfff0,
+		    "Error: too large for a medium-model ELKS a.out file.");
+	}
+	/DISCARD/ : { *(*) }
+}

--- a/elks/fs/config.in
+++ b/elks/fs/config.in
@@ -40,6 +40,6 @@ mainmenu_option next_comment
 
 	comment 'Executable file formats'
 
-	bool 'Support ELKS file format'        CONFIG_EXEC_ELKS           y
+	bool 'Support medium memory model'     CONFIG_EXEC_MMODEL         y
 
 endmenu

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -117,7 +117,9 @@ int sys_execve(char *filename, char *sptr, size_t slen)
     segment_s * seg_code;
     segment_s * seg_data;
     lsize_t len;
+#ifdef CONFIG_EXEC_MMODEL
     int need_reloc_code = 1;
+#endif
 
     /* Open the image */
     /*debug1("EXEC: opening file: %s\n", filename);*/

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -160,7 +160,7 @@ int sys_execve(char *filename, char *sptr, size_t slen)
     /* Sanity check it.  */
     if (retval != (int)sizeof(mh) ||
 	(mh.type != MINIX_SPLITID_AHISTORICAL && mh.type != MINIX_SPLITID) ||
-	mh.tseg == 0) {
+	mh.tseg == 0 || mh.version != 0) {
 	debug1("EXEC: bad header, result %u\n", retval);
 	goto error_exec3;
     }
@@ -181,7 +181,7 @@ int sys_execve(char *filename, char *sptr, size_t slen)
     memset(&esuph, 0, sizeof(esuph));
 #endif
 
-    switch ((unsigned) mh.hlen) {
+    switch (mh.hlen) {
     case EXEC_MINIX_HDR_SIZE:
 	break;
 #ifdef CONFIG_EXEC_MMODEL
@@ -202,8 +202,7 @@ int sys_execve(char *filename, char *sptr, size_t slen)
 	    goto error_exec3;
 	if (esuph.msh_trsize % sizeof(struct minix_reloc) != 0 ||
 	    esuph.msh_drsize % sizeof(struct minix_reloc) != 0 ||
-	    esuph.esh_ftrsize % sizeof(struct minix_reloc) != 0 ||
-	    esuph.unused3 != 0 || esuph.unused4 != 0 || esuph.unused5 != 0)
+	    esuph.esh_ftrsize % sizeof(struct minix_reloc) != 0)
 	    goto error_exec3;
 	base_data = esuph.msh_dbase;
 #ifdef CONFIG_EXEC_LOW_STACK

--- a/elks/include/linuxmt/minix.h
+++ b/elks/include/linuxmt/minix.h
@@ -23,11 +23,11 @@ struct minix_exec_hdr {
     unsigned char	hlen;
     unsigned char	reserved1;
     unsigned short	version;
-    unsigned long	tseg;
-    unsigned long	dseg;
-    unsigned long	bseg;
+    unsigned short	tseg, reserved2;
+    unsigned short	dseg, reserved3;
+    unsigned short	bseg, reserved4;
     unsigned long	entry;
-    unsigned long	chmem;
+    unsigned short	chmem, reserved5;
     unsigned long	syms;
 };
 

--- a/elks/include/linuxmt/minix.h
+++ b/elks/include/linuxmt/minix.h
@@ -29,21 +29,18 @@ struct minix_exec_hdr {
     unsigned long	unused2;
 };
 
-struct minix_supl_hdr {
+struct elks_supl_hdr {
+    /* optional fields */
     long		msh_trsize;	/* text relocation size */
     long		msh_drsize;	/* data relocation size */
     long		msh_tbase;	/* text relocation base */
     long		msh_dbase;	/* data relocation base */
-};
-
-#ifdef CONFIG_EXEC_ELKS
-struct elks_supl_hdr {
+    /* even more optional fields --- for ELKS medium memory model support */
     unsigned short	esh_ftseg;	/* far text size */
     unsigned long	esh_ftrsize;	/* far text relocation size */
     unsigned short	unused3;
     unsigned long	unused4, unused5;
 };
-#endif
 
 struct minix_reloc {
     unsigned long	r_vaddr;	/* address of place within section */
@@ -52,17 +49,14 @@ struct minix_reloc {
 };
 
 /* r_type values */
-#ifdef CONFIG_EXEC_ELKS
 #define R_SEGWORD	80
-#endif
 
 /* special r_symndx values */
 #define S_ABS		((unsigned short)-1U)
 #define S_TEXT		((unsigned short)-2U)
 #define S_DATA		((unsigned short)-3U)
 #define S_BSS		((unsigned short)-4U)
-#ifdef CONFIG_EXEC_ELKS
+/* for ELKS medium memory model support */
 #define S_FTEXT		((unsigned short)-5U)
-#endif
 
 #endif

--- a/elks/include/linuxmt/minix.h
+++ b/elks/include/linuxmt/minix.h
@@ -36,4 +36,33 @@ struct minix_supl_hdr {
     long		msh_dbase;	/* data relocation base */
 };
 
+#ifdef CONFIG_EXEC_ELKS
+struct elks_supl_hdr {
+    unsigned short	esh_ftseg;	/* far text size */
+    unsigned long	esh_ftrsize;	/* far text relocation size */
+    unsigned short	unused3;
+    unsigned long	unused4, unused5;
+};
+#endif
+
+struct minix_reloc {
+    unsigned long	r_vaddr;	/* address of place within section */
+    unsigned short	r_symndx;	/* index into symbol table */
+    unsigned short	r_type;		/* relocation type */
+};
+
+/* r_type values */
+#ifdef CONFIG_EXEC_ELKS
+#define R_SEGWORD	80
+#endif
+
+/* special r_symndx values */
+#define S_ABS		((unsigned short)-1U)
+#define S_TEXT		((unsigned short)-2U)
+#define S_DATA		((unsigned short)-3U)
+#define S_BSS		((unsigned short)-4U)
+#ifdef CONFIG_EXEC_ELKS
+#define S_FTEXT		((unsigned short)-5U)
+#endif
+
 #endif

--- a/elks/include/linuxmt/minix.h
+++ b/elks/include/linuxmt/minix.h
@@ -31,10 +31,10 @@ struct minix_exec_hdr {
 
 struct elks_supl_hdr {
     /* optional fields */
-    long		msh_trsize;	/* text relocation size */
-    long		msh_drsize;	/* data relocation size */
-    long		msh_tbase;	/* text relocation base */
-    long		msh_dbase;	/* data relocation base */
+    unsigned long	msh_trsize;	/* text relocation size */
+    unsigned long	msh_drsize;	/* data relocation size */
+    unsigned long	msh_tbase;	/* text relocation base */
+    unsigned long	msh_dbase;	/* data relocation base */
     /* even more optional fields --- for ELKS medium memory model support */
     unsigned short	esh_ftseg;	/* far text size */
     unsigned long	esh_ftrsize;	/* far text relocation size */
@@ -58,5 +58,15 @@ struct minix_reloc {
 #define S_BSS		((unsigned short)-4U)
 /* for ELKS medium memory model support */
 #define S_FTEXT		((unsigned short)-5U)
+
+/* header sizes */
+/* executable with no far text, no relocations */
+#define EXEC_MINIX_HDR_SIZE	sizeof(struct minix_exec_hdr)
+/* executable with relocations, no far text (?) */
+#define SUPL_RELOC_HDR_SIZE	offsetof(struct elks_supl_hdr, esh_ftseg)
+#define EXEC_RELOC_HDR_SIZE	(EXEC_MINIX_HDR_SIZE + SUPL_RELOC_HDR_SIZE)
+/* executable with far text, and optionally relocations */
+#define SUPL_FARTEXT_HDR_SIZE	sizeof(struct elks_supl_hdr)
+#define EXEC_FARTEXT_HDR_SIZE	(EXEC_MINIX_HDR_SIZE + SUPL_FARTEXT_HDR_SIZE)
 
 #endif

--- a/elks/include/linuxmt/minix.h
+++ b/elks/include/linuxmt/minix.h
@@ -20,13 +20,15 @@
 
 struct minix_exec_hdr {
     unsigned long	type;
-    unsigned long	hlen;
+    unsigned char	hlen;
+    unsigned char	reserved1;
+    unsigned short	version;
     unsigned long	tseg;
     unsigned long	dseg;
     unsigned long	bseg;
     unsigned long	entry;
     unsigned long	chmem;
-    unsigned long	unused2;
+    unsigned long	syms;
 };
 
 struct elks_supl_hdr {
@@ -38,8 +40,8 @@ struct elks_supl_hdr {
     /* even more optional fields --- for ELKS medium memory model support */
     unsigned short	esh_ftseg;	/* far text size */
     unsigned long	esh_ftrsize;	/* far text relocation size */
-    unsigned short	unused3;
-    unsigned long	unused4, unused5;
+    unsigned short	esh_reserved1;
+    unsigned long	esh_reserved2, esh_reserved3;
 };
 
 struct minix_reloc {

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -138,7 +138,7 @@ pid_t sys_fork(void)
 
 pid_t sys_vfork(void)
 {
-#ifdef CONFIG_EXEC_ELKS
+#if 1
     return do_fork(0);
 #else
     register __ptask currentp = current;

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -90,13 +90,11 @@ endif
 
 MAINMULTISUBDIR=$(firstword $(subst ;, ,$(MAINMULTI)))
 
-# For now do not build multilibs for the regparmcall calling convention or
-# the medium memory model, as the assembly code in elks-libc does not yet
-# support these.  TODO.  -- tkchia
+# For now do not build multilibs for the regparmcall calling convention, as
+# the assembly code in elks-libc does not yet support it.  TODO.  -- tkchia
 BUILDMULTIS:=$(strip \
     $(foreach ml,$(BUILDMULTIS), \
-	$(if $(findstring @mregparmcall@,$(ml)@)$(findstring \
-			  @mcmodel=medium@,$(ml)@),,$(ml))))
+	$(if $(findstring @mregparmcall@,$(ml)@),,$(ml))))
 ifeq "" "$(BUILDMULTIS)"
 $(error no multilib variants to build for elks-libc)
 endif
@@ -144,9 +142,14 @@ install: $(LIBC)
 	mkdir -p $(DESTDIR)/ia16-elf/lib/$(MULTISUBDIR) \
 		 $(MULTIINCDIR)/asm $(MULTIINCDIR)/sys \
 		 $(MULTIINCDIR)/arch $(MULTIINCDIR)/linuxmt/arpa
+ifeq "" "$(filter -mcmodel=medium,$(MULTILIB))"
 	$(INSTALL_DATA) $(LIBC) $(CRT0) \
 	    $(TOPDIR)/elks/elks-small.ld $(TOPDIR)/elks/elks-tiny.ld \
 	    $(DESTDIR)/ia16-elf/lib/$(MULTISUBDIR)
+else
+	$(INSTALL_DATA) $(LIBC) $(CRT0) $(TOPDIR)/elks/elks-medium.ld \
+	    $(DESTDIR)/ia16-elf/lib/$(MULTISUBDIR)
+endif
 	$(INSTALL_DATA) include/*.h $(TOPDIR)/include/autoconf.h $(MULTIINCDIR)
 	$(INSTALL_DATA) include/asm/*.h $(MULTIINCDIR)/asm
 	$(INSTALL_DATA) include/sys/*.h $(MULTIINCDIR)/sys
@@ -157,6 +160,7 @@ install: $(LIBC)
 uninstall:
 	$(RM) $(DESTDIR)/ia16-elf/lib/$(MULTISUBDIR)/$(notdir $(LIBC)) \
 	      $(DESTDIR)/ia16-elf/lib/$(MULTISUBDIR)/$(notdir $(CRT0)) \
+	      $(DESTDIR)/ia16-elf/lib/$(MULTISUBDIR)/elks-medium.ld \
 	      $(DESTDIR)/ia16-elf/lib/$(MULTISUBDIR)/elks-small.ld \
 	      $(DESTDIR)/ia16-elf/lib/$(MULTISUBDIR)/elks-tiny.ld \
 	      $(MULTIINCDIR)/autoconf.h \

--- a/libc/Makefile.inc
+++ b/libc/Makefile.inc
@@ -4,10 +4,14 @@ VERSION=elks-0.3.0
 INCLUDES=-I$(TOPDIR)/include -I$(TOPDIR)/libc/include -I$(TOPDIR)/elks/include
 DEFINES=-D__LIBC__ -D__LIBC_VER__='"$(VERSION)"' -D__HAS_NO_FLOATS__
 
+INCS=$(INCLUDES)
 SDEFS=$(DEFINES)
 CDEFS=$(DEFINES)
 
-ARCH=-ffreestanding -fno-inline -melks -mcmodel=small -mno-segment-relocation-stuff -mtune=i8086
+ARCH=-ffreestanding -fno-inline -melks -mtune=i8086
+ifeq "" "$(filter -mcmodel=%,$(MULTILIB))"
+ARCH+=-mcmodel=small -mno-segment-relocation-stuff
+endif
 
 CC=ia16-elf-gcc
 AS=ia16-elf-as

--- a/libc/asm/memcpy-s.S
+++ b/libc/asm/memcpy-s.S
@@ -3,6 +3,8 @@
 // void * memcpy (void * dest, const void * src, size_t n);
 //------------------------------------------------------------------------------
 
+#include <libc-private/call-cvt.h>
+
 	.code16
 
 	.text
@@ -25,9 +27,9 @@ memcpy:
 
 	// Do the copy
 
-	mov 4(%bp),%di  // dest
-	mov 6(%bp),%si  // src
-	mov 8(%bp),%cx  // n
+	mov 4+FAR_ADJ_(%bp),%di  // dest
+	mov 6+FAR_ADJ_(%bp),%si  // src
+	mov 8+FAR_ADJ_(%bp),%cx  // n
 
 	cld
 	rep
@@ -42,15 +44,9 @@ memcpy:
 
 	// Return value is destination
 
-	mov 4(%bp),%ax
+	mov 4+FAR_ADJ_(%bp),%ax
 
 	pop %bp
-#ifdef __IA16_CALLCVT_CDECL
-	ret
-#elif defined __IA16_CALLCVT_STDCALL
-	ret $6
-#else
-#error "unknown calling convention"
-#endif
+	RET_(6)
 
 //------------------------------------------------------------------------------

--- a/libc/asm/memset-s.S
+++ b/libc/asm/memset-s.S
@@ -3,6 +3,8 @@
 // void * memset (void * s, int c, size_t n);
 //------------------------------------------------------------------------------
 
+#include <libc-private/call-cvt.h>
+
 	.code16
 
 	.text
@@ -24,9 +26,9 @@ memset:
 
 	// Do the setup
 
-	mov 4(%bp),%di  // s
-	mov 6(%bp),%ax  // c
-	mov 8(%bp),%cx  // n
+	mov 4+FAR_ADJ_(%bp),%di  // s
+	mov 6+FAR_ADJ_(%bp),%ax  // c
+	mov 8+FAR_ADJ_(%bp),%cx  // n
 
 	cld
 	rep
@@ -39,15 +41,9 @@ memset:
 
 	// Return value is destination
 
-	mov 4(%bp),%ax
+	mov 4+FAR_ADJ_(%bp),%ax
 
 	pop %bp
-#ifdef __IA16_CALLCVT_CDECL
-	ret
-#elif defined __IA16_CALLCVT_STDCALL
-	ret $6
-#else
-#error "unknown calling convention"
-#endif
+	RET_(6)
 
 //------------------------------------------------------------------------------

--- a/libc/asm/strcpy-s.S
+++ b/libc/asm/strcpy-s.S
@@ -3,6 +3,8 @@
 // char * strcpy (char * dest, const char * src);
 //------------------------------------------------------------------------------
 
+#include <libc-private/call-cvt.h>
+
 	.code16
 
 	.text
@@ -25,8 +27,8 @@ strcpy:
 
 	// Do the copy
 
-	mov 4(%bp),%di  // dest
-	mov 6(%bp),%si  // src
+	mov 4+FAR_ADJ_(%bp),%di  // dest
+	mov 6+FAR_ADJ_(%bp),%si  // src
 	cld
 
 _loop:
@@ -44,16 +46,10 @@ _loop:
 
 	// Return value is destination
 
-	mov 4(%bp),%ax
+	mov 4+FAR_ADJ_(%bp),%ax
 
 	pop %bp
-#ifdef __IA16_CALLCVT_CDECL
-	ret
-#elif defined __IA16_CALLCVT_STDCALL
-	ret $4
-#else
-#error "unknown calling convention"
-#endif
+	RET_(4)
 
 //------------------------------------------------------------------------------
 

--- a/libc/asm/strlen-s.S
+++ b/libc/asm/strlen-s.S
@@ -3,6 +3,8 @@
 // size_t strlen (const char * s);
 //------------------------------------------------------------------------------
 
+#include <libc-private/call-cvt.h>
+
 	.code16
 
 	.text
@@ -24,7 +26,7 @@ strlen:
 
 	// Do the scan
 
-	mov 4(%bp),%di  // s
+	mov 4+FAR_ADJ_(%bp),%di  // s
 	mov $-1,%cx
 	xor %ax,%ax
 
@@ -42,13 +44,7 @@ strlen:
 	mov %dx,%es
 
 	pop %bp
-#ifdef __IA16_CALLCVT_CDECL
-	ret
-#elif defined __IA16_CALLCVT_STDCALL
-	ret $2
-#else
-#error "unknown calling convention"
-#endif
+	RET_(2)
 
 //------------------------------------------------------------------------------
 

--- a/libc/crt0.S
+++ b/libc/crt0.S
@@ -1,6 +1,8 @@
 // C runtime bootstrap
 // This must be the first module of the executable
 
+#include <libc-private/call-cvt.h>
+
 	.code16
 
 	.text
@@ -29,12 +31,12 @@ _start:
 	push %ax
 	push %bx
 	push %cx
-	call main
+	CALL_(main)
 #ifdef __IA16_CALLCVT_CDECL
 	add $6,%sp
 #endif
 	push %ax  // main return value
-	call exit  // no return
+	CALL_N_(exit)  // no return
 	int $3
 
 	.global exit
@@ -42,14 +44,22 @@ _start:
 exit:
 	push %bp
 	mov %sp,%bp
+#if defined __MEDIUM__ || defined __LARGE__ || defined __HUGE__
+	mov $_cleanup,%si
+	mov (%si),%bx
+	or 2(%si),%bx
+	jz _exit_end
+	lcallw *(%si)
+#else
 	mov _cleanup,%bx
 	or %bx,%bx
 	jz _exit_end
 	call *%bx
+#endif
 
 _exit_end:
-	push 4(%bp)  // exit code
-	call _exit  // kernel one - no return
+	push 4+FAR_ADJ_(%bp)  // exit code
+	CALL_(_exit)  // kernel one - no return
 	int $3
 
 	.data

--- a/libc/include/libc-private/call-cvt.h
+++ b/libc/include/libc-private/call-cvt.h
@@ -1,0 +1,33 @@
+/* Internal macros to bridge differences between various calling conventions */
+
+#ifndef _LIBC_PRIVATE_CALL_CVT_H
+#define _LIBC_PRIVATE_CALL_CVT_H
+
+#if defined __MEDIUM__ || defined __LARGE__ || defined __HUGE__
+/* Adjustment to stack frame offsets to account for far return addresses */
+# define FAR_ADJ_	2
+/* How to return from a subroutine with N bytes of arguments */
+# ifdef __IA16_CALLCVT_STDCALL
+#   define RET_(n)	.if (n); lret $(n); .else; lret; .endif
+# elif defined __IA16_CALLCVT_CDECL
+#   define RET_(n)	lret
+# else
+#   error "unknown calling convention!"
+# endif
+/* How to call a subroutine of the same code far-ness in the (same) near text
+   segment */
+# define CALL_N_(s)	pushw %cs; call s
+/* How to call a subroutine which may be in a different text segment */
+# define CALL_(s)	.reloc .+3, R_386_OZSEG16, (s); lcall $0, $(s)
+#else
+# define FAR_ADJ_	0
+# ifdef __IA16_CALLCVT_STDCALL
+#   define RET_(n)	.if (n); ret $(n); .else; ret; .endif
+# else
+#   define RET_(n)	ret
+# endif
+# define CALL_N_(s)	call s
+# define CALL_(s)	call s
+#endif
+
+#endif

--- a/libc/include/setjmp.h
+++ b/libc/include/setjmp.h
@@ -11,6 +11,9 @@
 typedef struct
 {
    unsigned int pc;
+#if defined __MEDIUM__ || defined __LARGE__ || defined __HUGE__
+   unsigned int cs;
+#endif
    unsigned int sp;
    unsigned int bp;
    unsigned int si;

--- a/libc/system/setjmp.S
+++ b/libc/system/setjmp.S
@@ -1,3 +1,4 @@
+#include <libc-private/call-cvt.h>
 
 	.code16
 
@@ -8,6 +9,9 @@
 _setjmp:
 
 	pop %cx  // PC
+#if defined __MEDIUM__ || defined __LARGE__ || defined __HUGE__
+	pop %dx  // CS
+#endif
 #ifdef __IA16_CALLCVT_CDECL
 	mov %sp,%bx
 	mov (%bx),%bx  // TOS is prt -> env
@@ -18,14 +22,23 @@ _setjmp:
 #endif
 
 	mov %cx,0(%bx)  // PC
-	mov %sp,2(%bx)  // This registers are all that may be constant.
-	mov %bp,4(%bx)
-	mov %si,6(%bx)  // SI, DI & ES must be saved for GCC
-	mov %di,8(%bx)
-	mov %es,10(%bx)
+#if defined __MEDIUM__ || defined __LARGE__ || defined __HUGE__
+	mov %dx,2(%bx)  // CS
+#endif
+	mov %sp,2+FAR_ADJ_(%bx) // This registers are all that may be constant.
+	mov %bp,4+FAR_ADJ_(%bx)
+	mov %si,6+FAR_ADJ_(%bx) // SI, DI & ES must be saved for GCC
+	mov %di,8+FAR_ADJ_(%bx)
+	mov %es,10+FAR_ADJ_(%bx)
 
 	xor %ax,%ax
+#if defined __MEDIUM__ || defined __LARGE__ || defined __HUGE__
+	push %dx
+	push %cx
+	lret
+#else
 	jmp *%cx
+#endif
 
 
 	.global _longjmp
@@ -33,14 +46,26 @@ _setjmp:
 _longjmp:
 
 	pop %cx  // PC
+#if defined __MEDIUM__ || defined __LARGE__ || defined __HUGE__
+	pop %dx  // CS
+#endif
 	pop %bx  // env->
 	pop %ax  // rv
 
 	mov 0(%bx),%cx  // PC
-	mov 2(%bx),%sp
-	mov 4(%bx),%bp
-	mov 6(%bx),%si
-	mov 8(%bx),%di
-	mov 10(%bx),%es
+#if defined __MEDIUM__ || defined __LARGE__ || defined __HUGE__
+	mov 2(%bx),%dx  // CS
+#endif
+	mov 2+FAR_ADJ_(%bx),%sp
+	mov 4+FAR_ADJ_(%bx),%bp
+	mov 6+FAR_ADJ_(%bx),%si
+	mov 8+FAR_ADJ_(%bx),%di
+	mov 10+FAR_ADJ_(%bx),%es
 
+#if defined __MEDIUM__ || defined __LARGE__ || defined __HUGE__
+	push %dx
+	push %cx
+	lret
+#else
 	jmp *%cx
+#endif

--- a/libc/system/syscall0.S
+++ b/libc/system/syscall0.S
@@ -1,6 +1,8 @@
 // Actual system calls
 // Must be consistent with kernel system entry
 
+#include <libc-private/call-cvt.h>
+
 	.code16
 
 	.text
@@ -24,35 +26,35 @@ _syscall_test:
 	mov    $-1,%ax
 
 _syscall_ok:
-	ret
+	RET_(0)
 
 #ifdef __IA16_CALLCVT_CDECL
 _syscall_1:
 	mov    %sp,%bx
-	mov    2(%bx),%bx
+	mov    2+FAR_ADJ_(%bx),%bx
 	jmp    _syscall_0
 
 _syscall_2:
 	mov    %sp,%bx
-	mov    4(%bx),%cx
-	mov    2(%bx),%bx
+	mov    4+FAR_ADJ_(%bx),%cx
+	mov    2+FAR_ADJ_(%bx),%bx
 	jmp    _syscall_0
 
 _syscall_3:
 _syscall_2p:
 	mov    %sp,%bx
-	mov    6(%bx),%dx
-	mov    4(%bx),%cx
-	mov    2(%bx),%bx
+	mov    6+FAR_ADJ_(%bx),%dx
+	mov    4+FAR_ADJ_(%bx),%cx
+	mov    2+FAR_ADJ_(%bx),%bx
 	jmp    _syscall_0
 
 _syscall_4:
 	mov    %sp,%bx
 	push   %di
-	mov    8(%bx),%di
-	mov    6(%bx),%dx
-	mov    4(%bx),%cx
-	mov    2(%bx),%bx
+	mov    8+FAR_ADJ_(%bx),%di
+	mov    6+FAR_ADJ_(%bx),%dx
+	mov    4+FAR_ADJ_(%bx),%cx
+	mov    2+FAR_ADJ_(%bx),%bx
 	int    $0x80
 	pop    %di
 	jmp    _syscall_test
@@ -60,72 +62,89 @@ _syscall_4:
 _syscall_5:
 	mov    %sp,%bx
 	push   %si
-	mov    10(%bx),%si
+	mov    10+FAR_ADJ_(%bx),%si
 	push   %di
-	mov    8(%bx),%di
-	mov    6(%bx),%dx
-	mov    4(%bx),%cx
-	mov    2(%bx),%bx
+	mov    8+FAR_ADJ_(%bx),%di
+	mov    6+FAR_ADJ_(%bx),%dx
+	mov    4+FAR_ADJ_(%bx),%cx
+	mov    2+FAR_ADJ_(%bx),%bx
 	int    $0x80
 	pop    %di
 	pop    %si
 	jmp    _syscall_test
 #elif defined __IA16_CALLCVT_STDCALL
 _syscall_1:
+# if defined __MEDIUM__ || defined __LARGE__ || defined __HUGE__
+	pop %dx
+	pop %cx
+	pop %bx
+	push %cx
+	push %dx
+# else
 	pop %dx
 	pop %bx
 	push %dx
+# endif
 	jmp _syscall_0
 
 _syscall_2:
+# if defined __MEDIUM__ || defined __LARGE__ || defined __HUGE__
+	mov %sp,%bx
+	mov 6(%bx),%cx
+	mov 4(%bx),%bx
+	pushw %cs
+	call _syscall_0
+	RET_(4)
+# else
 	pop %dx
 	pop %bx
 	pop %cx
 	push %dx
 	jmp _syscall_0
+# endif
 
 _syscall_2p:
 	/* variadic function, callee must not pop any arguments */
 	mov %sp,%bx
-	mov 6(%bx),%dx
-	mov 4(%bx),%cx
-	mov 2(%bx),%bx
+	mov 6+FAR_ADJ_(%bx),%dx
+	mov 4+FAR_ADJ_(%bx),%cx
+	mov 2+FAR_ADJ_(%bx),%bx
 	jmp _syscall_0
 
 _syscall_3:
 	mov %sp,%bx
-	mov 6(%bx),%dx
-	mov 4(%bx),%cx
-	mov 2(%bx),%bx
-	call _syscall_0
-	ret $6
+	mov 6+FAR_ADJ_(%bx),%dx
+	mov 4+FAR_ADJ_(%bx),%cx
+	mov 2+FAR_ADJ_(%bx),%bx
+	CALL_N_(_syscall_0)
+	RET_(6)
 
 _syscall_4:
 	mov %sp,%bx
 	push %di
-	mov 8(%bx),%di
-	mov 6(%bx),%dx
-	mov 4(%bx),%cx
-	mov 2(%bx),%bx
-	call _syscall_0
+	mov 8+FAR_ADJ_(%bx),%di
+	mov 6+FAR_ADJ_(%bx),%dx
+	mov 4+FAR_ADJ_(%bx),%cx
+	mov 2+FAR_ADJ_(%bx),%bx
+	CALL_N_(_syscall_0)
 	pop %di
-	ret $8
+	RET_(8)
 
 _syscall_5:
 	mov %sp,%bx
 	push %si
-	mov 10(%bx),%si
+	mov 10+FAR_ADJ_(%bx),%si
 	push %di
-	mov 8(%bx),%di
-	mov 6(%bx),%dx
-	mov 4(%bx),%cx
-	mov 2(%bx),%bx
-	call _syscall_0
+	mov 8+FAR_ADJ_(%bx),%di
+	mov 6+FAR_ADJ_(%bx),%dx
+	mov 4+FAR_ADJ_(%bx),%cx
+	mov 2+FAR_ADJ_(%bx),%bx
+	CALL_N_(_syscall_0)
 	pop %di
 	pop %si
-	ret $10
+	RET_(10)
 #else
-#error "unknown calling convention"
+# error "unknown calling convention"
 #endif
 
 //-----------------------------------------------------------------------------
@@ -149,9 +168,15 @@ _syscall_signal:
 
 	mov 6(%bp),%bx
 	push %bx
+#if defined __MEDIUM__ || defined __LARGE__ || defined __HUGE__
+	add %bx,%bx
+	add %bx,%bx
+	lcallw *_sigtable-4(%bx)  // offset by 4 because no entry for signal 0
+#else
 	add %bx,%bx
 	mov	_sigtable-2(%bx),%bx  // offset by 2 because no entry for signal 0
 	call *%bx
+#endif
 #ifdef __IA16_CALLCVT_CDECL
 	inc %sp
 	inc %sp
@@ -176,7 +201,7 @@ _syscall_signal:
 breakpoint:
 
 	int $3
-	ret
+	RET_(0)
 
 //------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR adds initial support for some form of "medium memory model" `a.out` programs to the ELKS kernel.

The format for such programs is (sort of) documented in the updated `elks/include/linuxmt/minix.h` file.  It adds optional fields to the `a.out` header to allow a 64 KiB "far text" section, in addition to the existing near text, data, and BSS sections.  Segment relocations are 8 bytes each, per Minix's documented relocation format.

I also bumped up the `gcc-ia16` toolchain version and added a linker script, to allow experimenting with writing programs for this new format.

This is a follow-up on https://github.com/tkchia/build-ia16/issues/14 .

Thank you!