### PR TITLE
[ktcp] More cleanup and debugging for networking

### DIFF
--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -173,8 +173,10 @@ static int inet_listen(register struct socket *sock, int backlog)
     /* Sleep until tcpdev has news */
     while (bufin_sem == 0) {
         interruptible_sleep_on(sock->wait);
-        if (current->signal)
+        if (current->signal) {
+printk("inet_listen: RESTARTSYS\n");
             return -ERESTARTSYS;
+        }
     }
 
     ret = ((struct tdb_return_data *)tdin_buf)->ret_value;
@@ -204,6 +206,7 @@ static int inet_accept(register struct socket *sock,
         interruptible_sleep_on(sock->wait);
         sock->flags &= ~SO_WAITDATA;
         if (current->signal) {
+printk("inet_accept: RESTARTSYS\n");
             return -ERESTARTSYS;
 	}
     }
@@ -297,6 +300,7 @@ static int inet_write(register struct socket *sock, char *ubuf, int size,
 	tcpdev_clear_data_avail();
 	if (ret < 0) {
             if (ret == -ERESTARTSYS) {
+printk("inet_write: RESTARTSYS\n");
                 schedule();
             } else
                 return ret;

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -36,7 +36,6 @@ ipaddr_t local_ip;
 ipaddr_t gateway_ip;
 ipaddr_t netmask_ip;
 
-char junk[8000];	//FIXME low core getting trashed
 char deveth[] = "/dev/eth";
 
 static int intfd;	/* interface fd*/
@@ -63,7 +62,8 @@ extern int cbs_in_user_timeout;
 	FD_SET(intfd, &fdset);
 	FD_SET(tcpdevfd, &fdset);
 	count = select(intfd > tcpdevfd ? intfd + 1 : tcpdevfd + 1, &fdset, NULL, NULL, tv);
-	if (count < 0) return;
+	if (count < 0)
+		return;	//FIXME
 
 	Now = timer_get_time();
 

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -203,9 +203,10 @@ static void tcp_established(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 	/* Process the data */
 	data = (__u8 *)h + TCP_DATAOFF(h);
 
+//printf("space free %d\n", CB_BUF_SPACE(cb));
 	/* FIXME : check if it fits */
 	if (datasize > CB_BUF_SPACE(cb)) {
-	    printf("tcp: packet data too large: %u\n", datasize);
+	    printf("tcp: packet data too large: %u > %d\n", datasize, CB_BUF_SPACE(cb));
 	    return;
 	}
 
@@ -392,11 +393,11 @@ void tcp_process(struct iphdr_s *iph)
     tcp_print(&iptcp, 1);
 
     if (tcp_chksum(&iptcp) != 0) {
-	debug_tcp("tcp: bad checksum (%x) len %d\n", tcp_chksum(&iptcp), iptcp.tcplen);
-	return;
+	printf("tcp: bad checksum (%x) len %d\n", tcp_chksum(&iptcp), iptcp.tcplen);
+	//return;
     }
 
-debug_tcp("tcbcb_find %lx, %u, %u\n", iph->saddr, ntohs(tcph->dport), ntohs(tcph->sport));
+//debug_tcp("tcbcb_find %lx, %u, %u\n", iph->saddr, ntohs(tcph->dport), ntohs(tcph->sport));
     cbnode = tcpcb_find(iph->saddr, ntohs(tcph->dport), ntohs(tcph->sport));
 
     if (!cbnode) {

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -9,10 +9,10 @@
 #include <linuxmt/arpa/inet.h>
 
 /* control block input buffer size - max window size*/
-#define CB_IN_BUF_SIZE	2048
+#define CB_IN_BUF_SIZE	1024	/* must be power of 2*/
 
 /* bytes to subtract from window size and when to force app write*/
-#define PUSH_THRESHOLD	1024
+#define PUSH_THRESHOLD	512
 
 #define PROTO_TCP	0x06
 
@@ -77,7 +77,7 @@ struct iptcp_s {
 
 #define CB_BUF_USED(x)	((x)->buf_len)
 #define CB_BUF_SPACE(x)	(CB_IN_BUF_SIZE - CB_BUF_USED((x)))
-#define CB_BUF_TAIL(x)	(((x)->buf_head + (x)->buf_len) % (CB_IN_BUF_SIZE - 1))
+#define CB_BUF_TAIL(x)	((((x)->buf_head + (x)->buf_len)) & (CB_IN_BUF_SIZE - 1))
 
 struct tcpcb_s {
 	void *	newsock;

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -247,8 +247,9 @@ void tcpcb_buf_read(struct tcpcb_s *cb, __u8 *data, __u16 len)
 {
     register int head = cb->buf_head, i;
 
+if (len > cb->buf_len) printf("tcpcb_buf_read: BAD READ\n"); //FIXME
     for (i=0; i<len; i++)
 	*(data + i) = cb->in_buf[head++ & (CB_IN_BUF_SIZE - 1)];
-    cb->buf_head = head;
+    cb->buf_head = head & (CB_IN_BUF_SIZE - 1);
     cb->buf_len -= len;
 }

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -329,7 +329,7 @@ if (tcp_retrans_memory > TCP_RETRANS_MAXMEM || tcp_timeruse > 5) {
 	    continue;
 	}
 
-printf("retrans %d mem %d\n", tcp_timeruse, tcp_retrans_memory);
+debug_tcp("retrans %d mem %d\n", tcp_timeruse, tcp_retrans_memory);
 	if (TIME_GEQ(Now, n->next_retrans)) {
 	    tcp_reoutput(n);
 	    return;
@@ -361,6 +361,7 @@ void tcp_output(struct tcpcb_s *cb)
     th->flags = cb->flags;
 
     header_len = 20;
+#if 0
     option_len = 0;
     options = &th->options;
     if (cb->flags & TF_SYN) {
@@ -370,7 +371,7 @@ void tcp_output(struct tcpcb_s *cb)
 	options[1] = 4;
 	*(__u16 *)(options + 2) = htons(SLIP_MTU - 40);
     }
-
+#endif
     TCP_SETHDRSIZE(th, header_len);
 
     len = cb->datalen + header_len;

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -240,6 +240,7 @@ debug_tcp("tcpdev_read: returning -EPIPE to socket read\n");
     if (cb->bytes_to_push <= 0)
 	tcpcb_need_push--;
 
+//printf("tcpdev read: sending %d bytes\n", data_avail);
     ret_data = (struct tdb_return_data *)sbuf;
     ret_data->type = 0;
     ret_data->ret_value = data_avail;
@@ -259,6 +260,7 @@ void tcpdev_checkread(struct tcpcb_s *cb)
 	return;
 
     if (cb->wait_data == 0) {
+//printf("tcpdev checkread: updating select for %d bytes\n", cb->bytes_to_push);
 
 	/* Update the avail_data in the kernel socket (for select) */
 	sock = cb->sock;
@@ -275,6 +277,7 @@ void tcpdev_checkread(struct tcpcb_s *cb)
     if (cb->bytes_to_push <= 0)
 	tcpcb_need_push--;
 
+//printf("tcpdev checkread: sending %d bytes\n", data_avail);
     ret_data->type = 0;
     ret_data->ret_value = data_avail;
     ret_data->sock = cb->sock;

--- a/elkscmd/ktcp/tcpdev.h
+++ b/elkscmd/ktcp/tcpdev.h
@@ -1,7 +1,7 @@
 #ifndef TCPDEV_H
 #define TCPDEV_H
 
-#define TCPDEV_BUFSIZE	2046
+#define TCPDEV_BUFSIZE	2048	/* must be at least as big as CB_IN_BUF_SIZE*/
 
 #if 0
 #define MAX_ADDR_LEN    7

--- a/elkscmd/sys_utils/ps.c
+++ b/elkscmd/sys_utils/ps.c
@@ -171,13 +171,13 @@ int main(int argc, char **argv)
 
 		if (dseg) {
 			/* heap*/
-			printf("%5d ", (word_t)(task_table.t_endbrk - task_table.t_enddata));
+			printf("%5u ", (word_t)(task_table.t_endbrk - task_table.t_enddata));
 
 			/* free*/
-			printf(" %5d ", (word_t)(task_table.t_regs.sp - task_table.t_endbrk));
+			printf(" %5u ", (word_t)(task_table.t_regs.sp - task_table.t_endbrk));
 
 			/* stack*/
-			//printf("%5d ", (word_t)(task_table.t_begstack - task_table.t_regs.sp));
+			//printf("%5u ", (word_t)(task_table.t_begstack - task_table.t_regs.sp));
 
 			/* size*/
 			segext_t size = getword(fd, (word_t)cseg+offsetof(struct segment, size), ds)


### PR DESCRIPTION
Cleanup `ktcp` to run longer connected to localhost.

Decreased TCP buffer size to 1024.
Temp remove MSS processing as it seems to somehow produce occasional bad checksums.
Temp don't drop packets on bad checksums (debugging in process).
Fix TCPDEV buffer too small 2046 -> 2048.
Add kernel printk's for -ERESTARTSYS return values from socket layer.
Correct read ring buffer code.
Add debug printf's various places to help find remaining major corruption bug.
Fix `ps` negative display of heap and stack when > 32k.
