### PR TITLE
[ktcp] Temporary fix arp wait buffer overwrite

### DIFF
--- a/elkscmd/ktcp/arp.c
+++ b/elkscmd/ktcp/arp.c
@@ -180,7 +180,7 @@ int arp_request(ipaddr_t ipaddress)
     int i = select(tcpdevfd + 1, &fdset, NULL, NULL, &timeint);
     if (i >= 0) {
 	printf("arp: got reply on timed wait\n");
-	deveth_process();
+	deveth_process(1);
 	return 0;	/* success*/
     }
     return 1;		/* error*/

--- a/elkscmd/ktcp/deveth.h
+++ b/elkscmd/ktcp/deveth.h
@@ -27,7 +27,7 @@ extern int eth_device;
 
 void deveth_printhex(unsigned char *packet, int len);
 int  deveth_init(char *fdev);
-void deveth_process(void);
+void deveth_process(int flag);
 void deveth_send(unsigned char *packet, int len);
 
 #endif /* !DEVETH_H */

--- a/elkscmd/ktcp/icmp.c
+++ b/elkscmd/ktcp/icmp.c
@@ -31,7 +31,7 @@ void icmp_process(struct iphdr_s *iph,unsigned char *packet)
 
     switch (packet[0]){
     case ICMP_TYPE_ECHO_REQ:
-	len = ntohs(iph->tot_len) - IP_HLEN(iph);
+	len = ntohs(iph->tot_len) - 4 * IP_HLEN(iph);
 	printf("icmp: PING from %s (len %d id %u seqnum %u)\n",
 	    in_ntoa(iph->saddr), len, ntohs(ep->id), ntohs(ep->seqnum));
 

--- a/elkscmd/ktcp/ip.c
+++ b/elkscmd/ktcp/ip.c
@@ -129,7 +129,7 @@ void ip_recvpacket(unsigned char *packet,int size)
 
     if (ip_calc_chksum((char *)iphdr, len)) {
 	printf("IP: BAD CHKSUM (%x) len %d\n", ip_calc_chksum((char *)iphdr, len), len);
-	//return;
+	return;
     }
 
     switch (iphdr->protocol) {

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -92,7 +92,7 @@ printp();
 	/* process received packets*/
 	if (FD_ISSET(intfd, &fdset)) {
 		if (eth_device)
-			deveth_process();
+			deveth_process(0);
 		else slip_process();
 	}
 

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -148,18 +148,19 @@ struct	tcpcb_list_s {
 };
 
 struct	tcp_retrans_list_s {
+	struct tcp_retrans_list_s	*prev;
+	struct tcp_retrans_list_s	*next;
+
 	int				retrans_num;
 	timeq_t 			rto;
 	timeq_t 			next_retrans;
 	timeq_t 			first_trans;
 
 	struct tcpcb_s			*cb;
-	struct tcphdr_s 		*tcph;
 	struct addr_pair		apair;
 	__u16				len;
+	struct tcphdr_s 		tcphdr[];
 
-	struct tcp_retrans_list_s	*prev;
-	struct tcp_retrans_list_s	*next;
 };
 
 int tcp_timeruse;

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -75,7 +75,8 @@ struct tcpcb_list_s *tcpcb_new(void)
 debug_mem("Alloc CB %d bytes\n", sizeof(struct tcpcb_list_s));
 
     memset(&n->tcpcb, 0, sizeof(struct tcpcb_s));
-    n->tcpcb.rtt = 4 << 4; /* 4 sec */
+    //n->tcpcb.rtt = 4 << 4; /* 4 sec */
+    n->tcpcb.rtt = 1 << 4; /* 1 sec */	//FIXME
 
     /* Link it to the list */
     if (tcpcbs) {

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -182,7 +182,6 @@ rmv_from_retrans(struct tcp_retrans_list_s *n)
 	n = next;
 	n->prev = NULL;
 debug_mem("retrans free buffers %d mem %d\n", tcp_timeruse, tcp_retrans_memory);
-	free(retrans_list->tcph);
 	free(retrans_list);
 	retrans_list = n;
 
@@ -193,7 +192,6 @@ debug_mem("retrans free buffers %d mem %d\n", tcp_timeruse, tcp_retrans_memory);
 	next->prev = n->prev;
 
 debug_mem("retrans free buffers %d mem %d\n", tcp_timeruse, tcp_retrans_memory);
-    free(n->tcph);
     free(n);
 
     return next;
@@ -239,19 +237,13 @@ void add_for_retrans(struct tcpcb_s *cb, struct tcphdr_s *th, __u16 len,
     if (cb->state == TS_CLOSED)	//FIXME remove
 	return;
 
-    n = (struct tcp_retrans_list_s *)malloc(sizeof(struct tcp_retrans_list_s));
+    n = (struct tcp_retrans_list_s *)malloc(sizeof(struct tcp_retrans_list_s) + len);
     if (n == NULL) {
 	printf("ktcp: Out of memory\n");
 	return;
     }
 
     n->cb = cb;
-    n->tcph = (struct tcphdr_s *)malloc(len);
-    if (!n->tcph) {
-	printf("ktcp: Out of memory 2\n");
-	free(n);
-	return;
-    }
 
     /* Link it to the list */
     if (retrans_list) {
@@ -261,8 +253,7 @@ void add_for_retrans(struct tcpcb_s *cb, struct tcphdr_s *th, __u16 len,
 	retrans_list = n;
     } else {
 	retrans_list = n;
-	n->next = NULL;
-	n->prev = NULL;
+	n->prev = n->next = NULL;
     }
 
     /* start timeout blocking in main loop*/
@@ -271,22 +262,23 @@ void add_for_retrans(struct tcpcb_s *cb, struct tcphdr_s *th, __u16 len,
     tcp_retrans_memory += len;
 debug_mem("retrans alloc buffers %d, mem %d\n", tcp_timeruse, tcp_retrans_memory);
     n->len = len;
-    memcpy(n->tcph, th, len);
+    memcpy(n->tcphdr, th, len);
     memcpy(&n->apair, apair, sizeof(struct addr_pair));
     n->retrans_num = 0;
     n->first_trans = Now;
 
-    n->rto = cb->rtt << 1;			//FIXME possibly shorten
+    //n->rto = cb->rtt << 1;			//FIXME possibly shorten
+    n->rto = cb->rtt;
     n->next_retrans = Now + n->rto;
 }
 
 void tcp_reoutput(struct tcp_retrans_list_s *n)
 {
     n->retrans_num ++;
-    n->rto *= 2;
+    //n->rto *= 2;		//FIXME
     n->next_retrans = Now + n->rto;
-printf("retrans retry #%d rto %ld\n", n->retrans_num, n->rto);
-    ip_sendpacket((unsigned char *)n->tcph, n->len, &n->apair);
+printf("retrans retry #%d rto %ld mem %u\n", n->retrans_num, n->rto, tcp_retrans_memory);
+    ip_sendpacket((unsigned char *)n->tcphdr, n->len, &n->apair);
 }
 
 /* called every ktcp cycle when tcp_timeruse nonzero*/
@@ -296,7 +288,7 @@ void tcp_retrans(void)
     int datalen, rtt;
 
 /* FIXME avoid running out of memory - bug in retrans recovery*/
-if (tcp_retrans_memory > TCP_RETRANS_MAXMEM || tcp_timeruse > 5) {
+if (tcp_retrans_memory > TCP_RETRANS_MAXMEM /*|| tcp_timeruse > 5*/) {
 	struct tcpcb_s *cb = NULL;
 	printf("tcp: RETRANS limit, timeruse %d\n", tcp_timeruse);
 	n = retrans_list;
@@ -313,10 +305,10 @@ if (tcp_retrans_memory > TCP_RETRANS_MAXMEM || tcp_timeruse > 5) {
 
     n = retrans_list;
     while (n != NULL) {
-	datalen = n->len - TCP_DATAOFF(n->tcph);
+	datalen = n->len - TCP_DATAOFF(&n->tcphdr[0]);
 
-	//debug_tcp("retrans: %lx %lx", ntohl(n->tcph->seqnum) + datalen,n->cb->send_una);
-	if (SEQ_LEQ(ntohl(n->tcph->seqnum) + datalen, n->cb->send_una)) {
+	//debug_tcp("retrans: %lx %lx", ntohl(n->tcphdr[0].seqnum) + datalen,n->cb->send_una);
+	if (SEQ_LEQ(ntohl(n->tcphdr[0].seqnum) + datalen, n->cb->send_una)) {
 	    if (n->retrans_num == 0) {
 		rtt = Now - n->first_trans;
 		if (rtt > 0)


### PR DESCRIPTION
Fixes ARP request buffer overwrite on ICMP reply reported by @Mellvik on #610.
Temporary fix, full fix requires outgoing packet queue.

Fix ICMP header length calculation.
Mandatory chksum on received IP packets.
Tested retrans algorithm - working ok.
Consolidate retransmit malloc's into one for use in later packet queue.
Relax retrans count restriction - now uses only max memory restriction of 2k bytes.
Temporary use 1 sec timeout on retrans retry, no RTT / RTO calculations.