### PR TITLE
[networking] Fix netstat, broken by #682

### DIFF
--- a/elks/arch/i86/drivers/net/eth-main.c
+++ b/elks/arch/i86/drivers/net/eth-main.c
@@ -185,8 +185,8 @@ static void ne2k_int (int irq, struct pt_regs * regs, void * dev_id)
 	word_t stat, page;
 
 	stat = ne2k_int_stat ();
-        page = ne2k_getpage();
-        printk("$%02x$B%02x$", (page>>8)&0xff, page&0xff);
+        //page = ne2k_getpage();
+        //printk("$%02x$B%02x$", (page>>8)&0xff, page&0xff);
 
         if (stat & NE2K_STAT_OF) {
 		printk("Warning: NIC receive buffer overflow\n");

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -36,7 +36,6 @@ static short rwlock;	/* global inet_read/write semaphore*/
 int inet_process_tcpdev(register char *buf, int len)
 {
     register struct socket *sock;
-//int n;
 
     sock = ((struct tdb_return_data *)buf)->sock;
     debug_net("inet_process_tcpdev(%d) sock %x, type %d, wait %x\n",
@@ -56,8 +55,7 @@ debug_net("avail_data sock %x %u, bufin %d\n", sock, sock->avail_data, bufin_sem
         wake_up(sock->wait);
 	break;
     default:
-//n = ((struct tdb_return_data *)buf)->ret_value;
-debug_net("retval %d, bufin %d\n", n, bufin_sem);
+debug_net("retval %d, bufin %d\n", ((struct tdb_return_data *)buf)->ret_value, bufin_sem);
         wake_up(sock->wait);
     }
 
@@ -253,6 +251,7 @@ static int inet_read(register struct socket *sock, char *ubuf, int size,
 
     /* ensure read blocks until data - wait for ktcp to report data available*/
     while (sock->avail_data == 0) {
+	debug_net("inet_read: waiting on sock->avail_data sock %x\n", sock);
 	interruptible_sleep_on(sock->wait);
 	if (current->signal)
 	    return -EINTR;

--- a/elkscmd/inet/nettools/netstat.c
+++ b/elkscmd/inet/nettools/netstat.c
@@ -60,7 +60,7 @@ int main(void)
     __u8 *addrbytes;
 	    
     if ( (s = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
-	perror("socket error");
+	fprintf(stderr, "netstat: Can't open socket (check if ktcp running)\n");
 	exit(-1);
     }
 

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -220,9 +220,6 @@ debug_tcp("tcpdev_read: returning -EPIPE to socket read\n");
 	return;
     }
 
-    if (cb->remport == NETCONF_PORT && cb->remaddr == 0)
-	netconf_send(cb);
-
     data_avail = cb->bytes_to_push;
 
     if (data_avail == 0) {
@@ -322,8 +319,11 @@ printf("tcp: RETRANS limit exceeded\n");
     }
 
     if (cb->remport == NETCONF_PORT && cb->remaddr == 0) {
-	if (db->size == sizeof(struct stat_request_s))
+	if (db->size == sizeof(struct stat_request_s)) {
 	    netconf_request(db->data);
+	    netconf_send(cb);		/* queue response*/
+	    tcpdev_checkread(cb);	/* set sock->data_avail to allow inet_read()*/
+	}
 	retval_to_sock(sock, db->size);
 	return;
     }


### PR DESCRIPTION
Fixes netstat, which broke in the removal of asynchronous reads in #682. Ktcp now returns data immediately upon request, which potentially limits future netstat output to the size of ktcp ring buffers, which is 4096. 

Netstat now reports a reasonable error message if run without ktcp running, instead of "socket error".

Also comments out 'getpage' debug printk from NE2K driver.