### PR TITLE
[ktcp] Retune timeouts for TCP retransmission timers

### DIFF
--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -29,16 +29,6 @@
 /* bytes to subtract from window size and when to force app write*/
 #define PUSH_THRESHOLD	512
 
-/* timeout values in seconds*/
-//#define TIMEOUT_ENTER_WAIT	30	/* length of TIME_WAIT state*/
-#define TIMEOUT_ENTER_WAIT	10	/* length of TIME_WAIT state*/
-//#define TIMEOUT_CLOSE_WAIT	240	/* length of CLOSING/LAST_ACK/FIN_WAIT states*/
-#define TIMEOUT_CLOSE_WAIT	10	/* length of CLOSING/LAST_ACK/FIN_WAIT states*/
-//#define TIMEOUT_INITIAL_RTT	4	/* initial RTT before retransmit*/
-#define TIMEOUT_INITIAL_RTT	1	/* initial RTT before retransmit*/
-
-/* following timeout is in 1/16 ticks, not seconds*/
-#define TIMEOUT_MIN_SLIP	8	/* minimum retrans timeout for slip/cslip (1/2 sec)*/
 
 #define PROTO_TCP	0x06
 
@@ -60,7 +50,7 @@
 
 #define TCP_SETHDRSIZE(c,s)	( (c)->data_off = (s) << 2 )
 
-#define ENTER_TIME_WAIT(cb)	{ (cb)->time_wait_exp = Now + (TIMEOUT_ENTER_WAIT << 4); \
+#define ENTER_TIME_WAIT(cb)	{ (cb)->time_wait_exp = Now + (30 << 4); \
 				  (cb)->state = TS_TIME_WAIT; \
 				  tcp_timeruse++; \
 				  cbs_in_time_wait++; }
@@ -116,7 +106,7 @@ struct tcpcb_s {
 	__u16	remport;
 
 	__u8	state;
-	timeq_t	rtt;				/* in 1/16 secs*/
+	timeq_t	rtt;
 
 	__u32	time_wait_exp;
 	__u8	unaccepted;			/* boolean */

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -29,6 +29,16 @@
 /* bytes to subtract from window size and when to force app write*/
 #define PUSH_THRESHOLD	512
 
+/* timeout values in seconds*/
+//#define TIMEOUT_ENTER_WAIT	30	/* length of TIME_WAIT state*/
+#define TIMEOUT_ENTER_WAIT	10	/* length of TIME_WAIT state*/
+//#define TIMEOUT_CLOSE_WAIT	240	/* length of CLOSING/LAST_ACK/FIN_WAIT states*/
+#define TIMEOUT_CLOSE_WAIT	10	/* length of CLOSING/LAST_ACK/FIN_WAIT states*/
+//#define TIMEOUT_INITIAL_RTT	4	/* initial RTT before retransmit*/
+#define TIMEOUT_INITIAL_RTT	1	/* initial RTT before retransmit*/
+
+/* following timeout is in 1/16 ticks, not seconds*/
+#define TIMEOUT_MIN_SLIP	8	/* minimum retrans timeout for slip/cslip (1/2 sec)*/
 
 #define PROTO_TCP	0x06
 
@@ -50,7 +60,7 @@
 
 #define TCP_SETHDRSIZE(c,s)	( (c)->data_off = (s) << 2 )
 
-#define ENTER_TIME_WAIT(cb)	{ (cb)->time_wait_exp = Now + (30 << 4); \
+#define ENTER_TIME_WAIT(cb)	{ (cb)->time_wait_exp = Now + (TIMEOUT_ENTER_WAIT << 4); \
 				  (cb)->state = TS_TIME_WAIT; \
 				  tcp_timeruse++; \
 				  cbs_in_time_wait++; }
@@ -106,7 +116,7 @@ struct tcpcb_s {
 	__u16	remport;
 
 	__u8	state;
-	timeq_t	rtt;
+	timeq_t	rtt;				/* in 1/16 secs*/
 
 	__u32	time_wait_exp;
 	__u8	unaccepted;			/* boolean */

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -75,7 +75,8 @@ struct tcpcb_list_s *tcpcb_new(void)
 debug_mem("Alloc CB %d bytes\n", sizeof(struct tcpcb_list_s));
 
     memset(&n->tcpcb, 0, sizeof(struct tcpcb_s));
-    n->tcpcb.rtt = TIMEOUT_INITIAL_RTT << 4;
+    //n->tcpcb.rtt = 4 << 4; /* 4 sec */
+    n->tcpcb.rtt = 1 << 4; /* 1 sec */	//FIXME
 
     /* Link it to the list */
     if (tcpcbs) {
@@ -212,7 +213,8 @@ debug_tcp("expire state %d\n", n->tcpcb.state);
 	    case TS_FIN_WAIT_2:
 	    case TS_LAST_ACK:
 	    case TS_CLOSING:
-		if (TIME_GT(Now - (TIMEOUT_CLOSE_WAIT << 4), n->tcpcb.time_wait_exp)) {
+		//if (TIME_GT(Now - (240 << 4), n->tcpcb.time_wait_exp)) {
+		if (TIME_GT(Now - (10 << 4), n->tcpcb.time_wait_exp)) { //FIXME 10 secs
 		    cbs_in_user_timeout--;
 		    tcpcb_remove(n);
 		}

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -75,8 +75,7 @@ struct tcpcb_list_s *tcpcb_new(void)
 debug_mem("Alloc CB %d bytes\n", sizeof(struct tcpcb_list_s));
 
     memset(&n->tcpcb, 0, sizeof(struct tcpcb_s));
-    //n->tcpcb.rtt = 4 << 4; /* 4 sec */
-    n->tcpcb.rtt = 1 << 4; /* 1 sec */	//FIXME
+    n->tcpcb.rtt = TIMEOUT_INITIAL_RTT << 4;
 
     /* Link it to the list */
     if (tcpcbs) {
@@ -213,8 +212,7 @@ debug_tcp("expire state %d\n", n->tcpcb.state);
 	    case TS_FIN_WAIT_2:
 	    case TS_LAST_ACK:
 	    case TS_CLOSING:
-		//if (TIME_GT(Now - (240 << 4), n->tcpcb.time_wait_exp)) {
-		if (TIME_GT(Now - (10 << 4), n->tcpcb.time_wait_exp)) { //FIXME 10 secs
+		if (TIME_GT(Now - (TIMEOUT_CLOSE_WAIT << 4), n->tcpcb.time_wait_exp)) {
 		    cbs_in_user_timeout--;
 		    tcpcb_remove(n);
 		}

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -268,16 +268,15 @@ debug_mem("retrans alloc buffers %d, mem %d\n", tcp_timeruse, tcp_retrans_memory
     n->retrans_num = 0;
     n->first_trans = Now;
 
-    n->rto = cb->rtt << 1;
-    if (linkprotocol != LINK_ETHER && n->rto < TIMEOUT_MIN_SLIP)
-	n->rto = TIMEOUT_MIN_SLIP;		/* 1/2 sec min retrans timeout for slip/cslip*/
+    //n->rto = cb->rtt << 1;			//FIXME possibly shorten
+    n->rto = cb->rtt;
     n->next_retrans = Now + n->rto;
 }
 
 void tcp_reoutput(struct tcp_retrans_list_s *n)
 {
     n->retrans_num ++;
-    n->rto *= 2;
+    //n->rto *= 2;		//FIXME
     n->next_retrans = Now + n->rto;
 printf("retrans retry #%d rto %ld mem %u\n", n->retrans_num, n->rto, tcp_retrans_memory);
     ip_sendpacket((unsigned char *)n->tcphdr, n->len, &n->apair);

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -268,15 +268,16 @@ debug_mem("retrans alloc buffers %d, mem %d\n", tcp_timeruse, tcp_retrans_memory
     n->retrans_num = 0;
     n->first_trans = Now;
 
-    //n->rto = cb->rtt << 1;			//FIXME possibly shorten
-    n->rto = cb->rtt;
+    n->rto = cb->rtt << 1;
+    if (linkprotocol != LINK_ETHER && n->rto < TIMEOUT_MIN_SLIP)
+	n->rto = TIMEOUT_MIN_SLIP;		/* 1/2 sec min retrans timeout for slip/cslip*/
     n->next_retrans = Now + n->rto;
 }
 
 void tcp_reoutput(struct tcp_retrans_list_s *n)
 {
     n->retrans_num ++;
-    //n->rto *= 2;		//FIXME
+    n->rto *= 2;
     n->next_retrans = Now + n->rto;
 printf("retrans retry #%d rto %ld mem %u\n", n->retrans_num, n->rto, tcp_retrans_memory);
     ip_sendpacket((unsigned char *)n->tcphdr, n->len, &n->apair);

--- a/elkscmd/ktcp/timer.h
+++ b/elkscmd/ktcp/timer.h
@@ -3,7 +3,7 @@
 
 #include <sys/types.h>
 
-/* time_t is the time type counted in 62.5ms (1/16 sec) quantums */
+/* time_t is the time type counted in 62ms quantums */
 typedef	__u32 timeq_t;
 
 #define TIME_LT(a,b)		((long)((a)-(b)) < 0)

--- a/elkscmd/ktcp/timer.h
+++ b/elkscmd/ktcp/timer.h
@@ -3,7 +3,7 @@
 
 #include <sys/types.h>
 
-/* time_t is the time type counted in 62ms quantums */
+/* time_t is the time type counted in 62.5ms (1/16 sec) quantums */
 typedef	__u32 timeq_t;
 
 #define TIME_LT(a,b)		((long)((a)-(b)) < 0)


### PR DESCRIPTION
Adjust default TCP timer settings for retransmitting packets.
Set minimum timeout for SLIP/CSLIP to be 1/2 second. This should fix the needless retransmissions seen by @pawosm-arm and mentioned in https://github.com/jbruchon/elks/issues/610#issuecomment-660626265.

