### PR TITLE
[kernel] Fix unneeded and slow locks in kernel, small cleanups

### DIFF
--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -199,7 +199,7 @@ ifneq ($(USEBCC), N)
 AS      = ia16-elf-as
 ASFLAGS = $(CPU_AS) $(ARCH_AS)
 CC      = $(CROSS_CC)
-CFLAGS  = $(CROSS_CFLAGS) $(CPU_CC) $(ARCH_CC) $(CFLBASE) -Wall -Os
+CFLAGS  = $(CROSS_CFLAGS) $(CPU_CC) $(ARCH_CC) $(CFLBASE) -Wall -Os -Wno-strict-aliasing
 LD      = ia16-elf-ld
 LDFLAGS = $(CPU_LD) -s
 AR      = ia16-elf-ar

--- a/elks/include/linuxmt/net.h
+++ b/elks/include/linuxmt/net.h
@@ -3,7 +3,6 @@
 
 #include <linuxmt/types.h>
 #include <linuxmt/config.h>
-#include <linuxmt/wait.h>
 #include <linuxmt/socket.h>
 
 /* Number of protocols */

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -69,7 +69,7 @@ struct task_struct {
     __s16			state;
     __u32			timeout;	/* for select() */
     struct wait_queue		*waitpt;	/* Wait pointer */
-    struct wait_queue       *poll [POLL_MAX];  /* polled queues */
+    struct wait_queue		*poll[POLL_MAX];  /* polled queues */
     struct task_struct		*next_run;
     struct task_struct		*prev_run;
     struct file_struct		files;		/* File system structure */
@@ -83,10 +83,9 @@ struct task_struct {
     struct task_struct		*p_child;
     struct wait_queue		child_wait;
     int				exit_status;	/* process exit status*/
-    struct inode		* t_inode;
+    struct inode		*t_inode;
     sigset_t			signal;		/* Signal status */
     struct signal_struct	sig;		/* Signal block */
-    int 			dumpable;	/* Can core dump */
 
 #ifdef CONFIG_SUPPLEMENTARY_GROUPS
     gid_t			groups[NGROUPS];
@@ -162,11 +161,8 @@ extern void _wake_up(struct wait_queue *,unsigned short int);
 
 /*@+namechecks@*/
 
-// These old style semaphore functions are unsafe
-// Use count_t for reference counting
-// Use lock_t for object locking
-extern void down (short int *)  DEPRECATED;
-extern void up (short int *)  DEPRECATED;
+extern void down(short *);
+extern void up(short *);
 
 extern void wake_up_process(struct task_struct *);
 

--- a/elks/include/linuxmt/wait.h
+++ b/elks/include/linuxmt/wait.h
@@ -24,7 +24,7 @@ extern struct wait_queue select_queue;
 // to allow composite ones through indirection (poll and select cases)
 // while saving code size (see issue #222)
 
-typedef __u16 bool_t;
+typedef __u16 bool_t;	//FIXME should not introduce boolean type here
 
 typedef bool_t (* test_t) (void *);
 

--- a/elks/kernel/sleepwake.c
+++ b/elks/kernel/sleepwake.c
@@ -152,13 +152,13 @@ void _wake_up(register struct wait_queue *q, unsigned short int it)
  *	Semaphores. These are not IRQ safe nor needed to be so for ELKS
  */
 
-void up(register short int *s)
+void up(register short *s)
 {
     if (++(*s) == 0)		/* Gone non-negative */
 	wake_up((void *) s);
 }
 
-void down(register short int *s)
+void down(register short *s)
 {
     /* Wait for the semaphore */
     while (*s < 0)

--- a/elks/kernel/sys.c
+++ b/elks/kernel/sys.c
@@ -113,7 +113,7 @@ int sys_knlvsn(char *vsn)
 int sys_setgid(gid_t gid)
 {
     register __ptask currentp = current;
-    gid_t old_egid = currentp->egid;
+    //gid_t old_egid = currentp->egid;
 
     if (suser())
 	currentp->gid = currentp->egid = currentp->sgid = gid;
@@ -121,8 +121,8 @@ int sys_setgid(gid_t gid)
 	currentp->egid = gid;
     else
 	return -EPERM;
-    if (currentp->egid != old_egid)
-	currentp->dumpable = 0;
+    //if (currentp->egid != old_egid)
+	//currentp->dumpable = 0;
     return 0;
 }
 
@@ -173,7 +173,7 @@ unsigned short int sys_umask(unsigned short int mask)
 int sys_setuid(uid_t uid)
 {
     register __ptask currentp = current;
-    uid_t old_euid = currentp->euid;
+    //uid_t old_euid = currentp->euid;
 
     if (suser())
 	currentp->uid = currentp->euid = currentp->suid = uid;
@@ -181,8 +181,8 @@ int sys_setuid(uid_t uid)
 	currentp->euid = uid;
     else
 	return -EPERM;
-    if (currentp->euid != old_euid)
-	currentp->dumpable = 0;
+    //if (currentp->euid != old_euid)
+	//currentp->dumpable = 0;
     return 0;
 }
 

--- a/elkscmd/inet/httpd/httpd.c
+++ b/elkscmd/inet/httpd/httpd.c
@@ -38,7 +38,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #endif
-//#include <sys/wait.h>		// FIXME conflict with linuxmt/net.h including linuxmt/wait.h above*/
+#include <sys/wait.h>
 extern pid_t waitpid(pid_t, int *, int);
 
 #define DEF_PORT		80


### PR DESCRIPTION
Remove wait_lock/event_lock in near heap critical sections, they are unnecessary and slow, since wake_up is called by event_unlock and kernel heap critical section is not necessary unless SMP or reentrant kernel implemented.

Fix linuxmt/net.h from including wait.h which conflicted libc sys/wait.h in http.c
No need to fix up/down semaphores as no interrupt routine use possible, remove DEPRECATED.
Up/down are safe unless SMP or reentrant kernel is implemented.
Functions wait_event, wait_lock, event_unlock, try_lock and atomic\* are all unused.
Remove task struct dumpable member - unused.
Turn on -Wno-strict-aliasing to remove unneeded warnings.
