### PR TITLE
[kernel] Implement read-only and read-write remounts on filesystems

### DIFF
--- a/elks/arch/i86/kernel/syscall.dat
+++ b/elks/arch/i86/kernel/syscall.dat
@@ -39,7 +39,7 @@ brk		+17	1	* This is only to tell the system
 stat		+18	2	 
 lseek		+19	3	* nb 2nd arg is an io ptr to long not a long.
 getpid		+20	1	* this gets both pid & ppid
-mount		+21	5	 
+mount		+21	4	 
 umount		+22	1	 
 setuid		+23	1	 
 getuid		+24	1	* this gets both uid and euid

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -395,11 +395,6 @@ struct super_operations {
 struct file_system_type {
     struct super_block		*(*read_super) ();
     char			*name;
-
-#ifdef BLOAT_FS
-    int 			requires_dev;
-#endif
-
 };
 
 extern int event;		/* Event counter */

--- a/libc/include/sys/mount.h
+++ b/libc/include/sys/mount.h
@@ -1,5 +1,12 @@
 /* sys/mount.h*/
 
+#define MS_RDONLY	    1	/* mount read-only */
+#define MS_NOSUID	    2	/* ignore suid and sgid bits */
+#define MS_NODEV	    4	/* disallow access to device special files */
+#define MS_NOEXEC	    8	/* disallow program execution */
+#define MS_SYNCHRONOUS	   16	/* writes are synced at once */
+#define MS_REMOUNT	   32	/* alter flags of a mounted FS */
+
 int mount(const char *dev, const char *dir, const char *type, int flags);
 int umount(const char *dir);
 


### PR DESCRIPTION
Implements new mount option to allow root and other filesystems to be remounted while running.

Add mount -o option:
```
mount -o ro /dev/fd1 /mnt                      Mounts filesystem read-only.
mount -o remount,ro /dev/fd0 /                 Remounts root filesystem read-only (or use 'umount /').
mount -o remount,rw /dev/fd0 /                 Remounts root filesystem read-write.
```
Fixes issues in #464 requiring root filesystem to be remounted read-only to run fsck, then remounted read-only afterwards.