### PR TITLE
[kernel] Add restartable system calls to ELKS, sti before reschedule

### DIFF
--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -393,13 +393,13 @@ ktask:				// Already using interrupt stack
 //	Already using interrupt stack, keep using it
 //
 	mov	%sp,%si
-	sub	$6,%si
+	sub	$8,%si		// 14 offsets less 6 already on stack
 	jmp	save_regs
 //
 //	Using a process's kernel stack, switch to interrupt stack
 //
 itask:
-	mov	$_intstack-12,%si
+	mov	$_intstack-14,%si // 14 offsets 0-13 of SI below
 	jmp	save_regs
 //
 //	User mode case
@@ -432,12 +432,13 @@ save_regs:
 	incw	_gint_count
 	pop	(%si)		// DI
 	pop	2(%si)		// SI
-	pop	6(%si)		// DS
+	pop	8(%si)		// DS
 	pop	%di		// Pointer to interrupt number
 	push	%bp		// BP
-	mov	%sp,8(%si)	// SP
-	mov	%ss,10(%si)	// SS
-	mov	%es,4(%si)	// ES
+	mov	%sp,10(%si)	// SP
+	mov	%ss,12(%si)	// SS
+	mov	%es,6(%si)	// ES
+	mov	%ax,4(%si)	// orig_ax
 //
 //	Load new segment and SP registers
 //
@@ -580,8 +581,10 @@ was_trap:
 //
 // This path will return directly to user space
 //
+	sti			// Enable interrupts to help fast devices
 	call	schedule	// Task switch
 	call	do_signal	// Check signals
+	cli
 //
 //	Restore registers and return
 //
@@ -593,12 +596,13 @@ restore_regs:
 	pop	%dx
 	pop	%di
 	pop	%si
+	pop	%bp		// discard orig_AX
 	pop	%es
 	pop	%ds
-	pop	%bp
+	pop	%bp		// SP
 	pop	%ss
 	mov	%bp,%sp
-	pop	%bp
+	pop	%bp		// user BP
 //
 //	Iret restores CS:IP and F (thus including the interrupt bit)
 //

--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -196,3 +196,17 @@ void arch_build_stack(struct task_struct *t, char *addr)
     t->t_xregs.ksp = (__u16)(tsp - 3);	/* Initial value for SP register */
 #endif
 }
+
+/*
+ * Restart last system call.
+ * Usage: instead of returning -ERESTARTSYS from kernel system call,
+ * use "return restart_syscall()".
+ */
+int restart_syscall(void)
+{
+    struct uregs __far *user_stack;
+
+    user_stack = _MK_FP(current->t_regs.ss, current->t_regs.sp);
+    user_stack->ip -= 2;		/* backup to INT 80h*/
+    return current->t_regs.orig_ax;	/* restore syscall # to user mode AX*/
+}

--- a/elks/include/arch/types.h
+++ b/elks/include/arch/types.h
@@ -31,20 +31,28 @@ typedef __u32 addr_t;
 
 /* Then we define registers, etc... */
 
+/* ordering of saved registers on kernel stack after syscall/interrupt entry*/
 struct _registers {
-    __u16	ax, bx, cx, dx, di, si,
-		es, ds, sp, ss;
+    /* SI offset                 0   2        4   6   8  10  12*/
+    __u16       ax, bx, cx, dx, di, si, orig_ax, es, ds, sp, ss;
 };
 
 typedef struct _registers		__registers,	*__pregisters;
 
 struct xregs {
-    __u16	cs, ksp;
+    __u16       cs;	/* code segment to use in arch_setup_user_stack()*/
+    __u16       ksp;	/* saved kernel SP used by twsitch()*/
 };
 
+/* ordering of saved registers on user stack after interrupt entry*/
+struct uregs {
+    __u16       bp, ip, cs, f;
+};
+
+/* duplicate of _registers*/
 struct pt_regs {
-    __u16	ax, bx, cx, dx, di, si,
-		es, ds, sp, ss;
+    /* SI offset                 0   2        4   6   8  10  12*/
+    __u16       ax, bx, cx, dx, di, si, orig_ax, es, ds, sp, ss;
 };
 
 /* Changed to unsigned short int as that is what it is here.

--- a/elks/include/linuxmt/memory.h
+++ b/elks/include/linuxmt/memory.h
@@ -20,8 +20,9 @@ extern void fmemcpyw (byte_t * dst_off, seg_t dst_seg, byte_t * src_off, seg_t s
 extern word_t fmemcmpb (word_t dst_off, seg_t dst_seg, word_t src_off, seg_t src_seg, word_t count);
 extern word_t fmemcmpw (word_t dst_off, seg_t dst_seg, word_t src_off, seg_t src_seg, word_t count);
 
-/* macros from decomposing far pointers (a la Turbo C++ and Open Watcom) */
+/* macros for far pointers (a la Turbo C++ and Open Watcom) */
 #define _FP_SEG(fp)	((unsigned)((unsigned long)(void __far *)(fp) >> 16))
 #define _FP_OFF(fp)	((unsigned)(unsigned long)(void __far *)(fp))
+#define _MK_FP(seg,off)	((void __far *)((((unsigned long)(seg)) << 16) | (off)))
 
 #endif

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -166,6 +166,7 @@ extern void add_to_runqueue(struct task_struct *);
 
 extern struct task_struct *find_empty_process(void);
 extern void arch_build_stack(struct task_struct *, char *);
+extern int restart_syscall(void);
 extern unsigned int get_ustack(struct task_struct *,int);
 extern void put_ustack(register struct task_struct *,int,int);
 


### PR DESCRIPTION
Adds the ability to restart interrupted system calls from the ELKS kernel.

Also removes an occasional extended period of interrupts disabled, which happens when a hardware interrupt occurs when the CPU was executing user (not kernel) code. In that case, after running the interrupt service routine with interrupts enabled, interrupts are disabled and the 8259 interrupt controller reset and the saved registers popped off the interrupt stack with an IRET to user code. However, `schedule` and `do_signal` are called just before the register restore sequence, which now are executed with interrupts enabled, to help high-speed (serial and ethernet) devices not lose data.

A little history on restartable system calls:

In Linux, a driver can return -ERESTARTSYS (restart system call) instead of -EINTR, which the kernel interprets specially (in the above-discussed code just before restoring registers during a system call or hardware interrupt), and restarts the system call automatically, rather than requiring an application to check for errno == EINTR and calling the system call again. In ELKS, there are a number of code fragments from Linux that return -ERESTARTSYS, which is just returned to the user application, which is incorrect, as ERESTARTSYS is never supposed to be returned to applications.

In addition, there is some code in the ethernet driver that returns ERESTARTSYS as a "panic" when a packet cannot be read, seemingly coded as "restart system", which is also incorrect. It should probably return -EIO (I/O error) or just ignore it.

System calls in ELKS are coded in libc by moving all arguments to registers (AX, BX, CX, etc) and executing an INT 80h. When a system call or hardware interrupt occurs in ELKS, all CPU registers are pushed/saved onto a kernel stack, and then accessible as parameters to the appropriate system call routine handler in the kernel. 

To restart a system call, all that is necessary is to adjust two items on the kernel and user stacks before the common IRET (interrupt return) is executed. The saved CS:IP on the user stack is backed up by two bytes to point to the INT 80h instruction, and the original AX value is restored in the kernel stack frame. The IRET sequence then restores all the registers to exactly as they were before the system call, and the INT 80h is re-executed.

This PR slightly rearranges the saved CPU registers to add an 'orig_ax' value, which can be used to restore AX. For ELKS, instead of the overhead of automatically processing a driver/kernel "return -ERESTARTSYS" value, a "return restart_syscall()" is used instead. A later PR will correct the various incorrect portions of the kernel and drivers discussed above.
