### PR TITLE
[kernel] Reduce kernel per-task stack size to 512 bytes

### DIFF
--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -4,7 +4,7 @@
 #define MAX_TASKS 16
 #define NGROUPS	13		/* Supplementary groups */
 #define NOGROUP 0xFFFF
-#define KSTACK_BYTES 988	/* Size of kernel stacks */
+#define KSTACK_BYTES 512	/* Size of kernel stacks */
 
 #include <linuxmt/config.h>
 #include <linuxmt/types.h>

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -118,12 +118,15 @@ static void init_task(void)
 
     mount_root();
 
-    /* Open std files in case init= is a shell*/
-    num = sys_open(s="/dev/console", O_RDWR, 0);
-    if (num < 0) /* FIXME w/o "s" below, sys_open fails, guessing string addr == DS:0*/
-	printk("Unable to open %s (error %d)\n", s, num, "s");
-    sys_dup(num);		/* open stdout*/
-    sys_dup(num);		/* open stderr*/
+    /* Don't open /dev/console for /bin/init, 0-2 closed immediately and fragments heap*/
+    if (strcmp(init_command, bininit) != 0) {
+	/* Set stdin/stdout/stderr to /dev/console if not running /bin/init*/
+	num = sys_open(s="/dev/console", O_RDWR, 0);
+	if (num < 0) /* FIXME w/o "s" below, sys_open fails, guessing string addr == DS:0*/
+	    printk("Unable to open %s (error %d)\n", s, num, "s");
+	sys_dup(num);		/* open stdout*/
+	sys_dup(num);		/* open stderr*/
+    }
 
 #ifdef CONFIG_BOOTOPTS
     /* special handling if argc/argv array setup*/

--- a/elks/lib/heap.c
+++ b/elks/lib/heap.c
@@ -109,7 +109,7 @@ void * heap_alloc (word_t size, byte_t tag)
 	wait_lock (&_heap_lock);
 	heap_s * h = free_get (size, tag);
 	if (h) h++;  // skip header
-	event_unlock (&_heap_lock);
+	EVENT_UNLOCK (&_heap_lock);
 	if (!h) printk("HEAP: no memory (%u bytes)\n", size);
 	return h;
 }

--- a/elks/lib/heap.c
+++ b/elks/lib/heap.c
@@ -109,8 +109,7 @@ void * heap_alloc (word_t size, byte_t tag)
 	wait_lock (&_heap_lock);
 	heap_s * h = free_get (size, tag);
 	if (h) h++;  // skip header
-	EVENT_UNLOCK (&_heap_lock);
-	if (!h) printk("HEAP: no memory (%u bytes)\n", size);
+	event_unlock (&_heap_lock);
 	return h;
 }
 

--- a/elks/lib/heap.c
+++ b/elks/lib/heap.c
@@ -110,6 +110,7 @@ void * heap_alloc (word_t size, byte_t tag)
 	heap_s * h = free_get (size, tag);
 	if (h) h++;  // skip header
 	event_unlock (&_heap_lock);
+	if (!h) printk("HEAP: no memory (%u bytes)\n", size);
 	return h;
 }
 

--- a/elkscmd/sys_utils/getty.c
+++ b/elkscmd/sys_utils/getty.c
@@ -53,7 +53,7 @@
 #define CONSOLE		"/dev/console"
 
 #define LOGIN		"/bin/login"
-#define HOSTFILE	"/etc/HOSTNAME"
+#define HOSTFILE	"/etc/hostname"
 #define ISSUE		"/etc/issue"
 
 /* For those requiring a super-small getty, the following define cuts out


### PR DESCRIPTION
Reduces kernel stack size from 988 to 512 bytes per process.
This saves 7.5k kernel data space for 16 tasks. My strace trials show max kernel stack usage at 348 bytes, so this could be brought lower over time.

The kernel data segment was almost full when strace is compiled in and console=ttyS0, causing getty to fail opening additional TTY devices. The near heap allocator only gets to use what's left of the kernel data segment after .data and .bss sections from C code. This restores it to around 10k at boot.
Meminfo can be used to show kernel near heap pointer values, total heap and used/free allocations.

Add HEAP: no memory kernel message to see if/when kernel near heap allocations fail.
Don't open /dev/console at startup if running /bin/init to avoid heap fragmentation.
Change getty open /etc/HOSTNAME to /etc/hostname for FAT compatibility.