### PR TITLE
[networking] Add multiple session support to telnetd

### DIFF
--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -138,8 +138,7 @@ int sys_execve(char *filename, char *sptr, size_t slen)
 #endif
 
     /* Open the image */
-    /*debug1("EXEC: opening file: %s\n", filename);*/
-    debug1("EXEC: slen = %d\n", slen);
+    debug2("EXEC: '%t' env %d\n", filename, slen);
 
     retval = open_namei(filename, 0, 0, &inode, NULL);
 

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -1,7 +1,7 @@
 #ifndef __LINUXMT_SCHED_H
 #define __LINUXMT_SCHED_H
 
-#define MAX_TASKS 15
+#define MAX_TASKS 16
 #define NGROUPS	13		/* Supplementary groups */
 #define NOGROUP 0xFFFF
 #define KSTACK_BYTES 988	/* Size of kernel stacks */

--- a/elkscmd/ktcp/Makefile
+++ b/elkscmd/ktcp/Makefile
@@ -14,7 +14,7 @@ OBJS		= $(CFILES:.c=.o)
 all:	ktcp
 
 ktcp:	$(OBJS)
-	$(LD) $(LDFLAGS) -maout-heap=24576 -maout-stack=2048  -o ktcp $(OBJS) $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-heap=32768 -maout-stack=2048  -o ktcp $(OBJS) $(LDLIBS)
 
 lint:
 	@for FILE in *.c ; do \

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -201,9 +201,12 @@ printp();
 
     /* become daemon now that tcpdev_inuse race condition over*/
     if (bflag) {
-	int fd;
-	if (fork())
-	    exit(0);
+	int fd, ret;
+	if ((ret = fork()) == -1) {
+	    printf("ktcp: Can't fork to become daemon\n");
+	    exit(1);
+	}
+	if (ret) exit(0);
 	close(0);
 	/* redirect messages to console*/
 	fd = open("/dev/console", O_WRONLY);

--- a/elkscmd/sys_utils/ps.c
+++ b/elkscmd/sys_utils/ps.c
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
 	}
 
 	printf("  PID   GRP  TTY USER STAT CSEG DSEG  HEAP   FREE   SIZE COMMAND\n");
-	for (j = 1; j < MAX_TASKS; j++) {
+	for (j = 1; j <= MAX_TASKS; j++) {
 		if (!memread(fd, off + j*sizeof(struct task_struct), ds, &task_table, sizeof(task_table))) {
 			perror("ps");
 			return 1;


### PR DESCRIPTION
Multiple simultaneous telnet localhost sessions also supported.

Enhance telnetd/httpd startup error messages and for can't fork/out of processes.
Catch failed fork() in network programs, can't assume forks work with only 15 max processes.
Increase MAX_TASKS to 16 to allow two local telnet sessions.
Fix `ps` never displaying last process in task table.
Increase ktcp heap size to 32k.