### PR TITLE
[kernel] High speed serial driver and slip networking fixes

### DIFF
--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -130,21 +130,21 @@ void ttystd_release(struct tty *tty)
 
 int tty_allocq(struct tty *tty, int insize, int outsize)
 {
-    if ((tty->inq_buf = heap_alloc(insize, HEAP_TAG_TTY)) == NULL)
+    if ((tty->inq.base = heap_alloc(insize, HEAP_TAG_TTY)) == NULL)
 	return -ENOMEM;
-    if ((tty->outq_buf = heap_alloc(outsize, HEAP_TAG_TTY)) == NULL) {
-	heap_free(tty->inq_buf);
+    if ((tty->outq.base = heap_alloc(outsize, HEAP_TAG_TTY)) == NULL) {
+	heap_free(tty->inq.base);
 	return -ENOMEM;
     }
-    chq_init(&tty->inq, tty->inq_buf, insize);
-    chq_init(&tty->outq, tty->outq_buf, outsize);
+    chq_init(&tty->inq, tty->inq.base, insize);
+    chq_init(&tty->outq, tty->outq.base, outsize);
     return 0;
 }
 
 void tty_freeq(struct tty *tty)
 {
-    heap_free(tty->inq_buf);
-    heap_free(tty->outq_buf);
+    heap_free(tty->inq.base);
+    heap_free(tty->outq.base);
 }
 
 int tty_open(struct inode *inode, struct file *file)

--- a/elks/arch/i86/drivers/net/eth-main.c
+++ b/elks/arch/i86/drivers/net/eth-main.c
@@ -234,12 +234,12 @@ static int eth_open (struct inode * inode, struct file * file)
 
 		ne2k_reset ();
 
-		err = ne2k_init ();
+		err = ne2k_init ();	/* FIXME always returns 0*/
 		if (err) break;
 
 		ne2k_addr_set (mac_addr);
 
-		err = ne2k_start ();
+		err = ne2k_start ();	/* FIXME always returns 0*/
 		if (err) break;
 
 		eth_inuse = 1;
@@ -293,13 +293,14 @@ void eth_drv_init ()
 
 	while (1)
 		{
+#if 0	/* FIXME probe routine does nothing because of QEMU*/
 		err = ne2k_probe ();
 		if (err)
 			{
 			printk ("eth: NE2K not detected\n");
 			break;
 			}
-
+#endif
 		err = request_irq (NE2K_IRQ, ne2k_int, NULL);
 		if (err)
 			{
@@ -314,7 +315,7 @@ void eth_drv_init ()
 			break;
 			}
 
-		printk ("eth: NE2K at 0x%x, irq %d\n", NE2K_PORT, NE2K_IRQ);
+		printk ("eth: NE2K driver compiled for 0x%x, irq %d\n", NE2K_PORT, NE2K_IRQ);
 		break;
 		}
 	}

--- a/elks/arch/i86/kernel/Makefile
+++ b/elks/arch/i86/kernel/Makefile
@@ -41,7 +41,7 @@ OBJS  = strace.o printreg.o system.o irq.o ../sibo/irqtab.o process.o \
 		entry.o signal.o timer.o
 else
 OBJS  = strace.o printreg.o system.o irq.o irqtab.o process.o bios16.o \
-		entry.o signal.o timer.o atomic.o
+		entry.o signal.o timer.o atomic.o serial.o
 endif
 
 #########################################################################

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -16,6 +16,7 @@
 	.align 1
 
 // FIXME: data in code segment - move to INITSEG
+	.global	ds_kernel
 ds_kernel:
 #if defined(CONFIG_ROMCODE)
 	.word	CONFIG_ROM_KERNEL_DATA
@@ -39,12 +40,12 @@ ds_kernel:
 #else
 #define M2	0
 #endif
-#ifdef CONFIG_NEED_IRQ3
+#if defined(CONFIG_NEED_IRQ3) || defined (CONFIG_FAST_IRQ3)
 #define M3	0x08
 #else
 #define M3	0
 #endif
-#ifdef CONFIG_NEED_IRQ4
+#if defined(CONFIG_NEED_IRQ4) || defined (CONFIG_FAST_IRQ4)
 #define M4	0x10
 #else
 #define M4	0
@@ -180,15 +181,29 @@ _irq2:			// Cascade
 	call	_irqit
 	.byte	2
 #endif
-#ifdef CONFIG_NEED_IRQ3
+#if defined(CONFIG_NEED_IRQ3) || defined(CONFIG_FAST_IRQ3)
 _irq3:			// COM2
-	call	_irqit
+#ifdef CONFIG_FAST_IRQ3
+	.global _irq_com2	// fastest possible interrupt routine, fixed com2 port
+	jmp	_irq_com2
+	.byte	3		// ignored
+#endif
+#ifdef CONFIG_NEED_IRQ3
+	call	_irqit		// original ELKS overhead interrupt routine
 	.byte	3
 #endif
-#ifdef CONFIG_NEED_IRQ4
+#endif
+#if defined(CONFIG_NEED_IRQ4) || defined(CONFIG_FAST_IRQ4)
 _irq4:			// COM1
-	call	_irqit
+#ifdef CONFIG_FAST_IRQ4
+	.global _irq_com1	// fastest possible interrupt routine, fixed com1 port
+	jmp	_irq_com1
+	.byte	4		// ignored
+#endif
+#ifdef CONFIG_NEED_IRQ4
+	call	_irqit		// original ELKS overhead interrupt routine
 	.byte	4
+#endif
 #endif
 #ifdef CONFIG_NEED_IRQ5
 _irq5:			// XT HD

--- a/elks/arch/i86/kernel/serial.S
+++ b/elks/arch/i86/kernel/serial.S
@@ -1,0 +1,71 @@
+// Fast custom serial COM interrupt routine for ELKS
+//
+// runs on any stack and skips all ELKS overhead
+// must run with interrupts disabled as could interrupt user, kernel or interrupt stack
+// reads character into ring buffer
+// timer interrupt runs rs_pump() which checks for non-zero queue and calls wake_up
+//
+// 25 June 2020 Greg Haerr
+//
+#include <linuxmt/config.h>
+#include <arch/ports.h>
+	.code16
+	.text
+
+	.extern	ds_kernel
+
+#ifdef CONFIG_FAST_IRQ4
+//
+// fast com1 interrupt routine, uses "jmp _irq_com1" from interrupt vector
+//
+	.extern	fast_com1_irq
+	.global	_irq_com1
+_irq_com1:
+	push	%ax			// save regs, uses 18 bytes of current stack
+	push	%bx
+	push	%cx
+	push	%dx
+	push	%ds
+
+	mov	%cs:ds_kernel,%ds	// recover kernel data segment
+	call	fast_com1_irq		// call special C interrupt routine
+					// which doesn't use any SS/SP/BP addressing
+
+	mov	$0x20,%al		// EOI on primary controller
+	out	%al,$0x20
+
+	pop	%ds			// restore regs
+	pop	%dx
+	pop	%cx
+	pop	%bx
+	pop	%ax
+	iret
+#endif
+
+#ifdef CONFIG_FAST_IRQ3
+//
+// fast com2 interrupt routine, uses "jmp _irq_com2" from interrupt vector
+//
+	.extern	fast_com2_irq
+	.global	_irq_com2
+_irq_com2:
+	push	%ax			// save regs, uses 18 bytes of current stack
+	push	%bx
+	push	%cx
+	push	%dx
+	push	%ds
+
+	mov	%cs:ds_kernel,%ds	// recover kernel data segment
+	call	fast_com2_irq		// call special C interrupt routine
+					// which doesn't use any SS/SP/BP addressing
+
+	mov	$0x20,%al		// EOI on primary controller
+	out	%al,$0x20
+
+	pop	%ds			// restore regs
+	pop	%dx
+	pop	%cx
+	pop	%bx
+	pop	%ax
+	iret
+#endif

--- a/elks/arch/i86/kernel/timer.c
+++ b/elks/arch/i86/kernel/timer.c
@@ -43,9 +43,15 @@ extern void keyboard_irq(int, struct pt_regs *, void *);
 
 #endif
 
+extern void rs_pump(void);
+
 void timer_tick(int irq, struct pt_regs *regs, void *data)
 {
     do_timer(regs);
+
+#if CONFIG_CHAR_DEV_RS
+    rs_pump();		/* check if received serial chars and call wake_up*/
+#endif
 
 #ifndef CONFIG_ARCH_SIBO
 

--- a/elks/fs/pipe.c
+++ b/elks/fs/pipe.c
@@ -77,11 +77,11 @@ int pipe_lseek(struct inode *inode, struct file *file, loff_t offset,
  *	V7, and they should be buffers
  */
 
-static char pipe_base[MAX_PIPES][PAGE_SIZE];
+static unsigned char pipe_base[MAX_PIPES][PAGE_SIZE];
 
 static int pipe_in_use[(MAX_PIPES + 15)/16];
 
-static char *get_pipe_mem(void)
+static unsigned char *get_pipe_mem(void)
 {
     register char *i = 0;
 
@@ -95,7 +95,7 @@ static char *get_pipe_mem(void)
     return NULL;
 }
 
-static void free_pipe_mem(char *buf)
+static void free_pipe_mem(unsigned char *buf)
 {
     register char *i;
 

--- a/elks/include/arch/ports.h
+++ b/elks/include/arch/ports.h
@@ -39,8 +39,10 @@
 //#define CONFIG_NEED_IRQ2		/* only available on XT, slave PIC on AT*/
 
 #ifdef CONFIG_CHAR_DEV_RS
-#define CONFIG_NEED_IRQ4		/* COM1*/
-#define CONFIG_NEED_IRQ3		/* COM2*/
+#define CONFIG_FAST_IRQ4		/* COM1 very fast serial driver, no ISIG handling*/
+//#define CONFIG_FAST_IRQ3		/* COM2 very fast serial driver, no ISIG handling*/
+//#define CONFIG_NEED_IRQ4		/* COM1 normal serial driver*/
+#define CONFIG_NEED_IRQ3		/* COM2 normal serial driver*/
 //#define CONFIG_NEED_IRQ5		/* COM3*/
 //#define CONFIG_NEED_IRQ2		/* COM4, XT only*/
 #endif

--- a/elks/include/linuxmt/chqueue.h
+++ b/elks/include/linuxmt/chqueue.h
@@ -4,9 +4,9 @@
 #define __LINUXMT_CHQ_H
 
 struct ch_queue {
-    char		*base;
-    struct wait_queue	wait;
+    unsigned char	*base;
     int 		size, start, len;
+    struct wait_queue	wait;
 };
 
 extern void chq_init(register struct ch_queue *,unsigned char *,int);

--- a/elks/include/linuxmt/ntty.h
+++ b/elks/include/linuxmt/ntty.h
@@ -5,10 +5,11 @@
  * 'ntty.h' defines some structures used by ntty.c and some defines.
  */
 
+/* NOTE: all queue sizes must be a power of two!*/
 #define INQ_SIZE	128	/* tty/pty input queue size*/
 #define OUTQ_SIZE	64	/* tty/pty output queue size*/
 
-#define RSINQ_SIZE	1200	/* serial input queue SLIP_MTU+128+8*/
+#define RSINQ_SIZE	1024	/* serial input queue SLIP_MTU+128+8*/
 #define RSOUTQ_SIZE	64	/* serial output queue size*/
 
 /*
@@ -81,8 +82,6 @@ struct tty {
     unsigned char ostate;
     unsigned char usecount;
     pid_t pgrp;
-    unsigned char *outq_buf;
-    unsigned char *inq_buf;
 };
 
 extern int tty_intcheck(struct tty *,unsigned char);

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -1,11 +1,10 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-//#include <autoconf.h>
-#undef CONFIG_CSLIP
-//#define CSLIP
-
 //#define ARP_WAIT_KLUGE	/* force loop on arp reply*/
+
+/* compile time options*/
+#define CSLIP		1	/* compile in CSLIP support*/
 
 /* turn these on for ELKS debugging*/
 #define DEBUG_TCP	0

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -3,6 +3,7 @@
 
 //#include <autoconf.h>
 #undef CONFIG_CSLIP
+//#define CSLIP
 
 //#define ARP_WAIT_KLUGE	/* force loop on arp reply*/
 

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -1,7 +1,8 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#include <autoconf.h>
+//#include <autoconf.h>
+#undef CONFIG_CSLIP
 
 //#define ARP_WAIT_KLUGE	/* force loop on arp reply*/
 

--- a/elkscmd/ktcp/deveth.c
+++ b/elkscmd/ktcp/deveth.c
@@ -81,10 +81,8 @@ void deveth_process(int flag)
 {
   eth_head_t * eth_head;
   int len = read (devfd, sbuf[flag], MAX_PACKET_ETH);
-  if (len < (int)sizeof(eth_head_t)) {
-	perror("deveth_process");
+  if (len < (int)sizeof(eth_head_t))
 	return;
-  }
 
   eth_head = (eth_head_t *) sbuf[flag];
 

--- a/elkscmd/ktcp/deveth.c
+++ b/elkscmd/ktcp/deveth.c
@@ -26,7 +26,6 @@
 #include "arp.h"
 
 eth_addr_t eth_local_addr;
-int eth_device;
 
 static unsigned char sbuf[2][MAX_PACKET_ETH];	//FIXME ARP wait fix
 static int devfd;

--- a/elkscmd/ktcp/deveth.h
+++ b/elkscmd/ktcp/deveth.h
@@ -23,7 +23,6 @@ struct eth_head_s {
 typedef struct eth_head_s eth_head_t;
 
 extern eth_addr_t eth_local_addr;
-extern int eth_device;
 
 void deveth_printhex(unsigned char *packet, int len);
 int  deveth_init(char *fdev);

--- a/elkscmd/ktcp/ip.c
+++ b/elkscmd/ktcp/ip.c
@@ -91,10 +91,10 @@ static void ip_print(struct iphdr_s *head, int size)
     debug_ip("%s -> ", in_ntoa(head->saddr));
     debug_ip("%s ", in_ntoa(head->daddr));
     debug_ip("v%d hl:%d ", IP_VERSION(head), IP_HLEN(head));
-    debug_ip("tos:%d len:%d ", head->tos, ntohs(head->tot_len));
+    debug_ip("tos:%d len:%u ", head->tos, ntohs(head->tot_len));
     debug_ip("id:%u ", ntohs(head->id));
     debug_ip("fo:%x ", ntohs(head->frag_off));	//FIXME add FM_ flags
-    debug_ip("chk:%d ", ip_calc_chksum((char *)head, 4 * IP_HLEN(head)));
+    debug_ip("chk:%x ", ip_calc_chksum((char *)head, 4 * IP_HLEN(head)));
     debug_ip("ttl:%d ", head->ttl);
     debug_ip("prot:%d\n", head->protocol);
 #if DEBUG_IP > 1

--- a/elkscmd/ktcp/ip.c
+++ b/elkscmd/ktcp/ip.c
@@ -159,7 +159,7 @@ void ip_sendpacket(unsigned char *packet,int len,struct addr_pair *apair)
     localpacket =  apair->saddr == local_ip && apair->daddr == local_ip;
 
     /* deal with ethernet layer if destination not local_ip*/
-    if (eth_device && !localpacket) {
+    if (linkprotocol == LINK_ETHER && !localpacket) {
         /* Is this the best place for the IP routing to happen ? */
         /* I think no, because actual sending interface is coming from the routing */
 
@@ -240,7 +240,7 @@ void ip_sendpacket(unsigned char *packet,int len,struct addr_pair *apair)
 	return;
     }
 
-    if (eth_device)
+    if (linkprotocol == LINK_ETHER)
 	deveth_send((unsigned char *)ipll, sizeof(struct ip_ll) + iphdrlen + len);
     else
 	slip_send((unsigned char *)iph, iphdrlen + len);

--- a/elkscmd/ktcp/ip.h
+++ b/elkscmd/ktcp/ip.h
@@ -47,6 +47,13 @@ extern ipaddr_t local_ip;
 extern ipaddr_t gateway_ip;
 extern ipaddr_t netmask_ip;
 
+#define LINK_ETHER	0
+#define LINK_SLIP	1
+#define LINK_CSLIP	2
+
+extern int linkprotocol;
+extern unsigned int MTU;
+
 int ip_init(void);
 __u16 ip_calc_chksum(char *data, int len);
 void ip_recvpacket(unsigned char *packet, int size);

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -18,6 +18,8 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <string.h>
+#include <getopt.h>
+#include <signal.h>
 
 #include "slip.h"
 #include "tcp.h"
@@ -36,8 +38,20 @@ ipaddr_t local_ip;
 ipaddr_t gateway_ip;
 ipaddr_t netmask_ip;
 
-char deveth[] = "/dev/eth";
+char foo[] = "/dev/eth";	// FIXME remove after memory errors
 
+#define DEFAULT_IP		"10.0.2.15"
+#define DEFAULT_GATEWAY		"10.0.2.2"
+#define DEFAULT_NETMASK		"255.255.255.0"
+
+/* defaults*/
+int linkprotocol = 	LINK_ETHER;
+unsigned int MTU =	SLIP_MTU;
+char ethdev[] = 	"/dev/eth";
+char *serdev = 		"/dev/ttyS0";
+speed_t baudrate = 	57600;
+
+int dflag;
 static int intfd;	/* interface fd*/
 
 void setp(unsigned char **p)
@@ -91,7 +105,7 @@ printp();
 
 	/* process received packets*/
 	if (FD_ISSET(intfd, &fdset)) {
-		if (eth_device)
+		if (linkprotocol == LINK_ETHER)
 			deveth_process(0);
 		else slip_process();
 	}
@@ -108,58 +122,80 @@ printp();
     }
 }
 
+void catch(int sig)
+{
+    printf("ktcp: exit signal %d\n", sig);
+}
+
+static void usage(void)
+{
+    printf("Usage: ktcp [-b] [-d] [-m MTU] [-p eth|slip|cslip] [-s baud] [-l device] [local_ip] [interface] [gateway] [netmask]\n");
+    exit(1);
+}
+
 int main(int argc,char **argv)
 {
-    int daemon = 0;
-    speed_t baudrate = 0;
-    char *progname = argv[0];
-
+    int ch;
+    int bflag = 0;
 printp();
 //printf("ZERO is at %x\n", zero);
-    if (argc > 1 && !strcmp("-b", argv[1])) {
-	daemon = 1;
-	argc--;
-	argv++;
-    }
-    if (argc > 1 && !strcmp("-s", argv[1])) {
-	if (argc <= 2) goto usage;
-	baudrate = atol(argv[2]);
-	argc -= 2;
-	argv += 2;
-    }
-    if (argc < 3) {
-usage:
-	printf("Usage: %s [-b] [-s baud] local_ip [interface] [gateway] [netmask]\n", progname);
-	exit(3);
+
+    while ((ch = getopt(argc, argv, "bdp:s:l:")) != -1) {
+	switch (ch) {
+	case 'b':		/* background daemon*/
+	    bflag = 1;
+	    break;
+	case 'd':		/* debug messages*/
+	    dflag++;
+	    break;
+	case 'm':		/* MTU*/
+		MTU = atoi(optarg);
+		break;
+	case 'p':		/* link protocol*/
+	    linkprotocol = !strcmp(optarg, "eth")? LINK_ETHER :
+			   !strcmp(optarg, "slip")? LINK_SLIP :
+			   !strcmp(optarg, "cslip")? LINK_CSLIP:
+			   -1;
+	    if (linkprotocol < 0) usage();
+	    break;
+	case 's':		/* serial speed*/
+	    baudrate = atol(optarg);
+	    break;
+	case 'l':		/* serial device*/
+	    serdev = optarg;
+	    break;
+	case 'h':		/* help*/
+	default:
+	    usage();
+	}
     }
 
-    local_ip = in_aton(argv[1]);
-
-    if (argc > 3) gateway_ip = in_aton(argv[3]);
-    else gateway_ip = in_aton("10.0.2.2"); /* use dhcp when implemented */
-
-    if (argc > 4) netmask_ip = in_aton(argv[4]);
-    else netmask_ip = in_aton("255.255.255.0");
+    local_ip = in_aton(optind < argc? argv[optind++]: DEFAULT_IP);
+    gateway_ip = in_aton(optind < argc? argv[optind++]: DEFAULT_GATEWAY);
+    netmask_ip = in_aton(optind < argc? argv[optind++]: DEFAULT_NETMASK);
 
     printf("ktcp: ip %s, ", in_ntoa(local_ip));
     printf("gateway %s, ", in_ntoa(gateway_ip));
     printf("netmask %s\n", in_ntoa(netmask_ip));
+    printf("link %d serdev %s baud %lu mtu %u\n", linkprotocol, serdev, baudrate, MTU);
 
     /* must exit() in next two stages on error to reset kernel tcpdev_inuse to 0*/
     if ((tcpdevfd = tcpdev_init("/dev/tcpdev")) < 0)
 	exit(1);
 
-    if (strcmp(argv[2],deveth) == 0) {
-	if ((intfd = deveth_init(deveth)) < 0)
+    if (linkprotocol == LINK_ETHER) {
+	if ((intfd = deveth_init(ethdev)) < 0)
 	    exit(1);
-	eth_device = 1;
     } else {
-	if ((intfd = slip_init(argv[2], baudrate)) < 0)
+	if ((intfd = slip_init(serdev, baudrate)) < 0)
 	    exit(2);
     }
 
+    signal(SIGHUP, catch);
+    signal(SIGINT, catch);
+
     /* become daemon now that tcpdev_inuse race condition over*/
-    if (daemon) {
+    if (bflag) {
 	int fd;
 	if (fork())
 	    exit(0);

--- a/elkscmd/ktcp/slip.c
+++ b/elkscmd/ktcp/slip.c
@@ -29,10 +29,10 @@
 /*
  * SLIP codes
  */
-#define END		0300
-#define ESC		0333
-#define ESC_END		0334
-#define ESC_ESC		0335
+#define END		0300	/* 0xC0*/
+#define ESC		0333	/* 0xDB*/
+#define ESC_END		0334	/* 0xDC*/
+#define ESC_ESC		0335	/* 0xDD*/
 
 static unsigned char 	sbuf[SERIAL_BUFFER_SIZE];
 static unsigned char	lastchar;
@@ -110,12 +110,12 @@ int slip_init(char *fdev, speed_t baudrate)
     tios.c_cflag |= CS8 | CREAD;
     tios.c_cflag |= CLOCAL;	/* ignore modem control lines*/
     //tios.c_cflag |= CRTSCTS;	/* hw flow control*/
-    tios.c_cc[VMIN] = 255;	/* try for max 255 byte reads*/
-    tios.c_cc[VTIME] = 1;	/* 100ms intercharacter timeout*/
+    //tios.c_cc[VMIN] = 255;	/* try for max 255 byte reads*/
+    //tios.c_cc[VTIME] = 1;	/* 100ms intercharacter timeout*/
+    tios.c_cc[VMIN] = 1;
+    tios.c_cc[VTIME] = 0;
     ioctl(devfd, TCSETS, &tios);
 
-    /* Init some variables
-     */
     packpos = 128;
     lastchar = 0;
 
@@ -168,22 +168,26 @@ void cslip_decompress(__u8 **packet, size_t *len){
 
 /*
  * slip_process()
- *  Called when we have new data waiting
- *  at the serial port
- *	FIXME : Handle the buffer overrun when out
- *          MTU is not honored.
+ *  Called when we have new data waiting at the serial port
  */
 void slip_process(void)
 {
     size_t p_size;
-    __u8 *p;
-    int i, len, packet_num = 0;
+    unsigned char *p;
+    int i, len;
 
-    while (packet_num < 3) {
-	len = read(devfd, &sbuf, SERIAL_BUFFER_SIZE);
-	if (len <= 0)
-	    break;
-
+    len = read(devfd, sbuf, SERIAL_BUFFER_SIZE);
+    if (len <= 0)
+	return;
+#ifdef DEBUG
+{
+printf("[%d]", len);
+printf("{");
+for (i=0; i<len; i++)
+    printf("%2x,", sbuf[i]);
+printf("}");
+}
+#endif
 	for (i=0; i < len ; i++) {
 	    if (lastchar == ESC) {
 		switch (sbuf[i]) {
@@ -221,26 +225,20 @@ void slip_process(void)
 		        if (p_size > 0)
 			    ip_recvpacket(p, p_size);
 
-			packet_num++;
-
 			/* Reset */
 			packpos = 128;
 			lastchar = 0;
-			break;
+			continue;
 
 		    default:
-			packet[packpos++] = sbuf[i];
+			/* drop characters over SLIP_MTU*/
+			if (packpos < sizeof(packet))
+			    packet[packpos++] = sbuf[i];
 		}
 	    }
 	    lastchar = sbuf[i];
 	}
     }
-}
-
-void send_char(__u8 ch)
-{
-    write(devfd, &ch, 1);
-}
 
 #ifdef CONFIG_CSLIP
 void cslip_compress(__u8 **packet, int *len)
@@ -266,40 +264,35 @@ void cslip_compress(__u8 **packet, int *len)
 }
 #endif
 
-/*
- * TODO : Use a buffer to reduse the write calls //FIXME
- */
 void slip_send(unsigned char *packet, int len)
 {
-    __u8 *p = (__u8 *)packet;
+    unsigned char buf[128+2];
+    unsigned char *p = packet;
+    unsigned char *q = buf;
 
 #ifdef CONFIG_CSLIP
     cslip_compress(&p, &len);
 #endif
 
-    send_char(END);
+    *q++ = END;
     while (len--) {
 	switch (*p) {
-
-	    case END:
-		send_char(ESC);
-		send_char(ESC_END);
-		break;
-
-	    case ESC:
-		send_char(ESC);
-		send_char(ESC_ESC);
-		break;
-
-	    default:
-		send_char(*p);
-		break;
-
+	case END:
+	    *q++ = ESC;
+	    *q++ = ESC_END;
+	    break;
+	case ESC:
+	    *q++ = ESC;
+	    *q++ = ESC_ESC;
+	    break;
+	default:
+	    *q++ = *p;
+	    break;
 	}
 	p++;
+	if (q - buf >= sizeof(buf) - 2)
+	    write(devfd, buf, q - buf);
     }
-    send_char(END);
+    *q++ = END;
+    write(devfd, buf, q - buf);
 }
-
-
-

--- a/elkscmd/ktcp/slip.c
+++ b/elkscmd/ktcp/slip.c
@@ -119,14 +119,14 @@ int slip_init(char *fdev, speed_t baudrate)
     packpos = 128;
     lastchar = 0;
 
-#ifdef CONFIG_CSLIP
+#ifdef CSLIP
     ip_vjhc_init();
 #endif
 
     return devfd;
 }
 
-#ifdef CONFIG_CSLIP
+#ifdef CSLIP
 void cslip_decompress(__u8 **packet, size_t *len){
     pkt_ut p;
     __u8 c;
@@ -216,7 +216,7 @@ printf("}");
 			    break;
 
 			p_size = packpos - 128;
-#ifdef CONFIG_CSLIP
+#ifdef CSLIP
 			p = packet;
 		        cslip_decompress(&p, &p_size);
 #else
@@ -240,7 +240,7 @@ printf("}");
 	}
     }
 
-#ifdef CONFIG_CSLIP
+#ifdef CSLIP
 void cslip_compress(__u8 **packet, int *len)
 {
     pkt_ut p;
@@ -270,7 +270,7 @@ void slip_send(unsigned char *packet, int len)
     unsigned char *p = packet;
     unsigned char *q = buf;
 
-#ifdef CONFIG_CSLIP
+#ifdef CSLIP
     cslip_compress(&p, &len);
 #endif
 

--- a/elkscmd/ktcp/slip.h
+++ b/elkscmd/ktcp/slip.h
@@ -1,7 +1,8 @@
 #ifndef __SLIP_H__
 #define __SLIP_H__
 
-#define SLIP_MTU   1064
+//#define SLIP_MTU   1064		/* default too large for 1024 serial ring buffer*/
+#define SLIP_MTU   1024
 
 void slip_process(void);
 int slip_init(char *fdev, speed_t baudrate);

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -354,7 +354,7 @@ len = 255;	//FIXME testing only
 
 	options[0] = TCP_OPT_MSS;
 	options[1] = TCP_OPT_MSS_LEN;		/* total options length (4)*/
-	*(__u16 *)(options + 2) = htons(SLIP_MTU - 40);
+	*(__u16 *)(options + 2) = htons(MTU - 40);
 	//*(__u16 *)(options + 2) = htons(512 - 40);
 	header_len += TCP_OPT_MSS_LEN;
     }

--- a/elkscmd/ktcp/vjhc.c
+++ b/elkscmd/ktcp/vjhc.c
@@ -16,7 +16,7 @@ Created:	Nov 11, 1993 by Philip Homburg <philip@cs.vu.nl>
 */
 
 #include "config.h"
-#ifdef CSLIP
+#if CSLIP
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/elkscmd/ktcp/vjhc.c
+++ b/elkscmd/ktcp/vjhc.c
@@ -16,7 +16,7 @@ Created:	Nov 11, 1993 by Philip Homburg <philip@cs.vu.nl>
 */
 
 #include "config.h"
-#ifdef CONFIG_CSLIP
+#ifdef CSLIP
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/elkscmd/misc_utils/miniterm.c
+++ b/elkscmd/misc_utils/miniterm.c
@@ -446,8 +446,6 @@ int main(int argc, char **argv)
 	}
 #endif
 
-	set_raw(0);
-
 	usage(argv[0]);
 	fprintf(stderr, "Connected to %s at %lubps. Press '%c%c' to exit, '%c%c' for help.\n\n",
 		device, (unsigned long)baudrate, ESCAPE_CHARACTER, EXIT_CHARACTER,
@@ -455,6 +453,8 @@ int main(int argc, char **argv)
 
 	if (mode == MODE_TEXT) {
 		struct termios new;
+
+		set_raw(0);
 
 		new.c_cflag |= CS8 | CREAD;
 		new.c_iflag = IGNPAR;
@@ -646,7 +646,14 @@ int main(int argc, char **argv)
 				}
 			} else {
 				printf("Read %d byte(s):\n", len);
-				dump(buf, len);
+{
+int i;
+printf("{");
+for (i=0; i<len; i++)
+    printf("%2x,", buf[i]&0xff);
+printf("}");
+}
+				//dump(buf, len);
 				printf("\n");
 			}
 		}

--- a/elkscmd/misc_utils/miniterm.c
+++ b/elkscmd/misc_utils/miniterm.c
@@ -646,14 +646,7 @@ int main(int argc, char **argv)
 				}
 			} else {
 				printf("Read %d byte(s):\n", len);
-{
-int i;
-printf("{");
-for (i=0; i<len; i++)
-    printf("%2x,", buf[i]&0xff);
-printf("}");
-}
-				//dump(buf, len);
+				dump(buf, len);
 				printf("\n");
 			}
 		}

--- a/elkscmd/rootfs_template/bin/net
+++ b/elkscmd/rootfs_template/bin/net
@@ -1,0 +1,93 @@
+# Start/stop ELKS networking
+#
+# Usage: net [start|stop] [eth|slip|cslip] [baud] [device]
+#
+# Examples:
+#	net start eth			start ethernet networking
+#	net start slip			start slip networking at default baudrate
+#	net start slip 19200	start slip at 19200 baud
+#	net start cslip 4800 /dev/ttyS1
+#
+# See slattach.sh for Linux slip setup
+# See qemu.sh NET= line for host forwarding into ELKS using QEMU
+#
+
+# default IP address, gateway and network mask
+localip=10.0.2.15
+gateway=10.0.2.2
+netmask=255.255.255.0
+
+# default link layer [eth|slip|cslip]
+link=eth
+
+# default serial port and baud rate if slip/cslip
+device=/dev/ttyS0
+baud=57600
+
+usage()
+{
+	echo "Usage: net [start|stop] [eth|slip|cslip] [baud] [device]"
+	exit 1
+}
+
+getty_off()
+{
+	# turn off any serial gettys running
+	init 1
+}
+
+start_network()
+{
+	echo "Starting networking" on $link
+	case "$link" in
+	slip)
+		getty_off
+		ktcp="ktcp -b -s $baud $localip $device $gateway $netmask"
+		;;
+	cslip)
+		getty_off
+		ktcp="ktcp -b -c -s $baud $localip $device $gateway $netmask"
+		;;
+	eth)
+		ktcp="ktcp -b $localip /dev/eth $gateway $netmask"
+		;;
+	*)
+		usage ;;
+	esac
+	# run ktcp as background daemon if successful starting networking
+	echo $ktcp
+	if $ktcp; then
+		for daemon in telnetd httpd
+		do
+			if test -f /bin/$daemon
+			then
+				echo -n " $daemon "
+				$daemon || true
+			fi
+		done
+	else
+		echo "Network start failed"
+		exit 1
+	fi
+}
+
+stop_network()
+{
+	echo "Stopping network"
+}
+
+if test "$#" -lt 1; then
+	usage
+fi
+
+case "$1" in
+start)
+	if test "$2" != ""; then link=$2; fi
+	if test "$3" != ""; then baud=$3; fi
+	if test "$4" != ""; then device=$4; fi
+	start_network ;;
+stop) stop_network ;;
+*) usage ;;
+esac
+
+exit 0

--- a/elkscmd/rootfs_template/bin/net
+++ b/elkscmd/rootfs_template/bin/net
@@ -42,14 +42,14 @@ start_network()
 	case "$link" in
 	slip)
 		getty_off
-		ktcp="ktcp -b -s $baud $localip $device $gateway $netmask"
+		ktcp="ktcp -b -p slip -s $baud -l $device $localip $device $gateway $netmask"
 		;;
 	cslip)
 		getty_off
-		ktcp="ktcp -b -c -s $baud $localip $device $gateway $netmask"
+		ktcp="ktcp -b -p cslip -s $baud -l $device $localip $device $gateway $netmask"
 		;;
 	eth)
-		ktcp="ktcp -b $localip /dev/eth $gateway $netmask"
+		ktcp="ktcp -b $localip $gateway $netmask"
 		;;
 	*)
 		usage ;;

--- a/elkscmd/rootfs_template/etc/inittab
+++ b/elkscmd/rootfs_template/etc/inittab
@@ -1,4 +1,4 @@
-id:3:initdefault:
+id:1:initdefault:
 
 si::sysinit:/etc/rc.d/rc.sys
 

--- a/elkscmd/rootfs_template/etc/rc.d/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sys
@@ -8,37 +8,14 @@ export PATH=/bin
 # init date from hardware
 clock -s
 
-#
-# Network initialization
-# Defaults are QEMU ip address and external gateway
-# See qemu.sh NET= line for host forwarding into ELKS
-#
-localip=10.0.2.15
-gateway=10.0.2.2
-netmask=255.255.255.0
-interface=/dev/eth
-#interface=/dev/ttyS0
-#slipbaud="-s 4800"
+# start networking
+#net start
+#net start eth
+#net start cslip 19200
+#net start slip 115200 /dev/ttyS0
+#net stop
 
-if test -f /bin/ktcp
-then
-	echo 'Starting networking: ktcp'
-	# run ktcp as background daemon if successful starting networking
-	if ktcp -b $slipbaud $localip $interface $gateway $netmask; then
-		for daemon in telnetd httpd
-		do
-			if test -f /bin/$daemon
-			then
-				echo -n " $daemon "
-				$daemon || true
-			fi
-		done
-	fi
-fi
-
-# 
 # View message of day
-#
 if test -f /etc/motd
 then
     cat /etc/motd

--- a/elkscmd/sh_utils/test.c
+++ b/elkscmd/sh_utils/test.c
@@ -11,7 +11,7 @@
  *			| "!" expr
  *			;
  *		unary-operator ::= "-r"|"-w"|"-f"|"-d"|"-s"|"-t"|"-z"|"-n"|"-x";
- *		binary-operator ::= "="|"!="|"-eq"|"-ne"|"-ge"|"-gt"|"-le"|"-lt";
+ *		binary-operator ::= "="|"!="|"-eq"|"-ne"|"-ge"|"-gt"|"-le"|"-lt|-newer";
  *		operand ::= <any legal UNIX file name>
  *
  * Author:	Erik Baalbergen	erikb@cs.vu.nl
@@ -121,7 +121,7 @@ struct op {
   {	0,	0,	0	}
 };
 
-#define _PROTOTYPE(a,b)	
+#define _PROTOTYPE(a,b)	a b
 
 char **ip;
 char *prog;

--- a/slattach.sh
+++ b/slattach.sh
@@ -1,0 +1,23 @@
+# Helper script to setup SLIP connection between Linux and ELKS
+#
+# run "net start slip" on ELKS after running this script
+#
+
+baud=57600
+device=/dev/ttyS0
+protocol=slip
+elks=10.0.2.15
+gateway=10.0.2.2
+
+# stop any previously running slip
+pkill slattach
+
+# attach slip to serial line
+/sbin/slattach -p $protocol -s $baud -v -L $device &
+
+# configure sl0 interface
+/sbin/ifconfig sl0 $gateway pointtopoint $elks
+
+# display connection
+/sbin/ifconfig
+/sbin/route


### PR DESCRIPTION
Fixes all outstanding serial port speed and reliability issues, including #454, #515, and some issues brought up in #539.
Fixes and improvements made to SLIP networking now allow speeds up to 115200 baud between Linux and ELKS.
Adds "net start" script for starting networking on SLIP and ethernet.
Adds "slattach.sh" script to setup SLIP to ELKS link.
Tested on Compaq 386 Portable with working miniterm and SLIP up to 57600 baud.
`ktcp` networking now working quickly with telnet in both direction simultaneously over serial but many networking problems remain.

Details:
Fix serial receive ring buffer corruption bug due to no cli/sti protection on serial received characters.
Wrote fast optional asm com1/com2 interrupt driver; runs without any ELKS interrupt stack and processing overhead, uses timer interrupt for process wakeup.
Set via CONFIG_FAST_IRQ4 (default) and CONFIG_FAST_IRQ3 in include/arch/ports.h. No ISIG tty line signal handling, for use in CSLIP/SLIP networking or very fast terminal emulation access. Original serial port driver now runs well up to 19200 baud.
Speed up serial transmit to use transmitter holding buffer empty rather than transmitter empty.
Fix serial receiver buffer size not a power-of-two bug which lost characters.
Remove inb_p/outb_p 1us pause after all serial I/O, move to INB/OUTB macros.
Add SLIP packet write buffering for speed.
Fix SLIP packet overflow bug.
Fix ktcp deveth_process perror message bug.
Fix miniterm ^C exit son slip/hex dump mode, dump mode still broken.
Testing SLIP now, CSLIP coming.
Change NE2K driver non-probe to compilation printk

Add "net start" script for starting (and eventually stopping) networking. Exists as shell script in /bin/net. Add "net start" to /etc/rc.d/rc.sys for network startup at boot.
```
Usage: net [start|stop] [eth|skip|cslip] [baud] [device]
    net start eth
    net start slip 19200
    net start cslip 4800 /dev/ttyS1
```
Default no network startup at boot for time being. 
Default single user mode (init 1) for now (init 3 for serial gettys)


