### PR TITLE
[kernel] Fix wait system call

### DIFF
--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -16,8 +16,12 @@ int sys_wait4(pid_t pid, int *status, int options)
 {
 	register struct task_struct *p;
 	struct task_struct *q;
+	int waitagain;
 
 	debug_wait("WAIT(%d) for %d %s\n", current->pid, pid, (options & WNOHANG)? "nohang": "");
+
+ do {
+	waitagain = 0;
 
 	/* reparent orphan zombies to init*/
 	for_each_task(p) {
@@ -33,8 +37,13 @@ int sys_wait4(pid_t pid, int *status, int options)
 	}
 
 	for_each_task(p) {
-		if (p->p_parent == current
-		   && (p->state == TASK_ZOMBIE || p->state == TASK_STOPPED)) {
+		if (p->p_parent == current) {
+
+		  /* keep waiting while process has children*/
+		  if (current->pid != 1)	/* except for init reparented zombies*/
+			waitagain = 1;
+
+		  if (p->state == TASK_ZOMBIE || p->state == TASK_STOPPED) {
 			if (pid == -1 || p->pid == pid || (!pid && p->pgrp == current->pgrp)) {
 				if (status) {
 					if (verified_memcpy_tofs(status, &p->exit_status, sizeof(int)))
@@ -62,16 +71,19 @@ int sys_wait4(pid_t pid, int *status, int options)
 				return p->pid;
 			}
 		}
+	  }
 	}
 
 	if (options & WNOHANG)
 		return 0;
 
-	debug_wait("WAIT sleep\n");
+	debug_wait("WAIT(%d) sleep\n", current->pid);
 	interruptible_sleep_on(&current->child_wait);
-	debug_wait("WAIT wakeup\n");
+	debug_wait("WAIT(%d) wakeup\n", current->pid);
 
-	return -EINTR;
+  } while(waitagain);
+
+	return -ECHILD;
 }
 
 void do_exit(int status)

--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -38,11 +38,6 @@ int sys_wait4(pid_t pid, int *status, int options)
 
 	for_each_task(p) {
 		if (p->p_parent == current) {
-
-		  /* keep waiting while process has children*/
-		  if (current->pid != 1)	/* except for init reparented zombies*/
-			waitagain = 1;
-
 		  if (p->state == TASK_ZOMBIE || p->state == TASK_STOPPED) {
 			if (pid == -1 || p->pid == pid || (!pid && p->pgrp == current->pgrp)) {
 				if (status) {
@@ -70,6 +65,11 @@ int sys_wait4(pid_t pid, int *status, int options)
 				debug_wait("WAIT(%d) got %d\n", current->pid, p->pid);
 				return p->pid;
 			}
+		} else {
+		  /* keep waiting while process has non-zombie/stopped children*/
+		  if (current->pid != 1)	/* except for init reparented zombies*/
+			waitagain = 1;
+
 		}
 	  }
 	}

--- a/libc/system/wait.c
+++ b/libc/system/wait.c
@@ -5,12 +5,5 @@
 pid_t
 wait(int * status)
 {
-	int ret;
-
-	/* for compatibility, loop while EINTR return*/
-	do {
-		ret = wait4(-1, status, 0, (void*)0);
-	} while (ret == -1 && errno == EINTR);
-
-	return ret;
+	return wait4(-1, status, 0, (void*)0);
 }


### PR DESCRIPTION
Fixes `wait` as described in #622.

`wait` now waits in the kernel for a child process to terminate if the current process has children, otherwise returns -ECHILD if no children. The previous version looped in libc until a child terminated, which was an error if the process had no children.`waitpid` returned -EINTR if a process had no children, and did not loop. Both behave identically now, and wait for a child to terminate, or return -ECHILD.

Georg, this should also fix your having had to code `waitpid` instead of `wait` in your cron PR #620. You're welcome to change it back for testing, or leave it. I can test after you are finished with the latest commit if you'd rather.