### PR TITLE
[fsck] Cleanup display output, add -vv option for max verbose

### DIFF
--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -71,8 +71,8 @@ static void add_partition(struct gendisk *hd, unsigned short int minor,
      * Some BIOS subtract a cylinder, making direct comparison incorrect.
      * A CHS cylinder can have 63 max sectors * 255 heads, so adjust for that.
      */
-    sector_t adj_nr_sects = hd0->nr_sects + 63 * 255;
 #if 0	/* partition skipping disabled as virtual cylinder values sometimes needed for CF cards*/
+    sector_t adj_nr_sects = hd0->nr_sects + 63 * 255;
     if (start > adj_nr_sects || start+size > adj_nr_sects) {
 	printk("skipped ");
 	hdp->start_sect = -1;

--- a/elkscmd/disk_utils/fsck.c
+++ b/elkscmd/disk_utils/fsck.c
@@ -565,7 +565,7 @@ void read_tables(void)
 		printf("Pre-zone blocks 2+%d+%d+%d %d\n", IMAPS, ZMAPS, INODE_BLOCKS, NORM_FIRSTZONE);
 		printf("Firstdatazone=%d (%d)\n",FIRSTZONE,NORM_FIRSTZONE);
 		printf("Zonesize=%d\n",BLOCK_SIZE<<ZONESIZE);
-		printf("Maxsize=%ld\n",MAXSIZE);
+		printf("Maxsize=%ld bytes\n",MAXSIZE);
 		printf("Filesystem state=%d\n", SupeP->s_state);
 		printf("namelen=14\n\n"); /* RUBOUT */
 	}
@@ -628,7 +628,7 @@ void check_root(void)
 
 	if (!inode || !S_ISDIR(inode->i_mode))
 		die("root inode isn't a directory");
-	printf("Root inode is a directory.\n");
+	printd("Root inode is a directory.\n");
 }
 
 static int add_zone(unsigned short * znr, int * corrected)
@@ -768,8 +768,10 @@ void check_file(struct minix_inode * dir, unsigned long offset)
 	if (name_depth < MAX_DEPTH)
 		strncpy(name_list[name_depth],name,NAMELEN);
 	name_depth++;
-	print_current_name();
-	inode_dump(inode);
+	if (verbose > 1) {
+		print_current_name();
+		inode_dump(inode);
+	}
 	if (list) {
 		if (verbose)
 			printf("%6d %07o %3d ",ino,inode->i_mode,inode->i_nlinks);
@@ -880,8 +882,10 @@ void check(void)
 	memset(inode_count,0,INODES*sizeof(*inode_count));
 	memset(zone_count,0,ZONES*sizeof(*zone_count));
 	check_zones(ROOT_INO);
-	printf("/");
-	inode_dump(map_inode(ROOT_INO));
+	if (verbose > 1) {
+		printf("/");
+		inode_dump(map_inode(ROOT_INO));
+	}
 	recursive_check(ROOT_INO);
 	check_counts();
 }
@@ -909,7 +913,7 @@ int main(int argc, char ** argv)
 				case 'l': list=1; break;
 				case 'a': automatic=1; repair=1; break;
 				case 'r': automatic=0; repair=1; break;
-				case 'v': verbose=1; break;
+				case 'v': verbose++; break;
 				case 's': show=1; break;
 				case 'm': warn_mode=1; break;
 				case 'f': force=1; break;
@@ -929,6 +933,7 @@ int main(int argc, char ** argv)
 	IN = open(device_name,repair?O_RDWR:O_RDONLY);
 	if (IN < 0)
 		die("unable to open '%s'");
+	printf("%s %s\n", program_name, program_version);
 	for (count=0 ; count<3 ; count++)
 		sync();
 	read_tables();
@@ -939,7 +944,6 @@ int main(int argc, char ** argv)
 	 * flags and whether or not the -f switch was specified on the
 	 * command line.
 	 */
-	printf("%s, %s\n", program_name, program_version);
 	if (!(SupeP->s_state & MINIX_ERROR_FS) &&
 	      (SupeP->s_state & MINIX_VALID_FS) &&
 	      !force) {

--- a/elkscmd/disk_utils/fsck.c
+++ b/elkscmd/disk_utils/fsck.c
@@ -771,10 +771,9 @@ void check_file(struct minix_inode * dir, unsigned long offset)
 	if (verbose > 1) {
 		print_current_name();
 		inode_dump(inode);
-	}
-	if (list) {
+	} else if (list) {
 		if (verbose)
-			printf("%6d %07o %3d ",ino,inode->i_mode,inode->i_nlinks);
+			printf("%6d %06o %3d ",ino,inode->i_mode,inode->i_nlinks);
 		print_current_name();
 		if (S_ISDIR(inode->i_mode))
 			printf(":\n");


### PR DESCRIPTION
Adds display fixes discussed in #731.

Use `fsck -s` to show superblock information.
Use `fsck -v` to show inodes and zones used.
Use `fsck -vv` to show full inode data.
Use `fsck -l` to list filenames.
Use `fsck -lv` to list inode number, filename and mode.


Also fixes compiler warning in genhd.c.

Use `fsck -r` to repair filesystem interactively (untested, needs testing).
Use `fsck -a` to automatically repair filesystem (untested, needs testing).