### PR TITLE
[cmds] Reduce buffer sizes for stack limits and efficiency

### DIFF
--- a/elkscmd/busyelks/sash.h
+++ b/elkscmd/busyelks/sash.h
@@ -39,7 +39,7 @@ struct  chunk   {
 #define	FALSE	0
 #define	TRUE	1
 
-#define BUF_SIZE 4096
+#define BUF_SIZE 1024		/* for stack limit and efficiency*/
 
 extern	void	do_alias(), do_cd(), do_exec(), do_exit(), do_prompt();
 extern	void	do_source(), do_umask(), do_unalias(), do_help(), do_ln();

--- a/elkscmd/file_utils/cat.c
+++ b/elkscmd/file_utils/cat.c
@@ -12,7 +12,7 @@
 #include <fcntl.h>
 #include <errno.h>
 
-#define CAT_BUF_SIZE 4096
+#define CAT_BUF_SIZE	BUFSIZ		/* use disk block size for stack limit and efficiency*/
 
 static char readbuf[CAT_BUF_SIZE];
 

--- a/elkscmd/file_utils/cp.c
+++ b/elkscmd/file_utils/cp.c
@@ -21,7 +21,7 @@
 #include <utime.h>
 #include <errno.h>
 
-#define BUF_SIZE 4096
+#define BUF_SIZE	BUFSIZ		/* use disk block size for stack limit and efficiency*/
 
 static char buf[BUF_SIZE];
 

--- a/elkscmd/file_utils/dd.c
+++ b/elkscmd/file_utils/dd.c
@@ -41,7 +41,7 @@ static struct param params[] = {
 
 
 /* Fixed buffer */
-static char localbuf[4096];
+static char localbuf[BUFSIZ];		/* use disk block size for efficiency*/
 
 
 /*

--- a/elkscmd/minix1/fgrep.c
+++ b/elkscmd/minix1/fgrep.c
@@ -33,7 +33,7 @@
 
 #define MAX_STR_LEN	 256	/* maximum length of strings to search for */
 #define BYTE		0xFF	/* convert from char to int */
-#define READ_SIZE	4096	/* read() request size */
+#define READ_SIZE	BUFSIZ	/* read() request size */
 #define BUF_SIZE (2*READ_SIZE)	/* size of buffer */
 
 typedef struct test_str {

--- a/elkscmd/minix2/Makefile
+++ b/elkscmd/minix2/Makefile
@@ -12,7 +12,7 @@ include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
-# TODO: lpd mt	# Do not compile.
+# TODO: lpd mt install	# Do not compile.
 PRGS=env lp pwdauth remsync synctree tget
 
 env: env.o

--- a/elkscmd/minix2/synctree.c
+++ b/elkscmd/minix2/synctree.c
@@ -64,7 +64,7 @@
 #endif
 
 #define NUMBYTES     4	/* Any number fits in this many bytes. */
-#define CHUNK     4096	/* Transfer files in this size chunks. */
+#define CHUNK     BUFSIZ	/* Transfer files in this size chunks. */
 
 static int install= 0;	/* Install files, do not delete, update if newer. */
 static int interact= 0;	/* Ask permission to install too. */

--- a/elkscmd/minix3/tee.c
+++ b/elkscmd/minix3/tee.c
@@ -12,7 +12,7 @@
 #include "defs.h"
 
 #define	MAXFD	18
-#define CHUNK_SIZE	4096
+#define CHUNK_SIZE	BUFSIZ		/* use disk block size for stack limit and efficiency*/
 
 int fd[MAXFD];
 

--- a/elkscmd/sash/cmd_tar.c
+++ b/elkscmd/sash/cmd_tar.c
@@ -68,7 +68,7 @@ do_tar(argc, argv)
 	int	blocksize;
 	BOOL	listflag;
 	BOOL	fileflag;
-	char	buf[1024];
+	char	buf[BUFSIZ];
 
 	if (argc < 2) {
 		fprintf(stderr, "Too few arguments for tar\n");


### PR DESCRIPTION
Stack and I/O based buffers set to BUFSIZ (1024) to avoid stack overflow, since new default ELKS stack limit is 2k bytes.
Increases ELKS usability as all I/O is blocking/synchronous and limited to 1k bytes for BIOS and EXTBUFFER size reasons.

Fixes `tee` and `synctree` stack overflow crashes.
Updates Busyelks, cat, cp, dd, fgrep.