### PR TITLE
[boot] Set ROOTDEV= environment variable at boot for rc.sys fsck

### DIFF
--- a/elkscmd/rootfs_template/etc/rc.d/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sys
@@ -8,6 +8,23 @@ export PATH=/bin
 # init date from hardware
 clock -s
 
+check_filesystem()
+{
+	if test "$ROOTDEV" != ""
+	then
+		echo -n "Checking $ROOTDEV... "
+		umount /
+		fsck $ROOTDEV
+		mount -o remount,rw $ROOTDEV /
+	fi
+}
+
+if test "$ROOTDEV" != "/dev/fd0" -a "$ROOTDEV" != "/dev/fd1"
+then
+#	uncomment next line to check minix HD filesystem, will fail on msdos fat
+#	check_filesystem
+fi
+
 #
 # start networking
 #


### PR DESCRIPTION
Implements ability to optionally run fsck on root filesystem at boot time, finalizes enhancement request #464.

The etc/rc.d/rc.sys script is now supplied with a ROOTDEV= environment variable name of the root filesystem, which can then be used to verify integrity checking with `fsck`. Requires CONFIG_BOOTOPTS to be configured, although no /bootopts file or boot options are necessary.

I finally figured a way to get the root device name available to a shell script at system startup and am using the bootopts environment variable mechanism to pass ROOTDEV=/dev/fd0 (or whatever) to the rc.sys script, which has been enhanced to call a function "check_filesystem":
```
check_filesystem()
{
    if test "$ROOTDEV" != ""
    then
        echo -n "Checking $ROOTDEV... "
        umount /
        fsck $ROOTDEV
        mount -o remount,rw $ROOTDEV /
    fi
}

if test "$ROOTDEV" != "/dev/fd0" -a "$ROOTDEV" != "/dev/fd1"
then
#   uncomment next line to check minix HD filesystem, will fail on msdos fat
#   check_filesystem
fi
```
Currently the automatic check_filesystem is commented out, as it won't work when booting MSDOS filesystems. As can be seen, it is also set to skip running on floppy boots.

The fsck itself does not try to repair the filesystem, I'll leave that to individual user setups to turn on and test or run with -r or -a options.



