### PR TITLE
[kernel] Use number rather than string for mount(2) system call fs type

### DIFF
--- a/elks/fs/minix/inode.c
+++ b/elks/fs/minix/inode.c
@@ -475,11 +475,8 @@ int minix_sync_inode(register struct inode *inode)
 #endif
 
 struct file_system_type minix_fs_type = {
-#ifdef BLOAT_FS
-    minix_read_super, "minix", 1
-#else
-    minix_read_super, "minix"
-#endif
+    minix_read_super,
+	FST_MINIX
 };
 
 int init_minix_fs(void)

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -335,10 +335,8 @@ void msdos_write_inode(register struct inode *inode)
 }
 
 struct file_system_type msdos_fs_type = {
-	msdos_read_super, "msdos"
-#ifdef BLOAT_FS
-	,1
-#endif
+	msdos_read_super,
+	FST_MSDOS
 };
 
 int init_msdos_fs(void)

--- a/elks/fs/romfs/romfs.c
+++ b/elks/fs/romfs/romfs.c
@@ -394,11 +394,7 @@ static struct super_block * romfs_read_super (struct super_block * s, void * dat
 }
 
 
-struct file_system_type romfs_fs_type =
-	{
+struct file_system_type romfs_fs_type = {
 	romfs_read_super,
-	"romfs"
-#ifdef BLOAT_FS
-	,1  /* device required ? not really ! */
-#endif
-	};
+	FST_ROMFS
+};

--- a/elks/fs/super.c
+++ b/elks/fs/super.c
@@ -46,6 +46,7 @@ extern struct file_system_type msdos_fs_type;
 #endif
 
 static struct file_system_type *file_systems[] = {
+/* first filesystem is default filesystem for mount w/o -t parm*/
 #ifdef CONFIG_MINIX_FS
 	&minix_fs_type,
 #endif

--- a/elkscmd/sys_utils/mount.c
+++ b/elkscmd/sys_utils/mount.c
@@ -16,7 +16,7 @@
 int main(int argc, char **argv)
 {
 	char	*str;
-	char	*type = "minix";
+	int		type = FST_MINIX;
 	int		flags = 0;
 	char	*option;
 
@@ -34,7 +34,13 @@ int main(int argc, char **argv)
 					return 1;
 				}
 
-				type = *argv++;
+				option = *argv++;
+				if (!strcmp(option, "minix"))
+					type = FST_MINIX;
+				else if (!strcmp(option, "msdos") || !strcmp(option, "fat"))
+					type = FST_MSDOS;
+				else if (!strcmp(option, "romfs"))
+					type = FST_ROMFS;
 				argc--;
 				break;
 

--- a/elkscmd/sys_utils/mount.c
+++ b/elkscmd/sys_utils/mount.c
@@ -16,7 +16,7 @@
 int main(int argc, char **argv)
 {
 	char	*str;
-	int		type = FST_MINIX;
+	int		type = 0;		/* default fs*/
 	int		flags = 0;
 	char	*option;
 

--- a/libc/include/sys/mount.h
+++ b/libc/include/sys/mount.h
@@ -1,5 +1,11 @@
 /* sys/mount.h*/
 
+/* filesystem types*/
+#define FST_MINIX	1
+#define FST_MSDOS	2
+#define FST_ROMFS	3
+
+/* filesystem mount flags*/
 #define MS_RDONLY	    1	/* mount read-only */
 #define MS_NOSUID	    2	/* ignore suid and sgid bits */
 #define MS_NODEV	    4	/* disallow access to device special files */
@@ -7,7 +13,7 @@
 #define MS_SYNCHRONOUS	   16	/* writes are synced at once */
 #define MS_REMOUNT	   32	/* alter flags of a mounted FS */
 
-int mount(const char *dev, const char *dir, const char *type, int flags);
+int mount(const char *dev, const char *dir, int type, int flags);
 int umount(const char *dir);
 
 int reboot(int magic1, int magic2, int magic3);


### PR DESCRIPTION
Moves mount -t types from kernel into mount command.
Cleans up kernel filesystem structures, reduces kernel code.

Allows `mount -t fat ...` as synonym for `mount -t msdos ...`.
