### PR TITLE
[ktcp] Major ktcp overhaul, fix telnetd

### DIFF
--- a/elks/arch/i86/drivers/net/eth-main.c
+++ b/elks/arch/i86/drivers/net/eth-main.c
@@ -296,25 +296,25 @@ void eth_drv_init ()
 		err = ne2k_probe ();
 		if (err)
 			{
-			printk ("[ne2k] not detected @ IO 300h\n");
+			printk ("eth: NE2K not detected\n");
 			break;
 			}
 
 		err = request_irq (NE2K_IRQ, ne2k_int, NULL);
 		if (err)
 			{
-			printk ("[ne2k] IRQ 9 request error: %i\n", err);
+			printk ("eth: NE2K IRQ %d request error: %i\n", NE2K_IRQ, err);
 			break;
 			}
 
 		err = register_chrdev (ETH_MAJOR, "eth", &eth_fops);
 		if (err)
 			{
-			printk ("[eth] register error: %i\n", err);
+			printk ("eth: register error: %i\n", err);
 			break;
 			}
 
-		printk ("[eth] NE2K driver OK\n");
+		printk ("eth: NE2K at 0x%x, irq %d\n", NE2K_PORT, NE2K_IRQ);
 		break;
 		}
 	}

--- a/elks/include/arch/ports.h
+++ b/elks/include/arch/ports.h
@@ -98,7 +98,7 @@
 /* ne2k, eth-main.c*/
 #define io_ne2k_command 0x0300		/* FIXME needs to be included in ne2k-mac.s*/
 #define NE2K_IRQ	9
-
+#define NE2K_PORT	0x300
 
 /* obsolete - experimental IDE hard drive, directhd.c (broken)*/
 #define HD1_PORT	0x1f0

--- a/elkscmd/ash/linenoise_elks.c
+++ b/elkscmd/ash/linenoise_elks.c
@@ -280,8 +280,8 @@ static int enableRawMode(int fd) {
     /* input modes: no break, no CR to NL, no parity check, no strip char,
      * no start/stop output control. */
     raw.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
-    /* output modes - disable post processing */
-    raw.c_oflag &= ~(OPOST);
+    /* output modes - don't disable post processing (for kernel printk when running)*/
+    /*raw.c_oflag &= ~(OPOST);*/
     /* control modes - set 8 bit chars */
     raw.c_cflag |= (CS8);
     /* local modes - echo nothing, canonical off, no extended functions,

--- a/elkscmd/inet/httpd/Makefile
+++ b/elkscmd/inet/httpd/Makefile
@@ -13,6 +13,7 @@ include $(BASEDIR)/Make.rules
 PRG=httpd
 
 LOCALFLAGS=-I$(ELKSCMD_DIR)
+LDFLAGS += -maout-chmem=0x1100
 
 all: $(PRG)
 

--- a/elkscmd/inet/nettools/netstat.c
+++ b/elkscmd/inet/nettools/netstat.c
@@ -84,7 +84,7 @@ int main(void)
     write(s, &sr, sizeof(sr));	
     ret = read(s, buf, sizeof(buf));
     gstats = buf;	
-    printf("Retransmition memory     : %d bytes\n", gstats->retrans_memory);
+    printf("Retransmit memory        : %d bytes\n", gstats->retrans_memory);
     printf("Number of control blocks : %d\n\n", gstats->cb_num);
 
     printf(" no        State    RTT lport        raddress  rport\n");
@@ -99,7 +99,7 @@ int main(void)
 		addrbytes = (__u8 *)&cbstats->remaddr;
 		sprintf(addr,"%d.%d.%d.%d",addrbytes[0],addrbytes[1],addrbytes[2],addrbytes[3]);
 		printf("%3d %12s %4dms", i+1, tcp_states[cbstats->state], cbstats->rtt);
-		printf(" %5d %15s  %5d\n", cbstats->localport, addr, cbstats->remport);
+		printf(" %5u %15s  %5u\n", cbstats->localport, addr, cbstats->remport);
     }
 }
 

--- a/elkscmd/inet/telnet/ttn.c
+++ b/elkscmd/inet/telnet/ttn.c
@@ -205,7 +205,7 @@ int main(int argc, char *argv[])
 	remadr.sin_port = htons( port );
 	remadr.sin_addr.s_addr = in_aton(argv[1]);
 
-	printf("Connecting to %s port %u\n",argv[1], port);
+	printf("Connecting to %s (%lx) port %u\n",argv[1], in_aton(argv[1]), port);
 	ret = connect(tcp_fd, (struct sockaddr *)&remadr,
     			sizeof(struct sockaddr_in));
 	if (ret < 0){

--- a/elkscmd/inet/telnetd/Makefile
+++ b/elkscmd/inet/telnetd/Makefile
@@ -12,8 +12,9 @@ include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
-SRCS = telnetd.c
+SRCS = telnetd.c telnet.c
 OBJS = $(SRCS:.c=.o) 
+LDFLAGS += -maout-chmem=0x1100
 
 all:	telnetd
 

--- a/elkscmd/inet/telnetd/telnet.c
+++ b/elkscmd/inet/telnetd/telnet.c
@@ -15,7 +15,6 @@
 #include <errno.h>
 #include <unistd.h>
 #include <termios.h>
-#include "telnetd.h"
 #include "telnet.h"
 #include <stdio.h>
 #include <sys/ioctl.h>

--- a/elkscmd/inet/telnetd/telnet.c
+++ b/elkscmd/inet/telnetd/telnet.c
@@ -1,0 +1,337 @@
+/*
+ * TNET		A server program for MINIX which implements the TCP/IP
+ *		suite of networking protocols.  It is based on the
+ *		TCP/IP code written by Phil Karn et al, as found in
+ *		his NET package for Packet Radio communications.
+ *
+ *		This module handles telnet option processing.
+ *
+ * Author:	Michael Temari, <temari@temari.ae.ge.com>  01/13/93
+ *
+ */
+#include <sys/types.h>
+#include <string.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <unistd.h>
+#include <termios.h>
+#include "telnetd.h"
+#include "telnet.h"
+#include <stdio.h>
+#include <sys/ioctl.h>
+
+
+#define	IN_DATA	0
+#define	IN_CR	1
+#define	IN_IAC	2
+#define	IN_IAC2	3
+#define IN_SB	4
+
+static void dowill(int c);
+static void dowont(int c);
+static void dodo(int c);
+static void dodont(int c);
+static void respond(int ack, int option);
+static void respond_really(int ack, int option);
+
+#define	LASTTELOPT	TELOPT_SGA
+
+static int r_winch = 0;
+
+static int TelROpts[LASTTELOPT+1];
+static int TelLOpts[LASTTELOPT+1];
+
+static int telfdout;
+
+void tel_init()
+{
+int i;
+
+   for(i = 0; i <= LASTTELOPT; i++) {
+	TelROpts[i] = 0;
+	TelLOpts[i] = 0;
+   }
+}
+
+void telopt(fdout, what, option)
+int fdout;
+int what;
+int option;
+{
+char buf[3];
+int len;
+
+   buf[0] = IAC;
+   buf[1] = what;
+   buf[2] = option;
+   len = 0;
+
+   switch(what) {
+	case DO:
+		if(option <= LASTTELOPT) {
+			TelROpts[option] = 1;
+			len = 3;
+		} else if(option == TELOPT_WINCH && !r_winch) { r_winch = 1; len = 3; } 
+		break;
+	case DONT:
+		if(option <= LASTTELOPT) {
+			TelROpts[option] = 1;
+			len = 3;
+		}
+		break;
+	case WILL:
+		if(option <= LASTTELOPT) {
+			TelLOpts[option] = 1;
+			len = 3;
+		}
+		break;
+	case WONT:
+		if(option <= LASTTELOPT) {
+			TelLOpts[option] = 1;
+			len = 3;
+		}
+		break;
+   }
+   if(len > 0)
+	(void) write(fdout, buf, len);
+}
+
+void set_winsize(int fd, unsigned int cols, unsigned int rows)
+{
+	struct winsize w;
+	memset(&w, 0, sizeof(w));
+	w.ws_col = cols;
+	w.ws_row = rows;
+	ioctl(fd, TIOCSWINSZ, (char *) &w);
+}
+
+void tel_in(fdout, telout, buffer, len)
+int fdout;
+int telout;
+char *buffer;
+int len;
+{
+static int InState = IN_DATA;
+static int ThisOpt = 0;
+char *p;
+char *p2;
+int size;
+int c;
+
+   telfdout = telout;
+   p = p2 = buffer;
+   size = 0;
+
+   while(len > 0) {
+   	c = (unsigned char)*p++; len--;
+	switch(InState) {
+   		case IN_CR:
+   			InState = IN_DATA;
+   			if(c == 0 || c == '\n')
+   				break;
+   			/* fall through */
+   		case IN_DATA:
+   			if(c == IAC) {
+   				InState = IN_IAC;
+   				break;
+   			}
+   			*p2++ = c; size++;
+   			if(c == '\r') InState = IN_CR;
+   			break;
+   		case IN_IAC:
+   			switch(c) {
+   				case IAC:
+	   				*p2++ = c; size++;
+   					InState = IN_DATA;
+   					break;
+   				case WILL:
+   				case WONT:
+   				case DO:
+   				case DONT:
+   					InState = IN_IAC2;
+   					ThisOpt = c;
+   					break;
+   				case SB:
+   				 	InState = IN_SB; 
+   					break;
+   				case EOR:
+   				case SE:
+   				case NOP:
+   				case BREAK:
+   				case IP:
+   				case AO:
+   				case AYT:
+   				case EC:
+   				case EL:
+   				case GA:
+   					break;
+   				default:
+   					break;
+   			}
+   			break;
+   		case IN_IAC2:
+   			if(size > 0) {
+   				write(fdout, buffer, size);
+   				p2 = buffer;
+   				size = 0;
+   			}
+   			InState = IN_DATA;
+   			switch(ThisOpt) {
+   				case WILL:	dowill(c);	break;
+   				case WONT:	dowont(c);	break;
+   				case DO:	dodo(c);	break;
+   				case DONT:	dodont(c);	break;
+   			}
+   			break;
+   		case IN_SB:
+ 		{
+			static int winchpos = -1;
+   			/* Subnegotiation. */
+   			if(winchpos >= 0) {
+				static unsigned int winchbuf[5], iacs = 0;
+   				winchbuf[winchpos] = c;
+   				/* IAC is escaped - unescape it. */
+   				if(c == IAC) iacs++; else { iacs = 0; winchpos++; }
+   				if(iacs == 2) { winchpos++; iacs = 0; }
+   				if(winchpos >= 4) {
+   					/* End of WINCH data. */
+   					set_winsize(fdout,
+   					(winchbuf[0] << 8) | winchbuf[1],
+   					(winchbuf[2] << 8) | winchbuf[3]);
+   					winchpos = -1;
+   				}
+   			} else {
+				static int lastiac = 0;
+	   			switch(c) {
+   					case TELOPT_WINCH:
+   						/* Start listening. */
+   						winchpos = 0;
+   						break;
+   					case SE:
+   						if(lastiac) InState = IN_DATA;
+   						break;
+   					default:
+   						break;
+   				}
+   				if(c == IAC) lastiac = 1;
+   				else lastiac = 0;
+
+
+   			}
+   			break;
+   		}
+   	}
+   }
+
+   if(size > 0)
+   	write(fdout, buffer, size);
+}
+
+void tel_out(fdout, buf, size)
+int fdout;
+char *buf;
+int size;
+{
+char *p;
+int got_iac, len;
+
+   p = buf;
+   while(size > 0) {
+	buf = p;
+	got_iac = 0;
+	if((p = (char *)memchr(buf, IAC, size)) != (char *)NULL) {
+		got_iac = 1;
+		p++;
+	} else
+		p = buf + size;
+	len = p - buf;
+	if(len > 0)
+		(void) write(fdout, buf, len);
+	if(got_iac)
+		(void) write(fdout, p - 1, 1);
+	size = size - len;
+   }
+}
+
+static void dowill(c)
+int c;
+{
+int ack;
+
+   switch(c) {
+	case TELOPT_BINARY:
+	case TELOPT_ECHO:
+	case TELOPT_SGA:
+		if(TelROpts[c] == 1)
+			return;
+		TelROpts[c] = 1;
+		ack = DO;
+		break;
+	case TELOPT_WINCH:
+		if(r_winch) return;
+		r_winch = 1;
+		ack = DO;
+ 		respond_really(ack, c); 
+		return;
+	default:
+		ack = DONT;
+   }
+
+   respond(ack, c);
+}
+
+static void dowont(c)
+int c;
+{
+   if(c <= LASTTELOPT) {
+	if(TelROpts[c] == 0)
+		return;
+	TelROpts[c] = 0;
+   }
+   respond(DONT, c);
+}
+
+static void dodo(c)
+int c;
+{
+int ack;
+
+   switch(c) {
+	default:
+		ack = WONT;
+   }
+   respond(ack, c);
+}
+
+static void dodont(c)
+int c;
+{
+   if(c <= LASTTELOPT) {
+	if(TelLOpts[c] == 0)
+		return;
+	TelLOpts[c] = 0;
+   }
+   respond(WONT, c);
+}
+
+static void respond(ack, option)
+int ack, option;
+{
+   /**unsigned char c[3];
+
+   c[0] = IAC;
+   c[1] = ack;
+   c[2] = option;**/
+/*   write(telfdout, c, 3); */
+}
+
+static void respond_really(ack, option)
+int ack, option;
+{
+unsigned char c[3];
+
+   c[0] = IAC;
+   c[1] = ack;
+   c[2] = option;
+   write(telfdout, c, 3); 
+}

--- a/elkscmd/inet/telnetd/telnet.h
+++ b/elkscmd/inet/telnetd/telnet.h
@@ -1,0 +1,75 @@
+/*
+ * TNET		A server program for MINIX which implements the TCP/IP
+ *		suite of networking protocols.  It is based on the
+ *		TCP/IP code written by Phil Karn et al, as found in
+ *		his NET package for Packet Radio communications.
+ *
+ * 		Definitions for the TELNET protocol (see RFC XXX).
+ *
+ * Version:	@(#)arpa/telnet.h	1.00		07/02/92
+ *
+ * Authors:	Original taken from BSD 4.3/TAHOE.
+ *		Fred N. van Kempen, <waltje@uwalt.nl.mugnet.org>
+ */
+#ifndef _ARPA_TELNET_H
+#define _ARPA_TELNET_H
+
+#define	IAC		255	/* interpret as command:		*/
+#define	DONT		254	/* you are not to use option		*/
+#define	DO		253	/* please, you use option		*/
+#define	WONT		252	/* I won't use option			*/
+#define	WILL		251	/* I will use option			*/
+#define	SB		250	/* interpret as subnegotiation		*/
+#define	GA		249	/* you may reverse the line		*/
+#define	EL		248	/* erase the current line		*/
+#define	EC		247	/* erase the current character		*/
+#define	AYT		246	/* are you there			*/
+#define	AO		245	/* abort output--but let prog finish	*/
+#define	IP		244	/* interrupt process--permanently	*/
+#define	BREAK		243	/* break				*/
+#define	DM		242	/* data mark--for connect. cleaning	*/
+#define	NOP		241	/* nop					*/
+#define	SE		240	/* end sub negotiation			*/
+#define EOR     	239     /* end of record (transparent mode)	*/
+
+#define SYNCH		242	/* for telfunc calls			*/
+
+/* Telnet options. */
+#define TELOPT_BINARY	0	/* 8-bit data path			*/
+#define TELOPT_ECHO	1	/* echo					*/
+#define	TELOPT_RCP	2	/* prepare to reconnect			*/
+#define	TELOPT_SGA	3	/* suppress go ahead			*/
+#define	TELOPT_NAMS	4	/* approximate message size		*/
+#define	TELOPT_STATUS	5	/* give status				*/
+#define	TELOPT_TM	6	/* timing mark				*/
+#define	TELOPT_RCTE	7	/* remote controlled transmission and echo */
+#define TELOPT_NAOL 	8	/* negotiate about output line width	*/
+#define TELOPT_NAOP 	9	/* negotiate about output page size	*/
+#define TELOPT_NAOCRD	10	/* negotiate about CR disposition	*/
+#define TELOPT_NAOHTS	11	/* negotiate about horizontal tabstops	*/
+#define TELOPT_NAOHTD	12	/* negotiate about horizontal tab disposition */
+#define TELOPT_NAOFFD	13	/* negotiate about formfeed disposition	*/
+#define TELOPT_NAOVTS	14	/* negotiate about vertical tab stops	*/
+#define TELOPT_NAOVTD	15	/* negotiate about vertical tab disposition */
+#define TELOPT_NAOLFD	16	/* negotiate about output LF disposition */
+#define TELOPT_XASCII	17	/* extended ascic character set		*/
+#define	TELOPT_LOGOUT	18	/* force logout				*/
+#define	TELOPT_BM	19	/* byte macro				*/
+#define	TELOPT_DET	20	/* data entry terminal			*/
+#define	TELOPT_SUPDUP	21	/* supdup protocol			*/
+#define	TELOPT_SUPDUPOUTPUT 22	/* supdup output			*/
+#define	TELOPT_SNDLOC	23	/* send location			*/
+#define	TELOPT_TTYPE	24	/* terminal type			*/
+#define	TELOPT_EOR	25	/* end or record			*/
+#define	TELOPT_WINCH	31	/* window size				*/
+#define TELOPT_EXOPL	255	/* extended-options-list		*/
+
+/* Sub-option qualifiers. */
+#define	TELQUAL_IS	0	/* option is...				*/
+#define	TELQUAL_SEND	1	/* send option				*/
+
+void tel_init(void);
+void telopt(int fdout, int what, int option);
+void tel_in(int fdout, int telout, char *buffer, int len);
+void tel_out(int fdout, char *buf, int size);
+#endif /* _ARPA_TELNET_H */

--- a/elkscmd/inet/telnetd/telnetd.c
+++ b/elkscmd/inet/telnetd/telnetd.c
@@ -1,3 +1,9 @@
+/*
+ * telnetd for ELKS
+ *
+ * Debugged and added IAC processing.
+ * Greg Haerr May 2020
+ */
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -8,25 +14,17 @@
 #include <signal.h>
 #include <string.h>
 #include <sys/socket.h>
-
-#ifndef __linux__ 
 #include <linuxmt/socket.h>
 #include <linuxmt/in.h>
 #include <linuxmt/arpa/inet.h>
-#else
-#include <sys/types.h>
-#include <netdb.h>
-#endif
-#include <time.h>
+#include "telnet.h"
 
 #define MAX_BUFFER 100
 static char buf_in  [MAX_BUFFER];
 static char buf_out [MAX_BUFFER];
 
-static int tfd, tfs;
-pid_t pid;
-//char * nargv[2] = {"/bin/sh", NULL};
-char * nargv[2] = {"/bin/login", NULL};
+//char * nargv[2] = {"/bin/login", NULL};
+char * nargv[2] = {"/bin/sash", NULL};
 
 void sigchild(int signo)
 {
@@ -34,17 +32,17 @@ void sigchild(int signo)
 	exit(0);
 }
 
-int term_init()
+static pid_t term_init(int sockfd, int *pty_fd)
 {
-	char pty_name[12];
 	int n = 0;
-	
-	struct termios slave_orig_term_settings; // Saved terminal settings
-	struct termios new_term_settings; // Current terminal settings
+	int tty_fd;
+	pid_t pid;
+	char pty_name[12];
+	struct termios termios;
 
 again:
 	sprintf(pty_name, "/dev/ptyp%d", n);
-	if ((tfd = open(pty_name, O_RDWR)) < 0) {
+	if ((*pty_fd = open(pty_name, O_RDWR)) < 0) {
 		if ((errno == EBUSY) && (n < 3)) {
 			n++;
 			goto again;
@@ -52,66 +50,67 @@ again:
 		fprintf(stderr, "Can't create pty %s\n", pty_name);
 		return -1;
 	}
-	signal(SIGCHLD, sigchild);
-	signal(SIGINT, sigchild);
+	//signal(SIGCHLD, sigchild);
+	//signal(SIGINT, sigchild);
+	signal(SIGCHLD, SIG_IGN);
+	signal(SIGINT, SIG_IGN);
 	
 	if ((pid = fork()) == -1) {
-		fprintf(stderr, "No processes\n");
+		fprintf(stderr, "telnetd: No processes\n");
 		return -1;
 	}
-	if (pid>0) {
-		// Save the default parameters of the slave side of the PTY - unused yet
-		tcgetattr(tfs, &slave_orig_term_settings);
-		new_term_settings = slave_orig_term_settings;
-		// Set raw mode on the slave side of the PTY - not line oriented
-		//cfmakeraw (&new_term_settings);
-		//new_term_settings.c_lflag &= ~ECHO;
-		tcsetattr (tfs, TCSANOW, &new_term_settings);
+	if (!pid) {
 		
+		close(sockfd);
 		close(STDIN_FILENO);
 		close(STDOUT_FILENO);
 		close(STDERR_FILENO);
-		close(tfd);
+		close(*pty_fd);
 		
 		setsid();
 		pty_name[5] = 't'; /* results in: /dev/ttyp%d */
-		if ((tfs = open(pty_name, O_RDWR)) < 0) {
-			fprintf(stderr, "Child: Can't open pty %s\n", pty_name);
+		if ((tty_fd = open(pty_name, O_RDWR)) < 0) {
+			fprintf(stderr, "telnetd: Can't open pty %s\n", pty_name);
 			exit(1);
 		}
 	
-		dup2(tfs, STDIN_FILENO);
-		dup2(tfs, STDOUT_FILENO);
-		dup2(tfs, STDERR_FILENO);
+		/* turn off echo*/
+		tcgetattr(tty_fd, &termios);
+		termios.c_lflag &= ~(ECHO);
+		tcsetattr(tty_fd, TCSANOW, &termios);
+
+		dup2(tty_fd, STDIN_FILENO);
+		dup2(tty_fd, STDOUT_FILENO);
+		dup2(tty_fd, STDERR_FILENO);
 		execv(nargv[0], nargv);
 		perror("execv");
 		exit(1);
 	}
-	return 0;
+	return pid;
 }
 
-
-static void usage()
+static void telnet_init(int ofd)
 {
-	write(STDOUT_FILENO, "ELKS telnet server\n",16);
-	write(STDOUT_FILENO, "  default  internet sockets using 127.0.0.1\n",44);
-	write(STDOUT_FILENO, "  -h  print this message\n\n",26);
+  tel_init();
+
+  //telopt(ofd, WILL, TELOPT_SGA);
+  //telopt(ofd, DO,   TELOPT_SGA);
+  //telopt(ofd, WILL, TELOPT_BINARY);
+  //telopt(ofd, DO,   TELOPT_BINARY);
+  //telopt(ofd, WILL, TELOPT_ECHO);
+  //telopt(ofd, DO,   TELOPT_WINCH);
 }
 
-static int client_loop (int fdsock, int fdterm)
+static void client_loop (int fdsock, int fdterm)
 {
-    int count_fd;
     fd_set fds_read;
     fd_set fds_write;
-
     int count;
-    int count_in;
-    int count_out;
+    int count_in = 0;
+    int count_out = 0;
+    int count_fd = (fdsock > fdterm) ? (fdsock + 1) : (fdterm + 1);
 
-    count_fd = (fdsock > fdterm) ? (fdsock + 1) : (fdterm + 1);
-
-    count_in  = 0;
-    count_out = 0;
+	telnet_init(fdsock);
 
     while (1) {
 		FD_ZERO (&fds_read);
@@ -128,6 +127,7 @@ static int client_loop (int fdsock, int fdterm)
 			break;
 		}
 
+		/* network -> login process*/
 		if (!count_in && FD_ISSET (fdsock, &fds_read)) {
 			count_in = read (fdsock, buf_in, MAX_BUFFER);
 			if (count_in <= 0) {
@@ -135,18 +135,13 @@ static int client_loop (int fdsock, int fdterm)
 				break;
 			}
 		}
-
-		/* TODO: process IAC sequences */
-
 		if (count_in && FD_ISSET (fdterm, &fds_write)) {
-			count = write (fdterm, buf_in, count_in);
-			if (count <= 0) {
-				perror ("write term");
-				break;
-			}
-			count_in -= count;
+			//count = write (fdterm, buf_in, count_in);
+			tel_in(fdterm, fdsock, buf_in, count_in);
+			count_in = 0;
 		}
 
+		/* login process -> network*/
 		if (!count_out && FD_ISSET (fdterm, &fds_read)) {
 			count_out = read (fdterm, buf_out, MAX_BUFFER);
 			if (count_out <= 0) {
@@ -154,47 +149,22 @@ static int client_loop (int fdsock, int fdterm)
 				break;
 			}
 		}
-
 		if (count_out && FD_ISSET (fdsock, &fds_write)) {
-			count = write (fdsock, buf_out, count_out);
-			if (count <= 0) {
-				perror ("write sock");
-				break;
-			}
-			count_out -= count;
+			//count = write (fdsock, buf_out, count_out);
+			tel_out(fdsock, buf_out, count_out);
+			count_out = 0;
 		}
     }
-
-    return 0;
 }
 
-/****************************************************************************************/
-int main(int argc, char *argv[]) {
-
-  char	*cp;
+int main(int argc, char **argv)
+{
   struct sockaddr_in addr_in;
-  int sockfd,connectionfd,ret,lv = 10;
+  int sockfd,connectionfd,fd,lv = 10;
+  int pty_fd;
+  pid_t pid;
   
-#ifndef __linux__  
-  if (argv[1][0] == '-') {
-		cp = &argv[1][1];
-		if (strcmp(cp, "h") == 0) {
-			usage();
-			exit (0);
-		} else {
-			usage();
-			exit (0);			
-		}
-		argc--;
-		argv++;
-	} else if (argc == 2) {
-			usage();
-			exit (0);
-	}
-	  
-#endif
-
-  if ( (sockfd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
+  if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
     perror("socket error");
     exit(-1);
   }
@@ -214,15 +184,15 @@ int main(int argc, char *argv[]) {
     exit(-1);
   } 
 
+	/* become daemon, debug output on 1 and 2*/
 	if (fork())
 		exit(0);
-	ret = open("/dev/null", O_RDWR);
-	dup2(ret, 0);
-	dup2(ret, 1);
-	dup2(ret, 2);
-	if (ret > 2)
-		close(ret);
-	setsid();
+	fd = open("/dev/console", O_RDWR);
+	close(0);
+	dup2(fd, STDOUT_FILENO);
+	dup2(fd, STDERR_FILENO);
+	if (fd > STDERR_FILENO)
+		close(fd);
 
 	while (1) {
 		connectionfd = accept (sockfd, (struct sockaddr *) NULL, NULL);
@@ -231,13 +201,13 @@ int main(int argc, char *argv[]) {
 			break;
 		}
 
-		term_init ();
-
-		client_loop (connectionfd, tfd);
-
-		kill (pid, SIGKILL);
+		pid = term_init(sockfd, &pty_fd);
+		if (pid != -1) {
+			client_loop (connectionfd, pty_fd);
+			kill (pid, SIGKILL);
+		}
 		close (connectionfd);
-		close (tfd);
+		close (pty_fd);
 	}
 
 	close (sockfd);

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -3,4 +3,19 @@
 
 #include <autoconf.h>
 
+#define DEBUG_TCP	0
+#define DEBUG_IP	0
+
+#if DEBUG_TCP
+#define debug_tcp	printf
+#else
+#define debug_tcp(...)
+#endif
+
+#if DEBUG_IP
+#define debug_ip	printf
+#else
+#define debug_ip(...)
+#endif
+
 #endif

--- a/elkscmd/ktcp/ip.c
+++ b/elkscmd/ktcp/ip.c
@@ -15,6 +15,8 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <stdio.h>
+#include <string.h>
 #include <fcntl.h>
 
 #include "ip.h"
@@ -30,7 +32,6 @@
 #define IP_FLAGS(s)	((s)->frag_off>>13)
 #endif
 
-/*#define DEBUG*/
 //#define USE_ASM
 
 static char ipbuf[TCPDEV_BUFSIZE];
@@ -95,52 +96,48 @@ loop1:
 
 void ip_print(struct iphdr_s *head)
 {
-#ifdef DEBUG
+#if 0
     int i;
     __u8 *addr;
 
-    printf("Version/IHL: %d/%d ",IP_VERSION(head),IP_IHL(head));
-    printf("TypeOfService/Length: %d/%d\n",head->tos,ntohs(head->tot_len));
-    printf("Id/flags/fragment offset: %d/%d ",head->id,head->frag_off);
-    printf("ttl: %d ",head->ttl);
-    printf("Protocol: %d\n",head->protocol);
+    debug_ip("Version/IHL: %d/%d ",IP_VERSION(head),IP_IHL(head));
+    debug_ip("TypeOfService/Length: %d/%d\n",head->tos,ntohs(head->tot_len));
+    debug_ip("Id/flags/fragment offset: %d/%d ",head->id,head->frag_off);
+    debug_ip("ttl: %d ",head->ttl);
+    debug_ip("Protocol: %d\n",head->protocol);
 
     addr = (__u8 *)&head->saddr;
-    printf("saddr : %d.%d.%d.%d ",addr[0],addr[1],addr[2],addr[3]);
+    debug_ip("saddr : %d.%d.%d.%d ",addr[0],addr[1],addr[2],addr[3]);
     addr = (__u8 *)&head->daddr;
-    printf("daddr : %d.%d.%d.%d ",addr[0],addr[1],addr[2],addr[3]);
+    debug_ip("daddr : %d.%d.%d.%d ",addr[0],addr[1],addr[2],addr[3]);
 
-    printf("check sum = %d\n",ip_calc_chksum(head, 4 * IP_IHL(head)));
+    debug_ip("check sum = %d\n",ip_calc_chksum(head, 4 * IP_IHL(head)));
 
     addr = (__u8 *)head + 4 * IP_IHL(head);
     for ( i = 0 ; i < ntohs(head->tot_len) - 20 ; i++ )
-	printf("%x ",addr[i]);
+	debug_ip("%x ",addr[i]);
 
-    printf("\n");
+    debug_ip("\n");
 #endif
 }
 
 void ip_recvpacket(char *packet,int size)
 {
     struct iphdr_s *iphdr;
-    __u8 *addr, *data;
+    __u8 *data;
 
     iphdr = (struct iphdr_s *)packet;
 
-    /*printf("IP: Got packet of size : %d \n",size,*packet);
-    ip_print(iphdr);*/
+    debug_ip("IP: Got packet size %d\n",size);
+    ip_print(iphdr);
 
     if (IP_VERSION(iphdr) != 4){
-#ifdef DEBUG
-        printf("IP : Bad IP version\n");
-#endif
+        debug_ip("IP : Bad IP version\n");
 	return;
     }
 
     if (IP_IHL(iphdr) < 5){
-#ifdef DEBUG
-        printf("IP : Bad IHL\n");
-#endif
+        debug_ip("IP : Bad IHL\n");
 	return;
     }
 
@@ -148,44 +145,35 @@ void ip_recvpacket(char *packet,int size)
 
     switch (iphdr->protocol) {
     case PROTO_ICMP:
-#ifdef DEBUG
-                printf("IP : ICMP packet\n");
-#endif
-
-		icmp_process(iphdr, data);
-		break;
-
-    case PROTO_TCP:
-#ifdef DEBUG
-                printf("IP : TCP packet\n");
-#endif
-		tcp_process(iphdr);
-		break;
-
-    default:
+        debug_ip("IP: icmp packet\n");
+	icmp_process(iphdr, data);
 	break;
 
+    case PROTO_TCP:
+        debug_ip("IP: tcp packet\n");
+	tcp_process(iphdr);
+	break;
     }
 }
 
 void ip_sendpacket(char *packet,int len,struct addr_pair *apair)
 {
-    struct iphdr_s *iph = (struct iphdr_s *)&ipbuf;
+    struct iphdr_s *iph = (struct iphdr_s *)ipbuf;
     __u16 tlen;
-    __u8 *addr;
     ipaddr_t tmpaddress;
     char llbuf[15];
-    struct ip_ll *ipll = (struct ip_ll *)&llbuf;
-
+    struct ip_ll *ipll = (struct ip_ll *)llbuf;
     ipaddr_t ip_addr;
     eth_addr_t eth_addr;
 
-    /*
-    addr = (__u8 *) &apair->daddr;
-    printf ("daddr: %2X.%2X.%2X.%2X\n", addr [0], addr [1], addr [2], addr [3]);
-    */
+    unsigned char *addr = (unsigned char *) &apair->daddr;
+    debug_ip("IPSEND daddr: %d.%d.%d.%d\n", addr [0], addr [1], addr [2], addr [3]);
+
+if (apair->daddr == local_ip || apair->daddr == 0x0100007f) //FIXME
+    goto local;
 
     if (dev->type == 1) {  /* Ethernet */
+debug_ip("ETH ROUTE\n");
         /* Is this the best place for the IP routing to happen ? */
         /* I think no, because actual sending interface is coming from the routing */
 
@@ -218,6 +206,7 @@ void ip_sendpacket(char *packet,int len,struct addr_pair *apair)
     ipll->ll_type_len=0x08; /*=0x0800 bigendian*/
     } //if (dev->type == 1)
 
+local:
     /*ip layer*/
     iph->version_ihl	= 0x45;
 
@@ -233,6 +222,7 @@ void ip_sendpacket(char *packet,int len,struct addr_pair *apair)
     if (dev->type == 1) {
       iph->daddr		= apair->daddr;
       iph->saddr		= local_ip;
+//iph->saddr		= apair->saddr;
     } else {
       iph->daddr		= apair->daddr;
       iph->saddr		= apair->saddr;
@@ -241,21 +231,23 @@ void ip_sendpacket(char *packet,int len,struct addr_pair *apair)
     iph->check		= 0;
     iph->check		= ip_calc_chksum((char *)iph, tlen);
 
-    //ip_print(iph);
+    ip_print(iph);
 
     memcpy(&ipbuf[tlen], packet, len);
-    if (dev->type == 1) { /*add link layer*/
-      memmove(&ipbuf[14],&ipbuf, TCPDEV_BUFSIZE-14);
-      memcpy(&ipbuf,&llbuf,14);
+
+    /* "route"  127.0.0.1*/
+    if (iph->daddr == local_ip || iph->daddr == 0x0100007f) {
+	debug_ip("ip: route localhost\n");
+	ip_recvpacket(ipbuf, tlen + len);
+	return;
     }
 
-    /* "route" */
-    /* if (iph->daddr == local_ip && iph->daddr == 0x0100007f) { */
-	/* 127.0.0.1 */
-	/* TODO */
-
-	if (dev->type == 1)
-		deveth_send(&ipbuf, tlen + len + 14);  /* add link layer length */
-        else
-		slip_send(&ipbuf, tlen + len);
+    if (dev->type == 1) { /*add link layer*/
+      memmove(&ipbuf[14],ipbuf, TCPDEV_BUFSIZE-14);
+      memcpy(ipbuf,llbuf,14);
+    }
+    if (dev->type == 1)
+	deveth_send(ipbuf, tlen + len + 14);  /* add link layer length */
+    else
+	slip_send(ipbuf, tlen + len);
 }

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -3,6 +3,8 @@
  *
  * (C) 2001 Harry Kalogirou (harkal@rainbow.cs.unipi.gr)
  *
+ * Major debugging by Greg Haerr May 2020
+ *
  *	This program is free software; you can redistribute it and/or
  *	modify it under the terms of the GNU General Public License
  *	as published by the Free Software Foundation; either version
@@ -29,12 +31,10 @@
 #ifdef DEBUG
 #define debug	printf
 #else
-#define debug(s)
+#define debug(...)
 #endif
 
 char deveth[] = "/dev/eth";
-
-extern int tcp_timeruse;
 
 static int intfd;
 
@@ -65,9 +65,14 @@ void ktcp_run(void)
     fd_set fdset;
     struct timeval timeint, *tv;
     int count;
+extern int tcp_timeruse;
+extern int cbs_in_time_wait;
+extern int cbs_in_user_timeout;
 
     while (1) {
-	if (tcp_timeruse > 0 || tcpcb_need_push > 0) {
+	//if (tcp_timeruse > 0 || tcpcb_need_push > 0) {
+	if (tcp_timeruse > 0 || tcpcb_need_push > 0 || cbs_in_time_wait > 0 || cbs_in_user_timeout > 0) {
+
 	    timeint.tv_sec  = 1;
 	    timeint.tv_usec = 0;
 	    tv = &timeint;
@@ -91,9 +96,7 @@ void ktcp_run(void)
 
 	if (tcp_timeruse > 0) tcp_retrans();
 
-#ifdef DEBUG
 	tcpcb_printall();
-#endif
     }
 }
 

--- a/elkscmd/ktcp/netconf.c
+++ b/elkscmd/ktcp/netconf.c
@@ -29,9 +29,9 @@ void netconf_request(struct stat_request_s *sr)
     sreq.extra = sr->extra;
 }
 
+/* send netstat status*/
 void netconf_send(struct tcpcb_s *cb)
 {
-#ifdef CONFIG_INET_STATUS
     struct general_stats_s gstats;
     struct cb_stats_s cbstats;
     struct tcpcb_s *ncb;
@@ -53,6 +53,5 @@ void netconf_send(struct tcpcb_s *cb)
 	    cbstats.valid = 0;
 	tcpcb_buf_write(cb, &cbstats, sizeof(cbstats) );
     }
-#endif
     cb->bytes_to_push = CB_BUF_USED(cb);
 }

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -8,8 +8,6 @@
 #include "ip.h"
 #include <linuxmt/arpa/inet.h>
 
-//#define DEBUG
-
 #define PROTO_TCP	0x06
 
 #define SEQ_LT(a,b)	((long)((a)-(b)) < 0)
@@ -17,12 +15,12 @@
 #define SEQ_GT(a,b)	((long)((a)-(b)) > 0)
 #define SEQ_GEQ(a,b)	((long)((a)-(b)) >= 0)
 
-#define	TF_FIN	1
-#define TF_SYN	2
-#define	TF_RST	4
-#define	TF_PSH	8
-#define	TF_ACK	16
-#define TF_URG	32
+#define	TF_FIN	0x01
+#define TF_SYN	0x02
+#define	TF_RST	0x04
+#define	TF_PSH	0x08
+#define	TF_ACK	0x10
+#define TF_URG	0x20
 
 #define TF_ALL (TF_FIN | TF_SYN | TF_RST | TF_PSH | TF_ACK | TF_URG)
 
@@ -115,9 +113,7 @@ struct tcpcb_s {
 	__u16	datalen;
 };
 
-#ifdef CONFIG_INET_STATUS
-int tcpcb_num;
-#endif
+int tcpcb_num;		/* for netstat*/
 
 struct	tcpcb_list_s {
 	struct tcpcb_s		tcpcb;
@@ -144,7 +140,8 @@ int tcp_timeruse;
 int tcpcb_need_push;
 
 #define TCP_RTT_ALPHA		90
-#define TCP_RETRANS_MAXMEM	8192*2
+//#define TCP_RETRANS_MAXMEM	8192*2
+#define TCP_RETRANS_MAXMEM	2048
 int tcp_retrans_memory;
 
 struct tcpcb_list_s *tcpcb_new();

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -165,7 +165,7 @@ static void tcpdev_connect(void)
 
     n = tcpcb_find_by_sock(db->sock);
     if (!n || n->tcpcb.state != TS_CLOSED) {
-	printf("KTCP Panic in connect\n");
+	printf("ktcp: panic in connect\n");
 	exit(1);
     }
 
@@ -205,7 +205,7 @@ void tcpdev_read(void)
 
     n = tcpcb_find_by_sock(sock);
     if (!n) {
-	printf("KTCP Panic in read\n");
+	printf("ktcp: panic in read\n");
 	exit(1);
     }
 
@@ -293,13 +293,14 @@ static void tcpdev_write(void)
 
     /* This is a bit ugly but I'm to lazy right now */
     if (tcp_retrans_memory > TCP_RETRANS_MAXMEM) {
+printf("tcp: RETRANS limit exceeded\n");
 	retval_to_sock(sock, -ERESTARTSYS);
 	return;
     }
 
     n = tcpcb_find_by_sock(sock);
     if (!n) {
-	printf("KTCP panic in write (unknown sock:0x%x)\n",sock);
+	printf("ktcp: panic in write (unknown sock:0x%x)\n",sock);
 	return;
     }
 
@@ -385,6 +386,7 @@ void tcpdev_sock_state(struct tcpcb_s *cb, int state)
     write(tcpdevfd, sbuf, sizeof(struct tdb_return_data));
 }
 
+/* called every ktcp cycle when tcpdevfd data is ready*/
 void tcpdev_process(void)
 {
     int len = read(tcpdevfd, sbuf, TCPDEV_BUFSIZE);
@@ -392,9 +394,7 @@ void tcpdev_process(void)
     if (len <= 0)
 	return;
 
-#ifdef DEBUG
-    printf("tcpdev_process : read %d bytes\n",len);
-#endif
+    //printf("tcpdev_process : read %d bytes\n",len);
 
     switch (sbuf[0]){
 	case TDC_BIND:
@@ -404,6 +404,7 @@ void tcpdev_process(void)
 	    tcpdev_accept();
 	    break;
 	case TDC_CONNECT:
+//printf("tcpdev: got connect\n");
 	    tcpdev_connect();
 	    break;
 	case TDC_LISTEN:

--- a/elkscmd/ktcp/vjhc.c
+++ b/elkscmd/ktcp/vjhc.c
@@ -155,6 +155,10 @@ void ip_vjhc_init(void)
 			xmit_state= NULL;
 		}
 		xmit_state= calloc(ip_snd_vjhc_state_nr, sizeof(snd_state_ut));
+		if (!xmit_state) {
+			printf("ktcp: Out of memory 4\n");
+			return;	//FIXME return -1
+		}
 
 		xmit_head= 0;
 		for (i= 0; i<ip_snd_vjhc_state_nr; i++)
@@ -173,6 +177,10 @@ void ip_vjhc_init(void)
 			rcv_state= NULL;
 		}
 		rcv_state= calloc(ip_rcv_vjhc_state_nr, sizeof(snd_state_ut));
+		if (!rcv_state) {
+			printf("ktcp: Out of memory 5\n");
+			return;	//FIXME return -1
+		}
 	}
 }
 

--- a/qemu.sh
+++ b/qemu.sh
@@ -66,7 +66,8 @@ KEYBOARD=
 # HOSTFWD="-net user,hostfwd=tcp:127.0.0.1:2323-10.0.2.15:23"
 # Incoming http forwarding: example: connect to ELKS httpd with 'http://localhost:8080'
 # HOSTFWD="-net user,hostfwd=tcp:127.0.0.1:8080-10.0.2.15:80"
-HOSTFWD="-net user"
+# Simultaneous telnet and http forwarding
+HOSTFWD="-net user,hostfwd=tcp:127.0.0.1:8080-10.0.2.15:80,hostfwd=tcp:127.0.0.1:2323-10.0.2.15:23"
 
 # Enable network dump here:
 # NETDUMP="-net dump"


### PR DESCRIPTION
Major deep-dive into `ktcp`, first of several updates. This PR is the result of networking into ELKS QEMU from an outside host using an emulated NE2K card. Slip not tested. There were/are all sorts of problems, but finally have `ktcp` running without memory corruption, and telnetd working.

Fixes and enhancements include:

Eliminated all known memory corruption errors, all allocations checked.
Stopped ktcp from quickly running of memory.
Fixed telnetd to work with standards-compliant telnet client, added IAC processing.
Cleaned up httpd.
Added telnet and http host forwarding for testing using qemu.sh. Usage: `telnet localhost 2323` or `localhost:8080` from host telnet or outside browser
Enhanced NE2K detect message includes base and IRQ
Add extensive macros for debugging IP and TCP
Reduce retransmit memory from 16k to 2k
Stop retransmits after 2k bytes or 3 timer uses
Add unsigned output for port numbers
Add timeout capability on CLOSE_WAIT for telnet closes
Add prelim localhost facilities (not working)
Added short 10 sec TCP timeouts (temporary)
Don't turn off ONLCR processing in ash linenoise, fixes /dev/console CRLF problems

Known problems:
Only tested for incoming networking
Connection not closed on telnet shell exit or ^D
Can't reconnect via telnet second time
Multiple http requests use 2k memory each and ktcp doesn't reclaim memory 
Zombie processes after http requests, not reparented to init, ELKS runs out of processes

Anyone that has a physical NE2K card - please test on real hardware, both incoming and outgoing
QEMU testing welcomed.
Report problems or findings on #610 
More fixes coming
