### PR TITLE
[kernel] Fix compilation when CONFIG_FS_EXTERNAL_BUF not defined

### DIFF
--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -95,8 +95,8 @@ static void put_last_lru(register struct buffer_head *bh)
 
 void buffer_init(void)
 {
-#ifdef CONFIG_FS_EXTERNAL_BUFFER
     struct buffer_head *bh = buffer_heads;
+#ifdef CONFIG_FS_EXTERNAL_BUFFER
     segment_s *seg = 0;		/* init stops compiler warning*/
     int bufs_to_alloc = CONFIG_FS_NR_EXT_BUFFERS;
     int nbufs = 0;
@@ -106,7 +106,7 @@ void buffer_init(void)
 	L1map[--i] = NULL;
     } while (i > 0);
 #else
-	char * p = L1buf;
+    char *p = (char *)L1buf;
 #endif
 
     goto buf_init;

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -499,9 +499,11 @@ extern void ll_rw_blk(int,struct buffer_head *);
 extern void ll_rw_page(void);
 
 // FIXME: duplicates
+#ifdef CONFIG_FS_EXTERNAL_BUFFER
 extern void map_buffer(struct buffer_head *);
 extern void unmap_buffer(struct buffer_head *);
 extern void unmap_brelse(struct buffer_head *);
+#endif
 extern void print_bufmap_status(void);
 
 extern void put_super(kdev_t);


### PR DESCRIPTION
Fixes compilation error noted in #710.

