### PR TITLE
[ktcp] Rewrite ARP handling to be asynchronous

### DIFF
--- a/elkscmd/ktcp/arp.h
+++ b/elkscmd/ktcp/arp.h
@@ -27,13 +27,24 @@ struct arp
          __u32 ip_dest; 	/* IP destination address */
 };
 
+struct arp_cache {
+	ipaddr_t   ip_addr;	/* IPv4 address */
+	eth_addr_t eth_addr;	/* MAC address */
+	int valid;		/* eth_addr valid flag*/
+	unsigned char *qpacket;	/* queued packet waiting for ARP reply*/
+	int len;		/* queued packet length*/
+};
+
+/* arp_cache_get flags*/
+#define ARP_VALID	1	/* retrieve valid eth_addr entry only*/
+#define ARP_UPDATE	2	/* if present, update cache with passed eth_addr*/
+
 int arp_init (void);
-
-void arp_cache_add (ipaddr_t ip_addr, eth_addr_t * eth_addr);
-int arp_cache_get (ipaddr_t ip_addr, eth_addr_t * eth_addr, int merge);
-
+struct arp_cache *arp_cache_get(ipaddr_t ip_addr, eth_addr_t * eth_addr, int flags);
+struct arp_cache *arp_cache_update(ipaddr_t ip_addr, eth_addr_t *eth_addr);
+struct arp_cache *arp_cache_add(ipaddr_t ip_addr, eth_addr_t * eth_addr);
 void arp_recvpacket (unsigned char * packet, int size);
-int arp_request(ipaddr_t ipaddress);
+void arp_request(ipaddr_t ipaddress);
 
 char *mac_ntoa(unsigned char *p);
 

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -1,8 +1,6 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-//#define ARP_WAIT_KLUGE	/* force loop on arp reply*/
-
 /* compile time options*/
 #define CSLIP		1	/* compile in CSLIP support*/
 

--- a/elkscmd/ktcp/deveth.c
+++ b/elkscmd/ktcp/deveth.c
@@ -54,8 +54,6 @@ int deveth_init(char *fdev)
         return -2;
     }
 
-    debug_arp("eth_local_addr: %s\n", mac_ntoa(&eth_local_addr));
-
     return devfd;
 }
 
@@ -72,10 +70,12 @@ void eth_process(void)
 
   eth_head = (eth_head_t *) sbuf;
 
-  /* Filter on MAC addresses in case of promiscuous mode FIXME remove*/
+#if 0
+  /* Filter on MAC addresses in case of promiscuous mode*/
   if (memcmp (eth_head->eth_dst, broad_addr, sizeof (eth_addr_t))
     && memcmp (eth_head->eth_dst, eth_local_addr, sizeof (eth_addr_t)))
       return;
+#endif
 
   /* dispatch to IP or ARP*/
   switch (eth_head->eth_type) {

--- a/elkscmd/ktcp/deveth.c
+++ b/elkscmd/ktcp/deveth.c
@@ -1,6 +1,8 @@
 /*
  * This file is part of the ELKS TCP/IP stack
  *
+ * 13 Jul 20 Greg Haerr - added eth_route to handle ARP requests and packet queuing
+ *
  *	This program is free software; you can redistribute it and/or
  *	modify it under the terms of the GNU General Public License
  *	as published by the Free Software Foundation; either version
@@ -12,6 +14,7 @@
 #include <sys/ioctl.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -19,34 +22,19 @@
 #include <arch/ioctl.h>
 
 #include "config.h"
-#include "deveth.h"
 #include "tcp.h"
 #include "ip.h"
+#include "deveth.h"
 #include "tcpdev.h"
 #include "arp.h"
 
 eth_addr_t eth_local_addr;
 
-static unsigned char sbuf[2][MAX_PACKET_ETH];	//FIXME ARP wait fix
+static unsigned char sbuf[MAX_PACKET_ETH];
 static int devfd;
 
 static eth_addr_t broad_addr = {255, 255, 255, 255, 255, 255};
 
-
-#if DEBUG
-void deveth_printhex(unsigned char *packet, int len)
-{
-  unsigned char *p = packet;
-  int i = 0;
-  printf("deveth_process():%d bytes\n",len);
-  if (len > 128) len = 128;
-  while (len--) {
-	printf("%02X ", *p++);
-	if ((i++ & 15) == 15) printf("\n");
-  }
-  printf("\n");
-}
-#endif
 
 int deveth_init(char *fdev)
 {
@@ -74,42 +62,105 @@ int deveth_init(char *fdev)
 
 /*
  *  Called when select in ktcp indicates we have new data waiting
- *	FIXME also called by arp_request() which overwrites buffer on icmp reply
  */
-void deveth_process(int flag)
+void eth_process(void)
 {
   eth_head_t * eth_head;
-  int len = read (devfd, sbuf[flag], MAX_PACKET_ETH);
+  int len = read (devfd, sbuf, MAX_PACKET_ETH);
   if (len < (int)sizeof(eth_head_t))
 	return;
 
-  eth_head = (eth_head_t *) sbuf[flag];
+  eth_head = (eth_head_t *) sbuf;
 
-  /* Filter on MAC addresses */
-  /* in case of promiscuous mode */
-
+  /* Filter on MAC addresses in case of promiscuous mode FIXME remove*/
   if (memcmp (eth_head->eth_dst, broad_addr, sizeof (eth_addr_t))
     && memcmp (eth_head->eth_dst, eth_local_addr, sizeof (eth_addr_t)))
       return;
 
-  /* Decode Ethernet II header */
-  /* and dispatch to protocols */
-
+  /* dispatch to IP or ARP*/
   switch (eth_head->eth_type) {
   case ETH_TYPE_IPV4:
 	  /* strip link layer */
-	  ip_recvpacket (sbuf[flag] + sizeof(eth_head_t), len - sizeof(eth_head_t));
+	  ip_recvpacket (sbuf + sizeof(eth_head_t), len - sizeof(eth_head_t));
 	  break;
 
   case ETH_TYPE_ARP:
-	  arp_recvpacket (sbuf[flag], len);
+	  arp_recvpacket (sbuf, len);
 	  break;
   }
 }
 
-
-void deveth_send(unsigned char *packet, int len)
+/*
+ * Determine ethernet address for IP packet using ARP request/cache
+ * Packet will be sent if address cached, otherwise sent after ARP reply
+ * Only one packet will be queued per remote host waiting for ARP reply, others dropped
+ */
+void eth_route(unsigned char *packet, int len, ipaddr_t ip_addr)
 {
-    //deveth_printhex(packet,len);
+	struct arp_cache *entry;
+	eth_addr_t eth_addr;
+	unsigned char *p;
+
+	/* try to get cached ethernet address and send packet*/
+	if (arp_cache_get (ip_addr, &eth_addr, ARP_VALID)) {
+		eth_sendpacket(packet, len, eth_addr);
+		return;
+	}
+
+	/* no address in cache, create holding entry, queue packet and send ARP request*/
+	entry = arp_cache_add(ip_addr, NULL);
+	if (entry->qpacket) {
+		/* TCP packet will auto retrans, 2+ ICMP will be lost until ARP reply seen*/
+		printf("eth: DROPPING packet to %s, one already queued awaiting ARP reply\n",
+			in_ntoa(ip_addr));
+		arp_request(ip_addr);		/* resend ARP request*/
+		return;
+	}
+
+	/* allocate memory and queue packet*/
+	if ((p = malloc(len + sizeof(struct ip_ll)))) {
+		memcpy(p+sizeof(struct ip_ll), packet, len);
+		entry->qpacket = p + sizeof(struct ip_ll);
+		entry->len = len;
+		debug_arp("eth: queueing packet len %d\n", len);
+	}
+	arp_request(ip_addr);
+}
+
+/*
+ * Send IP packet after prepending ethernet header
+ */
+void eth_sendpacket(unsigned char *packet, int len, eth_addr_t eth_addr)
+{
+	/* space guaranteed before packet for ethernet header by ip_sendpacket()/ip_route()*/
+	struct ip_ll *ipll = (struct ip_ll *)(packet - sizeof(struct ip_ll));
+
+	/* add link layer*/
+	memcpy(ipll->ll_eth_dest, eth_addr, 6);
+	memcpy(ipll->ll_eth_src, eth_local_addr, 6);
+	ipll->ll_type_len = 0x08; //FIXME what is 0x0800
+
+	eth_write((unsigned char *)ipll, sizeof(struct ip_ll) + len);
+}
+
+/* raw ethernet packet send*/
+void eth_write(unsigned char *packet, int len)
+{
+    //eth_printhex(packet,len);
     write(devfd, packet, len);
 }
+
+#if DEBUG
+void eth_printhex(unsigned char *packet, int len)
+{
+  unsigned char *p = packet;
+  int i = 0;
+  printf("eth: write %d bytes: ", len);
+  if (len > 128) len = 128;
+  while (len--) {
+	printf("%02X ", *p++);
+	if ((i++ & 15) == 15) printf("\n");
+  }
+  printf("\n");
+}
+#endif

--- a/elkscmd/ktcp/deveth.h
+++ b/elkscmd/ktcp/deveth.h
@@ -16,17 +16,24 @@ typedef __u8 eth_addr_t [6];
 struct eth_head_s {
 	eth_addr_t eth_dst;  /* MAC destination address */
 	eth_addr_t eth_src;  /* MAC source address */
-
 	__u16 eth_type;      /* Ethernet II type */
-	};
+};
 
 typedef struct eth_head_s eth_head_t;
 
+struct ip_ll {			//FIXME rename or combine w/above
+	__u8  ll_eth_dest[6]; 	/* link layer MAC destination address */
+	__u8  ll_eth_src[6]; 	/* link layer MAC source address */
+	__u16 ll_type_len;
+};
+
 extern eth_addr_t eth_local_addr;
 
-void deveth_printhex(unsigned char *packet, int len);
 int  deveth_init(char *fdev);
-void deveth_process(int flag);
-void deveth_send(unsigned char *packet, int len);
+void eth_printhex(unsigned char *packet, int len);
+void eth_process(void);
+void eth_route(unsigned char *packet, int len, ipaddr_t ip_addr);
+void eth_sendpacket(unsigned char *packet, int len, eth_addr_t eth_addr);
+void eth_write(unsigned char *packet, int len);
 
 #endif /* !DEVETH_H */

--- a/elkscmd/ktcp/ip.h
+++ b/elkscmd/ktcp/ip.h
@@ -37,12 +37,6 @@ struct iphdr_s {
 
 typedef struct iphdr_s iphdr_t;
 
-struct ip_ll {
-	__u8  ll_eth_dest[6]; 	/* link layer MAC destination address */
-	__u8  ll_eth_src[6]; 	/* link layer MAC source address */
-	__u16 ll_type_len;
-};
-
 extern ipaddr_t local_ip;
 extern ipaddr_t gateway_ip;
 extern ipaddr_t netmask_ip;
@@ -58,6 +52,7 @@ int ip_init(void);
 __u16 ip_calc_chksum(char *data, int len);
 void ip_recvpacket(unsigned char *packet, int size);
 void ip_sendpacket(unsigned char *packet, int len, struct addr_pair *apair);
+void ip_route(unsigned char *packet, int len, struct addr_pair *apair);
 
 unsigned long in_aton(const char *str);
 char *in_ntoa(ipaddr_t in);

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -137,6 +137,7 @@ int main(int argc,char **argv)
 {
     int ch;
     int bflag = 0;
+    static char *linknames[3] = { "ethernet", "slip", "cslip" };
 printp();
 //printf("ZERO is at %x\n", zero);
 
@@ -174,22 +175,26 @@ printp();
     gateway_ip = in_aton(optind < argc? argv[optind++]: DEFAULT_GATEWAY);
     netmask_ip = in_aton(optind < argc? argv[optind++]: DEFAULT_NETMASK);
 
-    printf("ktcp: ip %s, ", in_ntoa(local_ip));
-    printf("gateway %s, ", in_ntoa(gateway_ip));
-    printf("netmask %s\n", in_ntoa(netmask_ip));
-    printf("link %d serdev %s baud %lu mtu %u\n", linkprotocol, serdev, baudrate, MTU);
-
     /* must exit() in next two stages on error to reset kernel tcpdev_inuse to 0*/
     if ((tcpdevfd = tcpdev_init("/dev/tcpdev")) < 0)
 	exit(1);
 
-    if (linkprotocol == LINK_ETHER) {
-	if ((intfd = deveth_init(ethdev)) < 0)
-	    exit(1);
-    } else {
-	if ((intfd = slip_init(serdev, baudrate)) < 0)
-	    exit(2);
-    }
+    if (linkprotocol == LINK_ETHER)
+	intfd = deveth_init(ethdev);
+    else
+	intfd = slip_init(serdev, baudrate);
+    if (intfd < 0)
+	exit(2);
+
+    printf("ktcp: ip %s, ", in_ntoa(local_ip));
+    printf("gateway %s, ", in_ntoa(gateway_ip));
+    printf("netmask %s\n", in_ntoa(netmask_ip));
+
+    printf("ktcp: %s ", linknames[linkprotocol]);
+    if (linkprotocol == LINK_ETHER)
+	printf("%s", mac_ntoa((unsigned char *)&eth_local_addr));
+    else printf("%s baud %lu", serdev, baudrate);
+    printf(" mtu %u\n", MTU);
 
     signal(SIGHUP, catch);
     signal(SIGINT, catch);

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -106,7 +106,7 @@ printp();
 	/* process received packets*/
 	if (FD_ISSET(intfd, &fdset)) {
 		if (linkprotocol == LINK_ETHER)
-			deveth_process(0);
+			eth_process();
 		else slip_process();
 	}
 

--- a/elkscmd/rootfs_template/bin/net
+++ b/elkscmd/rootfs_template/bin/net
@@ -42,11 +42,11 @@ start_network()
 	case "$link" in
 	slip)
 		getty_off
-		ktcp="ktcp -b -p slip -s $baud -l $device $localip $device $gateway $netmask"
+		ktcp="ktcp -b -p slip -s $baud -l $device $localip $gateway $netmask"
 		;;
 	cslip)
 		getty_off
-		ktcp="ktcp -b -p cslip -s $baud -l $device $localip $device $gateway $netmask"
+		ktcp="ktcp -b -p cslip -s $baud -l $device $localip $gateway $netmask"
 		;;
 	eth)
 		ktcp="ktcp -b $localip $gateway $netmask"
@@ -57,14 +57,16 @@ start_network()
 	# run ktcp as background daemon if successful starting networking
 	echo $ktcp
 	if $ktcp; then
+		echo -n "Starting daemons "
 		for daemon in telnetd httpd
 		do
 			if test -f /bin/$daemon
 			then
-				echo -n " $daemon "
+				echo -n "$daemon "
 				$daemon || true
 			fi
 		done
+		echo ""
 	else
 		echo "Network start failed"
 		exit 1


### PR DESCRIPTION
This fixes issue #67 which has been open for over three years.

Move ethernet routines out of IP layer.
Add `ip_route` function to centralize routing.
Create separate link layer to centralize ethernet sending and ARP processing.
Add `eth_route` function to handle ARP request/reply and single packet queuing.
Remove ARP wait kluge. ARP and IP packets all handled in main loop asynchronously.
Add single ethernet packet queuing per host to handle async ARP reply responses.
Queued packet freed when ARP reply seen, otherwise ARP request sent.

Tested on QEMU. Needs testing on real hardware!