### PR TITLE
[ktcp] Enhance netstat w/packet statistics, add arp command

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -150,6 +150,7 @@ ktcp/ktcp						:net
 ktcp/resolv.conf	::etc/resolv.conf	:net
 inet/nettools/netstat			:net
 inet/nettools/nslookup			:net
+inet/nettools/arp				:net
 inet/telnet/telnet				:net
 inet/telnetd/telnetd			:net
 inet/tinyirc/tinyirc			:net

--- a/elkscmd/inet/nettools/Makefile
+++ b/elkscmd/inet/nettools/Makefile
@@ -10,7 +10,7 @@ include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
-PRGS=netstat nslookup
+PRGS=netstat nslookup arp
 
 LOCALFLAGS=-I$(ELKSCMD_DIR)
 
@@ -24,6 +24,9 @@ netstat: netstat.o
 
 nslookup: nslookup.o
 	$(LD) $(LDFLAGS) nslookup.o -o nslookup $(LDLIBS)
+
+arp: arp.o
+	$(LD) $(LDFLAGS) arp.o -o arp $(LDLIBS)
 
 clean:
 	rm -f core *.o $(PRGS)

--- a/elkscmd/inet/nettools/netstat.c
+++ b/elkscmd/inet/nettools/netstat.c
@@ -52,6 +52,7 @@ int main(void)
 {
     struct general_stats_s *gstats;
     struct cb_stats_s *cbstats;
+    struct packet_stats_s *ns;
     struct stat_request_s sr;
     int i;
     char addr[16];
@@ -83,9 +84,25 @@ int main(void)
     sr.type = NS_GENERAL;
     write(s, &sr, sizeof(sr));	
     ret = read(s, buf, sizeof(buf));
-    gstats = buf;	
+    gstats = (struct general_stats_s *)buf;
     printf("Retransmit memory        : %d bytes\n", gstats->retrans_memory);
     printf("Number of control blocks : %d\n\n", gstats->cb_num);
+
+    sr.type = NS_NETSTATS;
+    write(s, &sr, sizeof(sr));
+    ret = read(s, buf, sizeof(buf));
+    ns = (struct packet_stats_s *)buf;
+    printf("TCP Packets Rcv%8ld  TCP Packets Sent%8ld\n", ns->tcprcvcnt, ns->tcpsndcnt);
+    printf("TCP Pkt Dropped%8ld  TCP Retransmits %8ld\n", ns->tcpdropcnt, ns->tcpretranscnt);
+    printf("TCP Bad Chksum %8ld\n", ns->tcpbadchksum);
+    printf("IP Packets Rcv %8ld  IP Packets Sent %8ld\n", ns->iprcvcnt, ns->ipsndcnt);
+    printf("IP Bad Chksum  %8ld  IP Bad Headers  %8ld\n", ns->ipbadchksum, ns->ipbadhdr);
+    printf("ICMP Pkts Rcv  %8ld  ICMP Packets Snt%8ld\n", ns->icmprcvcnt, ns->icmpsndcnt);
+    printf("ETH Packets Rcv%8ld  ETH Packets Sent%8ld\n", ns->ethrcvcnt, ns->ethsndcnt);
+    printf("ARP Reply Rcv  %8ld  ARP Reply Sent  %8ld\n", ns->arprcvreplycnt, ns->arpsndreplycnt);
+    printf("ARP Request Rcv%8ld  ARP Request Sent%8ld\n", ns->arprcvreqcnt, ns->arpsndreqcnt);
+    printf("ARP Cache Adds %8ld\n", ns->arpcacheadds);
+    printf("\n");
 
     printf(" no        State    RTT lport        raddress  rport\n");
     printf("-----------------------------------------------------\n");
@@ -94,7 +111,7 @@ int main(void)
 		sr.extra = i;
 		write(s, &sr, sizeof(sr));	
 		read(s, buf, sizeof(buf));
-		cbstats = buf;
+		cbstats = (struct cb_stats_s *)buf;
 		if (cbstats->valid == 0)break;
 		addrbytes = (__u8 *)&cbstats->remaddr;
 		sprintf(addr,"%d.%d.%d.%d",addrbytes[0],addrbytes[1],addrbytes[2],addrbytes[3]);

--- a/elkscmd/inet/nettools/netstat.c
+++ b/elkscmd/inet/nettools/netstat.c
@@ -101,8 +101,8 @@ int main(void)
     printf("ICMP Packets     %7lu  ICMP Packets     %7lu\n", ns->icmprcvcnt, ns->icmpsndcnt);
     printf("SLIP Packets     %7lu  SLIP Packets     %7lu\n", ns->sliprcvcnt, ns->slipsndcnt);
     printf("ETH Packets      %7lu  ETH Packets      %7lu\n", ns->ethrcvcnt, ns->ethsndcnt);
-    printf("ARP Requests     %7lu  ARP Requests     %7lu\n", ns->arprcvreqcnt, ns->arpsndreqcnt);
-    printf("ARP Replies      %7lu  ARP Replies      %7lu\n", ns->arprcvreplycnt, ns->arpsndreplycnt);
+    printf("ARP Replies      %7lu  ARP Requests     %7lu\n", ns->arprcvreplycnt, ns->arpsndreqcnt);
+    printf("ARP Requests     %7lu  ARP Replies      %7lu\n", ns->arprcvreqcnt, ns->arpsndreplycnt);
     printf("ARP Cache Adds   %7lu\n", ns->arpcacheadds);
     printf("\n");
 

--- a/elkscmd/ktcp/arp.c
+++ b/elkscmd/ktcp/arp.c
@@ -26,6 +26,7 @@
 #include "ip.h"
 #include "deveth.h"
 #include "arp.h"
+#include "netconf.h"
 
 /* ARP operations */
 #define ARP_REQUEST  1
@@ -101,6 +102,7 @@ struct arp_cache *arp_cache_add(ipaddr_t ip_addr, eth_addr_t *eth_addr)
 	entry->qpacket = NULL;
 	debug_arp("arp: adding cache entry for %s, valid=%d\n", in_ntoa(ip_addr), entry->valid);
 
+	netstats.arpcacheadds++;
 	return entry;
 }
 
@@ -152,6 +154,7 @@ void arp_reply(unsigned char *packet,int size)
 
     arp_print(arp);
     eth_write(packet, sizeof (struct arp));
+    netstats.arpsndreplycnt++;
 }
 
 void arp_request(ipaddr_t ipaddress)
@@ -177,6 +180,7 @@ void arp_request(ipaddr_t ipaddress)
 
     arp_print(&arpreq);
     eth_write((unsigned char *)&arpreq, sizeof(arpreq));
+    netstats.arpsndreqcnt++;
 }
 
 /* Process incoming ARP packets */
@@ -195,6 +199,7 @@ void arp_recvpacket(unsigned char *packet, int size)
 				arp_cache_add(arp->ip_src, &arp->eth_src);
 			arp_reply (packet, size);
 		}
+		netstats.arprcvreqcnt++;
 		break;
 
 	case ARP_REPLY:
@@ -209,6 +214,7 @@ void arp_recvpacket(unsigned char *packet, int size)
 				entry->qpacket = NULL;
 			}
 		}
+		netstats.arprcvreplycnt++;
 		break;
 	}
 }

--- a/elkscmd/ktcp/arp.h
+++ b/elkscmd/ktcp/arp.h
@@ -35,17 +35,25 @@ struct arp_cache {
 	int len;		/* queued packet length*/
 };
 
+/* ARP operations */
+#define ARP_REQUEST  1
+#define ARP_REPLY    2
+
 /* arp_cache_get flags*/
 #define ARP_VALID	1	/* retrieve valid eth_addr entry only*/
 #define ARP_UPDATE	2	/* if present, update cache with passed eth_addr*/
 
+/* Local ARP cache */
+#define ARP_CACHE_MAX 5
+extern struct arp_cache arp_cache [ARP_CACHE_MAX];
+
 int arp_init (void);
-struct arp_cache *arp_cache_get(ipaddr_t ip_addr, eth_addr_t * eth_addr, int flags);
-struct arp_cache *arp_cache_update(ipaddr_t ip_addr, eth_addr_t *eth_addr);
-struct arp_cache *arp_cache_add(ipaddr_t ip_addr, eth_addr_t * eth_addr);
+struct arp_cache *arp_cache_get(ipaddr_t ip_addr, eth_addr_t eth_addr, int flags);
+struct arp_cache *arp_cache_update(ipaddr_t ip_addr, eth_addr_t eth_addr);
+struct arp_cache *arp_cache_add(ipaddr_t ip_addr, eth_addr_t eth_addr);
 void arp_recvpacket (unsigned char * packet, int size);
 void arp_request(ipaddr_t ipaddress);
 
-char *mac_ntoa(unsigned char *p);
+char *mac_ntoa(eth_addr_t eth_addr);
 
 #endif /* !ARP_H */

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -8,6 +8,7 @@
 #define DEBUG_TCP	0
 #define DEBUG_IP	0
 #define DEBUG_ARP	0
+#define DEBUG_ETH	0
 
 /* leave these off for now - too much info*/
 #define DEBUG_MEM	0		/* debug memory allocations*/

--- a/elkscmd/ktcp/deveth.c
+++ b/elkscmd/ktcp/deveth.c
@@ -102,7 +102,7 @@ void eth_route(unsigned char *packet, int len, ipaddr_t ip_addr)
 	unsigned char *p;
 
 	/* try to get cached ethernet address and send packet*/
-	if (arp_cache_get (ip_addr, &eth_addr, ARP_VALID)) {
+	if (arp_cache_get (ip_addr, eth_addr, ARP_VALID)) {
 		eth_sendpacket(packet, len, eth_addr);
 		return;
 	}
@@ -146,12 +146,14 @@ void eth_sendpacket(unsigned char *packet, int len, eth_addr_t eth_addr)
 /* raw ethernet packet send*/
 void eth_write(unsigned char *packet, int len)
 {
-    //eth_printhex(packet,len);
+#if DEBUG_ETH
+    eth_printhex(packet,len);
+#endif
     write(devfd, packet, len);
     netstats.ethsndcnt++;
 }
 
-#if DEBUG
+#if DEBUG_ETH
 void eth_printhex(unsigned char *packet, int len)
 {
   unsigned char *p = packet;

--- a/elkscmd/ktcp/deveth.c
+++ b/elkscmd/ktcp/deveth.c
@@ -27,14 +27,13 @@
 #include "deveth.h"
 #include "tcpdev.h"
 #include "arp.h"
+#include "netconf.h"
 
 eth_addr_t eth_local_addr;
 
 static unsigned char sbuf[MAX_PACKET_ETH];
 static int devfd;
-
-static eth_addr_t broad_addr = {255, 255, 255, 255, 255, 255};
-
+//static eth_addr_t broad_addr = {255, 255, 255, 255, 255, 255};
 
 int deveth_init(char *fdev)
 {
@@ -88,6 +87,7 @@ void eth_process(void)
 	  arp_recvpacket (sbuf, len);
 	  break;
   }
+  netstats.ethrcvcnt++;
 }
 
 /*
@@ -148,6 +148,7 @@ void eth_write(unsigned char *packet, int len)
 {
     //eth_printhex(packet,len);
     write(devfd, packet, len);
+    netstats.ethsndcnt++;
 }
 
 #if DEBUG

--- a/elkscmd/ktcp/icmp.c
+++ b/elkscmd/ktcp/icmp.c
@@ -16,6 +16,7 @@
 #include "config.h"
 #include "ip.h"
 #include "icmp.h"
+#include "netconf.h"
 #include <linuxmt/arpa/inet.h>
 
 int icmp_init(void)
@@ -45,6 +46,7 @@ void icmp_process(struct iphdr_s *iph,unsigned char *packet)
 	apair.saddr = iph->daddr;
 	apair.protocol = PROTO_ICMP;
 	ip_sendpacket(packet, len, &apair);
+	netstats.icmpsndcnt++;
 	break;
    case ICMP_TYPE_DST_UNRCH:
 	printf("icmp: destination unreachable code %d from %s\n",

--- a/elkscmd/ktcp/ip.c
+++ b/elkscmd/ktcp/ip.c
@@ -27,6 +27,7 @@
 #include <linuxmt/arpa/inet.h>
 #include "deveth.h"
 #include "arp.h"
+#include "netconf.h"
 
 static unsigned char ipbuf[IP_BUFSIZ];
 
@@ -118,17 +119,20 @@ void ip_recvpacket(unsigned char *packet,int size)
 
     if (IP_VERSION(iphdr) != 4){
         debug_ip("IP: Bad IP version\n");
+	netstats.ipbadhdr++;
 	return;
     }
 
     len = IP_HLEN(iphdr) * 4;
     if (len < 20) {
         debug_ip("IP: Bad HLEN\n");
+	netstats.ipbadhdr++;
 	return;
     }
 
     if (ip_calc_chksum((char *)iphdr, len)) {
 	printf("IP: BAD CHKSUM (%x) len %d\n", ip_calc_chksum((char *)iphdr, len), len);
+	netstats.ipbadchksum++;
 	return;
     }
 
@@ -137,13 +141,16 @@ void ip_recvpacket(unsigned char *packet,int size)
         debug_ip("IP: recv icmp packet\n");
 	data = packet + 4 * IP_HLEN(iphdr);
 	icmp_process(iphdr, data);
+	netstats.icmprcvcnt++;
 	break;
 
     case PROTO_TCP:
         debug_ip("IP: recv tcp packet\n");
 	tcp_process(iphdr);
+	netstats.tcprcvcnt++;
 	break;
     }
+    netstats.iprcvcnt++;
 }
 
 void ip_sendpacket(unsigned char *packet, int len, struct addr_pair *apair)
@@ -178,6 +185,7 @@ void ip_sendpacket(unsigned char *packet, int len, struct addr_pair *apair)
 #endif
 
     ip_route((unsigned char *)iph, iphdrlen + len, apair);	/* route packet using src and dst address*/
+    netstats.ipsndcnt++;
 }
 
 void ip_route(unsigned char *packet, int len, struct addr_pair *apair)

--- a/elkscmd/ktcp/ip.c
+++ b/elkscmd/ktcp/ip.c
@@ -220,10 +220,13 @@ void *xxmemcpy(void * d, const void * s, int l)
 {
 	register char *s1=d, *s2=(char *)s;
 
-//printf("MEMCPY %u,%u,%u\n", d, s, l);
+//printf("MEMCPY %04x,%04x,%d->", d, s, l);
 if (s == NULL || s < 6) printf("SRC NULL\n");
 if (d == NULL || d < 6) printf("DST NULL\n");
-	for( ; l>0; l--)
+	for( ; l>0; l--) {
+		//printf("%x ", *(unsigned char *)s2);
 		*((unsigned char*)s1++) = *((unsigned char*)s2++);
+	}
+	//printf("\n");
 	return d;
 }

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -192,7 +192,7 @@ printp();
 
     printf("ktcp: %s ", linknames[linkprotocol]);
     if (linkprotocol == LINK_ETHER)
-	printf("%s", mac_ntoa((unsigned char *)&eth_local_addr));
+	printf("%s", mac_ntoa(eth_local_addr));
     else printf("%s baud %lu", serdev, baudrate);
     printf(" mtu %u\n", MTU);
 

--- a/elkscmd/ktcp/netconf.c
+++ b/elkscmd/ktcp/netconf.c
@@ -16,13 +16,13 @@
 #include "tcpdev.h"
 #include "netconf.h"
 
+struct packet_stats_s netstats;
+static struct stat_request_s sreq;
 
 void netconf_init(void)
 {
     /* Do nothing */
 }
-
-static struct stat_request_s sreq;
 
 void netconf_request(struct stat_request_s *sr)
 {
@@ -37,11 +37,13 @@ void netconf_send(struct tcpcb_s *cb)
     struct cb_stats_s cbstats;
     struct tcpcb_s *ncb;
 
-    if (sreq.type == NS_GENERAL) {
+    switch (sreq.type) {
+    case NS_GENERAL:
 	gstats.cb_num = tcpcb_num;
 	gstats.retrans_memory = tcp_retrans_memory;
 	tcpcb_buf_write(cb, (unsigned char *)&gstats, sizeof(gstats));
-    } else if (sreq.type == NS_CB) {
+	break;
+    case NS_CB:
 	ncb = tcpcb_getbynum(sreq.extra);
 	if (ncb) {
 	    cbstats.valid = 1;
@@ -52,7 +54,11 @@ void netconf_send(struct tcpcb_s *cb)
 	    cbstats.localport = ncb->localport;
 	} else
 	    cbstats.valid = 0;
-	tcpcb_buf_write(cb, (unsigned char *)&cbstats, sizeof(cbstats) );
+	tcpcb_buf_write(cb, (unsigned char *)&cbstats, sizeof(cbstats));
+	break;
+    case NS_NETSTATS:
+	tcpcb_buf_write(cb, (unsigned char *)&netstats, sizeof(netstats));
+	break;
     }
-	cb->bytes_to_push = CB_BUF_USED(cb);
+    cb->bytes_to_push = CB_BUF_USED(cb);
 }

--- a/elkscmd/ktcp/netconf.c
+++ b/elkscmd/ktcp/netconf.c
@@ -14,6 +14,8 @@
 #include "tcp.h"
 #include "tcp_cb.h"
 #include "tcpdev.h"
+#include "deveth.h"
+#include "arp.h"
 #include "netconf.h"
 
 struct packet_stats_s netstats;
@@ -58,6 +60,9 @@ void netconf_send(struct tcpcb_s *cb)
 	break;
     case NS_NETSTATS:
 	tcpcb_buf_write(cb, (unsigned char *)&netstats, sizeof(netstats));
+	break;
+    case NS_ARP:
+	tcpcb_buf_write(cb, (unsigned char *)&arp_cache, ARP_CACHE_MAX*sizeof(struct arp_cache));
 	break;
     }
     cb->bytes_to_push = CB_BUF_USED(cb);

--- a/elkscmd/ktcp/netconf.h
+++ b/elkscmd/ktcp/netconf.h
@@ -54,6 +54,7 @@ extern struct packet_stats_s netstats;
 #define NS_GENERAL	1
 #define NS_CB		2
 #define NS_NETSTATS	3
+#define NS_ARP		4
 
 void netconf_init();
 void netconf_send();

--- a/elkscmd/ktcp/netconf.h
+++ b/elkscmd/ktcp/netconf.h
@@ -43,6 +43,9 @@ struct packet_stats_s {
 	__u32	arpsndreplycnt;
 	__u32	arpsndreqcnt;
 	__u32	arpcacheadds;
+
+	__u32	slipsndcnt;
+	__u32	sliprcvcnt;
 };
 
 extern struct packet_stats_s netstats;

--- a/elkscmd/ktcp/netconf.h
+++ b/elkscmd/ktcp/netconf.h
@@ -22,9 +22,35 @@ struct stat_request_s {
 	__u8	extra;
 };
 
+struct packet_stats_s {
+	__u32	ipbadhdr;
+	__u32	ipbadchksum;
+	__u32	iprcvcnt;
+	__u32	ipsndcnt;
+	__u32	icmprcvcnt;
+	__u32	icmpsndcnt;
+
+	__u32	tcpbadchksum;
+	__u32	tcprcvcnt;
+	__u32	tcpsndcnt;
+	__u32	tcpdropcnt;	/* packet refused or dropped for no space*/
+	__u32	tcpretranscnt;
+
+	__u32	ethsndcnt;
+	__u32	ethrcvcnt;
+	__u32	arprcvreplycnt;
+	__u32	arprcvreqcnt;
+	__u32	arpsndreplycnt;
+	__u32	arpsndreqcnt;
+	__u32	arpcacheadds;
+};
+
+extern struct packet_stats_s netstats;
+
 #define NS_IDLE 	0
 #define NS_GENERAL	1
 #define NS_CB		2
+#define NS_NETSTATS	3
 
 void netconf_init();
 void netconf_send();

--- a/elkscmd/ktcp/slip.c
+++ b/elkscmd/ktcp/slip.c
@@ -21,6 +21,7 @@
 #include "ip.h"
 #include "slip.h"
 #include "vjhc.h"
+#include "netconf.h"
 
 /*#define DEBUG*/
 
@@ -224,8 +225,10 @@ printf("}");
 			} else
 #endif
 			    p = packet + 128;
-		        if (p_size > 0)
+		        if (p_size > 0) {
 			    ip_recvpacket(p, p_size);
+			    netstats.sliprcvcnt++;
+			}
 
 			/* Reset */
 			packpos = 128;
@@ -298,4 +301,5 @@ void slip_send(unsigned char *packet, int len)
     }
     *q++ = END;
     write(devfd, buf, q - buf);
+    netstats.slipsndcnt++;
 }

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -22,6 +22,7 @@
 #include <linuxmt/arpa/inet.h>
 #include "timer.h"
 #include "tcpdev.h"
+#include "netconf.h"
 
 static struct tcp_retrans_list_s *retrans_list;
 static unsigned char tcpbuf[TCP_BUFSIZ];
@@ -279,6 +280,7 @@ void tcp_reoutput(struct tcp_retrans_list_s *n)
     n->next_retrans = Now + n->rto;
 printf("retrans retry #%d rto %ld mem %u\n", n->retrans_num, n->rto, tcp_retrans_memory);
     ip_sendpacket((unsigned char *)n->tcphdr, n->len, &n->apair);
+    netstats.tcpretranscnt++;
 }
 
 /* called every ktcp cycle when tcp_timeruse nonzero*/
@@ -374,4 +376,5 @@ len = 255;	//FIXME testing only
 
     add_for_retrans(cb, th, len, &apair);
     ip_sendpacket((unsigned char *)th, len, &apair);
+    netstats.tcpsndcnt++;
 }


### PR DESCRIPTION
First pass at adding networking stats to `ktcp`.

TCP, IP, ICMP, ARP and ETH sent/received/dropped/chksum error, etc reported.

Accessed via `netstat`.

Comments welcome!

<img width="832" alt="Screen Shot 2020-07-17 at 6 47 39 PM" src="https://user-images.githubusercontent.com/11985637/87840712-53679600-c85e-11ea-8f00-2d1707a5fa28.png">
