### PR TITLE
[kernel] Add configurable process heap+stack size

### DIFF
--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -11,8 +11,6 @@
 
 #include <arch/segment.h>
 
-#define MIN_STACK_SIZE 0x1000	/* 4k min stack above heap*/
-
 // TODO: reduce size
 
 // Segment descriptor
@@ -225,18 +223,17 @@ int sys_brk(__pptr newbrk)
     if (newbrk < currentp->t_enddata)
         return -ENOMEM;
 
-    if (currentp->t_begstack > currentp->t_endbrk) {	/* Old format? */
-        if (newbrk > currentp->t_endseg - MIN_STACK_SIZE) {	/* Yes */
+    if (currentp->t_begstack > currentp->t_endbrk) {				/* stack above heap?*/
+        if (newbrk > currentp->t_endseg - currentp->t_minstack) {
 			printk("sys_brk(%d) fail: brk %x over by %d bytes\n",
-				currentp->pid, newbrk, newbrk - (currentp->t_endseg - MIN_STACK_SIZE));
+				currentp->pid, newbrk, newbrk - (currentp->t_endseg - currentp->t_minstack));
             return -ENOMEM;
 		}
     }
 #ifdef CONFIG_EXEC_LOW_STACK
-    if (newbrk > currentp->t_endseg) {
+    if (newbrk > currentp->t_endseg)
         return -ENOMEM;
-    }
-#endif /* CONFIG_EXEC_LOW_STACK */
+#endif
     currentp->t_endbrk = newbrk;
 
     return 0;

--- a/elks/include/linuxmt/minix.h
+++ b/elks/include/linuxmt/minix.h
@@ -18,6 +18,10 @@
 #define MINIX_S_SPLITID	0x04600301UL
 #define MINIX_DLLID	0x04A00301UL
 
+/* Default data allocations*/
+#define INIT_HEAP  4096		/* Default heap*/
+#define INIT_STACK 4096		/* Default stack*/
+
 struct minix_exec_hdr {
     unsigned long	type;
     unsigned char	hlen;
@@ -27,7 +31,8 @@ struct minix_exec_hdr {
     unsigned short	dseg, reserved3;
     unsigned short	bseg, reserved4;
     unsigned long	entry;
-    unsigned short	chmem, reserved5;
+    unsigned short	chmem;
+    unsigned short	minstack;
     unsigned long	syms;
 };
 

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -52,6 +52,7 @@ struct task_struct {
     __pptr			t_begstack;
     __pptr			t_endbrk;
     __pptr			t_endseg;
+    int				t_minstack;
 
 /* Kernel info */
     pid_t			pid;

--- a/elkscmd/bc/Makefile
+++ b/elkscmd/bc/Makefile
@@ -34,7 +34,7 @@ LOCALFLAGS=-D_POSIX_SOURCE
 CFLBASE += -mrtd
 
 # For ELKS, bc needs more data segment space than the kernel-given default.
-LDFLAGS += -maout-chmem=0xc000
+LDFLAGS += -maout-chmem=46000
 
 OFILES = scan.o util.o main.o number.o storage.o load.o execute.o 
 


### PR DESCRIPTION
Adds separately configurable heap and stack size for ELKS processes.
Adds per-process minimum stack size to kernel.

These will be used shortly for fine-tuning heap and stack allocations on a per-process basis to help get most ELKS applications to run in a default 2k heap, 2k stack environment.

Completely rewrote `chmem`, allows heap and stack to be specified with -h and -s options.
Can also be run with multiple arguments to display sizes of multiple programs.
New usage is:
`chmem [-h heap] [-s stack] file ...`
When run with no options, it functions as a size program (fixes request in #635).
Heap and stack values can be specified in hex or decimal.

The elks-small.ld linker script has not yet been modified to store the upper 16-bits of the -maout-chmem= value into the new a.out minstack header field.

![Screen Shot 2020-05-20 at 9 12 19 PM](https://user-images.githubusercontent.com/11985637/82519614-5143be00-9adf-11ea-8ea1-c3dc825efe49.png)
