### PR TITLE
[mkfs/fsck] Fix fsck to work on ELKS, mkfs MAXSIZE fix

### DIFF
--- a/elks/tools/mfs/super.c
+++ b/elks/tools/mfs/super.c
@@ -78,7 +78,8 @@ struct minix_fs_dat *new_fs(const char *fn,int magic,unsigned long fsize,int ino
   else
     fs->msb.s_nzones = fsize;
   fs->msb.s_state = MINIX_VALID_FS;
-  fs->msb.s_max_size = VERSION_2(fs) ? 0x7fffffff : (7+512+512*512) * 1024;
+  /* v1 volume limit is 7+512+512*512, but limit max_size to blocks in fs*/
+  fs->msb.s_max_size = VERSION_2(fs) ? 0x7fffffff : fsize * 1024;
   fs->msb.s_log_zone_size = 0;		/* zone size is always BLOCK_SIZE*/
 
   /* Manage inodes */

--- a/elkscmd/disk_utils/mkfs.c
+++ b/elkscmd/disk_utils/mkfs.c
@@ -84,7 +84,7 @@ static int dirsize = 16;
 static int magic = MINIX_SUPER_MAGIC;
 static unsigned int ikl;
 
-static char root_block[BLOCK_SIZE] = "\0";
+static char root_block[BLOCK_SIZE];
 
 static char * inode_buffer = NULL;
 #define Inode (((struct minix_inode *) inode_buffer)-1)
@@ -237,7 +237,8 @@ void setup_tables(void)
 	memset(super_block_buffer,0,BLOCK_SIZE);
 	MAGIC = magic;
 	ZONESIZE = 0;
-	MAXSIZE = (7+512+512L*512L)*1024L;
+	/* volume limit is 7+512+512L*512L but set max_size to blocks in fs*/
+	MAXSIZE = BLOCKS*1024L;
 	ZONES = BLOCKS;
 	INODES = BLOCKS/3;
 	if ( BLOCKS > 32768L ) INODES += (BLOCKS-32768)*4/3;


### PR DESCRIPTION
Fix major fsck bug with inodes >= 32.
Run "fsck -fsv /dev/name" for maximum information and to force check on dirty filesystems.

Various fsck display cleanups.
mkfs/mfs: set MINIX superblock max_size to blocks \* 1024, fixes issue described in #731.
