### PR TITLE
[ktcp] Fix odd length IP/ICMP checksum calcs

### DIFF
--- a/elkscmd/ktcp/icmp.c
+++ b/elkscmd/ktcp/icmp.c
@@ -33,11 +33,9 @@ void icmp_process(struct iphdr_s *iph,unsigned char *packet)
     switch (packet[0]){
     case ICMP_TYPE_ECHO_REQ:
 	len = ntohs(iph->tot_len) - 4 * IP_HLEN(iph);
-#if 0
-	/* for debugging */
-	printf("icmp: PING from %s (len %d id %u seqnum %u)\n",
+	debug_ip("icmp: PING from %s (len %d id %u seqnum %u)\n",
 	    in_ntoa(iph->saddr), len, ntohs(ep->id), ntohs(ep->seqnum));
-#endif
+
 	ep->type = ICMP_TYPE_ECHO_REPL;
 	ep->code = 0;
 	/* return received id, seqnum and extra data*/

--- a/elkscmd/ktcp/ip.c
+++ b/elkscmd/ktcp/ip.c
@@ -38,14 +38,15 @@ int ip_init(void)
 __u16 ip_calc_chksum(char *data, int len)
 {
     __u32 sum = 0;
-    register __u16 *p = (__u16 *) data;
+    __u16 *p = (__u16 *) data;
 
-if (len & 1) printf("ip: chksum on bad length %d\n", len); //FIXME
-    len >>= 1;
+//if (len & 1) printf("ip: chksum on bad length %d\n", len); //FIXME
 
-    do {
+    for (; len > 1 ; len -= 2)
 	sum += *p++;
-    } while (--len > 0);
+
+    if (len == 1)
+	sum += (__u16)(*(__u8 *)p);
 
     while (sum >> 16)
 	sum = (sum & 0xffff) + (sum >> 16);


### PR DESCRIPTION
Fixes ICMP echo reply bad checksum.

@Mellvik, please test that this fixes the wrong icmp checksum reported in https://github.com/jbruchon/elks/pull/720#issuecomment-680071734, thanks!