### PR TITLE
[kernel/fsck] Fix various fsck, signal and shutdown bugs`

### DIFF
--- a/elks/arch/i86/kernel/signal.c
+++ b/elks/arch/i86/kernel/signal.c
@@ -42,7 +42,7 @@ int do_signal(void)
 	if (*sd == SIGDISP_DFL) {			/* Default */
 	    if ((mask &					/* Default Ignore */
 			(SM_SIGCONT | SM_SIGCHLD | SM_SIGWINCH | SM_SIGURG))
-			|| (currentp->pid == 1))
+		|| (currentp->pid == 1 && signr != SIGKILL))
 		continue;
 	    else if (mask &				/* Default Stop */
 			(SM_SIGSTOP | SM_SIGTSTP | SM_SIGTTIN | SM_SIGTTOU)) {

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -155,7 +155,7 @@ int sys_execve(char *filename, char *sptr, size_t slen)
     currentp = &task[0];
     do {
 	if ((currentp->state <= TASK_STOPPED) && (currentp->t_inode == inode)) {
-	    debug_wait("EXEC found copy\n");
+	    debug("EXEC found copy\n");
 	    seg_code = currentp->mm.seg_code;
 	    break;
 	}

--- a/elks/fs/namei.c
+++ b/elks/fs/namei.c
@@ -400,7 +400,9 @@ int open_namei(char *pathname, int flag, int mode,
 
 int do_mknod(char *pathname, int offst, int mode, dev_t dev)
 {
-#ifndef CONFIG_FS_RO
+#ifdef CONFIG_FS_RO
+    return -EROFS;
+#else
     register struct inode *dirp;
     register struct inode_operations *iop;
     struct inode *dir;

--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -26,7 +26,7 @@ int sys_wait4(pid_t pid, int *status, int options)
 	/* reparent orphan zombies to init*/
 	orphans = 0;
 	for_each_task(p) {
-		if (p->state == TASK_ZOMBIE) {
+		if (p->state == TASK_ZOMBIE && p->p_parent) {
 			debug_wait("Zombie pid %d ppid %d\n", p->pid, p->p_parent->pid);
 			if (p->p_parent->state == TASK_UNUSED) {
 				debug_wait("WAIT(%d) reparenting %d to 1\n", current->pid, p->pid);

--- a/elks/kernel/sys.c
+++ b/elks/kernel/sys.c
@@ -47,27 +47,26 @@ extern int sys_kill(sig_t,pid_t);
 
 int sys_reboot(unsigned int magic, unsigned int magic_too, int flag)
 {
-    if (!suser()) {
+    if (!suser())
 	return -EPERM;
-    }
 
-    if ((magic == 0x1D1E) && (magic_too == 0xC0DE)) {
-	register int *pflag = (int *)flag;
-
-	switch((int)pflag) {
+    if (magic == 0x1D1E && magic_too == 0xC0DE) {
+	switch(flag) {
 	    case 0x4567:
-		pflag = (int *)1;
+		flag = 1;
+		/* fall through*/
 	    case 0:
-		C_A_D = (int)pflag;
+		C_A_D = flag;
 		return 0;
-	    case 0x0123:
+	    case 0x0123:		/* reboot*/
 		hard_reset_now();
-	    case 0x6789:
-		printk("System halted\n");
+	    case 0x6789:		/* shutdown*/
+		sys_kill(1, SIGKILL);
 		sys_kill(-1, SIGKILL);
+		printk("System halting\n");
 		do_exit(0);
 #ifdef CONFIG_APM
-	    case 0xDEAD:
+	    case 0xDEAD:		/* poweroff*/
 		apm_shutdown_now();
 		printk("APM shutdown failed\n");
 #endif

--- a/elkscmd/disk_utils/Makefile
+++ b/elkscmd/disk_utils/Makefile
@@ -23,7 +23,7 @@ install: all
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 fsck: fsck.o
-	$(LD) $(LDFLAGS) -o fsck fsck.o $(LDLIBS)
+	$(LD) $(LDFLAGS) -o fsck -maout-heap=0xffff fsck.o $(LDLIBS)
 
 fdisk: fdisk.o
 	$(LD) $(LDFLAGS) -o fdisk fdisk.o $(LDLIBS)

--- a/elkscmd/file_utils/touch.c
+++ b/elkscmd/file_utils/touch.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -9,8 +10,8 @@
 int main(int argc, char **argv)
 {
 	int i, ncreate = 0;
+	int err = 0;
 	struct stat sbuf;
-	int er = 0;
 
 	if (argc < 2) {
 		write(STDERR_FILENO, "usage: touch file1 [file2] [file3] ...\n", 39);
@@ -22,11 +23,15 @@ int main(int argc, char **argv)
 	for (i = ncreate + 1; i < argc; i++) {
 		if (argv[i][0] != '-') {
 			if (stat(argv[i], &sbuf)) {
-				if (!ncreate)
-					er = close(creat(argv[i], 0666));
+				if (!ncreate) {
+					int fd = creat(argv[i], 0666);
+					if (fd < 0)
+						perror("touch"), err = 1;
+					else close(fd);
+				}
 			} else
-				er = utime(argv[i], NULL);
+				err |= utime(argv[i], NULL);
 		}
 	}
-	return (er ? 0 : 1);
+	return (err ? 1 : 0);
 }

--- a/image/Makefile
+++ b/image/Makefile
@@ -33,7 +33,7 @@ images-minix: fd360-minix fd720-minix fd1440-minix fd2880-minix hd32-minix
 
 images-fat: fd360-fat fd720-fat fd1440-fat fd2880-fat hd32-fat hd32mbr-fat
 
-images-mbr: hd32mbr-minix
+images-mbr: hd32-minix hd32mbr-minix
 
 fd360-minix:
 	echo CONFIG_APPS_360K=y		> Config


### PR DESCRIPTION
Fixes numerous problems reported in https://github.com/jbruchon/elks/issues/464#issuecomment-687169899.

Fix major fsck memory corruption on large disks, zmap buffer too small
Increase fsck heap to max for large disk zone maps
Cleanup fsck compiler warnings
Fix wait4 reparenting bug on zombie w/no parent (/bin/init)
Allow sending pid 1 SIGKILL signal
Fix shutdown to kill init process
 Fix touch to report create error (unless -c given)
