### PR TITLE
[networking] Add lots of debug and error checking code

### DIFF
--- a/elks/arch/i86/drivers/char/tcpdev.c
+++ b/elks/arch/i86/drivers/char/tcpdev.c
@@ -7,6 +7,7 @@
  *
  */
 
+//#define DEBUG
 #include <linuxmt/kernel.h>
 #include <linuxmt/types.h>
 #include <linuxmt/config.h>
@@ -57,6 +58,7 @@ static size_t tcpdev_read(struct inode *inode, struct file *filp, char *data,
      *  buffer it will lose data, so the tcpip stack should read BIG.
      */
     len = len < tdout_tail ? len : tdout_tail;
+//printk("TDOUT_TAIL %u\n", len);
     debug1("TCPDEV: read() mark 1 - len = %u\n",len);
     memcpy_tofs(data, tdout_buf, len);
     tdout_tail = 0;
@@ -96,6 +98,7 @@ static size_t tcpdev_write(struct inode *inode, struct file *filp,
     if (len > 0) {
 	down(&bufin_sem);
 
+//printk("TDIN_TAIL %u\n", len);
 	tdin_tail = (unsigned) len;
 	memcpy_fromfs(tdin_buf, data, len);
 

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -8,6 +8,7 @@
  * user space (ktcp)..
  */
 
+//#define DEBUG
 #include <linuxmt/errno.h>
 #include <linuxmt/config.h>
 #include <linuxmt/socket.h>
@@ -250,6 +251,8 @@ static int inet_read(register struct socket *sock, char *ubuf, int size,
     ret = ((struct tdb_return_data *)tdin_buf)->ret_value;
 
     if (ret > 0) {
+//printk("INET_READ %d (%c%c)\n", ret, (ret>>8)&0xff, ret&0xff);
+//if (ret > 100) ret = 1;
         memcpy_tofs(ubuf, &((struct tdb_return_data *)tdin_buf)->data, (size_t) ret);
         sock->avail_data = 0;
     }
@@ -287,6 +290,7 @@ static int inet_write(register struct socket *sock, char *ubuf, int size,
 
         cmd->size = count > TDB_WRITE_MAX ? TDB_WRITE_MAX : count;
 
+//printk("INET_WRITE %u\n", cmd->size);
         memcpy_fromfs(cmd->data, ubuf, (size_t) cmd->size);
 	usize = cmd->size;
         tcpdev_inetwrite(cmd, sizeof(struct tdb_write));

--- a/elkscmd/inet/telnetd/telnetd.c
+++ b/elkscmd/inet/telnetd/telnetd.c
@@ -19,6 +19,8 @@
 #include <linuxmt/arpa/inet.h>
 #include "telnet.h"
 
+//#define RAWTELNET	/* set in telnet and telnetd for raw telnet without IAC*/
+
 #define MAX_BUFFER 100
 static char buf_in  [MAX_BUFFER];
 static char buf_out [MAX_BUFFER];
@@ -84,6 +86,7 @@ again:
 
 static void telnet_init(int ofd)
 {
+#ifndef RAWTELNET
   tel_init();
 
   telopt(ofd, WILL, TELOPT_SGA);
@@ -92,6 +95,7 @@ static void telnet_init(int ofd)
   telopt(ofd, DO,   TELOPT_BINARY);
   telopt(ofd, WILL, TELOPT_ECHO);
   //telopt(ofd, DO,   TELOPT_WINCH);
+#endif
 }
 
 static void client_loop (int fdsock, int fdterm)
@@ -129,8 +133,11 @@ static void client_loop (int fdsock, int fdterm)
 			}
 		}
 		if (count_in && FD_ISSET (fdterm, &fds_write)) {
-			//count = write (fdterm, buf_in, count_in);
+#ifdef RAWTELNET
+			count = write (fdterm, buf_in, count_in);
+#else
 			tel_in(fdterm, fdsock, buf_in, count_in);
+#endif
 			count_in = 0;
 		}
 
@@ -143,8 +150,11 @@ static void client_loop (int fdsock, int fdterm)
 			}
 		}
 		if (count_out && FD_ISSET (fdsock, &fds_write)) {
-			//count = write (fdsock, buf_out, count_out);
+#ifdef RAWTELNET
+			count = write (fdsock, buf_out, count_out);
+#else
 			tel_out(fdsock, buf_out, count_out);
+#endif
 			count_out = 0;
 		}
     }

--- a/elkscmd/ktcp/Makefile
+++ b/elkscmd/ktcp/Makefile
@@ -14,7 +14,7 @@ OBJS		= $(CFILES:.c=.o)
 all:	ktcp
 
 ktcp:	$(OBJS)
-	$(LD) $(LDFLAGS) -maout-chmem=0x4000 -o ktcp $(OBJS) $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-chmem=0x8000 -o ktcp $(OBJS) $(LDLIBS)
 
 lint:
 	@for FILE in *.c ; do \

--- a/elkscmd/ktcp/ip.h
+++ b/elkscmd/ktcp/ip.h
@@ -55,4 +55,6 @@ void ip_sendpacket(unsigned char *packet, int len, struct addr_pair *apair);
 unsigned long in_aton(const char *str);
 char *in_ntoa(ipaddr_t in);
 
+#define memcpy	xxmemcpy
+extern void *xxmemcpy(void *,const void *,int);
 #endif

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -40,6 +40,23 @@ char deveth[] = "/dev/eth";
 
 static int intfd;	/* interface fd*/
 
+void setp(unsigned char **p)
+{
+	*p = 0;
+}
+
+char *zero;
+void printp()
+{
+unsigned char *p;
+//int i;
+setp(&p);
+
+//printf(zero="ZERO\n");
+//for (i=0; i<16; i++) printf("%d (%c) ", p[i], p[i]);
+//printf("\n");
+}
+
 void ktcp_run(void)
 {
     fd_set fdset;
@@ -57,6 +74,8 @@ extern int cbs_in_user_timeout;
 	    timeint.tv_usec = 0;
 	    tv = &timeint;
 	} else tv = NULL;
+
+printp();
 
 	FD_ZERO(&fdset);
 	FD_SET(intfd, &fdset);
@@ -95,6 +114,8 @@ int main(int argc,char **argv)
     speed_t baudrate = 0;
     char *progname = argv[0];
 
+printp();
+//printf("ZERO is at %x\n", zero);
     if (argc > 1 && !strcmp("-b", argv[1])) {
 	daemon = 1;
 	argc--;

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -133,7 +133,7 @@ static void tcp_syn_sent(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 
 	cb->datalen = 0;
 	tcp_output(cb);
-
+printf("CONNECT complete\n");
 	retval_to_sock(cb->sock, 0);
 
 	return;
@@ -214,15 +214,16 @@ static void tcp_established(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 //printf("space free %d\n", CB_BUF_SPACE(cb));
 	/* FIXME : check if it fits */
 	if (datasize > CB_BUF_SPACE(cb)) {
-	    printf("tcp: packet data too large: %u > %d\n", datasize, CB_BUF_SPACE(cb));
-	    tcp_reset_connection(cb);	//FIXME this causes RST received then panic in read/write
+	    printf("tcp: dropping packet, data too large: %u > %d\n", datasize, CB_BUF_SPACE(cb));
+	    //tcp_reset_connection(cb);	//FIXME this causes RST received then panic in read/write
 	    return;
 	}
 
 	tcpcb_buf_write(cb, data, datasize);
 
-	if ((h->flags & TF_PSH) || CB_BUF_SPACE(cb) <= PUSH_THRESHOLD) {
-	    if (cb->bytes_to_push <= 0)
+	if (1 || (h->flags & TF_PSH) || CB_BUF_SPACE(cb) <= PUSH_THRESHOLD) {
+	    //if (cb->bytes_to_push <= 0)
+	    if (cb->bytes_to_push >= 0)
 		tcpcb_need_push++;
 	    cb->bytes_to_push = CB_BUF_USED(cb);
 	}
@@ -383,7 +384,7 @@ debug_tcp("ktcp: update %x,%x\n", cbs_in_time_wait, cbs_in_user_timeout);
     if (cbs_in_time_wait > 0 || cbs_in_user_timeout > 0)
 	tcpcb_expire_timeouts();
 
-    if (tcpcb_need_push > 0)
+    //if (tcpcb_need_push > 0)
 	tcpcb_push_data();
 }
 

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -23,7 +23,8 @@
 #define IP_BUFSIZ	(TCP_BUFSIZ + sizeof(iphdr_t) + sizeof(struct ip_ll))
 
 /* control block input buffer size - max window size*/
-#define CB_IN_BUF_SIZE	1024	/* must be power of 2*/
+//#define CB_IN_BUF_SIZE	1024	/* must be power of 2*/
+#define CB_IN_BUF_SIZE	4096	/* must be power of 2*/
 
 /* bytes to subtract from window size and when to force app write*/
 #define PUSH_THRESHOLD	512

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -316,7 +316,7 @@ if (tcp_retrans_memory > TCP_RETRANS_MAXMEM || tcp_timeruse > 5) {
 	datalen = n->len - TCP_DATAOFF(n->tcph);
 
 	//debug_tcp("retrans: %lx %lx", ntohl(n->tcph->seqnum) + datalen,n->cb->send_una);
-	if (SEQ_LEQ(ntohl(n->tcph->seqnum) + datalen ,n->cb->send_una)) {
+	if (SEQ_LEQ(ntohl(n->tcph->seqnum) + datalen, n->cb->send_una)) {
 	    if (n->retrans_num == 0) {
 		rtt = Now - n->first_trans;
 		if (rtt > 0)
@@ -326,7 +326,7 @@ if (tcp_retrans_memory > TCP_RETRANS_MAXMEM || tcp_timeruse > 5) {
 	    continue;
 	}
 
-debug_tcp("retrans %d mem %d\n", tcp_timeruse, tcp_retrans_memory);
+//debug_tcp("retrans %d mem %d\n", tcp_timeruse, tcp_retrans_memory);
 	if (TIME_GEQ(Now, n->next_retrans)) {
 	    tcp_reoutput(n);
 	    return;
@@ -351,6 +351,7 @@ void tcp_output(struct tcpcb_s *cb)
     len = CB_BUF_SPACE(cb) - PUSH_THRESHOLD;
     if (len <= 0)
 	len = 1;		/* Never advertise zero window size */
+len = 255;	//FIXME testing only
     th->window = htons(len);
     th->urgpnt = 0;
     th->flags = cb->flags;
@@ -368,8 +369,9 @@ void tcp_output(struct tcpcb_s *cb)
 
     TCP_SETHDRSIZE(th, header_len);
 
+    if (cb->datalen)
+	memcpy((char *)th + header_len, cb->data, cb->datalen);
     len = cb->datalen + header_len;
-    memcpy((char *)th + header_len, cb->data, cb->datalen);
 
     th->chksum = 0;
     th->chksum = tcp_chksumraw(th, cb->localaddr, cb->remaddr, len);

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -240,7 +240,7 @@ debug_tcp("tcpdev_read: returning -EPIPE to socket read\n");
     if (cb->bytes_to_push <= 0)
 	tcpcb_need_push--;
 
-//printf("tcpdev read: sending %d bytes\n", data_avail);
+//printf("tcpdev READ: %d bytes\n", data_avail);
     ret_data = (struct tdb_return_data *)sbuf;
     ret_data->type = 0;
     ret_data->ret_value = data_avail;
@@ -260,7 +260,7 @@ void tcpdev_checkread(struct tcpcb_s *cb)
 	return;
 
     if (cb->wait_data == 0) {
-//printf("tcpdev checkread: updating select for %d bytes\n", cb->bytes_to_push);
+//printf("tcpdev checkSELECT: %d bytes\n", cb->bytes_to_push);
 
 	/* Update the avail_data in the kernel socket (for select) */
 	sock = cb->sock;
@@ -277,7 +277,7 @@ void tcpdev_checkread(struct tcpcb_s *cb)
     if (cb->bytes_to_push <= 0)
 	tcpcb_need_push--;
 
-//printf("tcpdev checkread: sending %d bytes\n", data_avail);
+//printf("tcpdev checkREAD: %d bytes\n", data_avail);
     ret_data->type = 0;
     ret_data->ret_value = data_avail;
     ret_data->sock = cb->sock;
@@ -324,6 +324,8 @@ printf("tcp: RETRANS limit exceeded\n");
 	retval_to_sock(sock, db->size);
 	return;
     }
+
+//printf("WRITE window %ld timer %d\n", cb->send_nxt - cb->send_una, tcp_timeruse);
 
     cb->flags = TF_PSH|TF_ACK;
     cb->datalen = db->size;
@@ -399,24 +401,31 @@ void tcpdev_process(void)
 
     switch (sbuf[0]){
 	case TDC_BIND:
+	    //printf("tcpdev_bind\n");
 	    tcpdev_bind();
 	    break;
 	case TDC_ACCEPT:
+	    //printf("tcpdev_accept\n");
 	    tcpdev_accept();
 	    break;
 	case TDC_CONNECT:
+	    //printf("tcpdev_connect\n");
 	    tcpdev_connect();
 	    break;
 	case TDC_LISTEN:
+	    //printf("tcpdev_listen\n");
 	    tcpdev_listen();
 	    break;
 	case TDC_RELEASE:
+	    //printf("tcpdev_release\n");
 	    tcpdev_release();
 	    break;
 	case TDC_READ:
+	    //printf("tcpdev_read\n");
 	    tcpdev_read();
 	    break;
 	case TDC_WRITE:
+	    //printf("tcpdev_write\n");
 	    tcpdev_write();
 	    break;
     }


### PR DESCRIPTION
@Mellvik, this PR includes all the debug code mentioned in my last comment in #610. It runs for awhile on QEMU for incoming and outgoing telnet, but fails quickly when using telnet to localhost.

Changes include:
Add IP checksum on incoming packets
Allow ^C out of telnet connect hang
Restore terminal to cooked mode on telnet early exit
Add \#define RAWTELNET for non-IAC telnet/telnetd debugging
Large 4096 TCP buffer for debugging
Force-push TCP received data to application each packet received
Force 255-byte temp window size for debugging
Add memcpy check code
Add kernel inet sockets debug code
Add telnet buffer overrun check code
Add DS:0004 overwrite check code

Most of the extra check code is turned off for the time being, but can be enabled depending on what happens on your HW system.
