### PR TITLE
[networking] Add /etc/hosts file and gethostbyname

### DIFF
--- a/elks/include/linuxmt/in.h
+++ b/elks/include/linuxmt/in.h
@@ -11,8 +11,8 @@ struct sockaddr_in {
     struct in_addr sin_addr;
 };
 
-#define INADDR_ANY	((unsigned long int) 0x00000000)
-#define PORT_ANY	((unsigned int) 0x0000)
+#define INADDR_ANY	((unsigned long) 0x00000000)
+#define PORT_ANY	((unsigned short) 0x0000)
 #define INADDR_NODE	0xffffffff
 #define INADDR_LOOPBACK	0x7f000001
 

--- a/elkscmd/inet/nettools/.gitignore
+++ b/elkscmd/inet/nettools/.gitignore
@@ -1,2 +1,3 @@
 nslookup
 netstat
+arp

--- a/elkscmd/inet/telnet/Makefile
+++ b/elkscmd/inet/telnet/Makefile
@@ -12,7 +12,7 @@ include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
-SRCS = ttn.c ttn_conf.c
+SRCS = ttn.c ttn_conf.c netlib.c
 OBJS = $(SRCS:.c=.o)
 
 all:	telnet

--- a/elkscmd/inet/telnet/netlib.c
+++ b/elkscmd/inet/telnet/netlib.c
@@ -1,0 +1,101 @@
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <linuxmt/arpa/inet.h>
+#include "netlib.h"
+
+/* ascii to ip address in host byte order*/
+ipaddr_t in_aton(const char *str)
+{
+	unsigned long addr = 0;
+	unsigned int val;
+	int i;
+
+	for (i = 0; i < 4; i++) {
+		addr <<= 8;
+		if (*str) {
+			val = 0;
+			while (*str && *str != '.') {
+				val *= 10;
+				val += *str++ - '0';
+			}
+			addr |= val;
+			if (*str)
+				str++;
+		}
+	}
+	return htonl(addr);
+}
+
+/* ip address to ascii*/
+char *in_ntoa(ipaddr_t in)
+{
+	register unsigned char *p;
+	static char b[18];
+
+	p = (unsigned char *)&in;
+	sprintf(b, "%d.%d.%d.%d", p[0], p[1], p[2], p[3]);
+	return b;
+}
+
+#define HOSTSFILE	"/etc/hosts"
+
+ipaddr_t in_gethostbyname(char *str)
+{
+	char *p, *cp;
+	FILE *fp;
+	ipaddr_t addr = 0;
+	char *name;
+	char buf[80];
+
+	/* very basic check for ip address*/
+	if (*str >= '0' && *str <= '9')
+		return in_aton(str);
+
+	/* handle localhost without opening /etc/hosts*/
+	if (!strcmp(str, "localhost"))
+		return htonl(INADDR_LOOPBACK);
+
+	if ((fp = fopen(HOSTSFILE, "r")) == NULL)
+		return 0;
+
+	while ((p = fgets(buf, sizeof(buf), fp)) != NULL) {
+		if (*p == '#')
+			continue;
+		cp = strpbrk(p, "#\n");
+		if (cp == NULL)
+			continue;
+		*cp = '\0';
+		cp = strpbrk(p, " \t");
+		if (cp == NULL)
+			continue;
+		*cp++ = '\0';
+
+		addr = in_aton(p);
+		while (*cp == ' ' || *cp == '\t')
+			cp++;
+		name = cp;
+		cp = strpbrk(cp, " \t");
+		if (cp != NULL)
+			*cp++ = '\0';
+		//printf("name %s addr %s\n", name, in_ntoa(addr));
+		if (!strcmp(name, str))
+			break;
+		while (cp && *cp) {
+			if (*cp == ' ' || *cp == '\t') {
+				cp++;
+				continue;
+			}
+			name = cp;
+			cp = strpbrk(cp, " \t");
+			if (cp != NULL)
+				*cp++ = '\0';
+			if (!strcmp(name, str))
+				goto out;
+		}
+	}
+out:
+	//if (addr) printf("found %s\n", name);
+	fclose(fp);
+	return addr;
+}

--- a/elkscmd/inet/telnet/netlib.h
+++ b/elkscmd/inet/telnet/netlib.h
@@ -1,0 +1,7 @@
+typedef __u32 ipaddr_t;		/* ip address in network byte order*/
+
+#define INADDR_LOOPBACK	0x7f000001	/* move, from in.h*/
+
+ipaddr_t in_aton(const char *str);
+ipaddr_t in_gethostbyname(char *str);
+char *in_ntoa(ipaddr_t in);

--- a/elkscmd/ktcp/deveth.c
+++ b/elkscmd/ktcp/deveth.c
@@ -64,8 +64,11 @@ void eth_process(void)
 {
   eth_head_t * eth_head;
   int len = read (devfd, sbuf, MAX_PACKET_ETH);
-  if (len < (int)sizeof(eth_head_t))
+  if (len < (int)sizeof(eth_head_t)) {
+	if (len < 0) printf("ktcp: eth_process error %d, discarding packet\n", len); //FIXME
 	return;
+  }
+  if (len > (int)sizeof(sbuf)) { printf("ktcp: eth_process OVERFLOW\n"); exit(1); }
 
   eth_head = (eth_head_t *) sbuf;
 

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -113,13 +113,13 @@ static void tcp_syn_sent(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 
     if (h->flags & (TF_SYN|TF_ACK)) {
 	if (cb->seg_ack != cb->send_una + 1) {
-
+printf("SYN sent, wrong ACK (listen port not expired)\n");
 	    /* Send RST */
 	    cb->send_nxt = h->acknum;
 	    cb->state = TS_CLOSED;	//FIXME not needed
-	    tcp_reset_connection(cb);	/* deallocate*/
+	    //tcp_reset_connection(cb);	/* deallocate*/
 	    //tcp_send_reset(cb);
-	    //tcpcb_remove(cb);
+	    tcpcb_remove(cb);
 	    return;
 	}
 
@@ -134,7 +134,7 @@ static void tcp_syn_sent(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 
 	cb->datalen = 0;
 	tcp_output(cb);
-printf("CONNECT complete\n");
+//printf("CONNECT complete\n");
 	retval_to_sock(cb->sock, 0);
 
 	return;
@@ -391,7 +391,7 @@ debug_tcp("ktcp: update %x,%x\n", cbs_in_time_wait, cbs_in_user_timeout);
 	tcpcb_push_data();
 }
 
-/* called when input on tcpdevfd*/
+/* process an incoming TCP packet*/
 void tcp_process(struct iphdr_s *iph)
 {
     struct iptcp_s iptcp;

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,5 +1,5 @@
 ##
-#console=ttyS0 root=fd0 net=eth 3 # condensed
+#console=ttyS0 net=eth 3 # condensed
 #init=/bin/init 3	# multiuser serial
 #init=/bin/sh		# singleuser shell
 #console=ttyS0		# serial console

--- a/elkscmd/rootfs_template/etc/hosts
+++ b/elkscmd/rootfs_template/etc/hosts
@@ -1,0 +1,3 @@
+#127.0.0.1	localhost
+10.0.2.15	elks elks2
+10.0.2.2	gateway


### PR DESCRIPTION
Add ability to use names specified in /etc/hosts rather than IP addresses in telnet.

Add in_gethostbyname routine, /etc/hosts file.
Aliases supported in /etc/hosts, localhost handled without opening /etc/hosts for speed.
ktcp handles 127.0.0.1 on connects by and substitutes local IP.

Fix stack overflow in ktcp on sequential telnet localhost executions.
The tcp control block remains in the CLOSE_WAIT state after exiting from telnet with ^D. A subsequent telnet connection got an RST packet, which ktcp tried to ACK (incorrect behavior), and then also incorrectly ACKS the ACK, which got ktcp in an infinite loop resulting in stack overflow.
Current quick fix stops RST/ACK behavior, final fix coming.
Temporary workaround is to use "netstat" to check that telnet socket was fully closed before starting another telnet. This usually takes around 10 seconds to timeout.

Adds debugging printfs to ktcp when reading ethernet driver, for better error reporting during development.

The utility network functions in telnet and other network utilities will be moved into libc and the libc and kernel headers reorganized in a subsequent PR, as currently networking applications are including kernel headers.