### PR TITLE
[kernel] Fix to allow booting read-only root filesystem

### DIFF
--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -59,7 +59,6 @@ static void print_minor_name(register struct gendisk *hd,
 static void add_partition(struct gendisk *hd, unsigned short int minor,
 			  sector_t start, sector_t size)
 {
-    struct hd_struct *hd0 = &hd->part[0];
     struct hd_struct *hdp = &hd->part[minor];
 
     hdp->start_sect = start;
@@ -72,6 +71,7 @@ static void add_partition(struct gendisk *hd, unsigned short int minor,
      * A CHS cylinder can have 63 max sectors * 255 heads, so adjust for that.
      */
 #if 0	/* partition skipping disabled as virtual cylinder values sometimes needed for CF cards*/
+    struct hd_struct *hd0 = &hd->part[0];
     sector_t adj_nr_sects = hd0->nr_sects + 63 * 255;
     if (start > adj_nr_sects || start+size > adj_nr_sects) {
 	printk("skipped ");

--- a/elks/fs/namei.c
+++ b/elks/fs/namei.c
@@ -37,7 +37,8 @@ int permission(register struct inode *inode, int mask)
     __u16 mode = inode->i_mode;
     int error = -EACCES;
 
-    if ((mask & MAY_WRITE) && (IS_RDONLY(inode)))
+    if ((mask & MAY_WRITE) && IS_RDONLY(inode) &&
+        !S_ISCHR(inode->i_mode) && !S_ISBLK(inode->i_mode)) /* allow writable devices*/
 	error = -EROFS;
 
 #ifdef BLOAT_FS

--- a/elkscmd/sys_utils/login.c
+++ b/elkscmd/sys_utils/login.c
@@ -46,7 +46,7 @@ void login(register struct passwd * pwd, struct utmp * ut_ent)
 	environ = renv;
 
 
-	if (fchown(0,pwd->pw_uid,pwd->pw_gid)<0) perror("fchown");
+	if (fchown(0,pwd->pw_uid,pwd->pw_gid)<0) perror("login (chown)");
 #ifdef USE_UTMP
 	ut_ent->ut_type = USER_PROCESS;
 	strncpy(ut_ent->ut_user, pwd->pw_name, UT_NAMESIZE);


### PR DESCRIPTION
This allows setting "ro" in /bootopts to boot the root filesystem read-only.

Requested for testing in #464.

The reason the read-only boot was failing is that all character device write access was being denied, which disallowed /bin/getty to open the login ports from /bin/init. The system was running but no way access it.

This fix allows read-only filesystems read/write access to character devices, as well as to block devices (which would be required for fsck to run and repair a filesystem).

Enhanced an error message by /bin/login when failing to chown home directory on read-only filesystems.

Also fixes another compiler warning in genhd.c.