### PR TITLE
[elkscmd] Fine tune application heap & stack usage

### DIFF
--- a/elkscmd/ash/Makefile
+++ b/elkscmd/ash/Makefile
@@ -30,7 +30,7 @@ OBJS=	builtins.o cd.o dirent.o error.o eval.o exec.o expand.o input.o \
 	bltin/echo.o bltin/expr.o bltin/regexp.o bltin/operators.o \
 	linenoise_elks.o autocomplete.o
 
-LDFLAGS += -maout-heap=6144 -maout-stack=2048
+LDFLAGS += -maout-heap=6144 -maout-stack=5000
 
 #
 # Set READLINE in shell.h and add -ledit to LIBS if you want to use the

--- a/elkscmd/bc/Makefile
+++ b/elkscmd/bc/Makefile
@@ -34,7 +34,7 @@ LOCALFLAGS=-D_POSIX_SOURCE
 CFLBASE += -mrtd
 
 # For ELKS, bc needs more data segment space than the kernel-given default.
-LDFLAGS += -maout-chmem=46000
+LDFLAGS += -maout-heap=0xb000
 
 OFILES = scan.o util.o main.o number.o storage.o load.o execute.o 
 

--- a/elkscmd/cron/Makefile
+++ b/elkscmd/cron/Makefile
@@ -7,7 +7,7 @@ BASEDIR=..
 include $(BASEDIR)/Make.defs
 
 LOCALFLAGS = -Wno-implicit-int -Wno-return-type $(OPTIONS)
-CRONFLAGS = -maout-chmem=0x4800 
+CRONFLAGS = -maout-heap=0x3800
 
 ###############################################################################
 #

--- a/elkscmd/inet/httpd/Makefile
+++ b/elkscmd/inet/httpd/Makefile
@@ -13,7 +13,7 @@ include $(BASEDIR)/Make.rules
 PRG=httpd
 
 LOCALFLAGS=-I$(ELKSCMD_DIR)
-LDFLAGS += -maout-chmem=0x1100
+LDFLAGS += -maout-heap=1024 -maout-stack=1024
 
 all: $(PRG)
 

--- a/elkscmd/inet/telnetd/Makefile
+++ b/elkscmd/inet/telnetd/Makefile
@@ -14,7 +14,7 @@ include $(BASEDIR)/Make.rules
 
 SRCS = telnetd.c telnet.c
 OBJS = $(SRCS:.c=.o) 
-LDFLAGS += -maout-chmem=0x1100
+LDFLAGS += -maout-heap=1024 -maout-stack=1024
 
 all:	telnetd
 

--- a/elkscmd/ktcp/Makefile
+++ b/elkscmd/ktcp/Makefile
@@ -14,7 +14,7 @@ OBJS		= $(CFILES:.c=.o)
 all:	ktcp
 
 ktcp:	$(OBJS)
-	$(LD) $(LDFLAGS) -maout-chmem=0x8000 -o ktcp $(OBJS) $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-heap=24576 -maout-stack=2048  -o ktcp $(OBJS) $(LDLIBS)
 
 lint:
 	@for FILE in *.c ; do \

--- a/elkscmd/minix3/Makefile
+++ b/elkscmd/minix3/Makefile
@@ -40,7 +40,7 @@ sed: sed.o
 # Use gcc-ia16's -maout-chmem= option so that the a.out header will ask the
 # kernel for more non-static memory.
 sort: sort.o
-	$(LD) $(LDFLAGS) -maout-chmem=0xc000 -o sort sort.o $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-heap=0xb000 -o sort sort.o $(LDLIBS)
 
 tail: tail.o
 	$(LD) $(LDFLAGS) -o tail tail.o $(LDLIBS)

--- a/elkscmd/sash/Makefile
+++ b/elkscmd/sash/Makefile
@@ -15,7 +15,7 @@ include $(BASEDIR)/Make.rules
 ###############################################################################
 
 OBJS = sash.o cmds.o cmd_dd.o cmd_ed.o cmd_grep.o cmd_ls.o cmd_tar.o utils.o cmd_history.o
-#LDFLAGS += -maout-chmem=0xc000
+LDFLAGS += -maout-heap=6144 -maout-stack=3072
 
 all: sash
 

--- a/elkscmd/sash/cmd_dd.c
+++ b/elkscmd/sash/cmd_dd.c
@@ -58,7 +58,7 @@ do_dd(argc, argv)
 	long	intotal;
 	long	outtotal;
 	char	*buf;
-	char	localbuf[8192];
+	char	localbuf[1024];
 
 	infile = NULL;
 	outfile = NULL;

--- a/elkscmd/sash/cmd_tar.c
+++ b/elkscmd/sash/cmd_tar.c
@@ -68,7 +68,7 @@ do_tar(argc, argv)
 	int	blocksize;
 	BOOL	listflag;
 	BOOL	fileflag;
-	char	buf[8192];
+	char	buf[1024];
 
 	if (argc < 2) {
 		fprintf(stderr, "Too few arguments for tar\n");

--- a/elkscmd/sash/cmds.c
+++ b/elkscmd/sash/cmds.c
@@ -720,7 +720,7 @@ void
 do_setenv(argc, argv)
 	char	**argv;
 {
-	char	buf[1024];
+	char	buf[CMDLEN];
 
 	strcpy(buf, argv[1]);
 	if (argc > 2) {

--- a/elkscmd/sash/sash.h
+++ b/elkscmd/sash/sash.h
@@ -20,8 +20,8 @@
 #include "config.h"
 
 #define	PATHLEN		256	
-#define	CMDLEN		512	
-#define	MAXARGS		500	
+#define	CMDLEN		128
+#define	MAXARGS		256
 #define	ALIASALLOC	20
 #define	STDIN		0
 #define	STDOUT		1

--- a/elkscmd/sash/utils.c
+++ b/elkscmd/sash/utils.c
@@ -163,10 +163,10 @@ copyfile(srcname, destname, setmodes)
 	int		rcc;
 	int		wcc;
 	char		*bp;
-	static char buf[BUF_SIZE];
 	struct	stat	statbuf1;
 	struct	stat	statbuf2;
 	struct	utimbuf	times;
+	char buf[BUF_SIZE];
 
 	if (stat(srcname, &statbuf1) < 0) {
 		perror(srcname);

--- a/elkscmd/screen/Makefile
+++ b/elkscmd/screen/Makefile
@@ -35,7 +35,7 @@ LOCALFLAGS = -Wno-implicit-int \
 		-Wno-char-subscripts \
 		$(OPTIONS)
 		
-LOCALFLAGS += -maout-chmem=0x8000 
+LOCALFLAGS += -maout-heap=0x7000
 
 
 ###############################################################################

--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -37,10 +37,10 @@ PRGS = \
 	# EOL
 
 init: init.o
-	$(LD) $(LDFLAGS) -o init init.o $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-heap=4096 -maout-stack=1024 -o init init.o $(LDLIBS)
 
 getty: getty.o
-	$(LD) $(LDFLAGS) -o getty getty.o $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-heap=1024 -maout-stack=1024 -o getty getty.o $(LDLIBS)
 
 login: getpass.o login.o
 	$(LD) $(LDFLAGS) -o login getpass.o login.o $(LDLIBS)

--- a/libc/system/execve.c
+++ b/libc/system/execve.c
@@ -36,7 +36,7 @@ execve(char *fname, char **argv, char **envp)
 	if( argv_len < 0 || envp_len < 0 || stack_bytes <= 0
 	 || (int)(stk_ptr = (char*)sbrk(stack_bytes)) == -1)
 	{
-	   errno = ENOMEM;
+	   errno = E2BIG;
 	   return -1;
 	}
 

--- a/libc/system/execvp.c
+++ b/libc/system/execvp.c
@@ -43,7 +43,7 @@ __execvve(char * fname, char **interp, char **argv, char **envp)
 	if( argv_len < 0 || envp_len < 0 || stack_bytes <= 0
 	 || (int)(stk_ptr = (char*)sbrk(stack_bytes)) == -1)
 	{
-	   errno = ENOMEM;
+	   errno = E2BIG;
 	   return -1;
 	}
 
@@ -144,6 +144,10 @@ execvp(char *fname, char **argv)
 	    if(p) *p = '\0';
 	    plen = strlen(path);
 	    pname = sbrk(plen+flen);
+	    if ((int)pname == -1) {
+		errno = E2BIG;
+		goto out;
+	    }
 
 	    strcpy(pname, path);
 	    strcat(pname, "/");
@@ -161,6 +165,7 @@ execvp(char *fname, char **argv)
    }
 
    tryrun(pname, argv);
+out:
    brk(bp);
    if( errno == ENOENT || errno == 0 ) errno = besterr;
    return -1;


### PR DESCRIPTION
Now that the ELKS kernel supports separately specified heap and stack sizes, fine tuning of ELKS applications can begin in earnest. This PR reduces the size of all programs started at boot, allowing for more memory for normal user programs. These include `init`, `getty`, `httpd`, `telnetd`, `ktcp` and `sh`.  The savings has been in the range of 2k-6k each. Although this doesn't sound like much, this was obtained with no changes to the program sources and adds up.

`bc`, `cron` and `sort` were also updated.

There may be some issues with smaller stack sizes, even after analyzing the source code of each to determine tuning sizes. On occasion, `chmem /bin/*` is producing a stack overflow message; reasons unknown. For some reason, `ps` is reporting different FREE sizes for `sh` on serial and console logins. 

Before tune:
![old](https://user-images.githubusercontent.com/11985637/83341352-bb0e5580-a29f-11ea-9068-839681d1ffdf.png)

After tune:
![new](https://user-images.githubusercontent.com/11985637/83341354-c19ccd00-a29f-11ea-859c-a4d8919f7aa8.png)