### PR TITLE
[ktcp] Fix network ^C handling

### DIFF
--- a/elkscmd/inet/telnetd/telnetd.c
+++ b/elkscmd/inet/telnetd/telnetd.c
@@ -196,6 +196,7 @@ int main(int argc, char **argv)
 	dup2(fd, STDERR_FILENO);
 	if (fd > STDERR_FILENO)
 		close(fd);
+	setsid();
 
 	while (1) {
 		connectionfd = accept (sockfd, (struct sockaddr *) NULL, NULL);

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -209,6 +209,7 @@ printp();
 	fd = open("/dev/console", O_WRONLY);
 	dup2(fd, 1);		/* required for printf output*/
 	dup2(fd, 2);
+	setsid();
     }
 
     arp_init ();


### PR DESCRIPTION
Fixes ktcp and telnetd exiting when ^C generated SIGINT for another process, because they hadn't set a new process group with `setsid`.
