### PR TITLE
[kernel] Ensure initial stack pointer aligned to even boundary

### DIFF
--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -411,7 +411,8 @@ int sys_execve(char *filename, char *sptr, size_t slen)
     currentp->t_begstack = (base_data	/* Just above the top of stack */
 	? (__pptr)base_data
 	: currentp->t_endseg) - slen;
-    currentp->t_regs.sp = (__u16)(currentp->t_begstack);
+    currentp->t_begstack &= ~1;		/* force even stack pointer and argv/envp*/
+    currentp->t_regs.sp = (__u16)currentp->t_begstack;
     fmemcpyb((byte_t *)currentp->t_begstack, seg_data->base, (byte_t *)sptr, ds, (word_t) slen);
     currentp->t_minstack = stack;
 


### PR DESCRIPTION
Fixes many cases where initial application SP (and args/envp arrays) were set to non-even addresses, which would cause applications to run slowly, by using two memory cycles for every stack pointer fetch on non-8088 CPUs!!

Surmised by @tkchia in https://github.com/jbruchon/elks/pull/717#issuecomment-679139164, and fixed in this PR.
Thanks @tkchia!

Checked all cases of argv/envp allocations for compatibility. The kernel will now accept an unaligned argv/envp "blob" from any address (although all passed are currently even), but always place the argv/envp blob and the initial stack pointer on an even address. The boundary and SP were previously set to an odd address when the argv/envp length was non-even.