### PR TITLE
[kernel] Allow MBR CHS data to deviate from CMOS data (#730)

### DIFF
--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -72,12 +72,14 @@ static void add_partition(struct gendisk *hd, unsigned short int minor,
      * A CHS cylinder can have 63 max sectors * 255 heads, so adjust for that.
      */
     sector_t adj_nr_sects = hd0->nr_sects + 63 * 255;
+#if 0	/* partition skipping disabled as virtual cylinder values sometimes needed for CF cards*/
     if (start > adj_nr_sects || start+size > adj_nr_sects) {
 	printk("skipped ");
 	hdp->start_sect = -1;
 	hdp->nr_sects = 0;
 	return;
     }
+#endif
 
     /*
      * Save boot partition # based on start offset.  This is needed if

--- a/elkscmd/rootfs_template/etc/passwd
+++ b/elkscmd/rootfs_template/etc/passwd
@@ -13,6 +13,7 @@ uucp:*:10:14:UUCP Daemon:/var/spool/uucp:
 operator:*:11:0:Operator:/root:/bin/sash
 man:*:13:15:Manual pages:/usr/man:
 ftp:*:14:50:FTP User:/home/ftp:/bin/sash
+tty::15:0:tty command:/home:/bin/tty
 postmaster:*:14:12:Postmaster:/var/spool/mail:/bin/sash
 nobody:*:99:99:Nobody:/tmp:
 user1::501:501:User 1:/home:/bin/sh


### PR DESCRIPTION
- Remove 'sanity check' on partition tables to allow real disk capacity to deviate from BIOS CHS data. Allows CF disks to be fully utilized on old systems with a fixed set of BIOS-supported disk drives. This closes #730.

- Also add user 'tty' to /etc/password - which executes /bin/tty and exits.

This fix for #730 brings up a followup issue: Now /dev/bda and (say) /dev/bda1 mismatch, and /dev/bda is no longer a useable access point for the entire disk drive. Would it not make sense to update the date for the 'master' device when detecting new data in the MBR?