### PR TITLE
[networking] Fix slip buffer overrun

### DIFF
--- a/elkscmd/ktcp/Makefile
+++ b/elkscmd/ktcp/Makefile
@@ -14,7 +14,7 @@ OBJS		= $(CFILES:.c=.o)
 all:	ktcp
 
 ktcp:	$(OBJS)
-	$(LD) $(LDFLAGS) -maout-heap=32768 -maout-stack=2048  -o ktcp $(OBJS) $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-heap=32768 -maout-stack=3072  -o ktcp $(OBJS) $(LDLIBS)
 
 lint:
 	@for FILE in *.c ; do \

--- a/elkscmd/ktcp/slip.c
+++ b/elkscmd/ktcp/slip.c
@@ -271,13 +271,16 @@ void cslip_compress(__u8 **packet, int *len)
 
 void slip_send(unsigned char *packet, int len)
 {
-    unsigned char buf[128+2];
+    unsigned char buf[SLIP_MTU+2];
     unsigned char *p = packet;
     unsigned char *q = buf;
 
 #if CSLIP
     if (linkprotocol == LINK_CSLIP)
 	cslip_compress(&p, &len);
+#endif
+#ifdef DEBUG
+    printf("slip: send %d\n", len);
 #endif
 
     *q++ = END;


### PR DESCRIPTION
Fixes slip buffer overrun and subsequent stack overflow in ktcp reported in #704.

