### PR TITLE
[Nano-X] Fix nxdemo stack overflow crash

### DIFF
--- a/elkscmd/nano-X/demos/demo.c
+++ b/elkscmd/nano-X/demos/demo.c
@@ -190,6 +190,8 @@ main(int argc,char **argv)
 }
 
 
+static PIXELVAL	intable[W2_WIDTH * W2_HEIGHT];
+static PIXELVAL	outtable[W2_WIDTH * W2_HEIGHT * 4];
 /*
  * Here when a button is pressed.
  */
@@ -197,8 +199,6 @@ void
 do_buttondown(bp)
 	GR_EVENT_BUTTON	*bp;
 {
-	PIXELVAL	intable[W2_WIDTH * W2_HEIGHT];
-	PIXELVAL	outtable[W2_WIDTH * W2_HEIGHT * 4];
 	PIXELVAL	*inp;
 	PIXELVAL	*outp;
 	PIXELVAL	*oldinp;


### PR DESCRIPTION
Fixes stack overflow crash in `nxdemo`.

This fixes the 'freeze' issue @georgp24 brought up in #552.
