### PR TITLE
[nano-X] Fix stack overflow in nxworld

### DIFF
--- a/elkscmd/nano-X/demos/world.c
+++ b/elkscmd/nano-X/demos/world.c
@@ -516,7 +516,7 @@ load(fn)
 	GR_COLOR	newcolor;
 	int		n;
 	int		fh;
-	DBPOINT		p[PCount];
+	static DBPOINT		p[PCount];	/* static to avoid large stack usage*/
 
 	LonPrv = ITOF(0);
 	LatPrv = ITOF(0);


### PR DESCRIPTION
Fixes stack overflow into unused heap in nxworld. Default application stack allocation is 2K.

Reported by @toncho11 in https://github.com/jbruchon/elks/issues/718#issuecomment-680292821.
Thanks @toncho11!
