### PR TITLE
[kernel] Fix networking socket close issues

### DIFF
--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -113,7 +113,7 @@ struct tty *determine_tty(dev_t dev)
     return NULL;
 }
 
-/* standard ops open/release routines for dircon, bioscon, pty*/
+/* standard ops open/release routines for dircon and bioscon*/
 int ttystd_open(struct tty *tty)
 {
     /* increment use count, don't init if already open*/
@@ -452,7 +452,7 @@ static struct file_operations tty_fops = {
     tty_read,
     tty_write,
     NULL,
-    tty_select,			/* Select - needs doing */
+    tty_select,
     tty_ioctl,			/* ioctl */
     tty_open,
     tty_release

--- a/elks/include/linuxmt/net.h
+++ b/elks/include/linuxmt/net.h
@@ -68,6 +68,7 @@ struct proto_ops {
     int (*fcntl) ();
 };
 
+#define SO_CLOSING	(1 << 12)
 #define SO_ACCEPTCON	(1 << 13)
 #define SO_WAITDATA	(1 << 14)
 #define SO_NOSPACE	(1 << 15)

--- a/elks/include/linuxmt/ntty.h
+++ b/elks/include/linuxmt/ntty.h
@@ -6,8 +6,11 @@
  */
 
 /* NOTE: all queue sizes must be a power of two!*/
-#define INQ_SIZE	128	/* tty/pty input queue size*/
-#define OUTQ_SIZE	64	/* tty/pty output queue size*/
+#define INQ_SIZE	128	/* tty input queue size*/
+#define OUTQ_SIZE	64	/* tty output queue size*/
+
+#define PTYINQ_SIZE	64	/* pty input queue size*/
+#define PTYOUTQ_SIZE	128	/* pty output queue size*/
 
 #define RSINQ_SIZE	1024	/* serial input queue SLIP_MTU+128+8*/
 #define RSOUTQ_SIZE	64	/* serial output queue size*/

--- a/elkscmd/inet/telnet/ttn.c
+++ b/elkscmd/inet/telnet/ttn.c
@@ -119,24 +119,14 @@ static void scrn(void)
 			printf("\r\nTELNET BUFFER OVERFLOW\r\n");
 			finish();
 		}
-		if (count < 0)
+		if (count <= 0)
 		{
-			if (errno == EINTR)		//FIXME kernel debug of inet_read
-			{
-				printf("\r\nTELNET GOT EINTR\r\n");
-				return;
-			}
+			if (count < 0)
+				perror("Read socket");
 			printf("\r\nConnection closed\r\n");
 			finish();
 		}
-		if (!count)
-			return;
 #ifdef RAWTELNET
-		if (count > sizeof(buffer)) {
-			fprintf(stderr, "TELNET BAD READ %d\n", count);
-			exit(1);
-			return;
-		}
 		write(1, buffer, count);
 #else
 		bp= buffer;


### PR DESCRIPTION
Fixes both incoming and outgoing close issues with telnet/telnetd.
Incoming telnet and outgoing telnet now exit with ^D.
Fixes most, but not all, problems with running telnet multiple times, which didn't used to work.
Simultaneous telnet in and out work great, but run out of processes with more than three running.

Sockets now handle remote close and return read count = 0.
Fix telnet not closing with ^D to shell/login.
Fix pty driver to handle telnetd /bin/login exit and read return 0 to telnetd.
   (pty driver handles master close as read return 0).
Fix telnetd to close socket on /bin/login exit, sends TCP FIN to remote.
Fix telnetd to reap children to fix zombies leftover.
Occasional zombie still remains, reaped on next accept.
Set pty queue size to 128/64 instead of 64/128.
Remove debug messages/code from telnet and telnetd.


Bug: Outgoing telnet sometimes get packet refused after previous disconnect.