### PR TITLE
[networking] Fix pause in received data until keystroke, telnetd login problem

### DIFF
--- a/elks/include/linuxmt/ntty.h
+++ b/elks/include/linuxmt/ntty.h
@@ -10,7 +10,7 @@
 #define OUTQ_SIZE	64	/* tty output queue size*/
 
 #define PTYINQ_SIZE	64	/* pty input queue size*/
-#define PTYOUTQ_SIZE	128	/* pty output queue size*/
+#define PTYOUTQ_SIZE	256	/* pty output queue size*/
 
 #define RSINQ_SIZE	1024	/* serial input queue SLIP_MTU+128+8*/
 #define RSOUTQ_SIZE	64	/* serial output queue size*/

--- a/elkscmd/inet/telnetd/telnetd.c
+++ b/elkscmd/inet/telnetd/telnetd.c
@@ -64,14 +64,28 @@ again:
 			fprintf(stderr, "telnetd: Can't open pty %s\n", pty_name);
 			exit(1);
 		}
-	
-#if 0
+
+		/* set login tty to sane mode, since getty not called*/
+{
 		struct termios termios;
-		/* turn off echo - not needed with telnet ECHO option on*/
 		tcgetattr(tty_fd, &termios);
-		termios.c_lflag &= ~(ECHO);
+
+		termios.c_lflag |= ISIG | ICANON | ECHO | ECHOE;
+		termios.c_lflag &= ~(IEXTEN | ECHOK | NOFLSH | ECHONL);
+		termios.c_iflag |= BRKINT | ICRNL;
+		termios.c_iflag &= ~(IGNBRK | IGNPAR | PARMRK | INPCK | ISTRIP | INLCR | IGNCR | IXON | IXOFF | IXANY);
+		termios.c_oflag |= OPOST | ONLCR;
+		termios.c_oflag &= ~XTABS;
+		termios.c_cflag &= ~PARENB;
+		termios.c_cflag |= CS8 | CREAD | HUPCL;
+		termios.c_cflag |= CLOCAL;			/* ignore modem control lines*/
+		termios.c_cc[VMIN] = 1;
+		termios.c_cc[VTIME] = 0;
+
+		/* turn off echo - not needed with telnet ECHO option on*/
+		//termios.c_lflag &= ~ECHO;
 		tcsetattr(tty_fd, TCSANOW, &termios);
-#endif
+}
 
 		dup2(tty_fd, STDIN_FILENO);
 		dup2(tty_fd, STDOUT_FILENO);


### PR DESCRIPTION
Fixes pause seen sometimes when telnetting into ELKS: when long lines received, sometimes a character must be typed in order to continue receiving program output.
Temporary fix is to increase PTYOUTQ_SIZE from 128 to 256 for now, so process isn't blocked.
Longer term fix is a kernel wakeup issue.

Fixes login problem caused by raw mode when disconnecting from sh without logging out, then reconnecting.
telnetd now sets sane tty settings before exec /bin/login.
