### PR TITLE
[hd driver] Added IDE drive identity query to get more reliable CHS data.

### DIFF
--- a/elks/arch/i86/drivers/block/Makefile
+++ b/elks/arch/i86/drivers/block/Makefile
@@ -37,7 +37,7 @@ OBJS  = init.o genhd.o ll_rw_blk.o rd.o
 
 # BIOS floppy and hard drive support
 ifeq ($(CONFIG_BLK_DEV_BIOS), y)
-OBJS += bioshd.o
+OBJS += bioshd.o idequery.o
 endif
 
 ifeq ($(CONFIG_ROMFS_FS), y)

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -175,7 +175,7 @@ static unsigned short int bioshd_gethdinfo(void) {
 	if (arch_cpu > 5) {	/* Do this only if AT or higher */
 	    if (!get_ide_data(drive, drivep)) {	/* get CHS from the drive itself */
 		/* sanity checks already done, accepting data */
-	    	printk("bioshd: bd%c IDEdata CHS %d,%d,%d\n", 'a'+drive, drivep->cylinders,
+		printk("bioshd: bd%c IDE CHS %d,%d,%d\n", 'a'+drive, drivep->cylinders,
 		drivep->heads, drivep->sectors);
 	    }
 	}

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -130,7 +130,6 @@ static int bioshd_ioctl(struct inode *, struct file *, unsigned int, unsigned in
 static int bioshd_open(struct inode *, struct file *);
 static void bioshd_release(struct inode *, struct file *);
 static void bioshd_geninit(void);
-extern int get_ide_data(int, struct drive_infot *); 
 
 static struct gendisk bioshd_gendisk = {
     MAJOR_NR,			/* Major number */

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -46,7 +46,6 @@
 #include <arch/segment.h>
 #include <arch/system.h>
 #include <arch/irq.h>
-#include <linuxmt/heap.h>
 
 /* the following must match with /dev minor numbering scheme*/
 #define NUM_MINOR	32	/* max minor devices per drive*/
@@ -57,20 +56,7 @@
 
 #define MAJOR_NR BIOSHD_MAJOR
 #define BIOSDISK
-#define HD1_PORT	0x1f0	/* Port address, first controller [IDE] */
-#define HD2_PORT	0x170	/* Port address, first controller [IDE] */
-#define IDE_DRIVE_ID	0xec	/* IDE command to get access to drive data */
-#define IDE_STATUS	7	/* get drive status */
-#define IDE_ERROR	1
-
 #define IDE_PROBE_ENABLE	/* enable CHS priobing via the disk IDE interface */
-#define IDE_DEBUG	0	/* IDE probe debugging */
-
-/* For IDE/ATA access */
-#define STATUS(port) inb_p(port + IDE_STATUS)
-#define ERROR(port) inb_p(port + IDE_ERROR)
-
-#define WAITING(port) (STATUS(port) & 0x80) == 0x80
 
 #include "blk.h"
 
@@ -90,8 +76,6 @@ struct elks_boot_sect {
 } __attribute__((packed));
 
 static int bioshd_initialized = 0;
-static int io_ports[2] = { HD1_PORT, HD2_PORT };	/* physical port addresses */
-
 static struct biosparms bdt;
 
 /* Useful defines for accessing the above structure. */
@@ -146,7 +130,7 @@ static int bioshd_ioctl(struct inode *, struct file *, unsigned int, unsigned in
 static int bioshd_open(struct inode *, struct file *);
 static void bioshd_release(struct inode *, struct file *);
 static void bioshd_geninit(void);
-static int get_ide_data(word_t port, struct drive_infot *); 
+extern int get_ide_data(int, struct drive_infot *); 
 
 static struct gendisk bioshd_gendisk = {
     MAJOR_NR,			/* Major number */
@@ -168,8 +152,7 @@ static struct gendisk bioshd_gendisk = {
 
 #ifdef CONFIG_BLK_DEV_BHD
 
-static unsigned short int bioshd_gethdinfo(void)
-{
+static unsigned short int bioshd_gethdinfo(void) {
     unsigned short int ndrives = 0;
     int drive;
     register struct drive_infot *drivep = &drive_info[0];
@@ -178,6 +161,7 @@ static unsigned short int bioshd_gethdinfo(void)
     BD_DX = 0x80;
     BD_ES = BD_SI = 0;	/* some buggy BIOS's need this acoording to INT13 on Wiki*/
     ndrives = (call_bios(&bdt) ? 0 : BD_DX & 0xff);
+
     if (ndrives > NUM_DRIVES/2)
 	ndrives = NUM_DRIVES/2;
     for (drive = 0; drive < ndrives; drive++) {
@@ -195,14 +179,11 @@ static unsigned short int bioshd_gethdinfo(void)
 	}
 #ifdef IDE_PROBE_ENABLE
 	if (arch_cpu > 5) {	/* Do this only if AT or higher */
-		struct drive_infot ide_data;
-		if (!get_ide_data(drive, &ide_data)) {	/* get CHS from the drive itself */
-	    		printk("bioshd: bd%c IDEdata CHS %d,%d,%d\n", 'a'+drive, ide_data.cylinders,
-			ide_data.heads, ide_data.sectors);
-			/* sanity checks already done - using IDE data */
-			drivep->cylinders = ide_data.cylinders;
-			drivep->heads = ide_data.heads;
-			drivep->sectors = ide_data.sectors;
+
+		if (!get_ide_data(drive, drivep)) {	/* get CHS from the drive itself */
+			/* sanity checks already done, accepting data */
+	    		printk("bioshd: bd%c IDEdata CHS %d,%d,%d\n", 'a'+drive, drivep->cylinders,
+			drivep->heads, drivep->sectors);
 		}
 	}
 #endif
@@ -916,113 +897,3 @@ kdev_t bioshd_conv_bios_drive(unsigned int biosdrive)
 
     return MKDEV(BIOSHD_MAJOR, (minor << MINOR_SHIFT) + partition);
 }
-
-#ifdef IDE_PROBE_ENABLE
-/*
- * Query the IDE/ATA drive for physical data
- * Added by HS - sep-2020
- *
- * ELKS: ported from directhd.c 
- */
-
-void insw(word_t port, word_t *buffer, int count) {
-    int i;
-
-    for (i = 0; i < count / 2; i++)
-	buffer[i] = inw(port);
-    return;
-}
-
-void out_hd(word_t drive, word_t nsect, word_t sect,
-	    word_t head, word_t cyl, word_t cmd)
-{
-    word_t port;
-
-    port = io_ports[drive / 2];
-
-    outb(0xff, ++port);		/* the supposedly correct value for WPCOM on IDE */
-    outb_p(nsect, ++port);
-    outb_p(sect, ++port);
-    outb_p(cyl, ++port);
-    outb_p(cyl >> 8, ++port);
-    outb_p(0xA0 | ((drive % 2) << 4) | head, ++port);
-    outb_p(cmd, ++port);
-
-    return;
-}
-
-static int get_ide_data(word_t drive, struct drive_infot *drive_info) {
-
-	int port;
-	word_t *ide_buffer = (word_t *)heap_alloc(512, 0);
-
-	/* send drive_ID command to drive */
-	port = io_ports[drive / 2];
-	out_hd(drive, 0, 0, 0, 0, IDE_DRIVE_ID);
-
-	/* wait */
-	while (WAITING(port));
-	//printk("get_ide_data: drive %i at 0x%3X\n", drive, port);
-
-	if ((STATUS(port) & 1) == 1) {
-	    /* error - drive not found or non-ide */
-#if IDE_DEBUG
-	    printk("bd%s: drive at port 0x%x not found\n", 'a'+drive, port);
-#endif
-	   return -1;
-	}
-
-	/* get drive info */
-
-	insw(port, ide_buffer, 512);
-
-	/* Gather useful info	- this obviously works only for
-	 * IDE/ATA drives, don't call this function if arch < 5.
-	 * Could detect ATAPI drives here (extreme head count).
-	 *
-	 * Safety check - head, cyl and sector values must be other than
-	 * 0 and buffer has to contain valid data (first entry in buffer
-	 * must be other than 0)
-	 *
-	 * This is some sort of bugfix, we will use same method as real Linux -
-	 * work with disk geometry set in current translation mode rather than
-	 * using physical drive info. Physical info might correspond to logical
-	 * info for some drives (those which don't support/use LBA mode).
-	 *
-	 * We're using 'current numbers' from the ID data, could have used 'default CHS 
-	 * numbers' -  words 1, 3 and 6 instead of 54, 55 & 56.
-	 * Apparently, on some drives, the CHS values are programmable. In that case
-	 * the latter are the morer dependable ...
-	 * Surprisingly, the programmability does not seem to be the case on CF cards. 
-	 *  HS sep2020
-	 */
-
-	if ((ide_buffer[54] < 34096) && (*ide_buffer != 0)	/* this is the real sanity check */
-	    && (ide_buffer[54] != 0) && (ide_buffer[55] != 0)
-	    && (ide_buffer[56] != 0)) {
-	    /* Physical value word offsets: cyl 2, heads 3, sectors 6 */
-#if IDE_DEBUG
-	    ide_buffer[20] = 0;
-	    printk("IDE default CHS: %d/%d/%d serial %s\n", ide_buffer[1], ide_buffer[3], ide_buffer[6],
-			&ide_buffer[10]);
-#endif
-	    drive_info->cylinders = ide_buffer[54];
-	    drive_info->heads = ide_buffer[55];
-	    drive_info->sectors = ide_buffer[56];
-
-	}
-
-	/* print drive info */
-	/* sanity check */
-	if (drive_info->heads != 0) {
-#if IDE_DEBUG
-	    printk("bda: %d heads, %d cylinders, %d sectors\n",
-		   drive_info->heads, drive_info->cylinders, drive_info->sectors);
-#endif
-	} else 
-		printk("bd%c: Error in IDE device data.\n", 'a'+drive);
-
-	heap_free(ide_buffer);
-	return 0;
-}
-#endif

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -90,12 +90,7 @@ static struct biosparms bdt;
 #define BD_ES bdt.es
 #define BD_FL bdt.fl
 
-static struct drive_infot {		/* CHS per drive*/
-    int cylinders;
-    int sectors;
-    int heads;
-    int fdtype;				/* floppy fd_types[] index  or -1 if hd */
-} drive_info[NUM_DRIVES];
+static struct drive_infot drive_info[NUM_DRIVES];
 
 /* This makes probing order more logical and
  * avoids a few senseless seeks in some cases

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -179,12 +179,11 @@ static unsigned short int bioshd_gethdinfo(void) {
 	}
 #ifdef IDE_PROBE_ENABLE
 	if (arch_cpu > 5) {	/* Do this only if AT or higher */
-
-		if (!get_ide_data(drive, drivep)) {	/* get CHS from the drive itself */
-			/* sanity checks already done, accepting data */
-	    		printk("bioshd: bd%c IDEdata CHS %d,%d,%d\n", 'a'+drive, drivep->cylinders,
-			drivep->heads, drivep->sectors);
-		}
+	    if (!get_ide_data(drive, drivep)) {	/* get CHS from the drive itself */
+		/* sanity checks already done, accepting data */
+	    	printk("bioshd: bd%c IDEdata CHS %d,%d,%d\n", 'a'+drive, drivep->cylinders,
+		drivep->heads, drivep->sectors);
+	    }
 	}
 #endif
 	drivep++;

--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -302,3 +302,14 @@ static void end_request(int uptodate)
 	}
 
 #endif
+
+/* For bioshd.c, idequery.c */
+struct drive_infot {            /* CHS per drive*/
+    int cylinders;
+    int sectors;
+    int heads;
+    int fdtype;                 /* floppy fd_types[] index  or -1 if hd */
+};
+
+extern int get_ide_data(int, struct drive_infot *);
+

--- a/elks/arch/i86/drivers/block/idequery.c
+++ b/elks/arch/i86/drivers/block/idequery.c
@@ -109,13 +109,13 @@ int get_ide_data(int drive, struct drive_infot *drive_info) {
 	     * The difference is that some devices have selectable translation modes,
 	     * which is reflected in 'current' values. ELKS does not use translation 
 	     * modes, so they are always the same.
-	     * Check for large # of heads to detect ATPI CDROMs.
+	     * Check for large # of cyls to detect (and skip) ATAPI CDROMs. 
 	     * 							HS sep2020
 	     */
 
 	    if ((ide_buffer[54] < 34096) && (*ide_buffer != 0)	/* this is the real sanity check */
-	    	&& (ide_buffer[54] != 0) && (ide_buffer[55] != 0)
-	    	&& (ide_buffer[56] != 0)) {
+	    	&& (ide_buffer[54] != 0) && (ide_buffer[55] != 0) && (ide_buffer[55] < 256)
+	    	&& (ide_buffer[56] != 0) && (ide_buffer[56] < 64)) {
 #if IDE_DEBUG
 	    	ide_buffer[20] = 0; /* String termination */
 	    	printk("IDE default CHS: %d/%d/%d serial %s\n", ide_buffer[1], ide_buffer[3], ide_buffer[6],

--- a/elks/arch/i86/drivers/block/idequery.c
+++ b/elks/arch/i86/drivers/block/idequery.c
@@ -1,0 +1,166 @@
+
+/*
+ * Query the IDE/ATA drive for physical data
+ * Added by HS - sep-2020
+ *
+ * ELKS: ported from directhd.c 
+ */
+
+#include <linuxmt/kernel.h>
+#include <arch/io.h>
+#include <linuxmt/heap.h>
+#include <arch/ports.h>
+
+#define IDE_DRIVE_ID	0xec	/* IDE command to get access to drive data */
+#define IDE_STATUS	7	/* get drive status */
+#define IDE_ERROR	1
+
+#define IDE_DEBUG	1	/* IDE probe debugging */
+
+/* For IDE/ATA access */
+#define STATUS(port) inb_p(port + IDE_STATUS)
+#define ERROR(port) inb_p(port + IDE_ERROR)
+#define WAITING(port) (STATUS(port) & 0x80) == 0x80
+
+static int io_ports[2] = { HD1_PORT, HD2_PORT };	/* physical port addresses */
+
+/* FIXME: should be moved to a header file */
+struct drive_infot {		/* CHS per drive*/
+    int cylinders;
+    int sectors;
+    int heads;
+    int fdtype;			/* floppy fd_types[] index  or -1 if hd */
+};
+
+void insw(word_t port, word_t *buffer, int count) {
+
+    while (--count) {
+   	*buffer++ = inw(port);
+    }
+}
+
+void out_hd(word_t drive, word_t cmd)
+{
+    word_t port;
+
+    port = io_ports[drive / 2];
+
+    outb(0xff, ++port);		/* Feature set, should not matter */
+    outb_p(0, ++port);
+    outb_p(0, ++port);
+    outb_p(0, ++port);
+    outb_p(0, ++port);
+    outb_p(0xA0 | ((drive % 2) << 4), ++port);
+    outb_p(cmd, ++port);
+
+    /* wait for ready */
+    while (WAITING(port-7));
+}
+
+#if 0
+void out_hd(word_t drive, word_t nsect, word_t sect,
+	    word_t head, word_t cyl, word_t cmd)
+{
+    word_t port;
+
+    port = io_ports[drive / 2];
+
+    outb(0xff, ++port);		/* the supposedly correct value for WPCOM on IDE */
+    outb_p(nsect, ++port);
+    outb_p(sect, ++port);
+    outb_p(cyl, ++port);
+    outb_p(cyl >> 8, ++port);
+    outb_p(0xA0 | ((drive % 2) << 4) | head, ++port);
+    outb_p(cmd, ++port);
+
+}
+#endif
+
+#if IDE_DEBUG
+static void dump_ide(word_t *buffer, int size) {
+	int counter = 0;
+
+	while(--size) {
+		printk("%04X ", *buffer++);
+		if (++counter == 16) {
+			printk("\n");
+			counter = 0;
+		}
+	}
+	printk("\n");
+}
+#endif
+
+/* Collect useful info from IDE/ATA drives via the IDE ID cmd.
+ * Don't call this function if arch < 5.
+ * Could detect ATAPI drives here (extreme head count).
+ */
+
+static word_t ide_buffer[256];
+int get_ide_data(int drive, struct drive_infot *drive_info) {
+
+	int port = io_ports[drive / 2];
+	int retval = 0;
+
+#if IDE_DEBUG
+	printk("get_ide_data: drive %i at 0x%3X\n", drive, port);
+#endif
+	//word_t *ide_buffer = (word_t *)heap_alloc(512, 0);
+
+	out_hd(drive, IDE_DRIVE_ID);
+	//out_hd(drive, 0, 0, 0, 0, IDE_DRIVE_ID);
+
+	while (1) {
+	    if ((STATUS(port) & 1) == 1) {
+		/* error - drive not found or non-ide */
+#if IDE_DEBUG
+		printk("bd%s: drive at port 0x%x not found\n", 'a'+drive, port);
+#endif
+		retval = -1;
+		break;
+	    }
+
+	    insw(drive, ide_buffer, 512/2);	/* read - word size */
+
+	    /*
+	     * Sanity check: Head, cyl and sector values must be other than
+	     * 0 and buffer has to contain valid data (first entry in buffer
+	     * must be != 0).
+	     *
+	     * Using 'current' CHS values from the ID data (words 54, 55 & 56), 
+	     * considered more reliable than 'default' CHS values (words 1, 3 & 6).
+	     * The difference is that some devices have selectable translation modes,
+	     * which is reflected in 'current' values. ELKS does not use translation 
+	     * modes, so they are always the same.
+	     * Check for large # of heads to detect ATPI CDROMs.
+	     * 							HS sep2020
+	     */
+	    if ((ide_buffer[54] < 34096) && (*ide_buffer != 0)	/* this is the real sanity check */
+	    	&& (ide_buffer[54] != 0) && (ide_buffer[55] != 0)
+	    	&& (ide_buffer[56] != 0)) {
+#if IDE_DEBUG
+	    	ide_buffer[20] = 0;
+	    	printk("IDE default CHS: %d/%d/%d serial %s\n", ide_buffer[1], ide_buffer[3], ide_buffer[6],
+			&ide_buffer[10]);
+#endif
+	    	drive_info->cylinders = ide_buffer[54];
+	    	drive_info->heads = ide_buffer[55];
+	    	drive_info->sectors = ide_buffer[56];
+#if IDE_DEBUG
+	    	printk("bd%c: %d heads, %d cylinders, %d sectors\n", 'a'+drive,
+		   drive_info->heads, drive_info->cylinders, drive_info->sectors);
+#endif
+	    } else {
+		retval = -2;
+		printk("bd%c: Error in IDE device data.\n", 'a'+drive);
+#if IDE_DEBUG
+		dump_ide(ide_buffer, 256);
+#endif
+	    }
+	    break;
+	}
+
+	//heap_free(ide_buffer);
+
+	return retval;
+}

--- a/image/Make.devices
+++ b/image/Make.devices
@@ -58,6 +58,7 @@ devices:
 	$(MKDEV) /dev/bdb3 b 3 35
 	$(MKDEV) /dev/bdb4 b 3 36
 	$(MKDEV) /dev/bdc  b 3 64
+	$(MKDEV) /dev/bdc1 b 3 65
 	$(MKDEV) /dev/bdd  b 3 96
 	$(MKDEV) /dev/fd0  b 3 128
 	$(MKDEV) /dev/fd1  b 3 160


### PR DESCRIPTION
Code pulled from directhd.c and adapted. Tested on qemu (2 drives), physical (1 drive).

Makes the entire physical disk available via the 'master' device (/dev/bda etc).

For review.