### PR TITLE
[kernel] Implement simple, race-safe sleep/wait calls

### DIFF
--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -329,7 +329,6 @@ again:
 	else {
 	    if (!icanon && !vtime && (i >= vmin))
 		break;
-	    //FIXME: race between peekch and wait_rd could force wait for another character
 	    ch = chq_wait_rd(&tty->inq, nonblock);
 	    if (ch < 0) {
 		if (!icanon && vtime) {

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -151,10 +151,10 @@ extern void sleep_on(struct wait_queue *) DEPRECATED;
 extern void interruptible_sleep_on(struct wait_queue *) DEPRECATED;
 
 /* simple race-safe sleep calls */
-void pre_wait_interruptible(struct wait_queue *p);
-void pre_wait(struct wait_queue *p);
-void wait(void);
-void post_wait(struct wait_queue *p);
+void prepare_to_wait_interruptible(struct wait_queue *p);
+void prepare_to_wait(struct wait_queue *p);
+void do_wait(void);
+void finish_wait(struct wait_queue *p);
 
 /*@-namechecks@*/
 

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -141,10 +141,20 @@ extern void schedule(void);
 extern void wait_set(struct wait_queue *);
 extern void wait_clear(struct wait_queue *);
 
-// This old style sleep is unsafe
-// Use wait_event instead
+/*
+ * Using sleep_on allows a race condition which in certain circumstances
+ * may lose a wake_up between the condition check and sleep_on/schedule.
+ * Only wait queues or condition checks changed by hw interrupts need
+ * use race-safe sleep calls.
+ */
 extern void sleep_on(struct wait_queue *) DEPRECATED;
 extern void interruptible_sleep_on(struct wait_queue *) DEPRECATED;
+
+/* simple race-safe sleep calls */
+void pre_wait_interruptible(struct wait_queue *p);
+void pre_wait(struct wait_queue *p);
+void wait(void);
+void post_wait(struct wait_queue *p);
 
 /*@-namechecks@*/
 

--- a/elks/kernel/sleepwake.c
+++ b/elks/kernel/sleepwake.c
@@ -30,31 +30,31 @@
  *	if (!ready())
  *	    interruptible_sleep_on(&waitq);
  * New:
- *	pre_wait_interruptible(&waitq);
+ *	prepare_to_wait_interruptible(&waitq);
  *	if (!ready())
- *	    wait();
- *	post_wait(&waitq);
+ *	    do_wait();
+ *	finish_wait(&waitq);
  */
 
-void pre_wait_interruptible(struct wait_queue *p)
+void prepare_to_wait_interruptible(struct wait_queue *p)
 {
     current->state = TASK_INTERRUPTIBLE;;
     wait_set(p);
 }
 
-void pre_wait(struct wait_queue *p)
+void prepare_to_wait(struct wait_queue *p)
 {
     current->state = TASK_UNINTERRUPTIBLE;
     wait_set(p);
 }
 
-void wait(void)
+void do_wait(void)
 {
     debug_sched("sleep: %d waitq %04x\n", current->pid, current->waitpt);
     schedule();
 }
 
-void post_wait(struct wait_queue *p)
+void finish_wait(struct wait_queue *p)
 {
     current->state = TASK_RUNNING;
     wait_clear(p);

--- a/elks/kernel/sleepwake.c
+++ b/elks/kernel/sleepwake.c
@@ -8,6 +8,8 @@
 #include <linuxmt/wait.h>
 #include <linuxmt/debug.h>
 
+//#define CHECK	/* check matched sleep/wakeup when writing/testing drivers */
+
 /*
  *	Wait queue functionality for Linux ELKS. Taken from sched.c/h of
  *	its big brother..
@@ -20,12 +22,54 @@
  *	not Linux needs
  */
 
+/*
+ * Simple, race-safe versions of sleep/wait functions. Greg Haerr Aug 2020.
+ * Only required when wait queue used or condition check changed by hw interrupt.
+ *
+ * Old:
+ *	if (!ready())
+ *	    interruptible_sleep_on(&waitq);
+ * New:
+ *	pre_wait_interruptible(&waitq);
+ *	if (!ready())
+ *	    wait();
+ *	post_wait(&waitq);
+ */
+
+void pre_wait_interruptible(struct wait_queue *p)
+{
+    current->state = TASK_INTERRUPTIBLE;;
+    wait_set(p);
+}
+
+void pre_wait(struct wait_queue *p)
+{
+    current->state = TASK_UNINTERRUPTIBLE;
+    wait_set(p);
+}
+
+void wait(void)
+{
+    debug_sched("sleep: %d waitq %04x\n", current->pid, current->waitpt);
+    schedule();
+}
+
+void post_wait(struct wait_queue *p)
+{
+    current->state = TASK_RUNNING;
+    wait_clear(p);
+}
+
+/**********************************/
+
 void wait_set(struct wait_queue *p)
 {
     register __ptask pcurrent = current;
 
+#ifdef CHECK
     if (pcurrent->waitpt)
 	panic("double wait");
+#endif
     pcurrent->waitpt = p;
 }
 
@@ -33,19 +77,18 @@ void wait_clear(struct wait_queue *p)
 {
     register __ptask pcurrent = current;
 
+#ifdef CHECK
     if (pcurrent->waitpt != p)
 	panic("wrong waitpt");
+#endif
     pcurrent->waitpt = NULL;
 }
 
 static void __sleep_on(register struct wait_queue *p, __s16 state)
 {
-    register __ptask pcurrent = current;
-
-    if (pcurrent == &task[0])
-	panic("task[0] trying to sleep from %x", (int)p);
-    debug_sched("sleep: %d waitq %04x\n", pcurrent->pid, p);
-    pcurrent->state = state;
+    //if (current == &task[0]) panic("task[0] trying to sleep from %x", p);
+    debug_sched("sleep: %d waitq %04x\n", current->pid, p);
+    current->state = state;
     wait_set(p);
     schedule();
     wait_clear(p);
@@ -95,8 +138,6 @@ void wake_up_process(register struct task_struct *p)
 void _wake_up(register struct wait_queue *q, unsigned short int it)
 {
     register struct task_struct *p;
-
-    // FIXME: task list not protected against interruption
 
     for_each_task(p) {
 	if ((p->waitpt == q) || ((p->waitpt == &select_queue) && select_poll (p, q)))

--- a/elks/lib/chqueue.c
+++ b/elks/lib/chqueue.c
@@ -66,17 +66,17 @@ int chq_wait_rd(register struct ch_queue *q, int nonblock)
 {
     int	res = 0;
 
-    pre_wait_interruptible(&q->wait);
+    prepare_to_wait_interruptible(&q->wait);
     if (!q->len) {
 	if (nonblock)
 	    res = -EAGAIN;
 	else {
-	    wait();
+	    do_wait();
 	    if (!q->len)
 		res = -EINTR;
 	}
     }
-    post_wait(&q->wait);
+    finish_wait(&q->wait);
     return res;
 }
 

--- a/elks/lib/chqueue.c
+++ b/elks/lib/chqueue.c
@@ -64,16 +64,20 @@ void chq_addch(register struct ch_queue *q, unsigned char c)
 
 int chq_wait_rd(register struct ch_queue *q, int nonblock)
 {
+    int	res = 0;
+
+    pre_wait_interruptible(&q->wait);
     if (!q->len) {
 	if (nonblock)
-	    return -EAGAIN;
+	    res = -EAGAIN;
 	else {
-	    interruptible_sleep_on(&q->wait);
+	    wait();
 	    if (!q->len)
-		return -EINTR;
+		res = -EINTR;
 	}
     }
-    return 0;
+    post_wait(&q->wait);
+    return res;
 }
 
 /* Return first character in queue*/


### PR DESCRIPTION
Implements fast alternative to unwieldy wait_event for simply upgrading certain kernel sleep_on/wake_up code.
Required only when wait queue used or condition check changeable by hardware interrupts.
Designed to be very easy to replace existing sleep_on code when required to avoid the "lost wakeup" problem.

Adds prepare_to_wait_interruptible, prepare_to_wait, do_wait, finish_wait functions.
Fixes chq_wait_rd race condition in ntty.c from kbd/serial interrupt input.
Fixes race condition between chq_peekch and chq_wait_rd for TTY input.
Add \#define CHECK to match sleep/wait checking when writing new drivers in sleepwake.c for speed.

Close inspection shows that the more complex wait_event/wait_lock/event_unlock and atomic lock functions are not needed in the ELKS kernel, unless SMP or an interruptible kernel is implemented. These unneeded and time-consuming semaphores will be addressed in a future PR.