### PR TITLE
[ktcp] First pass at fixing synchronous ARP request problem

### DIFF
--- a/elks/arch/i86/drivers/char/console.c
+++ b/elks/arch/i86/drivers/char/console.c
@@ -317,8 +317,10 @@ static void std_char(register Console * C, char c)
 #ifdef CONFIG_CONSOLE_BIOS
 	PositionCursor(C);
 #endif
-	VideoWrite(C, c);
-	C->cx++;
+	if (c >= ' ') {
+		VideoWrite(C, c);
+		C->cx++;
+	}
       linewrap:
 	if (C->cx > MaxCol) {
 

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -68,7 +68,7 @@ file_utils/mv					:fileutil		:360k
 file_utils/ln					:fileutil			:720k
 file_utils/ls					:fileutil		:360k
 file_utils/rm					:fileutil		:360k
-file_utils/rmdir				:fileutil		:360k
+file_utils/rmdir				:fileutil			:720k
 file_utils/sync					:fileutil		:360k
 file_utils/touch				:fileutil			:720k
 sys_utils/chmem					:sysutil			:720k

--- a/elkscmd/ktcp/arp.c
+++ b/elkscmd/ktcp/arp.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <time.h>
 
 #include <linuxmt/arpa/inet.h>
 
@@ -25,20 +26,16 @@
 
 
 /* ARP operations */
-/* as big endian values */
-
-#define ARP_REQUEST  0x0100
-#define ARP_REPLY    0x0200
-
+#define ARP_REQUEST  1
+#define ARP_REPLY    2
 
 /* Local ARP cache */
-
 #define ARP_CACHE_MAX 5
 
 struct arp_cache_s {
 	ipaddr_t   ip_addr;   /* IPv4 address */
 	eth_addr_t eth_addr;  /* MAC address */
-	};
+};
 
 typedef struct arp_cache_s arp_cache_t;
 
@@ -53,32 +50,31 @@ static void arp_cache_init (void)
 
 int arp_cache_get (ipaddr_t ip_addr, eth_addr_t * eth_addr)
 {
-	int err = -1;
+	arp_cache_t * entry = _arp_cache;
 
 	/* First pair is the more recent */
-
-	arp_cache_t * entry = _arp_cache;
 	while (entry < _arp_cache + ARP_CACHE_MAX) {
-		if (!entry->ip_addr) break;
-
+		if (!entry->ip_addr)
+		    break;
 		if (entry->ip_addr == ip_addr) {
 			memcpy (eth_addr, entry->eth_addr, sizeof (eth_addr_t));
-			err = 0;
-			break;
+			debug_arp("arp: using cached entry for %s\n", in_ntoa(ip_addr));
+			return 0;
 		}
-
 		entry++;
 	}
 
-	return err;
+	debug_arp("arp: no cached entry for %s\n", in_ntoa(ip_addr));
+	memset(eth_addr, 0, sizeof(eth_addr_t));
+	return -1;
 }
 
 
 void arp_cache_add (ipaddr_t ip_addr, eth_addr_t * eth_addr)
 {
 	if (arp_cache_get (ip_addr, eth_addr)) {
-		/* Shift the whole cache */
 
+		/* Shift the whole cache */
 		arp_cache_t * entry = _arp_cache + ARP_CACHE_MAX - 1;
 		while (entry > _arp_cache) {
 			memcpy (entry, entry - 1, sizeof (arp_cache_t));
@@ -86,32 +82,35 @@ void arp_cache_add (ipaddr_t ip_addr, eth_addr_t * eth_addr)
 		}
 
 		/* Set the first pair as the more recent */
-
 		entry->ip_addr = ip_addr;
 		memcpy (entry->eth_addr, eth_addr, sizeof (eth_addr_t));
-	}
+		debug_arp("arp: adding cache entry for %s\n", in_ntoa(ip_addr));
+	} else
+		debug_arp("arp: already cache entry for %s, ignored\n", in_ntoa(ip_addr)); //FIXME
 }
 
 
-void arp_print(struct arp *arp_r)
+static char *mac_ntoa(unsigned char *p)
 {
-    __u8 *addr;
+    static char b[18];
 
-    addr = arp_r->ll_eth_src;
-    printf("ll_eth_src: %2X.%2X.%2X.%2X.%2X.%2X ",addr[0],addr[1],addr[2],addr[3],addr[4],addr[5]);
-    addr = arp_r->ll_eth_dest;
-    printf("ll_eth_dest: %2X.%2X.%2X.%2X.%2X.%2X \n",addr[0],addr[1],addr[2],addr[3],addr[4],addr[5]);
+    sprintf(b, "%02x.%02x.%02x.%02x.%02x.%02x",p[0],p[1],p[2],p[3],p[4],p[5]);
+    return b;
+}
 
-    printf("Op: %2X \n",arp_r->op);
-
-    addr = (__u8 *)&arp_r->ip_src;
-    printf("ip_src : %d.%d.%d.%d ",addr[0],addr[1],addr[2],addr[3]);
-    addr = (__u8 *)&arp_r->ip_dest;
-    printf("ip_dest: %d.%d.%d.%d \n",addr[0],addr[1],addr[2],addr[3]);
-    addr = arp_r->eth_src;
-    printf("eth_src: %2X.%2X.%2X.%2X.%2X.%2X ",addr[0],addr[1],addr[2],addr[3],addr[4],addr[5]);
-    addr = arp_r->eth_dest;
-    printf("eth_dest: %2X.%2X.%2X.%2X.%2X.%2X \n",addr[0],addr[1],addr[2],addr[3],addr[4],addr[5]);
+static void arp_print(struct arp *arp)
+{
+#if DEBUG_ARP
+    printf("ARP: ");
+    printf("op:%d ", ntohs(arp->op));
+    printf("ll:%s->", mac_ntoa(arp->ll_eth_src));
+    printf("%s ", mac_ntoa(arp->ll_eth_dest));
+    printf("%s->", in_ntoa(arp->ip_src));
+    printf("%s ", in_ntoa(arp->ip_dest));
+    printf("eth:%s->", mac_ntoa(arp->eth_src));
+    printf("%s", mac_ntoa(arp->eth_dest));
+    printf("\n");
+#endif
 }
 
 int arp_init (void)
@@ -120,14 +119,14 @@ int arp_init (void)
 	return 0;
 }
 
-void arp_reply(char *packet,int size)
+void arp_reply(unsigned char *packet,int size)
 {
     struct arp_addr apair;
     struct arp *arp_r;
 
     arp_r = (struct arp *) packet;
 
-    /* arp_print(arp_r); */
+    debug_arp("arp: SEND reply to %s\n", in_ntoa(arp_r->ip_src));
 
     /* swap ip addresses and mac addresses */
     apair.daddr = arp_r->ip_src;
@@ -136,7 +135,7 @@ void arp_reply(char *packet,int size)
     memcpy(apair.eth_src, eth_local_addr, 6);
 
     /* build arp reply */
-    arp_r->op=0x200; /*response - big endian*/
+    arp_r->op = htons(ARP_REPLY);
     memcpy(arp_r->ll_eth_dest, apair.eth_dest, 6);
     memcpy(arp_r->ll_eth_src, apair.eth_src, 6);
 
@@ -145,72 +144,68 @@ void arp_reply(char *packet,int size)
     memcpy(arp_r->eth_dest, apair.eth_dest, 6);
     arp_r->ip_dest=apair.daddr;
 
+    arp_print(arp_r);
     deveth_send(packet, sizeof (struct arp));
 }
 
 int arp_request(ipaddr_t ipaddress)
 {
-    int i;
-    fd_set fdset;
-    struct arp *arp_r;
-    static char packet[sizeof(struct arp)];
-    arp_r = (struct arp *)packet;
+    static struct arp arpreq;
 
-    debug_arp("arp: send request\n");
+    debug_arp("arp: SEND request\n");
+
     /* build arp request */
-    for (i=0;i<6;i++) arp_r->ll_eth_dest[i]=0xFF; /*broadcast*/
-    memcpy(arp_r->ll_eth_src, eth_local_addr, 6);
-    /*specify below in big endian*/
-    arp_r->ll_type_len=0x0608;
-    arp_r->hard_type=0x0100;
-    arp_r->proto_type=0x0008;
-    arp_r->hard_len=6;
-    arp_r->proto_len=4;
-    arp_r->op=0x0100; /*request - big endian*/
-    memcpy(arp_r->eth_src, eth_local_addr, 6);
-    arp_r->ip_src=local_ip;
-    for (i=0;i<6;i++) arp_r->eth_dest[i]=0;
-    arp_r->ip_dest=ipaddress;
+    memset(arpreq.ll_eth_dest, 0xFF, 6);	/* broadcast*/
+	memcpy(arpreq.ll_eth_src, eth_local_addr, 6);
+    /*specify below in big endian*/ //FIXME
+	arpreq.ll_type_len = ETH_TYPE_ARP;
+    arpreq.hard_type=0x0100;
+    arpreq.proto_type = ETH_TYPE_IPV4;
+    arpreq.hard_len=6;
+    arpreq.proto_len=4;
+    arpreq.op = htons(ARP_REQUEST);
+    memcpy(arpreq.eth_src, eth_local_addr, 6);
+    arpreq.ip_src=local_ip;
+    memset(arpreq.eth_dest, 0, 6);
+    arpreq.ip_dest=ipaddress;
 
-    deveth_send(&packet, sizeof (struct arp));
+    arp_print(&arpreq);
+    deveth_send((unsigned char *)&arpreq, sizeof(arpreq));
 
-    /* wait for reply */
-selectagain:
+    /* timeout wait for reply */
     debug_arp("arp: wait reply\n");
-
+    struct timeval timeint;
+    fd_set fdset;
+    timeint.tv_sec  = 0;
+    timeint.tv_usec = 500000L;	/* 1/2 second*/
     FD_ZERO(&fdset);
     FD_SET(tcpdevfd, &fdset);
-    i = select(tcpdevfd + 1, &fdset, NULL, NULL, NULL);
-    if (i < 0) {
-	if (errno == EINTR) {
-		fprintf(stderr, "arp: select EINTR\n");
-		goto selectagain;
-	}
-	perror("select");
-	return -1;
+    int i = select(tcpdevfd + 1, &fdset, NULL, NULL, &timeint);
+    if (i >= 0) {
+	printf("arp: got reply on timed wait\n");
+	deveth_process();
+	return 0;	/* success*/
     }
-    debug_arp("arp: got reply\n");
-    deveth_process(); /*get reply*/
-
-    return 0;
+    return 1;		/* error*/
 }
 
 
 /* Process incoming ARP packets */
-
-void arp_proc (char * packet, int size)
+void arp_recvpacket(unsigned char *packet, int size)
 {
 	struct arp * arp_r;
 
-	debug_arp("arp: incoming packet\n");
 	arp_r = (struct arp *) packet;
-	switch (arp_r->op) {
+	arp_print(arp_r);
+	switch (ntohs(arp_r->op)) {
 	case ARP_REQUEST:
+		debug_arp("arp: incoming REQUEST\n");
 		arp_cache_add (arp_r->ip_src, arp_r->eth_src);
 		arp_reply (packet, size);
 		break;
 
 	case ARP_REPLY:
+		debug_arp("arp: incoming REPLY\n");
 		arp_cache_add (arp_r->ip_src, arp_r->eth_src);
 		break;
 	}

--- a/elkscmd/ktcp/arp.h
+++ b/elkscmd/ktcp/arp.h
@@ -32,8 +32,7 @@ int arp_init (void);
 void arp_cache_add (ipaddr_t ip_addr, eth_addr_t * eth_addr);
 int arp_cache_get (ipaddr_t ip_addr, eth_addr_t * eth_addr);
 
-void arp_proc (char * packet, int size);
+void arp_recvpacket (unsigned char * packet, int size);
 int arp_request(ipaddr_t ipaddress);
-
 
 #endif /* !ARP_H */

--- a/elkscmd/ktcp/arp.h
+++ b/elkscmd/ktcp/arp.h
@@ -35,4 +35,6 @@ int arp_cache_get (ipaddr_t ip_addr, eth_addr_t * eth_addr);
 void arp_recvpacket (unsigned char * packet, int size);
 int arp_request(ipaddr_t ipaddress);
 
+char *mac_ntoa(unsigned char *p);
+
 #endif /* !ARP_H */

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -9,6 +9,8 @@
 #define DEBUG_IP	0
 #define DEBUG_ARP	0
 
+#define DEBUG_CB	0		/* dump control blocks*/
+
 #if DEBUG_TCP
 #define debug_tcp	printf
 #else

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -5,10 +5,13 @@
 
 //#define ARP_WAIT_KLUGE	/* force loop on arp reply*/
 
+/* turn these on for ELKS debugging*/
 #define DEBUG_TCP	0
 #define DEBUG_IP	0
 #define DEBUG_ARP	0
 
+/* leave these off for now - too much info*/
+#define DEBUG_MEM	0		/* debug memory allocations*/
 #define DEBUG_CB	0		/* dump control blocks*/
 
 #if DEBUG_TCP
@@ -27,6 +30,12 @@
 #define debug_arp	printf
 #else
 #define debug_arp(...)
+#endif
+
+#if DEBUG_MEM
+#define debug_mem	printf
+#else
+#define debug_mem(...)
 #endif
 
 #endif

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -3,6 +3,8 @@
 
 #include <autoconf.h>
 
+//#define ARP_WAIT_KLUGE	/* force loop on arp reply*/
+
 #define DEBUG_TCP	0
 #define DEBUG_IP	0
 #define DEBUG_ARP	0

--- a/elkscmd/ktcp/deveth.c
+++ b/elkscmd/ktcp/deveth.c
@@ -33,7 +33,7 @@ static int devfd;
 static eth_addr_t broad_addr = {255, 255, 255, 255, 255, 255};
 
 
-void deveth_printhex(char* packet, int len)
+void deveth_printhex(unsigned char *packet, int len)
 {
   unsigned char *p;
   int i;
@@ -112,13 +112,13 @@ void deveth_process ()
 	  break;
 
   case ETH_TYPE_ARP:
-	  arp_proc (sbuf, len);
+	  arp_recvpacket (sbuf, len);
 	  break;
   }
 }
 
 
-void deveth_send(char *packet, int len)
+void deveth_send(unsigned char *packet, int len)
 {
     //printf("deveth_send:\n");
     //deveth_printhex(packet,len);

--- a/elkscmd/ktcp/deveth.c
+++ b/elkscmd/ktcp/deveth.c
@@ -26,6 +26,7 @@
 #include "arp.h"
 
 eth_addr_t eth_local_addr;
+int eth_device;
 
 static unsigned char sbuf [MAX_PACKET_ETH];
 static int devfd;
@@ -33,23 +34,20 @@ static int devfd;
 static eth_addr_t broad_addr = {255, 255, 255, 255, 255, 255};
 
 
+#if DEBUG
 void deveth_printhex(unsigned char *packet, int len)
 {
-  unsigned char *p;
-  int i;
+  unsigned char *p = packet;
+  int i = 0;
   printf("deveth_process():%d bytes\n",len);
   if (len > 128) len = 128;
-  p = packet;
-  i = 1;
   while (len--) {
-	printf("%02X",*p);
-	if ((i % 2) == 0) printf(" "); /*%=modulo*/
-	if ((i % 16) == 0) printf("\n"); /*%=modulo*/
-	p++;
-	i++;
+	printf("%02X ", *p++);
+	if ((i++ & 15) == 15) printf("\n");
   }
   printf("\n");
 }
+#endif
 
 int deveth_init(char *fdev)
 {
@@ -61,7 +59,7 @@ int deveth_init(char *fdev)
 
     /* read mac of nic */
     if (ioctl (devfd, IOCTL_ETH_ADDR_GET, eth_local_addr) < 0) {
-        perror ("ioctl /dev/eth addr_get");
+        printf("ktcp: IOCTL_ETH_ADDR_GET fail\n");
 
         /* MAC not available is a fatal error */
         /* because it means the driver does not work */
@@ -69,11 +67,7 @@ int deveth_init(char *fdev)
         return -2;
     }
 
-    /*
-    __u8 addr = (__u8 *) &eth_local_addr;
-    printf ("eth_local_addr: %2X.%2X.%2X.%2X.%2X.%2X \n",
-        addr [0], addr [1], addr [2], addr [3], addr [4],addr [5]);
-    */
+    debug_arp("eth_local_addr: %s\n", mac_ntoa(&eth_local_addr));
 
     return devfd;
 }
@@ -83,16 +77,12 @@ int deveth_init(char *fdev)
  *  Called when select in ktcp indicates we have new data waiting
  */
 
-void deveth_process ()
+void deveth_process(void)
 {
-  int len;
-  int head_size;
   eth_head_t * eth_head;
-
-  head_size = sizeof (eth_head_t);
-
-  len = read (devfd, sbuf, MAX_PACKET_ETH);
-  if (len < head_size) return;
+  int len = read (devfd, sbuf, MAX_PACKET_ETH);
+  if (len < sizeof(eth_head_t))
+	return;
 
   eth_head = (eth_head_t *) sbuf;
 
@@ -108,7 +98,8 @@ void deveth_process ()
 
   switch (eth_head->eth_type) {
   case ETH_TYPE_IPV4:
-	  ip_recvpacket (sbuf + head_size, len - head_size);  /* strip link layer */
+	  /* strip link layer */
+	  ip_recvpacket (sbuf + sizeof(eth_head_t), len - sizeof(eth_head_t));
 	  break;
 
   case ETH_TYPE_ARP:
@@ -120,7 +111,6 @@ void deveth_process ()
 
 void deveth_send(unsigned char *packet, int len)
 {
-    //printf("deveth_send:\n");
     //deveth_printhex(packet,len);
     write(devfd, packet, len);
 }

--- a/elkscmd/ktcp/deveth.h
+++ b/elkscmd/ktcp/deveth.h
@@ -3,7 +3,7 @@
 
 
 /* Ethernet II types */
-/* as big endian values */
+/* as big endian values */ //FIXME
 
 #define ETH_TYPE_IPV4 0x0008
 #define ETH_TYPE_ARP  0x0608
@@ -25,9 +25,9 @@ typedef struct eth_head_s eth_head_t;
 extern eth_addr_t eth_local_addr;
 
 
-void deveth_printhex(char* packet, int len);
+void deveth_printhex(unsigned char *packet, int len);
 int  deveth_init(char *fdev);
 void deveth_process(void);
-void deveth_send(char *packet, int len);
+void deveth_send(unsigned char *packet, int len);
 
 #endif /* !DEVETH_H */

--- a/elkscmd/ktcp/deveth.h
+++ b/elkscmd/ktcp/deveth.h
@@ -23,7 +23,7 @@ struct eth_head_s {
 typedef struct eth_head_s eth_head_t;
 
 extern eth_addr_t eth_local_addr;
-
+extern int eth_device;
 
 void deveth_printhex(unsigned char *packet, int len);
 int  deveth_init(char *fdev);

--- a/elkscmd/ktcp/icmp.c
+++ b/elkscmd/ktcp/icmp.c
@@ -12,32 +12,36 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include "slip.h"
+#include <stdio.h>
+#include "config.h"
 #include "ip.h"
 #include "icmp.h"
 #include <linuxmt/arpa/inet.h>
+
+#define ICMP_ECHO_REPLY		0
 
 int icmp_init(void)
 {
     return 0;
 }
 
-void icmp_process(struct iphdr_s *iph,char *packet)
+void icmp_process(struct iphdr_s *iph,unsigned char *packet)
 {
     struct addr_pair apair;
     int len;
 
     switch (packet[0]){
 	case 8: /* ICMP_ECHO */
+	    debug_ip("icmp: PING from %s\n", in_ntoa(iph->saddr));
 	    apair.daddr = iph->saddr;
 	    apair.saddr = iph->daddr;
 	    apair.protocol = PROTO_ICMP;
 	    len = ntohs(iph->tot_len) - 20;	/* Do this right */
-
-/*	Set the type to ICMP_ECHO_REPLY
- */
-	    packet[0] = 0;
+	    packet[0] = ICMP_ECHO_REPLY;
 	    ip_sendpacket(packet, len, &apair);
+	    break;
+	default:
+	    debug_ip("icmp: unregocognized ICMP request %d\n", packet[0]);
 	    break;
     }
 }

--- a/elkscmd/ktcp/icmp.h
+++ b/elkscmd/ktcp/icmp.h
@@ -4,6 +4,6 @@
 #define PROTO_ICMP	1
 
 int icmp_init(void);
-void icmp_process(struct iphdr_s *iph, char *packet);
+void icmp_process(struct iphdr_s *iph, unsigned char *packet);
 
 #endif

--- a/elkscmd/ktcp/icmp.h
+++ b/elkscmd/ktcp/icmp.h
@@ -3,6 +3,18 @@
 
 #define PROTO_ICMP	1
 
+#define ICMP_ECHO_REPLY			0
+#define ICMP_ECHO_DESTUNREACHABLE	3
+#define ICMP_ECHO_REQUEST		8
+
+struct icmp_echo_s {
+	__u8	type;
+	__u8	code;
+	__u16	chksum;
+	__u16	id;
+	__u16	seqnum;
+};
+
 int icmp_init(void);
 void icmp_process(struct iphdr_s *iph, unsigned char *packet);
 

--- a/elkscmd/ktcp/ip.h
+++ b/elkscmd/ktcp/ip.h
@@ -37,24 +37,18 @@ struct iphdr_s {
 
 typedef struct iphdr_s iphdr_t;
 
-__u16 ip_calc_chksum(char *data, int len);
+struct ip_ll {
+	__u8  ll_eth_dest[6]; 	/* link layer MAC destination address */
+	__u8  ll_eth_src[6]; 	/* link layer MAC source address */
+	__u16 ll_type_len;
+};
 
 extern ipaddr_t local_ip;
 extern ipaddr_t gateway_ip;
 extern ipaddr_t netmask_ip;
 
-__u16	next_port;
-
-struct ip_ll
-{
-         __u8  ll_eth_dest[6]; 	/* link layer MAC destination address */
-         __u8  ll_eth_src[6]; 	/* link layer MAC source address */
-         __u16 ll_type_len;	/* 0x800 big endian for IP */
-};
-
-extern int tcpdevfd;
-
 int ip_init(void);
+__u16 ip_calc_chksum(char *data, int len);
 void ip_recvpacket(unsigned char *packet, int size);
 void ip_sendpacket(unsigned char *packet, int len, struct addr_pair *apair);
 

--- a/elkscmd/ktcp/ip.h
+++ b/elkscmd/ktcp/ip.h
@@ -55,7 +55,10 @@ struct ip_ll
 extern int tcpdevfd;
 
 int ip_init(void);
-void ip_recvpacket(char *packet, int size);
-void ip_sendpacket(char *packet, int len, struct addr_pair *apair);
+void ip_recvpacket(unsigned char *packet, int size);
+void ip_sendpacket(unsigned char *packet, int len, struct addr_pair *apair);
+
+unsigned long in_aton(const char *str);
+char *in_ntoa(ipaddr_t in);
 
 #endif

--- a/elkscmd/ktcp/ip.h
+++ b/elkscmd/ktcp/ip.h
@@ -39,9 +39,9 @@ typedef struct iphdr_s iphdr_t;
 
 __u16 ip_calc_chksum(char *data, int len);
 
-ipaddr_t local_ip;
-ipaddr_t gateway_ip;
-ipaddr_t netmask_ip;
+extern ipaddr_t local_ip;
+extern ipaddr_t gateway_ip;
+extern ipaddr_t netmask_ip;
 
 __u16	next_port;
 

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -22,6 +22,7 @@
 #include "slip.h"
 #include "tcp.h"
 #include "tcp_output.h"
+#include "tcp_cb.h"
 #include "tcpdev.h"
 #include "timer.h"
 #include <linuxmt/arpa/inet.h>
@@ -31,48 +32,13 @@
 #include "deveth.h"
 #include "arp.h"
 
-#ifdef DEBUG
-#define debug	printf
-#else
-#define debug(...)
-#endif
+ipaddr_t local_ip;
+ipaddr_t gateway_ip;
+ipaddr_t netmask_ip;
 
 char deveth[] = "/dev/eth";
 
-static int intfd;
-
-unsigned long in_aton(const char *str)
-{
-    unsigned long l = 0;
-    unsigned int val;
-    int i;
-
-    for (i = 0; i < 4; i++) {
-	l <<= 8;
-	if (*str != '\0') {
-	    val = 0;
-	    while (*str != '\0' && *str != '.') {
-		val *= 10;
-		val += *str++ - '0';
-	    }
-	    l |= val;
-	    if (*str != '\0')
-		str++;
-	}
-    }
-    return htonl(l);
-}
-
-char *
-in_ntoa(ipaddr_t in)
-{
-    register unsigned char *p;
-    static char b[18];
-
-    p = (unsigned char *)&in;
-    sprintf(b, "%d.%d.%d.%d", p[0], p[1], p[2], p[3]);
-    return b;
-}
+static int intfd;	/* interface fd*/
 
 void ktcp_run(void)
 {
@@ -103,8 +69,9 @@ extern int cbs_in_user_timeout;
 	tcp_update();
 
 	if (FD_ISSET(intfd, &fdset)) {
-		if (dev->type == 0) slip_process();
-		else deveth_process();
+		if (eth_device)
+			deveth_process();
+		else slip_process();
 	}
 	if (FD_ISSET(tcpdevfd, &fdset)) tcpdev_process();
 
@@ -137,7 +104,6 @@ usage:
 	exit(3);
     }
 
-    debug("KTCP: 1. local_ip \n");
     local_ip = in_aton(argv[1]);
 
     if (argc > 3) gateway_ip = in_aton(argv[3]);
@@ -146,29 +112,21 @@ usage:
     if (argc > 4) netmask_ip = in_aton(argv[4]);
     else netmask_ip = in_aton("255.255.255.0");
 
-    /*
-    addr = (__u8 *) &local_ip;
-    printf ("local_ip: %2X.%2X.%2X.%2X\n", addr [0], addr [1], addr [2], addr[3]);
-    addr = (__u8 *) &gateway_ip;
-    printf ("gateway_ip: %2X.%2X.%2X.%2X\n", addr [0], addr [1], addr [2], addr [3]);
-    addr = (__u8 *) &netmask_ip;
-    printf ("netmask_ip: %2X.%2X.%2X.%2X\n", addr [0], addr [1], addr [2], addr [3]);
-    */
+    printf("ktcp: ip %s, ", in_ntoa(local_ip));
+    printf("gateway %s, ", in_ntoa(gateway_ip));
+    printf("netmask %s\n", in_ntoa(netmask_ip));
 
     /* must exit() in next two stages on error to reset kernel tcpdev_inuse to 0*/
-    debug("\nKTCP: 2. init tcpdev\n");
-    if ((tcpdevfd = tcpdev_init("/dev/tcpdev")) < 0) exit(1);
+    if ((tcpdevfd = tcpdev_init("/dev/tcpdev")) < 0)
+	exit(1);
 
-    debug("KTCP: 3. init interface\n");
     if (strcmp(argv[2],deveth) == 0) {
-	debug("Init /dev/eth\n");
-    	dev->type = 1;
-	intfd = deveth_init(deveth);
-	if (intfd < 0) exit(1);
-    } else { /* fall back to slip */
-	dev->type=0;
-	intfd = slip_init(argv[2], baudrate);
-	if (intfd < 0) exit(2);
+	if ((intfd = deveth_init(deveth)) < 0)
+	    exit(1);
+	eth_device = 1;
+    } else {
+	if ((intfd = slip_init(argv[2], baudrate)) < 0)
+	    exit(2);
     }
 
     /* become daemon now that tcpdev_inuse race condition over*/
@@ -184,22 +142,45 @@ usage:
     }
 
     arp_init ();
-
-    debug("KTCP: 4. ip_init()\n");
     ip_init();
-
-    debug("KTCP: 5. icmp_init()\n");
     icmp_init();
-
-    debug("KTCP: 6. tcp_init()\n");
     tcp_init();
-
-    debug("KTCP: 7. netconf_init()\n");
     netconf_init();
 
-    debug("KTCP: 8. ktcp_run()\n");
     ktcp_run();
 
-    debug("KTCP: 9. exit(0)\n");
     exit(0);
+}
+
+unsigned long in_aton(const char *str)
+{
+    unsigned long l = 0;
+    unsigned int val;
+    int i;
+
+    for (i = 0; i < 4; i++) {
+	l <<= 8;
+	if (*str != '\0') {
+	    val = 0;
+	    while (*str != '\0' && *str != '.') {
+		val *= 10;
+		val += *str++ - '0';
+	    }
+	    l |= val;
+	    if (*str != '\0')
+		str++;
+	}
+    }
+    return htonl(l);
+}
+
+char *
+in_ntoa(ipaddr_t in)
+{
+    register unsigned char *p;
+    static char b[18];
+
+    p = (unsigned char *)&in;
+    sprintf(b, "%d.%d.%d.%d", p[0], p[1], p[2], p[3]);
+    return b;
 }

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -63,6 +63,17 @@ unsigned long in_aton(const char *str)
     return htonl(l);
 }
 
+char *
+in_ntoa(ipaddr_t in)
+{
+    register unsigned char *p;
+    static char b[18];
+
+    p = (unsigned char *)&in;
+    sprintf(b, "%d.%d.%d.%d", p[0], p[1], p[2], p[3]);
+    return b;
+}
+
 void ktcp_run(void)
 {
     fd_set fdset;

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -36,6 +36,7 @@ ipaddr_t local_ip;
 ipaddr_t gateway_ip;
 ipaddr_t netmask_ip;
 
+char junk[8000];	//FIXME low core getting trashed
 char deveth[] = "/dev/eth";
 
 static int intfd;	/* interface fd*/
@@ -66,16 +67,23 @@ extern int cbs_in_user_timeout;
 
 	Now = timer_get_time();
 
+	/* expire timeouts and push data*/
 	tcp_update();
 
+	/* process received packets*/
 	if (FD_ISSET(intfd, &fdset)) {
 		if (eth_device)
 			deveth_process();
 		else slip_process();
 	}
-	if (FD_ISSET(tcpdevfd, &fdset)) tcpdev_process();
 
-	if (tcp_timeruse > 0) tcp_retrans();
+	/* process application socket actions*/
+	if (FD_ISSET(tcpdevfd, &fdset))
+		tcpdev_process();
+
+	/* check for retransmit needed*/
+	if (tcp_timeruse > 0)
+		tcp_retrans();
 
 	tcpcb_printall();
     }

--- a/elkscmd/ktcp/slip.c
+++ b/elkscmd/ktcp/slip.c
@@ -268,9 +268,9 @@ void cslip_compress(__u8 **packet, int *len)
 #endif
 
 /*
- * TODO : Use a buffer to reduse the write calls
+ * TODO : Use a buffer to reduse the write calls //FIXME
  */
-void slip_send(char *packet, int len)
+void slip_send(unsigned char *packet, int len)
 {
     __u8 *p = (__u8 *)packet;
 

--- a/elkscmd/ktcp/slip.c
+++ b/elkscmd/ktcp/slip.c
@@ -247,6 +247,7 @@ void cslip_compress(__u8 **packet, int *len)
 {
     pkt_ut p;
     __u8 type;
+    //int orig_len = len;
 
     p.p_data = *packet;
     p.p_size = *len;
@@ -261,9 +262,7 @@ void cslip_compress(__u8 **packet, int *len)
         *packet[0] |= type;
     }
 
-#ifdef DEBUG
-    printf("cslip : from %d to %d\n", orig_len, p.p_size);
-#endif
+    //printf("cslip : from %d to %d\n", orig_len, p.p_size);
 }
 #endif
 

--- a/elkscmd/ktcp/slip.h
+++ b/elkscmd/ktcp/slip.h
@@ -5,6 +5,6 @@
 
 void slip_process(void);
 int slip_init(char *fdev, speed_t baudrate);
-void slip_send(char *packet, int len);
+void slip_send(unsigned char *packet, int len);
 
 #endif

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -210,15 +210,15 @@ static void tcp_established(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 
 	tcpcb_buf_write(cb, data, datasize);
 
-	if (h->flags & TF_PSH || CB_BUF_SPACE(cb) == 0) {
-	    if (cb->bytes_to_push <=0)
+	if ((h->flags & TF_PSH) || CB_BUF_SPACE(cb) == 0) {
+	    if (cb->bytes_to_push <= 0)
 		tcpcb_need_push++;
 	    cb->bytes_to_push = CB_BUF_USED(cb);
 	}
 	tcpdev_checkread(cb);
     } /* datasize != 0 */
 
-    if (h->flags & TF_ACK) { /*update una*/
+    if (h->flags & TF_ACK) { 	/*update unacked*/
 	acknum = ntohl(h->acknum);
 	if (SEQ_LT(cb->send_una, acknum))
 	    cb->send_una = acknum;
@@ -239,12 +239,8 @@ printf("tcp: RST received, removing retrans packets\n");
     }
 
     if (h->flags & TF_FIN) {
-	cb->rcv_nxt ++;
+	cb->rcv_nxt++;
 	cb->state = TS_CLOSE_WAIT;
-/* FIXME timeout if remote side terminated*/
-debug_tcp("Setting TS_CLOSE_WAIT\n");
-cb->time_wait_exp = Now;
-cbs_in_user_timeout++;
 	tcpdev_sock_state(cb, SS_DISCONNECTING);
     }
 

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -211,7 +211,7 @@ static void tcp_established(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 
 	tcpcb_buf_write(cb, data, datasize);
 
-	if ((h->flags & TF_PSH) || CB_BUF_SPACE(cb) == 0) {
+	if ((h->flags & TF_PSH) || CB_BUF_SPACE(cb) <= PUSH_THRESHOLD) {
 	    if (cb->bytes_to_push <= 0)
 		tcpcb_need_push++;
 	    cb->bytes_to_push = CB_BUF_USED(cb);

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -151,6 +151,7 @@ void tcpcb_remove();
 
 __u16 tcp_chksum(struct iptcp_s *h);
 __u16 tcp_chksumraw(struct tcphdr_s *h, __u32 saddr, __u32 daddr, __u16 len);
+void tcp_print(struct iptcp_s *head, int recv);
 void tcp_output();
 void tcp_update(void);
 int tcp_init(void);

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -8,6 +8,12 @@
 #include "ip.h"
 #include <linuxmt/arpa/inet.h>
 
+/* control block input buffer size - max window size*/
+#define CB_IN_BUF_SIZE	2048
+
+/* bytes to subtract from window size and when to force app write*/
+#define PUSH_THRESHOLD	1024
+
 #define PROTO_TCP	0x06
 
 #define SEQ_LT(a,b)	((long)((a)-(b)) < 0)
@@ -69,7 +75,6 @@ struct iptcp_s {
 #define	TS_LAST_ACK	9
 #define	TS_TIME_WAIT	10
 
-#define CB_IN_BUF_SIZE	2048 /* 1024 too small */
 #define CB_BUF_USED(x)	((x)->buf_len)
 #define CB_BUF_SPACE(x)	(CB_IN_BUF_SIZE - CB_BUF_USED((x)))
 #define CB_BUF_TAIL(x)	(((x)->buf_head + (x)->buf_len) % (CB_IN_BUF_SIZE - 1))

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -157,6 +157,6 @@ int tcp_init(void);
 void tcp_process(struct iphdr_s *iph);
 void tcp_connect(struct tcpcb_s *cb);
 void tcp_send_fin(struct tcpcb_s *cb);
-unsigned long in_aton(const char *str);
+void tcp_send_reset(struct tcpcb_s *cb);
 
 #endif

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -75,8 +75,8 @@ struct iptcp_s {
 #define CB_BUF_TAIL(x)	(((x)->buf_head + (x)->buf_len) % (CB_IN_BUF_SIZE - 1))
 
 struct tcpcb_s {
-	__u16	newsock;
-	__u16	sock;	/* the socket in kernel space */
+	void *	newsock;
+	void *	sock;	/* the socket in kernel space */
 #define SS_NULL		0
 #define	SS_ACCEPT	1
 	__u32	localaddr;
@@ -146,7 +146,7 @@ int tcp_retrans_memory;
 
 struct tcpcb_list_s *tcpcb_new();
 struct tcpcb_list_s *tcpcb_find(__u32 addr, __u16 lport, __u16 rport);
-struct tcpcb_list_s *tcpcb_find_by_sock(__u16 sock);
+struct tcpcb_list_s *tcpcb_find_by_sock(void *sock);
 void tcpcb_remove();
 
 __u16 tcp_chksum(struct iptcp_s *h);

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -33,15 +33,15 @@ void tcpcb_init(void)
 
 void tcpcb_printall(void)
 {
-#if 0
+#if DEBUG_CB
     struct tcpcb_list_s *n = tcpcbs;
 
     printf("--- Control Blocks --- %d (%d)\n",tcpcb_num,tcp_retrans_memory);
     while (n) {
-	printf("CB:%p sock:0x%x 0x%x State:%d LP:%u RP:%u RTT: %d ms unacc : %d\n",&n->tcpcb, n->tcpcb.sock,
-		n->tcpcb.newsock, n->tcpcb.state, n->tcpcb.localport,
-		n->tcpcb.remport, n->tcpcb.rtt * 1000 / 16,
-		n->tcpcb.unaccepted);
+	printf("CB:%p sock:%04x %04xx State:%d LP:%u RP:%u RTT:%d unacc: %d\n",
+	    &n->tcpcb, n->tcpcb.sock, n->tcpcb.newsock,
+	    n->tcpcb.state, n->tcpcb.localport, n->tcpcb.remport,
+	    n->tcpcb.rtt * 1000 / 16, n->tcpcb.unaccepted);
 	n = n->next;
     }
 #endif
@@ -156,7 +156,7 @@ struct tcpcb_list_s *tcpcb_find(__u32 addr, __u16 lport, __u16 rport)
     return NULL;
 }
 
-struct tcpcb_list_s *tcpcb_find_by_sock(__u16 sock)
+struct tcpcb_list_s *tcpcb_find_by_sock(void *sock)
 {
     struct tcpcb_list_s *n;
 
@@ -167,7 +167,7 @@ struct tcpcb_list_s *tcpcb_find_by_sock(__u16 sock)
     return NULL;
 }
 
-struct tcpcb_list_s *tcpcb_find_unaccepted(__u16 sock)
+struct tcpcb_list_s *tcpcb_find_unaccepted(void *sock)
 {
     struct tcpcb_list_s *n;
 

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -70,7 +70,7 @@ struct tcpcb_list_s *tcpcb_new(void)
 	debug_tcp("ktcp: Out of memory 3\n");
 	return NULL;
     }
-debug_tcp("alloc %d\n", sizeof(struct tcpcb_list_s));
+debug_mem("Alloc CB %d bytes\n", sizeof(struct tcpcb_list_s));
 
     memset(&n->tcpcb, 0, sizeof(struct tcpcb_s));
     n->tcpcb.rtt = 4 << 4; /* 4 sec */
@@ -102,7 +102,7 @@ void tcpcb_remove(struct tcpcb_list_s *n)
 {
     struct tcpcb_list_s *next = n->next;
 
-debug_tcp("REMOVING CB\n");
+debug_tcp("tcp: REMOVING control block\n");
     tcpcb_num--;	/* for netstat*/
 
     if (n->prev)
@@ -114,7 +114,7 @@ debug_tcp("REMOVING CB\n");
 	n->prev = NULL;
 
 	rmv_all_retrans(tcpcbs);
-debug_tcp("FREE 0\n");
+debug_mem("Free CB\n");
 	free(tcpcbs);
 	tcpcbs = n;
 
@@ -126,7 +126,7 @@ debug_tcp("FREE 0\n");
 
     rmv_all_retrans(n);
     free(n);
-debug_tcp("FREE 0\n");
+debug_mem("Free CB\n");
 }
 
 struct tcpcb_list_s *tcpcb_check_port(__u16 lport)

--- a/elkscmd/ktcp/tcp_cb.h
+++ b/elkscmd/ktcp/tcp_cb.h
@@ -8,8 +8,9 @@ void tcpcb_buf_write(struct tcpcb_s *cb, __u8 *data, __u16 len);
 void tcpcb_expire_timeouts(void);
 void tcpcb_push_data(void);
 struct tcpcb_list_s *tcpcb_check_port(__u16 lport);
-struct tcpcb_list_s *tcpcb_find_unaccepted(__u16 sock);
+struct tcpcb_list_s *tcpcb_find_unaccepted(void *sock);
 void tcpcb_rmv_all_unaccepted(struct tcpcb_s *cb);
 struct tcpcb_s *tcpcb_getbynum(int num);
+void tcpcb_printall(void);
 
 #endif

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -216,6 +216,19 @@ void rmv_all_retrans(struct tcpcb_list_s *lcb)
 	    n = n->next;
 }
 
+void rmv_all_retrans_cb(struct tcpcb_s *cb)
+{
+    struct tcp_retrans_list_s *n;
+
+    n = retrans_list;
+
+    while (n != NULL)
+	if (n->cb == cb)
+	    n = rmv_from_retrans(n);
+	else
+	    n = n->next;
+}
+
 void add_for_retrans(struct tcpcb_s *cb, struct tcphdr_s *th, __u16 len,
 		     struct addr_pair *apair)
 {
@@ -272,7 +285,7 @@ void tcp_reoutput(struct tcp_retrans_list_s *n)
     n->rto *= 2;
     n->next_retrans = Now + n->rto;
 
-    ip_sendpacket(n->tcph, n->len, &n->apair);
+    ip_sendpacket((unsigned char *)n->tcph, n->len, &n->apair);
 }
 
 /* called every ktcp cycle when tcp_timeruse nonzero*/
@@ -382,5 +395,5 @@ void tcp_output(struct tcpcb_s *cb)
     printf("daddr: %2X.%2X.%2X.%2X ",addr[0],addr[1],addr[2],addr[3]);
 */
     add_for_retrans(cb, th, len, &apair);
-    ip_sendpacket(th, len, &apair);
+    ip_sendpacket((unsigned char *)th, len, &apair);
 }

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -328,6 +328,8 @@ if (tcp_retrans_memory > TCP_RETRANS_MAXMEM || tcp_timeruse > 5) {
 	    n = rmv_from_retrans(n);
 	    continue;
 	}
+
+printf("retrans %d mem %d\n", tcp_timeruse, tcp_retrans_memory);
 	if (TIME_GEQ(Now, n->next_retrans)) {
 	    tcp_reoutput(n);
 	    return;
@@ -351,8 +353,8 @@ void tcp_output(struct tcpcb_s *cb)
 
     cb->send_nxt += cb->datalen;
 
-    len = CB_BUF_SPACE(cb);
-    if (len == 0)
+    len = CB_BUF_SPACE(cb) - PUSH_THRESHOLD;
+    if (len <= 0)
 	len = 1;		/* Never advertise zero window size */
     th->window = htons(len);
     th->urgpnt = 0;

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -234,7 +234,7 @@ void add_for_retrans(struct tcpcb_s *cb, struct tcphdr_s *th, __u16 len,
 {
     struct tcp_retrans_list_s *n;
 
-    if (cb->flags == TF_ACK && cb->datalen == 0)
+    if ((cb->flags & TF_ALL) == TF_ACK && cb->datalen == 0)
 	return;
 
     if (cb->state == TS_CLOSED)

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -33,7 +33,8 @@ static struct tcp_retrans_list_s *retrans_list;
 __u16 tcp_chksum(struct iptcp_s *h)
 {
     __u32 sum = htons(h->tcplen);
-    __u16 *data = (__u16 *)h->tcph, len = h->tcplen;
+    __u16 *data = (__u16 *)h->tcph;
+    __u16 len = h->tcplen;
 
     for (; len > 1 ; len -= 2)
 	sum += *data++;
@@ -185,7 +186,7 @@ rmv_from_retrans(struct tcp_retrans_list_s *n)
 	/* Head update */
 	n = next;
 	n->prev = NULL;
-debug_tcp("Free 1/2\n");
+debug_mem("retrans free buffers %d mem %d\n", tcp_timeruse, tcp_retrans_memory);
 	free(retrans_list->tcph);
 	free(retrans_list);
 	retrans_list = n;
@@ -196,7 +197,7 @@ debug_tcp("Free 1/2\n");
     if (next)
 	next->prev = n->prev;
 
-debug_tcp("Free 1/2\n");
+debug_mem("retrans free buffers %d mem %d\n", tcp_timeruse, tcp_retrans_memory);
     free(n->tcph);
     free(n);
 
@@ -245,7 +246,6 @@ void add_for_retrans(struct tcpcb_s *cb, struct tcphdr_s *th, __u16 len,
 	printf("ktcp: Out of memory\n");
 	return;
     }
-debug_tcp("Alloc %d\n", sizeof(struct tcp_retrans_list_s));
 
     n->cb = cb;
     n->tcph = (struct tcphdr_s *)malloc(len);
@@ -254,10 +254,6 @@ debug_tcp("Alloc %d\n", sizeof(struct tcp_retrans_list_s));
 	free(n);
 	return;
     }
-debug_tcp("Alloc %d\n", len);
-
-    /* So that select in ktcp.c blocks for a specified time only */
-    tcp_timeruse++;
 
     /* Link it to the list */
     if (retrans_list) {
@@ -271,8 +267,12 @@ debug_tcp("Alloc %d\n", len);
 	n->prev = NULL;
     }
 
-    n->len = len;
+    /* start timeout blocking in main loop*/
+    tcp_timeruse++;
+
     tcp_retrans_memory += len;
+debug_mem("retrans alloc buffers %d, mem %d\n", tcp_timeruse, tcp_retrans_memory);
+    n->len = len;
     memcpy(n->tcph, th, len);
     memcpy(&n->apair, apair, sizeof(struct addr_pair));
     n->retrans_num = 0;
@@ -287,7 +287,7 @@ void tcp_reoutput(struct tcp_retrans_list_s *n)
     n->retrans_num ++;
     n->rto *= 2;
     n->next_retrans = Now + n->rto;
-
+printf("retrans retry #%d rto %ld\n", n->retrans_num, n->rto);
     ip_sendpacket((unsigned char *)n->tcph, n->len, &n->apair);
 }
 
@@ -311,13 +311,13 @@ if (tcp_retrans_memory > TCP_RETRANS_MAXMEM || tcp_timeruse > 5) {
 	return;
 }
 
-    debug_tcp("Retrans buffers : %d ", tcp_timeruse);
+    debug_mem("retrans check buffers %d, mem %d\n", tcp_timeruse, tcp_retrans_memory);
 
     n = retrans_list;
     while (n != NULL) {
 	datalen = n->len - TCP_DATAOFF(n->tcph);
 
-	debug_tcp("retrans : %lx %lx", ntohl(n->tcph->seqnum) + datalen,n->cb->send_una);
+	//debug_tcp("retrans: %lx %lx", ntohl(n->tcph->seqnum) + datalen,n->cb->send_una);
 	if (SEQ_LEQ(ntohl(n->tcph->seqnum) + datalen ,n->cb->send_una)) {
 	    if (n->retrans_num == 0) {
 		rtt = Now - n->first_trans;
@@ -326,10 +326,8 @@ if (tcp_retrans_memory > TCP_RETRANS_MAXMEM || tcp_timeruse > 5) {
 		        (TCP_RTT_ALPHA * n->cb->rtt + (100 - TCP_RTT_ALPHA) * rtt) / 100;
 	    }
 	    n = rmv_from_retrans(n);
-	    debug_tcp(" remove\n");
 	    continue;
 	}
-	debug_tcp(" not\n");
 	if (TIME_GEQ(Now, n->next_retrans)) {
 	    tcp_reoutput(n);
 	    return;
@@ -344,18 +342,12 @@ void tcp_output(struct tcpcb_s *cb)
     struct addr_pair apair;
     int len;
     __u8 *options, header_len, option_len;
-    //__u8 addr[4], *addr2;
+    //__u8 addr[4];
 
     th->sport = htons(cb->localport);
     th->dport = htons(cb->remport);
     th->seqnum = htonl(cb->send_nxt);
     th->acknum = htonl(cb->rcv_nxt);
-/*
-    memcpy(&addr,&th->seqnum,4);
-    printf("sequence: %2X,%2X,%2X,%2X ",addr[0],addr[1],addr[2],addr[3]);
-    memcpy(&addr,&th->acknum,4);
-    printf("acknum: %2X,%2X,%2X,%2X\n",addr[0],addr[1],addr[2],addr[3]);
-*/
 
     cb->send_nxt += cb->datalen;
 
@@ -372,7 +364,7 @@ void tcp_output(struct tcpcb_s *cb)
     if (cb->flags & TF_SYN) {
 	header_len += 4;
 	option_len += 4;
-	options[0] = 2; 	/* MSS */
+	options[0] = 2; 	/* MSS */ //FIXME
 	options[1] = 4;
 	*(__u16 *)(options + 2) = htons(SLIP_MTU - 40);
     }
@@ -389,12 +381,6 @@ void tcp_output(struct tcpcb_s *cb)
     apair.daddr = cb->remaddr;
     apair.protocol = PROTO_TCP;
 
-/*
-    memcpy(addr,apair.saddr,4);
-    printf("saddr: %2X.%2X.%2X.%2X ",addr[0],addr[1],addr[2],addr[3]);
-    memcpy(addr,apair.daddr,4);
-    printf("daddr: %2X.%2X.%2X.%2X ",addr[0],addr[1],addr[2],addr[3]);
-*/
     add_for_retrans(cb, th, len, &apair);
     ip_sendpacket((unsigned char *)th, len, &apair);
 }

--- a/elkscmd/ktcp/tcp_output.h
+++ b/elkscmd/ktcp/tcp_output.h
@@ -3,5 +3,6 @@
 
 void tcp_retrans(void);
 void rmv_all_retrans(struct tcpcb_list_s *lcb);
+void rmv_all_retrans_cb(struct tcpcb_s *cb);
 
 #endif

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -39,13 +39,13 @@ int tcpdev_init(char *fdev)
 {
     int fd  = open(fdev, O_NONBLOCK | O_RDWR);
     if (fd < 0)
-	printf("ktcp: failed to open tcpdev device %s\n",fdev);
+	printf("ktcp: can't open tcpdev device %s\n",fdev);
     return fd;
 }
 
-void retval_to_sock(__u16 sock,short int r)
+void retval_to_sock(void *sock,short int r)
 {
-    struct tdb_return_data *ret_data = sbuf;
+    struct tdb_return_data *ret_data = (struct tdb_return_data *)sbuf;
 
     ret_data->type = 0;
     ret_data->ret_value = r;
@@ -55,7 +55,7 @@ void retval_to_sock(__u16 sock,short int r)
 
 static void tcpdev_bind(void)
 {
-    struct tdb_bind *db = sbuf;
+    struct tdb_bind *db = (struct tdb_bind *)sbuf;
     struct tcpcb_list_s *n;
     __u16 port;
 
@@ -102,10 +102,10 @@ static void tcpdev_bind(void)
 static void tcpdev_accept(void)
 {
     struct tcpcb_list_s *n,*newn;
-    struct tdb_accept *db = sbuf;
+    struct tdb_accept *db = (struct tdb_accept *)sbuf;
     struct tdb_accept_ret *ret_data;
     struct tcpcb_s *cb;
-    __u16  sock = db->sock;
+    void *  sock = db->sock;
 
     n = tcpcb_find_by_sock(sock);
     if (!n || n->tcpcb.state != TS_LISTEN) {
@@ -128,7 +128,7 @@ static void tcpdev_accept(void)
     cb->sock = db->newsock;
     cb->newsock = 0;
 
-    ret_data = sbuf;
+    ret_data = (struct tdb_accept_ret *)sbuf;
     ret_data->type = 0;
     ret_data->ret_value = 0;
     ret_data->sock = sock;
@@ -147,7 +147,7 @@ void tcpdev_checkaccept(struct tcpcb_s *cb)
 	return;
     listencb = &tcpcb_find_by_sock(cb->newsock)->tcpcb;
 
-    ret_data = sbuf;
+    ret_data = (struct tdb_accept_ret *)sbuf;
     ret_data->type = 123;
     ret_data->ret_value = 0;
     ret_data->sock = cb->sock;
@@ -162,7 +162,7 @@ void tcpdev_checkaccept(struct tcpcb_s *cb)
 
 static void tcpdev_connect(void)
 {
-    struct tdb_connect *db = sbuf;
+    struct tdb_connect *db = (struct tdb_connect *)sbuf;
     struct tcpcb_list_s *n;
 
     n = tcpcb_find_by_sock(db->sock);
@@ -183,7 +183,7 @@ static void tcpdev_connect(void)
 
 static void tcpdev_listen(void)
 {
-    struct tdb_listen *db = sbuf;
+    struct tdb_listen *db = (struct tdb_listen *)sbuf;
     struct tcpcb_list_s *n;
 
     n = tcpcb_find_by_sock(db->sock);
@@ -198,15 +198,15 @@ static void tcpdev_listen(void)
 
 void tcpdev_read(void)
 {
-    struct tdb_read *db = sbuf;
+    struct tdb_read *db = (struct tdb_read *)sbuf;
     struct tcpcb_list_s *n;
     struct tcpcb_s *cb;
     struct tdb_return_data *ret_data;
     int data_avail;
-    __u16 sock = db->sock;
+    void * sock = db->sock;
 
     n = tcpcb_find_by_sock(sock);
-    if (!n) {
+    if (!n || n->tcpcb.state == TS_CLOSED) {
 	printf("ktcp: panic in read\n");
 	exit(1);
     }
@@ -238,7 +238,7 @@ void tcpdev_read(void)
     if (cb->bytes_to_push <= 0)
 	tcpcb_need_push--;
 
-    ret_data = sbuf;
+    ret_data = (struct tdb_return_data *)sbuf;
     ret_data->type = 0;
     ret_data->ret_value = data_avail;
     ret_data->sock = sock;
@@ -249,9 +249,9 @@ void tcpdev_read(void)
 
 void tcpdev_checkread(struct tcpcb_s *cb)
 {
-    struct tdb_return_data *ret_data = sbuf;
+    struct tdb_return_data *ret_data = (struct tdb_return_data *)sbuf;
     int data_avail = CB_BUF_USED(cb);
-    __u16 sock;
+    void * sock;
 
     if (cb->bytes_to_push <= 0)
 	return;
@@ -285,12 +285,12 @@ void tcpdev_checkread(struct tcpcb_s *cb)
 
 static void tcpdev_write(void)
 {
-    struct tdb_write *db = sbuf;
+    struct tdb_write *db = (struct tdb_write *)sbuf;
     struct tcpcb_list_s *n;
     struct tcpcb_s *cb;
-    __u16  sock = db->sock;
+    void *  sock = db->sock;
 
-    db = sbuf;
+    db = (struct tdb_write *)sbuf;
     sock = db->sock;
 
     /* This is a bit ugly but I'm to lazy right now */
@@ -301,8 +301,8 @@ printf("tcp: RETRANS limit exceeded\n");
     }
 
     n = tcpcb_find_by_sock(sock);
-    if (!n) {
-	printf("ktcp: panic in write (unknown sock:0x%x)\n",sock);
+    if (!n || n->tcpcb.state == TS_CLOSED) {
+	printf("ktcp: panic in write\n");
 	return;
     }
 
@@ -332,11 +332,12 @@ printf("tcp: RETRANS limit exceeded\n");
 
 static void tcpdev_release(void)
 {
-    struct tdb_release *db = sbuf;
+    struct tdb_release *db = (struct tdb_release *)sbuf;
     struct tcpcb_list_s *n;
     struct tcpcb_s *cb;
-    __u16 sock = db->sock;
+    void * sock = db->sock;
 
+printf("tcpdev: got close from ELKS process\n");
     n = tcpcb_find_by_sock(sock);
     if (n) {
 	cb = &n->tcpcb;
@@ -358,13 +359,7 @@ static void tcpdev_release(void)
 		cb->state = TS_FIN_WAIT_1;
 		cbs_in_user_timeout++;
 		cb->time_wait_exp = Now;
-
 		tcp_send_fin(cb);
-		/* Handle it as abort */
-#if 0
-		tcp_send_reset(cb);
-		tcpcb_remove(cb);
-#endif
 		break;
 	    case TS_CLOSE_WAIT:
 		cb->state = TS_LAST_ACK;
@@ -378,8 +373,8 @@ static void tcpdev_release(void)
 
 void tcpdev_sock_state(struct tcpcb_s *cb, int state)
 {
-    struct tdb_return_data *ret_data = sbuf;
-    __u16 sock = cb->sock;
+    struct tdb_return_data *ret_data = (struct tdb_return_data *)sbuf;
+    void * sock = cb->sock;
 
     ret_data->type = TDT_CHG_STATE;
     ret_data->ret_value = state;
@@ -406,7 +401,6 @@ void tcpdev_process(void)
 	    tcpdev_accept();
 	    break;
 	case TDC_CONNECT:
-//printf("tcpdev: got connect\n");
 	    tcpdev_connect();
 	    break;
 	case TDC_LISTEN:

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -29,6 +29,7 @@
 #include "tcpdev.h"
 #include "netconf.h"
 
+static __u16	next_port;
 static unsigned char sbuf[TCPDEV_BUFSIZE];
 
 int tcpdevfd;

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -215,7 +215,7 @@ static void tcpdev_read(void)
     cb = &n->tcpcb;
     if (cb->state == TS_CLOSING || cb->state == TS_LAST_ACK ||
         cb->state == TS_TIME_WAIT) {
-printf("tcpdev_read: returning -EPIPE to socket read\n");
+debug_tcp("tcpdev_read: returning -EPIPE to socket read\n");
 	retval_to_sock(sock, -EPIPE);
 	return;
     }
@@ -339,7 +339,7 @@ static void tcpdev_release(void)
     struct tcpcb_s *cb;
     void * sock = db->sock;
 
-printf("tcpdev: got close from ELKS process\n");
+debug_tcp("tcpdev: got close from ELKS process\n");
     n = tcpcb_find_by_sock(sock);
     if (n) {
 	cb = &n->tcpcb;

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -196,7 +196,7 @@ static void tcpdev_listen(void)
     retval_to_sock(db->sock, 0);
 }
 
-void tcpdev_read(void)
+static void tcpdev_read(void)
 {
     struct tdb_read *db = (struct tdb_read *)sbuf;
     struct tcpcb_list_s *n;
@@ -212,8 +212,9 @@ void tcpdev_read(void)
     }
 
     cb = &n->tcpcb;
-    if (cb->state == TS_CLOSING && cb->state == TS_LAST_ACK
-				&& cb->state == TS_TIME_WAIT) {
+    if (cb->state == TS_CLOSING || cb->state == TS_LAST_ACK ||
+        cb->state == TS_TIME_WAIT) {
+printf("tcpdev_read: returning -EPIPE to socket read\n");
 	retval_to_sock(sock, -EPIPE);
 	return;
     }

--- a/elkscmd/ktcp/tcpdev.h
+++ b/elkscmd/ktcp/tcpdev.h
@@ -25,6 +25,8 @@ struct net_device {
 };
 #endif
 
+extern int tcpdevfd;
+
 void tcpdev_process(void);
 int tcpdev_init(char *fdev);
 void retval_to_sock(void *sock, short int r);

--- a/elkscmd/ktcp/tcpdev.h
+++ b/elkscmd/ktcp/tcpdev.h
@@ -3,20 +3,17 @@
 
 #define TCPDEV_BUFSIZE	2046
 
+#if 0
 #define MAX_ADDR_LEN    7
 #define IFNAMSIZ        16
-
-struct net_device
- {
+struct net_device {
     char name[ IFNAMSIZ ];	/* name of the device */
-
     unsigned long mem_start;
     unsigned long mem_end;
     unsigned short base_addr;
     unsigned char irq;
     unsigned char dma;
     unsigned char port;
-
 	int	ifindex;			            /* interface index */
 	unsigned short hard_header_len; 	/* value of hard_header_len is 14 (ETH_HLEN) for Ethernet interfaces */
 	unsigned int	mtu;	      	    /* maximum transmission unit */
@@ -24,44 +21,13 @@ struct net_device
 	unsigned short type; /* hardware type of the interface. Type field is used by ARP. Value for Ethernet interfaces is ARPHRD_ETHER */
 	unsigned char addr_len; /* Hardware (MAC) address length and device hardware addresses. The Ethernet address length is six octets*/
 	unsigned char broadcast[MAX_ADDR_LEN];
-
 	unsigned short flags; /* bit mask including the IFF_ prefixed interface flags */
-
 };
-
-struct net_device *dev; /* global */
-
- #define ARPHRD_ETHER    1 /* for net_device.type */
-
- /* Standard interface flags (netdevice->flags). */
-  #define IFF_UP          0x1             /* interface is up              */
-  #define IFF_BROADCAST   0x2             /* broadcast address valid      */
-  #define IFF_DEBUG       0x4             /* turn on debugging            */
-  #define IFF_LOOPBACK    0x8             /* is a loopback net            */
-  #define IFF_POINTOPOINT 0x10            /* interface is has p-p link    */
-  #define IFF_NOTRAILERS  0x20            /* avoid use of trailers        */
-  #define IFF_RUNNING     0x40            /* interface RFC2863 OPER_UP    */
-  #define IFF_NOARP       0x80            /* no ARP protocol              */
-  #define IFF_PROMISC     0x100           /* receive all packets          */
-  #define IFF_ALLMULTI    0x200           /* receive all multicast packets*/
-
-  #define IFF_MASTER      0x400           /* master of a load balancer    */
-  #define IFF_SLAVE       0x800           /* slave of a load balancer     */
-
-  #define IFF_MULTICAST   0x1000          /* Supports multicast           */
-
-  #define IFF_PORTSEL     0x2000          /* can set media type           */
-  #define IFF_AUTOMEDIA   0x4000          /* auto media select active     */
-  #define IFF_DYNAMIC     0x8000          /* dialup device with changing addresses*/
-
-  #define IFF_LOWER_UP    0x10000         /* driver signals L1 up         */
-  #define IFF_DORMANT     0x20000         /* driver signals dormant       */
-
-  #define IFF_ECHO        0x40000         /* echo sent packets            */
+#endif
 
 void tcpdev_process(void);
 int tcpdev_init(char *fdev);
-void retval_to_sock(__u16 sock, short int r);
+void retval_to_sock(void *sock, short int r);
 void tcpdev_checkread(struct tcpcb_s *cb);
 void tcpdev_sock_state(struct tcpcb_s *cb, int state);
 void tcpdev_checkaccept(struct tcpcb_s *cb);

--- a/elkscmd/ktcp/vjhc.h
+++ b/elkscmd/ktcp/vjhc.h
@@ -43,7 +43,7 @@ Created:	May 25, 1993 by Philip Homburg <philip@cs.vu.nl>
 
 typedef struct pkt
 {
-	char *p_data;
+	unsigned char *p_data;
 	size_t p_offset;
 	size_t p_size;
 	size_t p_maxsize;

--- a/libc/include/linuxmt/arpa/inet.h
+++ b/libc/include/linuxmt/arpa/inet.h
@@ -2,7 +2,8 @@
 #define	_ARPA_INET_H_
 
 #ifndef ntohs
-#define ntohs(x)	(((unsigned)(x) >> 8) | ((x) << 8))
+#define ntohs(x)	( (((x) >> 8) & 0xff) | ((unsigned char)(x) << 8) )
+//#define ntohs(x)	( ((unsigned)(x) >> 8) | ((x) << 8) )
 
 #define htons(x)	ntohs(x)
 #endif

--- a/libc/include/linuxmt/arpa/inet.h
+++ b/libc/include/linuxmt/arpa/inet.h
@@ -2,16 +2,16 @@
 #define	_ARPA_INET_H_
 
 #ifndef ntohs
+#define ntohs(x)	(((unsigned)(x) >> 8) | ((x) << 8))
 
-#define ntohs(x)	( (((x) >> 8) & 0xff) | ((x) << 8) )
 #define htons(x)	ntohs(x)
 #endif
 
-/* do not use <<24 and >>24 with bcc */
-#define ntohl(x)	( ((((unsigned long)x) /0x1000000) & 0xff)	| \
+
+#define ntohl(x)	( ((((unsigned long)x) >> 24) & 0xff)	| \
 			  ((((unsigned long)x) >> 8 ) & 0xff00)		| \
 			  ((((unsigned long)x) & 0xff00) << 8)		| \
-			  ((((unsigned long)x) & 0xff) *0x1000000) )
+			  ((((unsigned long)x) & 0xff) << 24) )
 
 #define	htonl(x)	ntohl(x)
 


### PR DESCRIPTION
Tries to fix issue #67 for now by time-waiting for an ARP reply, then dropping the IP packet, rather than permanently hanging in an ARP request/reply cycle. This fix is necessary for telnet to run on QEMU without having to have an inbound connection first to fill the ARP table. 

There are several debug statements left on by default to determine asynchronous ARP reply effectiveness, RST processing, and packet refusals. Try running first without additional debug turned on to see any messages, then ping can be debugged by setting DEBUG_ARP and DEBUG_IP to 1 in config.h.

If ARP fails to work using this new method, turn on the old method, \#define ARP_WAIT_KLUGE in config.h.

Other changes:
Fix bad pointer memory corruption when TCP RST received.
Improve htons and htonl macros.
Endian cleanup.
ARP debugging, cleanup, and packet display.
IP packet display.
Add in_ntoa, cleanup IP address display code.
Fix console output with NUL character (received via telnet on login).