### PR TITLE
Heavily updated ne2k driver

### DIFF
--- a/elks/arch/i86/drivers/net/eth-main.c
+++ b/elks/arch/i86/drivers/net/eth-main.c
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------------
-// Ethernet driver
+// NE2K Ethernet driver (really DP8390 driver)
 //-----------------------------------------------------------------------------
 
 #include <linuxmt/errno.h>
@@ -21,9 +21,10 @@
 
 static byte_t eth_inuse = 0;
 
-static byte_t mac_addr [6] = {0x52, 0x54, 0x00, 0x12, 0x34, 0x56};  // QEMU default
+static byte_t def_mac_addr [6] = {0x52, 0x54, 0x00, 0x12, 0x34, 0x56};  // QEMU default
+static byte_t mac_addr [6]; // Current MAC address, from HW or set
 
-static byte_t recv_buf [MAX_PACKET_ETH];
+static byte_t recv_buf [MAX_PACKET_ETH+4];
 static byte_t send_buf [MAX_PACKET_ETH];
 
 
@@ -45,6 +46,7 @@ static size_t eth_read (struct inode * inode, struct file * filp,
 	char * data, size_t len)
 {
 	size_t res;
+	word_t page;	//debug
 
 	while (1) {
 		size_t size;  // actual packet size
@@ -62,6 +64,8 @@ static size_t eth_read (struct inode * inode, struct file * filp,
 			}
 		}
 
+                //page = ne2k_getpage();
+                //printk("/C%02x|B%02x/ ", (page>>8)&0xff, page&0xff);
 		if (ne2k_pack_get (recv_buf)) {
 			res = -ERESTARTSYS;  // panic
 			break;
@@ -71,8 +75,9 @@ static size_t eth_read (struct inode * inode, struct file * filp,
 		// otherwise end of packet will be lost
 
 		size = *((word_t *) (recv_buf + 2));
+                //printk("|RD: l%d s%d b%04x|", len, size, *(unsigned short *)recv_buf);
 		if (len > size) len = size;
-		memcpy_tofs (data, recv_buf + 4, len);
+		memcpy_tofs (data, recv_buf + 4, len);	// discarding statusbyte & counter
 
 		res = len;
 		break;
@@ -141,6 +146,8 @@ int eth_select (struct inode * inode, struct file * filp, int sel_type)
 {
 	int res = 0;
 
+        //printk("S%d|", sel_type); // Enable this to see when and how often
+
 	switch (sel_type) {
 		case SEL_OUT:
 			if (ne2k_tx_stat () != NE2K_STAT_TX)
@@ -175,14 +182,38 @@ int eth_select (struct inode * inode, struct file * filp, int sel_type)
 
 static void ne2k_int (int irq, struct pt_regs * regs, void * dev_id)
 {
-	word_t stat;
+	word_t stat, page;
 
 	stat = ne2k_int_stat ();
-	if (stat & NE2K_STAT_RX)
-		wake_up ((struct wait_queue *) &rx_flag);
+        page = ne2k_getpage();
+        printk("$%02x$B%02x$", (page>>8)&0xff, page&0xff);
 
-	if (stat & NE2K_STAT_TX)
+        if (stat & NE2K_STAT_OF) {
+		printk("Warning: NIC receive buffer overflow\n");
+		//page = ne2k_getpage();
+		//printk("/C%02x|B%02x/ ", (page>>8)&0xff, page&0xff);
+		// FIXME: This procedure is still being debugged
+		wake_up ((struct wait_queue *) &rx_flag);
+		//ne2k_clr_oflow(recv_buf); // The reset procedure needs to read the
+                                          // last complete packet in the buffer.
+		// If recv_buf is busy, this will overwrite the contents.
+		// What do we do with the contents? As is, this is a discard..
+	}
+
+	if (stat & NE2K_STAT_RX) {
+		//printk("|r|");
+		wake_up ((struct wait_queue *) &rx_flag);
+	}
+
+	if (stat & NE2K_STAT_TX) {
+		//printk("|t|");
 		wake_up ((struct wait_queue *) &tx_flag);
+	}
+	if (stat & NE2K_STAT_RDC) {
+		printk("RDC intr.\n");
+		// debug only, but keep this code, the RDC interrupt should be disabled in
+		// the low level driver.
+	}
 }
 
 
@@ -193,6 +224,8 @@ static int eth_ioctl (struct inode * inode, struct file * file,
 
 	{
 	int err = 0;
+
+	// Add ioctl to reset NIC
 
 	switch (cmd)
 		{
@@ -287,38 +320,59 @@ static struct file_operations eth_fops =
 
 // Ethernet main initialization
 
-void eth_drv_init ()
-	{
+void eth_drv_init () {
 	int err;
+	word_t prom[32];	// PROM containing HW MAC address and more
+				// If byte 14 & 15 == 0x57, this is a ne2k clone.
+				// May be used to avoid attempts to use an unsupported NIC
+				// PROM size is 32 bytes, need 32 words because we're reading them 
+				// as words.
+	byte_t hw_addr[6];
+	byte_t *addr;
 
-	while (1)
-		{
-#if 0	/* FIXME probe routine does nothing because of QEMU*/
+	while (1) {
 		err = ne2k_probe ();
-		if (err)
-			{
+		if (err) {
 			printk ("eth: NE2K not detected\n");
 			break;
-			}
-#endif
+		}
 		err = request_irq (NE2K_IRQ, ne2k_int, NULL);
-		if (err)
-			{
+		if (err) {
 			printk ("eth: NE2K IRQ %d request error: %i\n", NE2K_IRQ, err);
 			break;
-			}
+		}
 
 		err = register_chrdev (ETH_MAJOR, "eth", &eth_fops);
-		if (err)
-			{
+		if (err) {
 			printk ("eth: register error: %i\n", err);
 			break;
-			}
-
-		printk ("eth: NE2K driver compiled for 0x%x, irq %d\n", NE2K_PORT, NE2K_IRQ);
-		break;
 		}
+
+		int i = 0;
+
+		ne2k_get_hw_addr(prom); // get HW address if present
+
+		while (i < 6) hw_addr[i] = prom[i]&0xff,i++;
+		//i=0;while (i < 6) printk("%02X ", hw_addr[i++]);
+
+		// if there is no prom (i.e. emulator), use default
+		if ((hw_addr[0] == 0xff) && (hw_addr[1] == 0xff))
+		        addr = def_mac_addr;
+		else
+		        addr = hw_addr; // use hardware mac address
+
+		printk ("eth: NE2K at 0x%x, irq %d, MAC %02X", NE2K_PORT, NE2K_IRQ, addr[0]);
+		i=1;
+		while (i < 6) printk(":%02X", addr[i++]);
+		printk("\n");
+
+		memcpy(mac_addr, addr, 6);
+		ne2k_addr_set (addr);   // set NIC mac addr now so IOCTL works
+
+		break;
+
 	}
+}
 
 
 //-----------------------------------------------------------------------------

--- a/elks/arch/i86/drivers/net/ne2k-mac.S
+++ b/elks/arch/i86/drivers/net/ne2k-mac.S
@@ -1,16 +1,22 @@
 //-----------------------------------------------------------------------------
 // NE2K driver - low part - MAC routines
+//
+// Updated by Helge Skrivervik July 2020:
+//	. pick up MAC address from prom
+//	. fixed read ring buffer wrap around errors
+//	. added ring buffer overflow handling
 //-----------------------------------------------------------------------------
+
+#include "arch/ports.h"
 
 	.code16
 
 // TODO: move definitions to ne2k-defs.s
-
 // adjust only this line for card base address
-base               = 0x0300     // I/O base address
+base               = NE2K_PORT     // I/O base address
 
 // register array
-io_ne2k_command    = base+0x00  // command
+io_ne2k_command    = base + 0x00  // command
 io_ne2k_rx_first   = base+0x01  // page 0
 io_ne2k_rx_last    = base+0x02  // page 0
 io_ne2k_rx_get     = base+0x03  // page 0
@@ -51,11 +57,11 @@ tx_first           = 0x40
 rx_first           = 0x46
 rx_last            = 0x80
 
-tx_first_word      = 0x4000
-rx_first_word      = 0x4600
-rx_last_word       = 0x8000
-
 	.text
+// --- not the right thing to do ...
+_ne2k_next_pk:
+	.word 0	// being used as byte ...
+	
 
 //-----------------------------------------------------------------------------
 // Select register page
@@ -70,8 +76,9 @@ page_select:
 	shl     $6,%ah
 
 	mov     $io_ne2k_command,%dx
-	in      %dx,%al
-	and     $0x3F,%al
+	//in      %dx,%al
+	//and     $0x3F,%al
+	mov	$0x22,%al
 	or      %ah,%al
 	out     %al,%dx
 
@@ -116,7 +123,7 @@ ems_loop:
 	ret
 
 //-----------------------------------------------------------------------------
-// DMA initialization
+// DMA initialization - Prepare for internal NIC DMA transfer
 //-----------------------------------------------------------------------------
 
 // BX : chip memory address (4000h...8000h)
@@ -163,6 +170,11 @@ dma_init:
 // BX    : chip memory address (to write to)
 // CX    : byte count
 // DS:SI : host memory address (to read from)
+//-------------------------------------
+// TODO: It would make sense to have the first read operation get a full page (256 bytes) 
+// instead of just the first 4 bytes. That way a single DMA read operation will cover
+// most incoming packets in interactive sessions.
+//
 
 dma_write:
 
@@ -171,7 +183,11 @@ dma_write:
 	push    %dx
 	push    %si
 
+	inc     %cx     // make byte count even
+	and     $0xfffe,%cx
 	call    dma_init
+	shr     %cx     // half -> word size transf
+
 
 	// start DMA write
 
@@ -188,11 +204,22 @@ dma_write:
 
 emw_loop:
 
-	lodsb
-	out     %al,%dx
+	lodsw
+	out     %ax,%dx
 	loop    emw_loop
 
-	// maybe check DMA completed ?
+	// wait for DMA completed
+
+	mov     $io_ne2k_int_stat,%dx
+check_dma_w:
+	in      %dx,%al
+	test    $0x40,%al       // dma done?
+	jz      check_dma_w     // loop if not
+
+	mov     $0x40,%al       //clear DMA intr bit in ISR
+	out     %al,%dx
+	clc
+
 
 	pop     %si
 	pop     %dx
@@ -200,8 +227,56 @@ emw_loop:
 	pop     %ax
 	ret
 
+#if 0
+//-------------------------------------------------------------------------
+// This is an (untested) skeleton routine for DMA-assiste paket transfer
+// from the NIC to host memory.
+// TODO: Add DMA channel setup and teardown. Makes sens to do that outiside of this
+// routine.
+//
+dma_r:	// Use the send data command to read exactly one backet, 
+	// the nic does everything on its own, needs only ES:DI
+	
+	push	%ax
+	push	%di
+	push	%dx
+	push    %es  // compiler scratch
+
+	mov     %ds,%ax
+	mov     %ax,%es	// only required if we're setting up the dma locally
+
+	mov	$io_ne2k_tx_len2,%dx
+	mov	$0x0f,%al	// prep for using the 'send packet' cmd
+	out	%al,%dx
+
+	mov     $io_ne2k_command,%dx
+	mov	$0x18,%al	// send packet
+	out	%al,%dx
+	// now the dma does the rest, and an RDC interrupt is fielded when complete
+	// we can loop here while waiting, or return and handle completion separately.
+	in	%dx,%al
+	test	$0x40,%al
+	jz	rlp
+rlp1:	
+	mov	$io_ne2k_int_stat,%dx
+	mov     $0x40,%al       // reset (only this bit in) ISR
+	out     %al,%dx         // Clear RDC
+
+rlp_ret:	
+	pop     %es
+	pop	%dx
+	pop	%di
+	pop	%ax
+
+	ret
+#endif
+	
 //-----------------------------------------------------------------------------
 // Read block from chip with internal DMA
+//
+// FIXME: The first read operation should get a full page (256 bytes)
+// instead of just the first 4 bytes. That way a single DMA read operation will cover
+// most incoming packets in interactive sessions.
 //-----------------------------------------------------------------------------
 
 // BX    : chip memory to read from
@@ -215,14 +290,18 @@ dma_read:
 	push    %dx
 	push    %di
 
+	inc     %cx     // make byte count even
+	and     $0xfffe,%cx
 	call    dma_init
+	shr     %cx     // half -> word size transf
 
 	// start DMA read
 
 	mov     $io_ne2k_command,%dx
-	in      %dx,%al
-	and     $0xC7,%al
-	or      $0x08,%al  // 001b : read
+	in	%dx,%al
+	and	$0xC7,%al
+	or	$0x08,%al	// 0x8 = read
+	//mov	$0x0a,%al	// 0ah per application note
 	out     %al,%dx
 
 	// I/O read loop
@@ -231,24 +310,63 @@ dma_read:
 	mov     %ds,%ax
 	mov     %ax,%es
 
+
 	mov     $io_ne2k_data_io,%dx
 	cld
+	//cli	// FIXME disable interrupts - for testing
 
 emr_loop:
 
-	in      %dx,%al
-	stosb
+	in      %dx,%ax
+	stosw
 	loop    emr_loop
 
-	pop     %es
+	//sti	// re-enable int
+	pop	%es
 
-	// maybe check DMA completed ?
+	// wait for DMA to complete
+
+	mov     $io_ne2k_int_stat,%dx
+
+check_dma_r:
+	in      %dx,%al
+	test    $0x40,%al       // dma done?
+	jz      check_dma_r     // loop if not
+
+	mov     $0x40,%al       // reset ISR (RDC bit only)
+	out     %al,%dx
 
 	pop     %di
 	pop     %dx
 	pop     %cx
 	pop     %ax
 	ret
+
+//
+//-----------------------------------------------------------------------
+// ne2k_getpage -- return current page numbers in BOUNDARY / CURRENT registers
+// AH = CURRENT, AL = BOUNDARY
+// for debugging only
+//
+	.global ne2k_getpage
+
+ne2k_getpage:
+	mov     $1,%al
+	call    page_select
+
+	mov     $io_ne2k_rx_put,%dx     // CURRENT
+	in      %dx,%al
+	mov     %al,%cl
+
+	xor     %al,%al
+	call    page_select
+
+	mov     $io_ne2k_rx_get,%dx     // BOUNDARY
+	in      %dx,%al
+	mov     %cl,%ah
+
+	ret
+
 
 //-----------------------------------------------------------------------------
 // Get RX status
@@ -274,15 +392,7 @@ ne2k_rx_stat:
 
 	// get RX get pointer
 
-	xor     %al,%al
-	call    page_select
-
-	mov     $io_ne2k_rx_get,%dx
-	in      %dx,%al
-	inc     %al
-	cmp     $rx_last,%al
-	jnz     nrs_nowrap
-	mov     $rx_first,%al
+	mov	_ne2k_next_pk,%al
 
 nrs_nowrap:
 
@@ -319,102 +429,83 @@ ne2k_pack_get:
 	push    %bp
 	mov     %sp,%bp
 	push    %di  // used by compiler
+	push	%bx
+
+	// Check for buffer overflow
+	xor	%al,%al	
+	call	page_select
+
+	mov	$io_ne2k_int_stat,%dx
+	in	%dx,%al
+	push	%ax	// save for use after packet read
+	test	$0x10,%al
+	jz	no_oflow
+	
+	// We have buffer overflow: Stop NIC, read a packet to open up space, 
+	// then reset and restart the nic
+        mov     $io_ne2k_command,%dx
+        mov     $0x21,%al       // pg 0, stop, reset DMA
+        out     %al,%dx
+
+no_oflow:
+	//-------------------- In case of a real DMA transfer ----
+	//mov     4(%bp),%di	// dest address
+
+	//call	dma_r	// new dmaread routine
+			// no error checking, the NIC has done that already
+			// Erroneous packets don't even cause an interrupt with this setup
+	//xor	%ax,%ax
+	//jmp	npg_exit
+	//-------------------------------------------------
 
 	// get RX put pointer
 
-	mov     $1,%al
-	call    page_select
+	mov	_ne2k_next_pk,%bh
+	xor	%bl,%bl		//	Next pkt to read in BX
 
-	mov     $io_ne2k_rx_put,%dx
-	in      %dx,%al
-	mov     %al,%cl
+	// get packet header	FIXME - read entire page instead, may happen to
+	// 			contain the entire packet
 
-	// get RX get pointer
-
-	xor     %al,%al
-	call    page_select
-
-	mov     $io_ne2k_rx_get,%dx
-	in      %dx,%al
-	inc     %al
-	cmp     $rx_last,%al
-	jnz     npg_nowrap1
-	mov     $rx_first,%al
-
-npg_nowrap1:
-
-	// check ring is not empty
-
-	cmp     %al,%cl
-	jz      npg_err
-
-	xor     %bl,%bl
-	mov     %al,%bh
-
-	// get packet header
-
-	mov     4(%bp),%di
-	mov     $4,%cx
+	mov     4(%bp),%di	// Buffer address to receive data - duplicate above ...
+	mov     $4,%cx	
 	call    dma_read
 
 	mov     0(%di),%ax  // AH : next record, AL : status
 	mov     2(%di),%cx  // packet size (without CRC)
 
-	// check packet size
+	// check packet size - not really required since the NIC will not
+	// accept such packets per our initialization
 
 	or      %cx,%cx
-	jz      npg_err
+	jz      npg_err2
 
 	cmp     $1528,%cx  // max - head - crc
 	jnc     npg_err
 
-	add     $4,%bx
-	add     $4,%di
+	add     $4,%bx		// source memory address 'inside ' the chip
+	add     $4,%di		// Destination memory address (+4 to keep the header)
 
 	push    %ax
 	push    %cx
 
-	mov     %bx,%ax
-	add     %cx,%ax
-	cmp     $rx_last_word,%ax
-	jbe     npg_nowrap2
-
-	mov     $rx_last_word,%ax
-	sub     %bx,%ax
-	mov     %ax,%cx
-
-npg_nowrap2:
-
-	// get packet body (first segment)
+	// get packet body
 
 	call    dma_read
-
-	add     %cx,%di
-
-	mov     %cx,%ax
 	pop     %cx
-	sub     %ax,%cx
-	jz      npg_nowrap3
-
-	// get packet body (second segment)
-
-	mov     $rx_first_word,%bx
-	call    dma_read
-
-npg_nowrap3:
 
 	// update RX get pointer
 
 	pop     %ax
-	xchg    %al,%ah
-	dec     %al
-	cmp     $rx_first,%al
-	jae     npg_next
-	mov     $rx_last - 1,%al
+	xchg    %al,%ah		// get next pointer to %al
+	mov	%al,_ne2k_next_pk	// save 'real' next ptr
+	dec	%al
+	cmp	$rx_first,%al
+	jnb	npg_next		// if the decrement sent us outside the ring..
+	mov	$rx_last-1,%al		// make it right ...
 
 npg_next:
 
-	mov     $io_ne2k_rx_get,%dx
+	mov     $io_ne2k_rx_get,%dx	// update read_ptr reg (BOUNDARY)
 	out     %al,%dx
 
 	xor     %ax,%ax
@@ -423,9 +514,22 @@ npg_next:
 npg_err:
 
 	mov     $-1,%ax
+	jmp	npg_exit
+
+npg_err2:
+	mov	$-2,%ax
 
 npg_exit:
+	mov	%ax,%bx	// save return value
+	pop	%ax	// check if we have buffer overflow pending
+	test	$0x10,%al
+	jz	npg_finis
+	call	ne2k_clr_oflow	// do the rest of the reset processing
 
+npg_finis:
+	mov	%bx,%ax
+	
+	pop	%bx
 	pop     %di
 	pop     %bp
 	ret
@@ -505,7 +609,7 @@ ne2k_pack_put:
 	// start TX
 
 	mov     $io_ne2k_command,%dx
-	mov     $0x26,%al
+	mov     $0x26,%al	// 26h per the applicaton note
 	out     %al,%dx
 
 	xor     %ax, %ax
@@ -524,6 +628,7 @@ ne2k_pack_put:
 //   01h = packet received
 //   02h = packet sent
 //   10h = RX ring overflow
+//   40h = Remote DMA complete
 
 	.global ne2k_int_stat
 
@@ -540,10 +645,13 @@ ne2k_int_stat:
 
 	mov     $io_ne2k_int_stat,%dx
 	in      %dx,%al
-	test    $0x03,%al
+	test    $0x13,%al	// ring buffer overflow, tx, rx
+				// Dont reset RDC intr here, it will break things.
 	jz      nis_next
 
 	// acknowledge interrupt
+	// resetting interrupt flags here makes it impossible to find the source 
+	// of an interrupt later???
 
 	out     %al,%dx
 
@@ -568,32 +676,39 @@ ne2k_init:
 	// TODO: is this really needed after a reset ?
 
 	mov     $io_ne2k_command,%dx
-	in      %dx,%al
-	and     $0xC0,%al
-	or      $0x21,%al
+	//in      %dx,%al
+	//and     $0xC0,%al
+	//or      $0x21,%al
+	mov	$0x21,%al	// ++ Abort DMA; STOP
 	out     %al,%dx
 
-	// data I/O in single bytes
-	// and low endian for 80188
-	// plus magical stuff (48h)
+	// data I/O in words for PC/AT and higher
 
 	mov     $io_ne2k_data_conf,%dx
-	mov     $0x48,%al
+	mov     $0x49,%al
+	out     %al,%dx
+
+	// clear DMA length - Important!
+
+	xor     %al,%al
+	mov     $io_ne2k_dma_len1,%dx
+	out     %al,%dx
+	inc     %dx  // = io_ne2k_dma_len2
 	out     %al,%dx
 
 	// accept packet without error
 	// unicast & broadcast & promiscuous
 
 	mov     $io_ne2k_rx_conf,%dx
-	mov     $0x54,%al
+	//mov     $0x54,%al	// 54 is nonsensical
+	mov     $0x04,%al	// ++ Broadcast OK, no multicast
 	out     %al,%dx
 
 	// half-duplex and internal loopback
 	// to insulate the MAC while stopped
-	// TODO: loopback cannot be turned off later !
 
 	mov     $io_ne2k_tx_conf,%dx
-	mov     $0,%al  // 2 for loopback
+	mov     $2,%al  // 2 for loopback
 	out     %al,%dx
 
 	// set RX ring limits
@@ -604,27 +719,17 @@ ne2k_init:
 	mov     $rx_first,%al
 	out     %al,%dx
 
-	inc     %dx  // io_ne2k_rx_last
+	// set RX get pointer -- BOUNDARY
+
+	mov     $io_ne2k_rx_get,%dx
+	out     %al,%dx
+
+	mov     $io_ne2k_rx_last,%dx
 	mov     $rx_last,%al
 	out     %al,%dx
 
 	mov     $io_ne2k_tx_start,%dx
 	mov     $tx_first,%al
-	out     %al,%dx
-
-	// set RX get pointer
-
-	mov     $io_ne2k_rx_get,%dx
-	mov     $rx_first,%al
-	out     %al,%dx
-
-	// clear DMA length
-	// TODO: is this really needed after a reset ?
-
-	xor     %al,%al
-	mov     $io_ne2k_dma_len1,%dx
-	out     %al,%dx
-	inc     %dx  // = io_ne2k_dma_len2
 	out     %al,%dx
 
 	// clear all interrupt flags
@@ -637,7 +742,7 @@ ne2k_init:
 	// TX & RX without error and overflow
 
 	mov     $io_ne2k_int_mask,%dx
-	mov     $0x03,%al
+	mov     $0x13,%al	// 53 = Overflow, RX, TX + RDC (debug)
 	out     %al,%dx
 
 	// select page 1
@@ -645,34 +750,21 @@ ne2k_init:
 	mov     $1,%al
 	call    page_select
 
-	// clear unicast address
-
-	mov     $6,%cx
-	mov     io_ne2k_unicast,%dx
-	xor     %al,%al
-
-ei_loop_u:
-
-	out     %al,%dx
-	inc     %dx
-	loop    ei_loop_u
-
-	// clear multicast bitmap
-
-	mov     $8,%cx
-	mov     $io_ne2k_multicast,%dx
-
-ei_loop_m:
-
-	out     %al,%dx
-	inc     %dx
-	loop    ei_loop_m
-
-	// set RX put pointer to first bloc + 1
+	// set RX put pointer  = RX get
 
 	mov     $io_ne2k_rx_put,%dx
 	mov     $rx_first,%al
-	inc     %al
+	inc     %al	// set CURRENT = always one ahead
+	out     %al,%dx
+	mov	%al,_ne2k_next_pk
+
+	// back to page 0
+	xor	%al,%al
+	call	page_select
+
+	// now enable transmitter
+	mov     $io_ne2k_tx_conf,%dx
+	mov     $0,%al  // 2 for loopback
 	out     %al,%dx
 
 	// return no error
@@ -843,6 +935,117 @@ nr_loop:
 	jz      nr_loop
 
 	ret
+//-----------------------------------------------------------------------------
+// Get  MAC address from NIC's prom
+// WARNING: This function will reset the controller. Use before the init()!
+//-----------------------------------------------------------------------------
+
+// arg1 : pointer to 6 bytes buffer
+
+	.global ne2k_get_hw_addr
+
+ne2k_get_hw_addr:
+
+	push    %bp
+	mov     %sp,%bp
+	push    %di  // used by compiler
+
+	mov     4(%bp),%di
+
+	// s partly reset of the NIC is required in ordet to get access to the
+	// PROM - 32 bytes of which only the first 6 bytes are of interest
+	// This routine leaves the NIC initialized but not activated (TX is in loopback).
+
+	//mov   $io_ne2k_reset,%dx
+	//in    %dx,%al
+	//out   %al,%dx         //reset NIC
+	//mov   $io_ne2k_int_stat,%dx
+
+w_reset:
+	//in    %dx,%al // wait for reset to complete
+	//test  $0x80,%al
+	//jz    w_reset
+
+	mov   $io_ne2k_command,%dx
+	mov   $0x21,%al       // pg 0, stop, reset DMA
+	out   %al,%dx
+	mov     $io_ne2k_data_conf,%dx
+	mov     $0x49,%al       //word access
+	out     %al,%dx
+	mov	$io_ne2k_dma_len1, %dx
+	xor	%al,%al         // clear count regs
+	out	%al,%dx         // 
+	inc	%dx
+	out	%al,%dx
+	mov   $io_ne2k_int_mask,%dx
+	out   %al,%dx         // mask completion irq
+	mov   $io_ne2k_int_stat,%dx
+	mov   $0xff,%al
+	out   %al,%dx // clear interrupt status reg, required
+
+	mov   $io_ne2k_rx_conf,%dx
+	mov   $0x20,%al
+	out   %al,%dx         // set to monitor mode
+	inc   %dx             // $io_ne2k_tx_conf
+	mov   $2,%al          // %al = 2
+	out   %al,%dx         // Loopback mode
+
+// use dma read instead
+	mov	$32,%cx
+	xor	%bx,%bx	// read from 0:0
+	call	dma_read
+
+	pop	%di
+	pop     %bp
+	ret
+
+//-----------------------------------------------------------------------------
+// NE2K clear overflow --- respond to an input ring buffer overflow interrupt
+// The recovery reads the last compete pcket into the provided (arg1) buffer.
+//-----------------------------------------------------------------------------
+
+	.global ne2k_clr_oflow
+
+ne2k_clr_oflow:
+
+	xor	%al,%al
+	call	page_select
+
+        //mov	$io_ne2k_command,%dx
+        //mov	$0x21,%al       // pg 0, stop, reset DMA
+        //out	%al,%dx
+
+	// NIC has stopped, now read next packet to make space in the buffer
+	//call	ne2k_pack_get
+
+	// If using real dma to read packets, the procedure is different,
+	// read the app note.
+	
+	//push	%ax
+	mov	$io_ne2k_int_stat,%dx
+
+of_reset:	// maybe put a hlt in here to save cycles ...
+	in	%dx,%al		// wait for reset to complete
+	test	$0x80,%al
+	jz	of_reset
+
+	mov	$io_ne2k_tx_conf,%dx	// must set tx to loopback
+	mov	$2,%al
+	out	%al,%dx
+	mov	$io_ne2k_command,%dx	// restart NIC
+	mov	$0x22,%al
+	out	%al,%dx
+	
+	mov	$io_ne2k_tx_conf,%dx	// set tx back to normal
+	xor	%al,%al
+	out	%al,%dx
+	mov	$io_ne2k_int_stat,%dx	// reset the interrupt bit
+	mov	$0x10,%al
+	out	%al,%dx
+
+	//pop	%ax	// return value as if we'd callet get_packet()
+	ret
+
 
 //-----------------------------------------------------------------------------
 // NE2K test

--- a/elks/arch/i86/drivers/net/ne2k.h
+++ b/elks/arch/i86/drivers/net/ne2k.h
@@ -8,6 +8,7 @@
 #define NE2K_STAT_RX    0x0001  // packet received
 #define NE2K_STAT_TX    0x0002  // packet sent
 #define NE2K_STAT_OF    0x0010  // RX ring overflow
+#define NE2K_STAT_RDC   0x0040  // Remote DMA complete
 
 
 // From low level NE2K PHY
@@ -39,5 +40,10 @@ extern word_t ne2k_pack_get (byte_t * pack);
 extern word_t ne2k_pack_put (byte_t * pack, word_t len);
 
 extern word_t ne2k_test ();
+
+extern word_t ne2k_getpage(void);
+extern void ne2k_get_addr(byte_t *);
+extern void ne2k_get_hw_addr(word_t *);
+extern void ne2k_clr_oflow(byte_t *);
 
 #endif /* !NE2K_H */

--- a/elks/include/arch/ports.h
+++ b/elks/include/arch/ports.h
@@ -39,11 +39,11 @@
 //#define CONFIG_NEED_IRQ2		/* only available on XT, slave PIC on AT*/
 
 #ifdef CONFIG_CHAR_DEV_RS
-//#define CONFIG_FAST_IRQ4		/* COM1 very fast serial driver, no ISIG handling*/
+#define CONFIG_FAST_IRQ4		/* COM1 very fast serial driver, no ISIG handling*/
 //#define CONFIG_FAST_IRQ3		/* COM2 very fast serial driver, no ISIG handling*/
-#define CONFIG_NEED_IRQ4		/* COM1 normal serial driver*/
+//#define CONFIG_NEED_IRQ4		/* COM1 normal serial driver*/
 #define CONFIG_NEED_IRQ3		/* COM2 normal serial driver*/
-#define CONFIG_NEED_IRQ5		/* COM3*/
+//#define CONFIG_NEED_IRQ5		/* COM3*/
 //#define CONFIG_NEED_IRQ2		/* COM4, XT only*/
 #endif
 
@@ -53,7 +53,7 @@
 //#define CONFIG_NEED_IRQ8
 
 #ifdef CONFIG_ETH_NE2K
-#define CONFIG_NEED_IRQ12
+#define CONFIG_NEED_IRQ9
 #endif
 
 /* unused*/
@@ -98,7 +98,8 @@
 #define COM4_IRQ	2		/* unregistered unless COM4_PORT found*/
 
 /* ne2k, eth-main.c*/
-#define NE2K_IRQ	12
+#define io_ne2k_command 0x0300		/* FIXME needs to be included in ne2k-mac.s*/
+#define NE2K_IRQ	9
 #define NE2K_PORT	0x300
 
 /* obsolete - experimental IDE hard drive, directhd.c (broken)*/

--- a/elks/include/arch/ports.h
+++ b/elks/include/arch/ports.h
@@ -39,11 +39,11 @@
 //#define CONFIG_NEED_IRQ2		/* only available on XT, slave PIC on AT*/
 
 #ifdef CONFIG_CHAR_DEV_RS
-#define CONFIG_FAST_IRQ4		/* COM1 very fast serial driver, no ISIG handling*/
+//#define CONFIG_FAST_IRQ4		/* COM1 very fast serial driver, no ISIG handling*/
 //#define CONFIG_FAST_IRQ3		/* COM2 very fast serial driver, no ISIG handling*/
-//#define CONFIG_NEED_IRQ4		/* COM1 normal serial driver*/
+#define CONFIG_NEED_IRQ4		/* COM1 normal serial driver*/
 #define CONFIG_NEED_IRQ3		/* COM2 normal serial driver*/
-//#define CONFIG_NEED_IRQ5		/* COM3*/
+#define CONFIG_NEED_IRQ5		/* COM3*/
 //#define CONFIG_NEED_IRQ2		/* COM4, XT only*/
 #endif
 
@@ -53,7 +53,7 @@
 //#define CONFIG_NEED_IRQ8
 
 #ifdef CONFIG_ETH_NE2K
-#define CONFIG_NEED_IRQ9
+#define CONFIG_NEED_IRQ12
 #endif
 
 /* unused*/
@@ -98,8 +98,7 @@
 #define COM4_IRQ	2		/* unregistered unless COM4_PORT found*/
 
 /* ne2k, eth-main.c*/
-#define io_ne2k_command 0x0300		/* FIXME needs to be included in ne2k-mac.s*/
-#define NE2K_IRQ	9
+#define NE2K_IRQ	12
 #define NE2K_PORT	0x300
 
 /* obsolete - experimental IDE hard drive, directhd.c (broken)*/

--- a/elks/include/arch/ports.h
+++ b/elks/include/arch/ports.h
@@ -53,7 +53,8 @@
 //#define CONFIG_NEED_IRQ8
 
 #ifdef CONFIG_ETH_NE2K
-#define CONFIG_NEED_IRQ9
+//#define CONFIG_NEED_IRQ9
+#define CONFIG_NEED_IRQ12
 #endif
 
 /* unused*/
@@ -98,8 +99,7 @@
 #define COM4_IRQ	2		/* unregistered unless COM4_PORT found*/
 
 /* ne2k, eth-main.c*/
-#define io_ne2k_command 0x0300		/* FIXME needs to be included in ne2k-mac.s*/
-#define NE2K_IRQ	9
+#define NE2K_IRQ	12
 #define NE2K_PORT	0x300
 
 /* obsolete - experimental IDE hard drive, directhd.c (broken)*/

--- a/elkscmd/inet/nettools/netstat.c
+++ b/elkscmd/inet/nettools/netstat.c
@@ -101,8 +101,8 @@ int main(void)
     printf("ICMP Packets     %7lu  ICMP Packets     %7lu\n", ns->icmprcvcnt, ns->icmpsndcnt);
     printf("SLIP Packets     %7lu  SLIP Packets     %7lu\n", ns->sliprcvcnt, ns->slipsndcnt);
     printf("ETH Packets      %7lu  ETH Packets      %7lu\n", ns->ethrcvcnt, ns->ethsndcnt);
-    printf("ARP Replies      %7lu  ARP Requests     %7lu\n", ns->arprcvreplycnt, ns->arpsndreqcnt);
-    printf("ARP Requests     %7lu  ARP Replies      %7lu\n", ns->arprcvreqcnt, ns->arpsndreplycnt);
+    printf("ARP Replies (rcv)%7lu  ARP Requests(snd)%7lu\n", ns->arprcvreplycnt, ns->arpsndreqcnt);
+    printf("ARP Requests(rcv)%7lu  ARP Replies (snd)%7lu\n", ns->arprcvreqcnt, ns->arpsndreplycnt);
     printf("ARP Cache Adds   %7lu\n", ns->arpcacheadds);
     printf("\n");
 

--- a/qemu.sh
+++ b/qemu.sh
@@ -72,7 +72,7 @@ FWD="hostfwd=tcp:127.0.0.1:8080-10.0.2.15:80,hostfwd=tcp:127.0.0.1:2323-10.0.2.1
 # new style
 #NET="-net nic,model=ne2k_isa -net user,$FWD"
 # old style, with configurable interrupt line
-NET="-netdev user,id=mynet,$FWD -device ne2k_isa,irq=9,netdev=mynet"
+NET="-netdev user,id=mynet,$FWD -device ne2k_isa,irq=12,netdev=mynet"
 
 # Enable network dump here:
 # NETDUMP="-net dump"


### PR DESCRIPTION
This is a major rewrite of the ELKS NE2K driver. A short rundown of the changes:

**Fixes**
- A major flaw in the NIC ring buffer handling code caused random (occasional) data loss and driver hangs. The bug affected only 8390-based NICs, not newer PnP NICs, for reasons unknown. The fix replaces the rather convoluted (and slow) ring buffer wraparound code with a simple mechanism suggested by one of the 8390 application notes available on line.
- The old driver cleared the interrupt status register bits at the start of the interrupt service routines rather than at the end. For interrupts that trigger processing rather than indicating completion, this is some times catastrophic. As was the case with packet reads. If the time between arrival of packets was less than 10 milliseconds, a race condition occured with unpredictable results, normally a hung driver and hard hung system. The fix moves the clearing of interrupt status bits to the actual processinc routines rather than the  general interrupt dispatcher.
- NIC buffer overruns are handled, see below.

**Speed improvements**
The rewritten driver has a number of speed/resource improvements:
- Data transfer from to NIC to the system is now in word units rather than bytes, doubling the transfer speed.
- The bug fixes in the ring buffer handling will also improve speed significantly, leaving much more of the mechanics to the NIC rather than the driver.
- For most packets, there is only one data transfer from the NIC to main memory, instead of two, some times 3 previously. The NIC ring buffer consists of pages @ 256bytes ea. The old driver would read the first 4 bytes of a packet to get its size, the field a 2nd read to get the rest, and finally - if the packet traversed the ring buffer wraparound, a 3rd read to get the rest. The rewritten driver reads a full page (256 bytes), which in many cases contains the entire packet. For larger packets there is a 2nd read, and (for reasons mentioned above) there is never a 3rd read.

**Functional improvements**
- Notably, the driver now reads the NIC PROM at initalization and sets the MAC address to the NICs own address rather than a predetermined QEMU address. The MAC address can still be set via an IOCTL.
- The assembly part of the driver now uses the C preprocessor, eliminating the need for manual edit for port addresses other than the default 0x300.
- The rewritten driver handles NIC buffer overruns, which the old driver didn't. Such overruns will trigger console messages. Overruns require a complete reset of the NIC. This operation does not erase stored packets. However, when overruns occur, the reason is either a problem on the host or just too many incoming packets, so the overflow handler has no option but to discard data from the ring buffer. How to do this is determined by parameters to the handler from the interrupt dispatcher in eth-main.c. If the 'skip' parameter is 0, the ring buffer is cleared. Otherwise the 'skip' number of packets are deleted from the NIC ring buffer, currently 3 - while testing.

**TODO**
- An IOCTL to retrieve the stats from the NIC - runt packets, oversize packets, collissions, overruns, …
- Real DMA: Rudimentary code has been added to the driver to support DMA transfer from the NIC to system RAM. Using DMA will simplify the read code significantly and reduce system load - if the ELKS DMA support is actually working. No attempt has been made to test this yet.
- More testing, see below.
- The ‘get entire packet in one read’ is unfinished in that it currently re-reads the first 252 bytes of the packet if the total length is longer than 252.
- The buffer overrun handling needs testing on real hardware.

The driver has been extensively tested with a 8390 based card, a RT8139 (PnP) card and QEMU. It seems 100% stable on QEMU. On real hardware, the driver will hang under heavy load and ‘long’ periods of interrupt blocking (floppy access). An upcoming fix will remove these problems.

There is stil quite a bit of debugging code in the source, supporting the ongoing test/improvement.

**Testing**
Pings using a wide range of packet sizes and speeds (packets per sec) have bombarded the system from several sources - some times concurrently. Telnet in and out likewise. Incoming telnet some times gets a RST while a ling listing (my favourite is hd /bin/vi). This does not happen on QEMU.

--Mellvik