### PR TITLE
[build] fix: beef up checking of gcc-ia16 toolchain versions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ clean_exit () {
 
 if [ "$1" != "auto" ]; then
 	mkdir -p "$CROSSDIR"
-	test -f "$CROSSDIR/.gcc.install" || tools/build.sh || clean_exit 1
+	tools/build.sh || clean_exit 1
 fi
 
 # Configure all

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -24,7 +24,9 @@ BINUTILS_DIST=binutils-ia16-$(BINUTILS_VER)
 
 $(DISTDIR)/$(BINUTILS_DIST).zip:
 	mkdir -p $(DISTDIR)
-	cd $(DISTDIR) && wget https://github.com/tkchia/binutils-ia16/archive/$(BINUTILS_VER).zip -O $(BINUTILS_DIST).zip
+	rm -rf $(DISTDIR)/binutils-ia16-*.zip $(DISTDIR)/binutils-ia16-*.zip.tmp
+	cd $(DISTDIR) && wget https://github.com/tkchia/binutils-ia16/archive/$(BINUTILS_VER).zip -O $(BINUTILS_DIST).zip.tmp
+	cd $(DISTDIR) && mv $(BINUTILS_DIST).zip.tmp $(BINUTILS_DIST).zip
 
 $(BUILDDIR)/.binutils.src: $(DISTDIR)/$(BINUTILS_DIST).zip
 	mkdir -p $(BUILDDIR)
@@ -54,7 +56,9 @@ GCC_DIST=gcc-ia16-$(GCC_VER)
 
 $(DISTDIR)/$(GCC_DIST).zip:
 	mkdir -p $(DISTDIR)
-	cd $(DISTDIR) && wget https://github.com/tkchia/gcc-ia16/archive/$(GCC_VER).zip -O $(GCC_DIST).zip
+	rm -rf $(DISTDIR)/gcc-ia16-*.zip $(DISTDIR)/gcc-ia16-*.zip.tmp
+	cd $(DISTDIR) && wget https://github.com/tkchia/gcc-ia16/archive/$(GCC_VER).zip -O $(GCC_DIST).zip.tmp
+	cd $(DISTDIR) && mv $(GCC_DIST).zip.tmp $(GCC_DIST).zip
 
 $(BUILDDIR)/.gcc.src: $(DISTDIR)/$(GCC_DIST).zip
 	mkdir -p $(BUILDDIR)
@@ -85,7 +89,9 @@ EMU86_DIST=emu86-$(EMU86_VER)
 
 $(DISTDIR)/$(EMU86_DIST).zip:
 	mkdir -p $(DISTDIR)
-	cd $(DISTDIR) && wget https://github.com/mfld-fr/emu86/archive/$(EMU86_VER).zip -O $(EMU86_DIST).zip
+	rm -rf $(DISTDIR)/emu86-*.zip $(DISTDIR)/emu86-*.zip.tmp
+	cd $(DISTDIR) && wget https://github.com/mfld-fr/emu86/archive/$(EMU86_VER).zip -O $(EMU86_DIST).zip.tmp
+	cd $(DISTDIR) && mv $(EMU86_DIST).zip.tmp $(EMU86_DIST).zip
 
 $(BUILDDIR)/.emu86.src: $(DISTDIR)/$(EMU86_DIST).zip
 	mkdir -p $(BUILDDIR)


### PR DESCRIPTION
`build.sh` was assuming that the toolchain did not need to be rebuilt whenever `cross/.gcc.install` exists, but this fails if we need to upgrade to a newer set of `gcc-ia16` tools.

This fix instead makes `build.sh` hand over to `tools/build.sh` (and `tools/Makefile`), which will do a more complete check.  See https://github.com/jbruchon/elks/pull/629#issuecomment-628105141 .

I also tweaked `tools/Makefile` to handle cases where a tool's `.zip` file was downloaded only partially, and to clean away old versions of `.zip` files.