### PR TITLE
[LD scripts] allow small-model a.out's to (maybe) have far text

### DIFF
--- a/elks/elks-small.ld
+++ b/elks/elks-small.ld
@@ -7,6 +7,16 @@ SECTIONS {
 		*(.text .text.*)
 		. = ALIGN(0x10);
 	}
+	.fartext 0 : AT(0x10000) {
+		/*
+		 * Some small-model programs might want to break out of the
+		 * small memory model a bit --- and choose to place some of
+		 * their code in a far segment outside the default text
+		 * segment.  Allow this.
+		 */
+		*(.fartext .fartext$ .fartext.*)
+		. = ALIGN(0x10);
+	}
 	.data 0 : AT(0x20000) {
 		*(.nildata .nildata.*)
 		*(.rodata .rodata.*)


### PR DESCRIPTION
This change to `elks-small.ld` allows small-model programs to "break out" of the small memory model a bit, and place some of their function code in a far text segment outside the normal text segment (https://github.com/tkchia/gcc-ia16/issues/63).

E.g. one can now do this:
```
$ cat test.c
#include <stdio.h>

static __far __attribute__ ((far_section, noinline)) int
foo (void)
{
  printf ("Hello world!\n");
  return 0;
}

int
main (void)
{
  return foo ();
}
$ ia16-elf-gcc -melks -O3 test.c -o test
```