### PR TITLE
[cmds] Fixes, updates, new commands: uuencode/uudecode

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -72,6 +72,8 @@ file_utils/rm					:fileutil		:360k
 file_utils/rmdir				:fileutil			:720k
 file_utils/sync					:fileutil		:360k
 file_utils/touch				:fileutil			:720k
+file_utils/uuencode				:fileutil			:1440k
+file_utils/uudecode				:fileutil			:1440k
 sys_utils/chmem					:sysutil			:720k
 sys_utils/kill					:sysutil			:720k
 sys_utils/ps					:sysutil		:360k

--- a/elkscmd/file_utils/Makefile
+++ b/elkscmd/file_utils/Makefile
@@ -12,7 +12,7 @@ include $(BASEDIR)/Make.rules
 
 # note: grep doesn't read stdin, replaced with minix1/grep
 PRGS = ln ls mkdir mkfifo mknod more mv rm rmdir sync touch \
-	cat chgrp chmod chown cmp cp dd df grep
+	cat chgrp chmod chown cmp cp dd df grep uuencode uudecode
 
 all: $(PRGS)
 
@@ -78,6 +78,12 @@ sync: sync.o
 
 touch: touch.o
 	$(LD) $(LDFLAGS) -o touch touch.o $(LDLIBS)
+
+uuencode: uuencode.o
+	$(LD) $(LDFLAGS) -o uuencode uuencode.o $(LDLIBS)
+
+uudecode: uudecode.o
+	$(LD) $(LDFLAGS) -o uudecode uudecode.o $(LDLIBS)
 
 install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin

--- a/elkscmd/file_utils/uudecode.c
+++ b/elkscmd/file_utils/uudecode.c
@@ -1,0 +1,168 @@
+/*
+ * uudecode [input]
+ *
+ * create the specified file, decoding as you go.
+ * used with uuencode.
+ * Based on BSD2.9 version, ELKS version by HS/aug/2020
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <pwd.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+/* single character decode */
+#define DEC(c)	(((c) - ' ') & 077)
+
+/*
+ * output a group of 3 bytes (4 input characters).
+ * the input chars are pointed to by p, they are to
+ * be output to file f.  n is used to tell us not to
+ * output all of them at the end of the file.
+ */
+void
+outdec(p, f, n)
+char *p;
+FILE *f;
+{
+	int c1, c2, c3;
+
+	c1 = DEC(*p) << 2 | DEC(p[1]) >> 4;
+	c2 = DEC(p[1]) << 4 | DEC(p[2]) >> 2;
+	c3 = DEC(p[2]) << 6 | DEC(p[3]);
+	if (n >= 1)
+		putc(c1, f);
+	if (n >= 2)
+		putc(c2, f);
+	if (n >= 3)
+		putc(c3, f);
+}
+
+/*
+ * copy from in to out, decoding as you go along.
+ */
+void 
+decode(in, out)
+FILE *in;
+FILE *out;
+{
+	char buf[80];
+	char *bp;
+	int n;
+
+	for (;;) {
+		/* for each input line */
+		if (fgets(buf, sizeof buf, in) == NULL) {
+			printf("Short file\n");
+			exit(10);
+		}
+		n = DEC(buf[0]);
+		if (n <= 0)
+			break;
+
+		bp = &buf[1];
+		while (n > 0) {
+			outdec(bp, out, n);
+			bp += 4;
+			n -= 3;
+		}
+	}
+}
+
+
+/* fr: like read but stdio */
+int
+fr(fd, buf, cnt)
+FILE *fd;
+char *buf;
+int cnt;
+{
+	int c, i;
+
+	for (i=0; i<cnt; i++) {
+		c = getc(fd);
+		if (c == EOF)
+			return(i);
+		buf[i] = c;
+	}
+	return (cnt);
+}
+
+
+main(argc, argv)
+char **argv;
+{
+	FILE *in, *out;
+	int mode;
+	char dest[128];
+	char buf[80];
+
+	/* optional input arg */
+	if (argc > 1) {
+		if ((in = fopen(argv[1], "r")) == NULL) {
+			perror(argv[1]);
+			exit(1);
+		}
+		argv++; argc--;
+	} else
+		in = stdin;
+
+	if (argc != 1) {
+		printf("Usage: uudecode [infile]\n");
+		exit(2);
+	}
+
+	/* search for header line */
+	for (;;) {
+		if (fgets(buf, sizeof buf, in) == NULL) {
+			fprintf(stderr, "No begin line\n");
+			exit(3);
+		}
+		if (strncmp(buf, "begin ", 6) == 0)
+			break;
+	}
+	sscanf(buf, "begin %o %s", &mode, dest);
+
+	/* handle ~user/file format */
+	if (dest[0] == '~') {
+		char *sl;
+		struct passwd *getpwnam();
+		struct passwd *user;
+		char dnbuf[100];
+
+		sl = strchr(dest, '/');
+		if (sl == NULL) {
+			fprintf(stderr, "Illegal ~user\n");
+			exit(3);
+		}
+		*sl++ = 0;
+		user = getpwnam(dest+1);
+		if (user == NULL) {
+			fprintf(stderr, "No such user as %s\n", dest);
+			exit(4);
+		}
+		strcpy(dnbuf, user->pw_dir);
+		strcat(dnbuf, "/");
+		strcat(dnbuf, sl);
+		strcpy(dest, dnbuf);
+	}
+
+	/* create output file */
+	out = fopen(dest, "w");
+	if (out == NULL) {
+		perror(dest);
+		exit(4);
+	}
+	chmod(dest, mode);
+
+	decode(in, out);
+
+	if (fgets(buf, sizeof buf, in) == NULL || strcmp(buf, "end\n")) {
+		fprintf(stderr, "No end line\n");
+		exit(5);
+	}
+	exit(0);
+}
+
+

--- a/elkscmd/file_utils/uuencode.c
+++ b/elkscmd/file_utils/uuencode.c
@@ -1,0 +1,108 @@
+/*
+ * uuencode [input] output
+ *
+ * Encode a file so it can be mailed to a remote system.
+ * Based on BSD2.9 version, ELKS port by HS/aug/2020
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+/* ENC is the basic 1 character encoding function to make a char printing */
+#define ENC(c) (((c) & 077) + ' ')
+
+/*
+ * output one group of 3 bytes, pointed at by p, on file f.
+ */
+void
+outdec(p, f)
+char *p;
+FILE *f;
+{
+	int c1, c2, c3, c4;
+
+	c1 = *p >> 2;
+	c2 = ((*p << 4) & 060) | ((p[1] >> 4) & 017);
+	c3 = ((p[1] << 2) & 074) | ((p[2] >> 6) & 03);
+	c4 = p[2] & 077;
+	putc(ENC(c1), f);
+	putc(ENC(c2), f);
+	putc(ENC(c3), f);
+	putc(ENC(c4), f);
+}
+
+/* fr: like read but stdio */
+int
+fr(FILE *fd, char *buf, int cnt) {
+	int c, i;
+
+	for (i=0; i<cnt; i++) {
+		c = getc(fd);
+		if (c == EOF)
+			return(i);
+		buf[i] = c;
+	}
+	return (cnt);
+}
+
+
+/*
+ * copy from in to out, encoding as you go along.
+ */
+void
+encode(in, out)
+FILE *in;
+FILE *out;
+{
+	char buf[80];
+	int i, n;
+
+	for (;;) {
+		/* 1 (up to) 45 character line */
+		n = fr(in, buf, 45);
+		putc(ENC(n), out);
+
+		for (i=0; i<n; i += 3)
+			outdec(&buf[i], out);
+
+		putc('\n', out);
+		if (n <= 0)
+			break;
+	}
+}
+
+main(argc, argv)
+char **argv;
+{
+	FILE *in;
+	struct stat sbuf;
+	int mode;
+
+	/* optional 1st argument */
+	if (argc > 2) {
+		if ((in = fopen(argv[1], "r")) == NULL) {
+			perror(argv[1]);
+			exit(1);
+		}
+		argv++; argc--;
+	} else
+		in = stdin;
+
+	if (argc != 2) {
+		printf("Usage: uuencode [infile] remotefile\n");
+		exit(2);
+	}
+
+	/* figure out the input file mode */
+	fstat(fileno(in), &sbuf);
+	mode = sbuf.st_mode & 0777;
+	printf("begin %o %s\n", mode, argv[1]);
+
+	encode(in, stdout);
+
+	printf("end\n");
+	exit(0);
+}
+

--- a/elkscmd/inet/nettools/netstat.c
+++ b/elkscmd/inet/nettools/netstat.c
@@ -99,8 +99,8 @@ int main(void)
     printf("ICMP Packets     %7lu  ICMP Packets     %7lu\n", ns->icmprcvcnt, ns->icmpsndcnt);
     printf("SLIP Packets     %7lu  SLIP Packets     %7lu\n", ns->sliprcvcnt, ns->slipsndcnt);
     printf("ETH Packets      %7lu  ETH Packets      %7lu\n", ns->ethrcvcnt, ns->ethsndcnt);
-    printf("ARP Replies (rcv)%7lu  ARP Requests(snd)%7lu\n", ns->arprcvreplycnt, ns->arpsndreqcnt);
-    printf("ARP Requests(rcv)%7lu  ARP Replies (snd)%7lu\n", ns->arprcvreqcnt, ns->arpsndreplycnt);
+    printf("ARP Reqs Sent    %7lu  ARP Replies Rcvd %7lu\n", ns->arpsndreqcnt, ns->arprcvreplycnt);
+    printf("ARP Reqs Rcvd    %7lu  ARP Replies Sent %7lu\n", ns->arprcvreqcnt, ns->arpsndreplycnt);
     printf("ARP Cache Adds   %7lu\n", ns->arpcacheadds);
     printf("\n");
 

--- a/elkscmd/ktcp/icmp.c
+++ b/elkscmd/ktcp/icmp.c
@@ -33,9 +33,11 @@ void icmp_process(struct iphdr_s *iph,unsigned char *packet)
     switch (packet[0]){
     case ICMP_TYPE_ECHO_REQ:
 	len = ntohs(iph->tot_len) - 4 * IP_HLEN(iph);
+#if 0
+	/* for debugging */
 	printf("icmp: PING from %s (len %d id %u seqnum %u)\n",
 	    in_ntoa(iph->saddr), len, ntohs(ep->id), ntohs(ep->seqnum));
-
+#endif
 	ep->type = ICMP_TYPE_ECHO_REPL;
 	ep->code = 0;
 	/* return received id, seqnum and extra data*/

--- a/elkscmd/misc_utils/hd.c
+++ b/elkscmd/misc_utils/hd.c
@@ -57,8 +57,7 @@ printline(long address, int *num, char *chr, int eofflag)
 
    lastaddr = address;
    fprintf(ofd, "%06lx:", address);
-   for (j = 0; j < 16; j++)
-   {
+   for (j = 0; j < 16; j++) {
       if (j == 8)
 	 fputc(' ', ofd);
       if (num[j] >= 0)
@@ -82,13 +81,11 @@ void do_fd(void)
    if (offset)
       fseek(fd, offset, 0);
 
-   for (ch = 0; ch != EOF; offset += 16)
-   {
+   for (ch = 0; ch != EOF; offset += 16) {
       memset(buf, '\0', 16);
       for (j = 0; j < 16; j++)
 	 num[j] = -1;
-      for (j = 0; j < 16; j++)
-      {
+      for (j = 0; j < 16; j++) {
 	 ch = fgetc(fd);
 	 if (ch == EOF)
 	    break;
@@ -99,7 +96,7 @@ void do_fd(void)
 	 else
 	    buf[j] = '.';
       }
-       printline(offset, num, buf, ch == EOF);
+       if (j) printline(offset, num, buf, ch == EOF);
    }
 }
 
@@ -116,8 +113,7 @@ void do_mem(char *spec)
 
    addr = (unsigned char __far *)(((unsigned long)seg << 16) | off);
    offset = (((unsigned long)seg << 4) | off);
-   for ( ; count > 0; count -= 16, offset += 16)
-   {
+   for ( ; count > 0; count -= 16, offset += 16) {
       int j, ch;
       memset(buf, '\0', 16);
       for (j = 0; j < 16; j++)
@@ -201,8 +197,7 @@ int main(int argc, char **argv)
 
    for (ar = 1; ar < argc; ar++)
       if (aflag && argv[ar][0] == '-')
-	 switch (argv[ar][1])
-	 {
+	 switch (argv[ar][1]) {
 	 case 'r': /* Reverse */
 	    reverse = 1;
 	    break;
@@ -214,8 +209,7 @@ int main(int argc, char **argv)
 	    break;
 	 case 'o': /* Output */
 	    if( argv[ar][2] ) outfile = argv[ar]+2;
-	    else
-	    {
+	    else {
 	       if( ++ar >= argc ) usage();
 	       outfile = argv[ar];
 	    }
@@ -223,14 +217,11 @@ int main(int argc, char **argv)
 	 default:
 	    usage();
 	 }
-      else
-      {
-         if( outfile )
-	 {
+      else {
+         if( outfile ) {
 	    if( ofd != stdout ) fclose(ofd);
 	    ofd = fopen(outfile, "w");
-	    if( ofd ==  0 )
-	    {
+	    if( ofd ==  0 ) {
 	       fprintf(stderr, "Cannot open file '%s'\n", outfile);
 	       exit(9);
 	    }
@@ -241,9 +232,8 @@ int main(int argc, char **argv)
 	    fd = fopen(argv[ar], "rb");
 	    if (fd == 0)
 	       fprintf(stderr, "Cannot open file '%s'\n", argv[ar]);
-	    else
-	    {
-	       if( reverse )
+	    else {
+	       if (reverse)
 	          do_rev_fd();
 	       else
 	          do_fd();
@@ -253,8 +243,7 @@ int main(int argc, char **argv)
 	 done = 1;
       }
 
-   if (!done)
-   {
+   if (!done) {
       fd = stdin;
       if( reverse )
          do_rev_fd();

--- a/elkscmd/sh_utils/stty.c
+++ b/elkscmd/sh_utils/stty.c
@@ -23,11 +23,11 @@
 
 /* Default settings, the Minix ones are defined in <termios.h> */
 #ifndef TCTRL_DEF
-#define TCTRL_DEF	(PARENB | CREAD | CS7)
+#define TCTRL_DEF	(CREAD | CS8)
 #endif
 
 #ifndef TSPEED_DEF
-#define TSPEED_DEF	B1200
+#define TSPEED_DEF	B9600
 #endif
 
 #ifndef TINPUT_DEF
@@ -914,6 +914,10 @@ char *opt, *next;
 		termios.c_cc[VMIN]= TMIN_DEF;
 		termios.c_cc[VTIME]= TTIME_DEF;
 	}
+	if (cfgetispeed(&termios) < B1200) // not sane ...
+		cfsetispeed(&termios, TSPEED_DEF);
+	if (cfgetospeed(&termios) < B1200) // not sane ...
+		cfsetospeed(&termios, TSPEED_DEF);
 	return 0;
   }
 


### PR DESCRIPTION
Minor bugfixes & enhancements and a couple of new commands:
- netstat: Changed legend and sequence for arp stats.
- ICMP: commented out debug print.
- hd: hd produces and extra line if the source file size was a multiple of 16, which  - when re-read by hd -r - would add a null byte to the resulting file. So two presumably equivalent files would have different checksums and sizes.
- more: Added a ':1G' command (a la vi) to rewind to the beginning of the file, and some minor visual fixes.
- stty: stty sane would ignore the fact that speed was zero (yes, it happens!). stty will now restore line speed to stty default, which is (now) 9600bps.
- added uuencode/uudecode as aids for transferring binary files in ascii via serial lines.