### PR TITLE
[kernel] Add kernel stack usage per system call to strace

### DIFF
--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -6,6 +6,7 @@
 #include <linuxmt/signal.h>
 #include <linuxmt/types.h>
 #include <linuxmt/memory.h>
+#include <linuxmt/strace.h>
 
 #include <arch/segment.h>
 
@@ -43,6 +44,9 @@ void stack_check(void)
     register __ptask currentp = current;
     register char *end = (char *)currentp->t_endbrk;
 
+#if defined(CONFIG_STRACE) && defined(STRACE_KSTACKUSED)
+    memset(current->t_kstack, 0x55, KSTACK_BYTES-16);
+#endif
 #ifdef CONFIG_EXEC_LOW_STACK
     if (currentp->t_begstack <= currentp->t_enddata) {	/* stack below heap?*/
 	if (currentp->t_regs.sp < (__u16)end)

--- a/elks/arch/i86/kernel/strace.c
+++ b/elks/arch/i86/kernel/strace.c
@@ -106,7 +106,20 @@ void ret_strace(unsigned int retval)
 #ifdef STRACE_RETWAIT
     print_syscall(&current->sc_info, retval);
 #else
+#ifdef STRACE_KSTACKUSED
+    int n;
+    static int max = 0;
+
+    for (n=0; n<KSTACK_BYTES; n++)
+	if (current->t_kstack[n] != 0x55)
+	    break;
+    n = KSTACK_BYTES - n;
+    if (n > max) max = n;
+    printk("[%d:%s/ret=%d,ks=%d/%d]\n",
+	current->pid, current->sc_info.s_name, retval, n, max);
+#else
     printk("[%d:%s/ret=%d]\n", current->pid, current->sc_info.s_name, retval);
+#endif
 #endif
 }
 

--- a/elks/include/linuxmt/strace.h
+++ b/elks/include/linuxmt/strace.h
@@ -11,7 +11,8 @@
 /* Config parameters */
 
 #define STRACE_PRINTSTACK 	/* This tells strace to print stack params */
-//#define STRACE_RETWAIT	/* Wait until syscall finished before print*/
+#define STRACE_KSTACKUSED	/* Calculate amount of kernel stack used */
+//#define STRACE_RETWAIT	/* Wait until syscall finished before print */
 
 struct syscall_info
 {


### PR DESCRIPTION
Calculates and displays amount of kernel stack used during each system call, along with maximum usage over time.
Configurable with STRACE_KSTACKUSED ins trace.h.

So far, I've only seen 348 bytes used out of each 988 byte stack allocated in the 16-member task array.
If this can be safely decreased to 512 bytes or less, over 7k kernel data space would be regained. The task array is one of the largest data structures in the ELKS kernel.

All hardware interrupts (including nested interrupts), currently execute on a separate 512 byte interrupt stack.