### PR TITLE
[console] Add Alt-1 thru Alt-3 for virtual console switch for macOS…

### DIFF
--- a/elks/arch/i86/drivers/char/xt_key.c
+++ b/elks/arch/i86/drivers/char/xt_key.c
@@ -321,15 +321,21 @@ void keyboard_irq(int irq, struct pt_regs *regs, void *dev_id)
 	key = *(scan_tabs[mode] + code);
 
         /* Step 6: Modify keyboard character based on some special states*/
-	if ((ModeState & (CTRL|ALT)) == ALT)
+	if ((ModeState & (CTRL|ALT)) == ALT) {
+	    /* Alt-1 - Alt-3 are also console switch (for systems w/no fnkeys)*/
+	    if (key >= '1' && key <= '3') {
+		Console_set_vc(key - '1');
+		return;
+	    }
 	    key |= 0x80;	/* ALT-.. (assume codepage is OEM 437) */
+	}
 	    
 	if (!key)		/* map zero table entries to '@' */
 	    key = '@';
 	    
 	if ((ModeState & (CTRL|ALT)) == CTRL)
 	    key &= 0x1F;	/* CTRL-.. */
-	    
+
 #ifdef CONFIG_EMUL_ANSI
 	/* Step 7: Convert octal 0260-0277 values to ANSI escape sequences*/
 	code = mode = 0;

--- a/elks/include/linuxmt/errno.h
+++ b/elks/include/linuxmt/errno.h
@@ -159,7 +159,7 @@
 
 /* Should never be seen by user programs */
 
-#define ERESTARTSYS	512	/* Restart system */
+#define ERESTARTSYS	512	/* Restart system call*/
 #define ERESTARTNOINTR	513	/* Restart without interrupts */
 #define ENOIOCTLCMD	515	/* No ioctl command */
 

--- a/elks/kernel/sched.c
+++ b/elks/kernel/sched.c
@@ -17,18 +17,17 @@
 #define idle_task task[0]
 
 __task task[MAX_TASKS];
-unsigned char nr_running;
-
 __ptask current = task;
 __ptask previous;
 
+//static unsigned char nr_running;
 extern int intr_count;
 
 static void run_timer_list();
 
 void add_to_runqueue(register struct task_struct *p)
 {
-    nr_running++;
+    //nr_running++;
     (p->prev_run = idle_task.prev_run)->next_run = p;
     p->next_run = &idle_task;
     idle_task.prev_run = p;
@@ -38,15 +37,15 @@ void del_from_runqueue(register struct task_struct *p)
 {
 #if 0       /* sanity tests */
     if (!p->next_run || !p->prev_run) {
-    printk("task %d not on run-queue (state=%d)\n", p->pid, p->state);
-    return;
+	printk("task %d not on run-queue (state=%d)\n", p->pid, p->state);
+	return;
     }
-#endif
     if (p == &idle_task) {
         printk("idle task may not sleep\n");
         return;
     }
-    nr_running--;
+#endif
+    //nr_running--;
     (p->next_run->prev_run = p->prev_run)->next_run = p->next_run;
     p->next_run = p->prev_run = NULL;
 
@@ -102,13 +101,13 @@ void schedule(void)
 	    timeout = prev->timeout;
 	}
     }
+
     /* Choose a task to run next */
     next = prev->next_run;
     if (prev->state != TASK_RUNNING)
 	del_from_runqueue(prev);
     if (next == &idle_task)
         next = next->next_run;
-
     set_irq();
 
     if (next != prev) {

--- a/elks/lib/heap.c
+++ b/elks/lib/heap.c
@@ -113,6 +113,7 @@ void * heap_alloc (word_t size, byte_t tag)
 	WAIT_LOCK (&_heap_lock);
 	heap_s * h = free_get (size, tag);
 	if (h) h++;  // skip header
+	if (!h) printk("HEAP: no memory (%u bytes)\n", size);
 	EVENT_UNLOCK (&_heap_lock);
 	return h;
 }

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -49,13 +49,13 @@ int inet_process_tcpdev(register char *buf, int len)
     case TDT_AVAIL_DATA:
         down(&sock->sem);
         sock->avail_data = ((struct tdb_return_data *)buf)->ret_value;
-debug_net("avail_data sock %x %u, bufin %d\n", sock, sock->avail_data, bufin_sem);
+	debug_net("avail_data sock %x %u, bufin %d\n", sock, sock->avail_data, bufin_sem);
         up(&sock->sem);
         tcpdev_clear_data_avail();
         wake_up(sock->wait);
 	break;
     default:
-debug_net("retval %d, bufin %d\n", ((struct tdb_return_data *)buf)->ret_value, bufin_sem);
+	debug_net("retval %d, bufin %d\n", ((struct tdb_return_data *)buf)->ret_value, bufin_sem);
         wake_up(sock->wait);
     }
 
@@ -225,7 +225,6 @@ printk("inet_accept: RESTARTSYS\n");
 
     ret = ((struct tdb_accept_ret *)tdin_buf)->ret_value;
     tcpdev_clear_data_avail();
-debug_net("ACCEPT retval %d\n", ret);
     if (ret >= 0) {
 	newsock->state = SS_CONNECTED;
 	ret = 0;
@@ -243,8 +242,6 @@ static int inet_read(register struct socket *sock, char *ubuf, int size,
 
     debug_net("inet_READ(socket: 0x%x size:%d nonblock: %d bufin %d)\n", sock, size,
 	   nonblock, bufin_sem);
-
-//printk("[[[[[[ %d\n", bufin_sem);
 
     if (size > TCPDEV_MAXREAD)
 	size = TCPDEV_MAXREAD;
@@ -279,7 +276,7 @@ static int inet_read(register struct socket *sock, char *ubuf, int size,
     ret = ((struct tdb_return_data *)tdin_buf)->ret_value;
 
     if (ret > 0) {
-debug_net("INET_READ %u, %u\n", ret, sock->avail_data);
+	debug_net("INET_READ %u, %u\n", ret, sock->avail_data);
         memcpy_tofs(ubuf, &((struct tdb_return_data *)tdin_buf)->data, (size_t) ret);
         sock->avail_data = 0;
     } else debug_net("INET_READ %d, %u\n", ret, sock->avail_data);
@@ -288,7 +285,6 @@ debug_net("INET_READ %u, %u\n", ret, sock->avail_data);
 
     tcpdev_clear_data_avail();
     up(&rwlock);
-//printk("]]]]]\n");
     return ret;
 }
 
@@ -319,7 +315,7 @@ static int inet_write(register struct socket *sock, char *ubuf, int size,
 
         cmd->size = count > TDB_WRITE_MAX ? TDB_WRITE_MAX : count;
 
-debug_net("INET_WRITE(%d) %u\n", current->pid, cmd->size);
+	debug_net("INET_WRITE(%d) %u\n", current->pid, cmd->size);
         memcpy_fromfs(cmd->data, ubuf, (size_t) cmd->size);
 	usize = cmd->size;
         tcpdev_inetwrite(cmd, sizeof(struct tdb_write));
@@ -330,8 +326,10 @@ debug_net("INET_WRITE(%d) %u\n", current->pid, cmd->size);
             interruptible_sleep_on(sock->wait);
 	}
 	debug_net("got write WAIT(%d) bufin_sem %d\n", current->pid, bufin_sem);
+
 	ret = ((struct tdb_return_data *)tdin_buf)->ret_value;
-debug_net("INET_WRITE retval %d\n", ret);
+
+	debug_net("INET_WRITE retval %d\n", ret);
 	tcpdev_clear_data_avail();
 	up(&rwlock);
 
@@ -387,7 +385,7 @@ static int inet_recv(struct socket *sock, void *buff, int len, int nonblock,
     return inet_read(sock, (char *) buff, len, nonblock);
 }
 
-int not_implemented(void)	/* Originally returned void */
+int not_implemented(void)
 {
     debug("not_implemented\n");
     return 0;


### PR DESCRIPTION
One can now switch consoles using Alt-1 through 3 for systems with no fn keys (Opt=Alt on macOS).
Alt-F1 through 3 also works.

Various other small cleanups:
Cleanup printk/debug statements in kernel networking code.
Clarify comment on ERESTARTSYS in errno.h.
Remove unneeded checks and global variables in sched.c.
Added back in HEAP: no memory printk missing from previous PR.
