### PR TITLE
[ktcp] Fix ARP request and cache handling

### DIFF
--- a/elkscmd/ktcp/arp.h
+++ b/elkscmd/ktcp/arp.h
@@ -30,7 +30,7 @@ struct arp
 int arp_init (void);
 
 void arp_cache_add (ipaddr_t ip_addr, eth_addr_t * eth_addr);
-int arp_cache_get (ipaddr_t ip_addr, eth_addr_t * eth_addr);
+int arp_cache_get (ipaddr_t ip_addr, eth_addr_t * eth_addr, int merge);
 
 void arp_recvpacket (unsigned char * packet, int size);
 int arp_request(ipaddr_t ipaddress);

--- a/elkscmd/ktcp/ip.c
+++ b/elkscmd/ktcp/ip.c
@@ -177,17 +177,17 @@ void ip_sendpacket(unsigned char *packet,int len,struct addr_pair *apair)
         /* So this part should be moved upward in the IP protocol automaton */
         /* to avoid this dangerous unlimited try again loop */
         /* Until issue jbruchon#67 fixed, we block until ARP reply */
-        while (arp_cache_get (ip_addr, &eth_addr))
+        while (arp_cache_get (ip_addr, &eth_addr, 0))
             arp_request (ip_addr);
 #else
 	/* get ethernet address if cached, otherwise TCP packet will auto retans*/
-        if (arp_cache_get (ip_addr, &eth_addr)) {
+        if (arp_cache_get (ip_addr, &eth_addr, 0)) {
 
 	    /* send ARP request once, timed wait for reply*/
             if (!arp_request (ip_addr))
 
 		/* succeeded, try cache once more*/
-		if (arp_cache_get (ip_addr, &eth_addr)) {
+		if (arp_cache_get (ip_addr, &eth_addr, 0)) {
 
 		    /* No ARP reply. Temporary solution, drop sending IP packet.
 		     * TCP should retransmit after timeout,


### PR DESCRIPTION
Contributed by @Mellvik. Corrects `ktcp` problem of answering any and all ARP requests. Also updates ARP cache/merge handling to RFC 826 algorithm.

@Mellik,

Thanks for the fix!

I would like to get rid of the merge_flag global in arp.c, but have left this exactly as your diff for now. As I was getting ready to make the merge_flag change to be a passed parameter, I noticed that the code in arp_recvpacket() calls arp_cache_get when merge_flag = 1, but also calls arp_cache_add when not found, and that routine calls arp_cache_get again (with an implied merge_flag = 1). I want to clarify whether both calls to arp_cache_get need merge_flag set, as then arp_cache_add would also have to be have a merge_flag parameter added. That is - when do you see the merge requirement, in the first or second call to arp_cache_get (or both)? It seems it is only needed in the first call to arp_cache_get, but since I can't test, I didn't want to change it.

Thanks!


