### PR TITLE
[kernel] Don't call wake_up after each TTY character written to console or serial

### DIFF
--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -298,10 +298,11 @@ size_t tty_write(struct inode *inode, struct file *file, char *data, size_t len)
 		i = s;
 	    break;
 	}
-	chq_addch(&tty->outq, get_user_char((void *)(data++)));
+	chq_addch_nowakeup(&tty->outq, get_user_char((void *)data++));
 	tty->ops->write(tty);
 	i++;
     }
+    wake_up(&tty->outq.wait);
     return i;
 }
 

--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -298,11 +298,10 @@ size_t tty_write(struct inode *inode, struct file *file, char *data, size_t len)
 		i = s;
 	    break;
 	}
-	chq_addch_nowakeup(&tty->outq, get_user_char((void *)data++));
+	chq_addch(&tty->outq, get_user_char((void *)(data++)));
 	tty->ops->write(tty);
 	i++;
     }
-    wake_up(&tty->outq.wait);
     return i;
 }
 

--- a/elks/arch/i86/drivers/char/serial.c
+++ b/elks/arch/i86/drivers/char/serial.c
@@ -287,14 +287,8 @@ void rs_irq(int irq, struct pt_regs *regs, void *dev_id)
     /* read uart/fifo until empty*/
     do {
 	unsigned char c = INB(io + UART_RX);		/* Read received data */
-	if (!tty_intcheck(sp->tty, c)) {
-	    clr_irq();
-	    if (q->len < q->size) {
-		q->base[(unsigned int)((q->start + q->len) & (q->size - 1))] = c;
-		q->len++;
-	    }
-	    set_irq();
-	}
+	if (!tty_intcheck(sp->tty, c))
+	    chq_addch_nowakeup(q, c);
     } while (INB(io + UART_LSR) & UART_LSR_DR); /* while data available (for FIFOs)*/
 
     wake_up(&q->wait);

--- a/elks/include/linuxmt/chqueue.h
+++ b/elks/include/linuxmt/chqueue.h
@@ -13,6 +13,7 @@ extern void chq_init(register struct ch_queue *,unsigned char *,int);
 /*extern void chq_erase(register struct ch_queue *);*/
 extern int chq_wait_wr(register struct ch_queue *,int);
 extern void chq_addch(register struct ch_queue *,unsigned char);
+extern void chq_addch_nowakeup(register struct ch_queue *,unsigned char);
 extern int chq_delch(register struct ch_queue *);
 extern int chq_peekch(register struct ch_queue *);
 /*extern int chq_full(register struct ch_queue *);*/

--- a/elks/include/linuxmt/chqueue.h
+++ b/elks/include/linuxmt/chqueue.h
@@ -13,7 +13,6 @@ extern void chq_init(register struct ch_queue *,unsigned char *,int);
 /*extern void chq_erase(register struct ch_queue *);*/
 extern int chq_wait_wr(register struct ch_queue *,int);
 extern void chq_addch(register struct ch_queue *,unsigned char);
-extern void chq_addch_nowakeup(register struct ch_queue *,unsigned char);
 extern int chq_delch(register struct ch_queue *);
 extern int chq_peekch(register struct ch_queue *);
 /*extern int chq_full(register struct ch_queue *);*/

--- a/elks/lib/chqueue.c
+++ b/elks/lib/chqueue.c
@@ -62,6 +62,16 @@ void chq_addch(register struct ch_queue *q, unsigned char c)
     } else set_irq();
 }
 
+void chq_addch_nowakeup(register struct ch_queue *q, unsigned char c)
+{
+    clr_irq();
+    if (q->len < q->size) {
+	q->base[(unsigned int)((q->start + q->len) & (q->size - 1))] = c;
+	q->len++;
+    }
+    set_irq();
+}
+
 int chq_wait_rd(register struct ch_queue *q, int nonblock)
 {
     int	res = 0;

--- a/elks/lib/chqueue.c
+++ b/elks/lib/chqueue.c
@@ -62,16 +62,6 @@ void chq_addch(register struct ch_queue *q, unsigned char c)
     } else set_irq();
 }
 
-void chq_addch_nowakeup(register struct ch_queue *q, unsigned char c)
-{
-    clr_irq();
-    if (q->len < q->size) {
-	q->base[(unsigned int)((q->start + q->len) & (q->size - 1))] = c;
-	q->len++;
-    }
-    set_irq();
-}
-
 int chq_wait_rd(register struct ch_queue *q, int nonblock)
 {
     int	res = 0;


### PR DESCRIPTION
Fixes time-consuming wake_up call after every character in `write` to console or serial.
Create chq_addch_nowakeup routine for adding ring buffer characters w/o wake_up.