### PR TITLE
[kernel] make execve syscall return more useful error codes

### DIFF
--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -78,6 +78,7 @@ static int relocate(seg_t place_base, lsize_t rsize, segment_s *seg_code,
 		    segment_s *seg_data, __ptask currentp, struct inode *inode,
 		    struct file *filp)
 {
+    int retval = 0;
     __u16 save_ds = currentp->t_regs.ds;
     currentp->t_regs.ds = kernel_ds;
     debug2("EXEC: applying 0x%lx bytes of relocations to segment 0x%x\n",
@@ -85,8 +86,7 @@ static int relocate(seg_t place_base, lsize_t rsize, segment_s *seg_code,
     while (rsize >= sizeof(struct minix_reloc)) {
 	struct minix_reloc reloc;
 	word_t val;
-	int retval = filp->f_op->read(inode, filp, (char *)&reloc,
-				      sizeof(reloc));
+	retval = filp->f_op->read(inode, filp, (char *)&reloc, sizeof(reloc));
 	if (retval != (int)sizeof(reloc))
 	    goto error;
 	switch (reloc.r_type) {
@@ -116,7 +116,9 @@ static int relocate(seg_t place_base, lsize_t rsize, segment_s *seg_code,
   error:
     debug("EXEC: error in relocations\n");
     currentp->t_regs.ds = save_ds;
-    return -1;
+    if (retval >= 0)
+	retval = -EINVAL;
+    return retval;
 }
 #endif
 
@@ -180,8 +182,10 @@ int sys_execve(char *filename, char *sptr, size_t slen)
     }
 
     min_len = mh.dseg;
-    if (add_overflow(min_len, mh.bseg, &min_len))
+    if (add_overflow(min_len, mh.bseg, &min_len)) {
+	retval = -ENOMEM;
 	goto error_exec3;
+    }
 
 #ifdef CONFIG_EXEC_MMODEL
     memset(&esuph, 0, sizeof(esuph));
@@ -204,12 +208,16 @@ int sys_execve(char *filename, char *sptr, size_t slen)
 	       "far text reloc size 0x%x, text base 0x%lx\n",
 	       esuph.msh_trsize, esuph.msh_drsize, esuph.esh_ftrsize,
 	       esuph.msh_tbase);
-	if (esuph.msh_tbase != 0)
+	if (esuph.msh_tbase != 0) {
+	    retval = -EINVAL;
 	    goto error_exec3;
+	}
 	if (esuph.msh_trsize % sizeof(struct minix_reloc) != 0 ||
 	    esuph.msh_drsize % sizeof(struct minix_reloc) != 0 ||
-	    esuph.esh_ftrsize % sizeof(struct minix_reloc) != 0)
+	    esuph.esh_ftrsize % sizeof(struct minix_reloc) != 0) {
+	    retval = -EINVAL;
 	    goto error_exec3;
+	}
 	base_data = esuph.msh_dbase;
 #ifdef CONFIG_EXEC_LOW_STACK
 	if (base_data & 0xf)
@@ -217,8 +225,10 @@ int sys_execve(char *filename, char *sptr, size_t slen)
 	if (base_data != 0)
 	    debug1("EXEC: New type executable stack = %x\n", base_data);
 
-	if (add_overflow(min_len, base_data, &min_len))	/* adds stack size*/
+	if (add_overflow(min_len, base_data, &min_len))	{ /* adds stack size*/
+	    retval = -ENOMEM;
 	    goto error_exec3;
+	}
 #else
 	if (base_data != 0)
 	    goto error_exec3;
@@ -242,8 +252,10 @@ int sys_execve(char *filename, char *sptr, size_t slen)
 	    len = INIT_HEAP;				/* default heap */
 	else
 	    debug1("EXEC: heap %u\n", len);
-	if (add_overflow(len, min_len, &len))
+	if (add_overflow(len, min_len, &len)) {
+	    retval = -ENOMEM;
 	    goto error_exec3;
+	}
 	debug1("EXEC: len with heap is %u\n", len);
 #ifdef CONFIG_EXEC_LOW_STACK
 	if (!base_data)
@@ -255,16 +267,20 @@ int sys_execve(char *filename, char *sptr, size_t slen)
 	    else
 		debug1("EXEC: stack %u\n", stack);
 	    if (add_overflow(len, stack, &len) ||	/* add stack */
-		add_overflow(len, slen, &len))		/* add argv, envp */
+		add_overflow(len, slen, &len)) {	/* add argv, envp */
+		retval = -ENOMEM;
 		goto error_exec3;
+	    }
 	    debug1("EXEC: len with stack, argv, envp is %u\n", len);
 	}
 	break;
     case 0:
 	len = mh.chmem;
 	if (len) {
-	    if (len <= min_len)
+	    if (len <= min_len) {
+		retval = -EINVAL;
 		goto error_exec3;
+	    }
 	    /*
 	     * Try to reserve INIT_STACK bytes of the non-static data memory
 	     * for a stack.  If this is not possible, reserve all the
@@ -280,13 +296,17 @@ int sys_execve(char *filename, char *sptr, size_t slen)
 	    len = min_len;
 #ifdef CONFIG_EXEC_LOW_STACK
 	    if (base_data) {
-		if (add_overflow(len, INIT_HEAP, &len))
+		if (add_overflow(len, INIT_HEAP, &len)) {
+		    retval = -ENOMEM;
 		    goto exec_error3;
+		}
 	    } else
 #endif
 	    {
-		if (add_overflow(len, INIT_HEAP + INIT_STACK, &len))
+		if (add_overflow(len, INIT_HEAP + INIT_STACK, &len)) {
+		    retval = -ENOMEM;
 		    goto error_exec3;
+		}
 		stack = INIT_STACK;
 	    }
 	    if (add_overflow(len, slen, &len))
@@ -295,8 +315,10 @@ int sys_execve(char *filename, char *sptr, size_t slen)
     }
 
     /* Round data segment length up to a paragraph boundary */
-    if (add_overflow(len, 15, &len))
+    if (add_overflow(len, 15, &len)) {
+	retval = -ENOMEM;
 	goto error_exec3;
+    }
     len &= ~(size_t)15;
 
     debug("EXEC: Malloc time\n");
@@ -361,13 +383,15 @@ int sys_execve(char *filename, char *sptr, size_t slen)
 #ifdef CONFIG_EXEC_MMODEL
     if (need_reloc_code) {
 	/* Read and apply text segment relocations */
-	if (relocate(seg_code->base, esuph.msh_trsize, seg_code, seg_data,
-		     currentp, inode, filp) != 0)
+	retval = relocate(seg_code->base, esuph.msh_trsize, seg_code, seg_data,
+			  currentp, inode, filp);
+	if (retval != 0)
 	    goto error_exec5;
 	/* Read and apply far text segment relocations */
-	if (relocate(seg_code->base + bytes_to_paras(mh.tseg),
-		     esuph.esh_ftrsize, seg_code, seg_data, currentp, inode,
-		     filp) != 0)
+	retval = relocate(seg_code->base + bytes_to_paras(mh.tseg),
+			  esuph.esh_ftrsize, seg_code, seg_data, currentp,
+			  inode, filp);
+	if (retval != 0)
 	    goto error_exec5;
     } else {
 	/* If reusing existing text segments, no need to re-relocate */
@@ -375,8 +399,9 @@ int sys_execve(char *filename, char *sptr, size_t slen)
 	filp->f_pos += esuph.esh_ftrsize;
     }
     /* Read and apply data relocations */
-    if (relocate(seg_data->base, esuph.msh_drsize, seg_code, seg_data,
-		 currentp, inode, filp) != 0)
+    retval = relocate(seg_data->base, esuph.msh_drsize, seg_code, seg_data,
+		      currentp, inode, filp);
+    if (retval != 0)
 	goto error_exec5;
 #endif
 


### PR DESCRIPTION
...such as `-EINVAL` and `-ENOMEM`, when processing a.out headers, not always `-ENOEXEC`.