### PR TITLE
[kernel] Fix kernel panic when accessing path with multiple '/' characters

### DIFF
--- a/elks/fs/namei.c
+++ b/elks/fs/namei.c
@@ -114,11 +114,7 @@ static int lookup(register struct inode *dir, char *name, size_t len,
 	}
 	iop = dir->i_op;
 	if (!iop || !iop->lookup) {
-
-#if 1
-	    panic("Oops - trying to access dir\n");
-#endif
-
+	    printk("Oops - trying to access dir\n");	//FIXME remove
 	    iput(dir);
 	    retval = -ENOTDIR;
 	} else if (perm != 0) {
@@ -199,6 +195,9 @@ static int dir_namei(register char *pathname, size_t * namelen,
 	    }
 	    debug("namei: left dir_namei succesfully\n");
 	    break;
+	} else { /* discard multiple '/'s*/
+	    while (get_user_char(pathname) == '/')
+		pathname++;
 	}
 	error = lookup(base, thisname, len, &inode);
 	if (error)


### PR DESCRIPTION
Fixes kernel panic caused by typing as few as 3 characters to the shell. From the root directory, or any directory with files in it, any of the following will immediately crash ELKS:
```
*//
echo *//
ls /bootopts//
```

For those in disbelief, I've included a screenshot. This was randomly found while testing the keypad keys, which happened to provide the *// sequence that expanded into a path with multiple '/' characters, which the kernel `dir_namei` function couldn't handle. Changed the panic to a printk for now and added code to handle the problem.
<img width="832" alt="ELKS panic" src="https://user-images.githubusercontent.com/11985637/87832983-72592e80-c844-11ea-836a-f439c6e275d4.png">


