### PR TITLE
[kernel] Fix gettimeofday syscall, ktcp RTO

### DIFF
--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -128,7 +128,8 @@ extern __ptask current;		/* next; */
 extern int need_resched;
 
 extern struct timeval xtime;
-#define CURRENT_TIME ((xtime.tv_sec) + (jiffies/HZ))
+extern jiff_t xtime_jiffies;
+#define CURRENT_TIME (xtime.tv_sec + (jiffies - xtime_jiffies)/HZ)
 
 #define for_each_task(p) \
 	for (p = &task[0] ; p!=&task[MAX_TASKS]; p++ )

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -415,7 +415,8 @@ void tcp_process(struct iphdr_s *iph)
     cbnode = tcpcb_find(iph->saddr, ntohs(tcph->dport), ntohs(tcph->sport));
 
     if (!cbnode) {
-	printf("tcp: Refusing packet\n");
+	printf("tcp: Refusing packet %s:%d->%d\n", in_ntoa(iph->saddr), ntohs(tcph->sport), ntohs(tcph->dport));
+
 	/* TODO : send RST and stuff */
 	netstats.tcpdropcnt++;
 	return;

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -316,7 +316,7 @@ if (tcp_retrans_memory > TCP_RETRANS_MAXMEM /*|| tcp_timeruse > 5*/) {
 		rtt = Now - n->first_trans;
 		if (rtt > 0)
 		    n->cb->rtt = (TCP_RTT_ALPHA * n->cb->rtt + (100 - TCP_RTT_ALPHA) * rtt) / 100;
-		debug_tcp("rtt %d RTT %ld RTO %ld\n", rtt, n->cb->rtt, n->rto*2);
+		debug_tcp("rtt %d RTT %ld RTO %ld\n", rtt, n->cb->rtt, n->rto);
 	    }
 	    n = rmv_from_retrans(n);
 	    continue;

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -316,6 +316,7 @@ if (tcp_retrans_memory > TCP_RETRANS_MAXMEM /*|| tcp_timeruse > 5*/) {
 		rtt = Now - n->first_trans;
 		if (rtt > 0)
 		    n->cb->rtt = (TCP_RTT_ALPHA * n->cb->rtt + (100 - TCP_RTT_ALPHA) * rtt) / 100;
+		debug_tcp("rtt %d RTT %ld RTO %ld\n", rtt, n->cb->rtt, n->rto*2);
 	    }
 	    n = rmv_from_retrans(n);
 	    continue;

--- a/elkscmd/ktcp/timer.c
+++ b/elkscmd/ktcp/timer.c
@@ -19,5 +19,6 @@ timeq_t timer_get_time(void)
 
     gettimeofday(&tv, &tz);
 
-    return (tv.tv_sec << 4) | (tv.tv_usec / 62500);
+	/* return 1/16 second ticks, 1,000,000/16 = 62500*/
+    return (tv.tv_sec << 4) | ((unsigned long)tv.tv_usec / 62500U);
 }

--- a/elkscmd/ktcp/timer.h
+++ b/elkscmd/ktcp/timer.h
@@ -3,7 +3,7 @@
 
 #include <sys/types.h>
 
-/* time_t is the time type counted in 62.5ms (1/16 sec) quantums */
+/* timeq_t is the time type counted in 62.5ms (1/16 sec) quantums */
 typedef	__u32 timeq_t;
 
 #define TIME_LT(a,b)		((long)((a)-(b)) < 0)


### PR DESCRIPTION
Fixes kernel `gettimeofday` system call, which was incorrectly sometimes returning negative values for the timeval tv_usec member.
Also fixes tv_secs not calculated precisely, which could result in file creation times being an average of a half-second off.
Fixes date bug if tv_usecs set nonzero with `settimeofday` syscall.

Fixes ktcp RTT calculation and fixes resulting bogus large RTO return trip time display (reported by @pawosm-arm  in https://github.com/jbruchon/elks/pull/678#issuecomment-661176662).
Fixes other (unreported) ktcp packet timing issues, since sometimes the packet time would be calculated as less than the current time. 

Added TCP remote IP/port info for ktcp "Refusing packet" display.

Tested on Compaq Portable at 19200 baud and desktop 386 at 115200 baud with no errors, proper RTT/RTO and no retransmits. RTT/RTO calculated values can be displayed by turning on DEBUG_TCP in ktcp config.h.