### PR TITLE
[kernel] Fix wait() failure when /bin/init not present

### DIFF
--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -94,6 +94,9 @@ static void init_task()
     sys_dup(num);		/* open stderr*/
     printk("No init - running /bin/sh\n");
 
+	/* unset special sys_wait4() processing for init, set ppid to 1*/
+	current->ppid = 1;
+
     run_init_process("/bin/sh");
     run_init_process("/bin/sash");
     panic("No init or sh found");

--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -74,7 +74,7 @@ int sys_wait4(pid_t pid, int *status, int options)
 			}
 		} else {
 		  /* keep waiting while process has non-zombie/stopped children*/
-		  if (current->pid != 1)	/* except for init reparented zombies*/
+		  if (current->pid != 1 || current->ppid != 0)	/* except for init reparented zombies*/
 			waitagain = 1;
 
 		}
@@ -90,6 +90,7 @@ int sys_wait4(pid_t pid, int *status, int options)
 
   } while(waitagain);
 
+    debug_wait("WAIT(%d) return -ECHILD\n", current->pid);
 	return -ECHILD;
 }
 


### PR DESCRIPTION
When ELKS is booted without /bin/init on disk, it attempts to run /bin/sh in a quasi single-user mode. When that shell ran, previous fixes (required for the zombie reparenting to init function) in the `wait4` system call caused the shell, which is running as PID 1 in this special case, to not wait for its commands (children) to exit, causing havoc. The shell is now run with a PPID of 1 (rather than 0) in single-user mode only, allowing for wait to differentiate between these cases.

