### PR TITLE
[kernel] Allow kernel to load and run with far text segments

### DIFF
--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -132,7 +132,7 @@ endif
 # No relocation stuff related to MSDOS 'MZ' executable
 
 CROSS_CC = ia16-elf-gcc
-CROSS_CFLAGS = -ffreestanding -fno-inline -melks -mcmodel=small -mno-segment-relocation-stuff
+CROSS_CFLAGS = -ffreestanding -fno-inline -melks -mcmodel=small -msegment-relocation-stuff
 
 #########################################################################
 # Define architecture-specific flags.

--- a/elks/arch/i86/boot/crt0.S
+++ b/elks/arch/i86/boot/crt0.S
@@ -20,10 +20,12 @@ entry:
 ! Setup.S already initialized DS and ES (but not SS)
 ! In addition, registers contain:
 !   BX, Text size
+!   DI  Far text size
 !   SI, Data size
 !   DX, BSS size
 */
 	mov	%bx,_endtext
+	mov	%di,_endftext
 	mov	%si,_enddata
 	add	%dx,%si
 	mov	%si,_endbss
@@ -82,6 +84,7 @@ ep_end:
 
 	.data
 	.global _endtext
+	.global _endftext
 	.global _enddata
 	.global _endbss
 	.extern	kernel_cs
@@ -89,6 +92,9 @@ ep_end:
 	.extern task
 
 _endtext:
+	.word	0
+
+_endftext:
 	.word	0
 
 _enddata:

--- a/elks/arch/i86/boot/crt0.S
+++ b/elks/arch/i86/boot/crt0.S
@@ -82,6 +82,12 @@ ep_end:
 
 //	Segment beginnings
 
+// Zero for NULL pointers (near and far)
+// Will be linked as first section in data segment
+	.section .nildata
+	.word 	0
+	.word	0
+
 	.data
 	.global _endtext
 	.global _endftext

--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -540,7 +540,10 @@ _next1:
 	jne sys_hdr_bad
 	cmpw $0x0430,2   // i8086 - executable with separated I & D
 	jne sys_hdr_bad
-	cmpb $0x20,4     // header size (no relocs)
+	mov 4,%bx        // BX = header size
+	cmp $0x20,%bx   // header size (no relocs)
+	je sys_hdr_good
+	cmp $0x40,%bx   // header size (relocs)
 	jne sys_hdr_bad
 	jmp sys_hdr_good
 
@@ -565,6 +568,7 @@ sys_hdr_good:
 	add $0xF,%dx     // align on next paragraph (issue #209)
 	mov	$4,%cl
 	shr %cl,%dx   // DX = code segment size in paragraph
+	shr %cl,%bx   // BX = header size in paragraphs
 
 	mov 12,%ax    // data size
 	push %ax
@@ -575,7 +579,8 @@ sys_hdr_good:
 
 // Relocate kernel code
 
-	mov $SYSSEG+2,%ax
+	mov $SYSSEG,%ax
+	add %bx,%ax   // skip header
 	mov %ax,%ds
 	mov $REL_SYSSEG,%ax
 	mov %ax,%es
@@ -587,11 +592,49 @@ sys_hdr_good:
 	rep
 	movsb
 
+// Relocate kernel far text
+
+	xor %ax,%ax   // far text size = 0
+	push %ax      // -10(%bp)
+	push %ax      // -12(%bp)
+	push %ax      // -14(%bp)
+	cmp $0x04,%bx // extended header?
+	jne sys_no_far_text
+	mov $SYSSEG,%ax
+	mov %ax,%ds
+	mov 0x30,%ax  // far text size in bytes
+	mov %ax,-12(%bp)
+	mov 0x20,%ax  // text relocation size in bytes
+	mov %ax,-14(%bp)
+	add $15,%ax
+	mov $4,%cl
+	shr %cl,%ax   // far text size in paragraphs
+	mov %ax,-10(%bp)
+
+	mov 0x30,%cx  // far text size in bytes
+	cmp %cx,%cx
+	jz sys_no_far_text
+	mov $SYSSEG,%ax
+	add %bx,%ax   // skip header
+	add %dx,%ax   // skip code
+	mov %ax,%ds
+	mov $REL_SYSSEG,%ax
+	add %dx,%ax
+	mov %ax,%es
+
+	xor	%si,%si
+	mov	%si,%di
+	cld
+	rep
+	movsb
+sys_no_far_text:
+
 // Relocate kernel data (not bss)
 // Kernel resets bss itself
 
-	mov $SYSSEG+2,%ax
-	add %dx,%ax
+	mov $SYSSEG,%ax
+	add %bx,%ax   // skip header
+	add %dx,%ax   // skip code
 	mov %ax,%ds
 	mov $REL_SYSSEG,%ax
 	add %dx,%ax
@@ -599,7 +642,8 @@ sys_hdr_good:
 
 	mov -4(%bp),%cx  // data size
 	xor %si,%si
-	mov %si,%di
+	add -12(%bp),%si // skip far text
+	xor %di,%di
 	cld
 	rep
 	movsb
@@ -610,6 +654,7 @@ sys_hdr_good:
 	mov %ax,%ds
 
 	mov -2(%bp),%bx    // code size
+	add -12(%bp),%bx   // FIXME may overflow, needs farcode size
 	mov -4(%bp),%si    // data size
 	mov -6(%bp),%dx    // bss size
 	mov -8(%bp),%cx    // entry point

--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -454,11 +454,12 @@ size_ok:
 */
 #if defined(CONFIG_ROMCODE)
 
-// BX,CX,DX,SI,DS,ES are expected in kernel crt0.S
+// BX,CX,DX,SI,DI,DS,ES are expected in kernel crt0.S
 
 	mov 0x10,%dx  // bss size
 	mov 0x0c,%si  // data size
 	mov 0x08,%bx  // text size
+	xor %di,%di   // far text size
 	mov 0x18,%ax  // entry point
 	mov %es,%cx   // data segment
 	mov %cx,%ds
@@ -558,72 +559,147 @@ sys_hdr_msg:
 	.ascii "Bad system header!"
 	.byte 0
 
+// Add AX to DS:SI and normalize segment
+add_ptr:
+	push %cx
+	add %si,%ax
+	mov	%ax,%si
+	and $15,%si
+	mov $4,%cl
+	shr %cl,%ax
+	mov %ds,%cx
+	add %cx,%ax
+	mov %ax,%ds
+	pop %cx
+	ret
+
+putc:
+	push %bx
+	push %cx
+	push %dx
+	mov   $0x0E,%ah
+	mov   $07,%bx
+	int   $0x10
+	pop %dx
+	pop %cx
+	pop %bx
+	ret
+
+hex1:
+	push %ax
+    and $0x0F,%al
+    add $'0',%al
+    cmp $'9',%al
+    jle 1f
+    add $('A'-'9'-1),%al
+1:  call putc
+	pop %ax
+	ret
+
+hex2:
+	push %ax
+	push %cx
+	push %dx
+    mov %al,%dl
+
+    mov $4,%cl
+    shr %cl,%al
+    call hex1
+    mov %dl,%al
+    call hex1
+	pop %dx
+	pop %cx
+	pop %ax
+	ret
+
+hex4:
+    push %ax
+    push %ax
+    mov %ah,%al
+    call hex2
+    pop %ax
+    call hex2
+	pop %ax
+	ret
+
+
 // System header is good
 
 sys_hdr_good:
 
 	mov %sp,%bp
-	mov 8,%dx     // code size
+	mov 8,%dx     // code size -2(%bp)
 	push %dx
 	add $0xF,%dx     // align on next paragraph (issue #209)
 	mov	$4,%cl
 	shr %cl,%dx   // DX = code segment size in paragraph
 	shr %cl,%bx   // BX = header size in paragraphs
 
-	mov 12,%ax    // data size
+	mov 12,%ax    // data size -(4%bp)
 	push %ax
-	mov 16,%ax    // bss size
+	mov 16,%ax    // bss size -6(%bp)
 	push %ax
-	mov 20,%ax    // entry point
+	mov 20,%ax    // entry point -8(%bp)
 	push %ax
 
 // Relocate kernel code
 
+	mov $'T',%ax
+	call putc
+
 	mov $SYSSEG,%ax
 	add %bx,%ax   // skip header
 	mov %ax,%ds
+	xor	%si,%si
+
 	mov $REL_SYSSEG,%ax
 	mov %ax,%es
+	xor %di,%di
+	call hex4
 
-	mov -2(%bp),%cx  // code size
-	xor	%si,%si
-	mov	%si,%di
+	mov -2(%bp),%cx  // code size in bytes
 	cld
 	rep
 	movsb
 
 // Relocate kernel far text
 
-	xor %ax,%ax   // far text size = 0
-	push %ax      // -10(%bp)
-	push %ax      // -12(%bp)
-	push %ax      // -14(%bp)
+	xor %ax,%ax   // far text size -10(%bp)
+	push %ax
+	push %ax      // text reloc size -12(%bp)
+	push %ax      // far text reloc size -14(%bp)
+	push %ax      // data reloc size -16(%bp)
 	cmp $0x04,%bx // extended header?
 	jne sys_no_far_text
 	mov $SYSSEG,%ax
 	mov %ax,%ds
-	mov 0x30,%ax  // far text size in bytes
+	mov 0x20,%ax  // text reloc size
 	mov %ax,-12(%bp)
-	mov 0x20,%ax  // text relocation size in bytes
+	mov 0x32,%ax  // far text reloc size
 	mov %ax,-14(%bp)
-	add $15,%ax
-	mov $4,%cl
-	shr %cl,%ax   // far text size in paragraphs
-	mov %ax,-10(%bp)
-
-	mov 0x30,%cx  // far text size in bytes
-	cmp %cx,%cx
+	mov 0x24,%ax  // data reloc size
+	mov %ax,-16(%bp)
+	mov 0x30,%cx  // far text size
+	mov %cx,-10(%bp)
+	and %cx,%cx
 	jz sys_no_far_text
-	mov $SYSSEG,%ax
-	add %bx,%ax   // skip header
-	add %dx,%ax   // skip code
-	mov %ax,%ds
-	mov $REL_SYSSEG,%ax
-	add %dx,%ax
-	mov %ax,%es
 
+	mov $'F',%ax
+	call putc
+
+	mov $SYSSEG,%ax
+	add %bx,%ax       // skip header
+	mov %ax,%ds
 	xor	%si,%si
-	mov	%si,%di
+	mov -2(%bp),%ax   // skip code bytes
+	call add_ptr
+
+	mov $REL_SYSSEG,%ax
+	add %dx,%ax       // skip code paragraphs
+	mov %ax,%es
+	xor %di,%di
+	call hex4
+
 	cld
 	rep
 	movsb
@@ -632,32 +708,105 @@ sys_no_far_text:
 // Relocate kernel data (not bss)
 // Kernel resets bss itself
 
+	mov $'f',%ax
+	call putc
+	mov -10(%bp),%ax // far text size
+	mov $4,%cl
+	shr %cl,%ax
+	mov %ax,%cx
+	call hex4
+
+	mov $'D',%ax
+	call putc
+
 	mov $SYSSEG,%ax
-	add %bx,%ax   // skip header
-	add %dx,%ax   // skip code
+	add %bx,%ax      // skip header
 	mov %ax,%ds
+	xor %si,%si
+	mov -2(%bp),%ax  // skip code bytes
+	call add_ptr
+	mov -10(%bp),%ax // far text size
+	call add_ptr
+	push %si
+
 	mov $REL_SYSSEG,%ax
-	add %dx,%ax
+	add %dx,%ax      // skip code paragraphs
+	add %cx,%ax      // skip far text
 	mov %ax,%es
+	call hex4
 
 	mov -4(%bp),%cx  // data size
-	xor %si,%si
-	add -12(%bp),%si // skip far text
 	xor %di,%di
 	cld
 	rep
 	movsb
 
+// Handle code/far text/data segment relocation
+
+	pop %si
+	mov -4(%bp),%ax  // skip data size
+	call add_ptr
+
+	push %es
+	mov -12(%bp),%cx // text reloc size
+
+text_reloc:
+	jcxz 1f
+	mov $'t',%ax
+	call putc
+	mov $REL_SYSSEG,%ax
+	mov %ax,%es      // ES -> text segment
+
+	call relocat
+	sub $8,%cx
+	add $8,%si
+	jmp text_reloc
+1:
+
+	mov -14(%bp),%cx // far text reloc size
+ftext_reloc:
+	jcxz 2f
+	mov $'f',%ax
+	call putc
+	mov $REL_SYSSEG,%ax
+	add %dx,%ax      // skip code
+	mov %ax,%es      // ES -> far text segment
+
+	call relocat
+	sub $8,%cx
+	add $8,%si
+	jmp ftext_reloc
+2:
+
+	mov -16(%bp),%cx // data reloc size
+data_reloc:
+	jcxz 3f
+	mov $'d',%ax
+	call putc
+	pop %es          // ES -> data segment
+	push %es
+
+	call relocat
+	sub $8,%cx
+	add $8,%si
+	jmp data_reloc
+3:
+	mov $'\r',%ax
+	call putc
+	mov $'\n',%ax
+	call putc
+
 // Load registers as kernel expects
 
+	pop %es          // ES -> data segment
 	mov %es,%ax
 	mov %ax,%ds
 
 	mov -2(%bp),%bx    // code size
-	add -12(%bp),%bx   // FIXME may overflow, needs farcode size
 	mov -4(%bp),%si    // data size
 	mov -6(%bp),%dx    // bss size
 	mov -8(%bp),%cx    // entry point
+	mov -10(%bp),%di   // far text size
 
 // Jump to kernel entry point
 
@@ -665,6 +814,75 @@ sys_no_far_text:
 	push %ax
 	push %cx
 	lret
+
+// Relocate segment at ES: from relocation record at DS:SI
+
+relocat:
+	mov (%si),%ax
+	call hex4
+	mov $' ',%ax
+	call putc
+	mov 2(%si),%ax
+	call hex4
+	mov $' ',%ax
+	call putc
+	mov 4(%si),%ax
+	call hex4
+	mov $' ',%ax
+	call putc
+	mov 6(%si),%ax
+	call hex4
+	mov $' ',%ax
+	call putc
+
+	mov (%si),%di      // get r_vaddr
+	mov 6(%si),%ax     // get r_type
+	cmp $80,%ax        // R_SEGWORD
+	jnz sys_hdr_bad
+	mov 4(%si),%ax     // get r_symndx
+	cmp $-2,%ax        // S_TEXT
+	jnz 1f
+
+	mov $REL_SYSSEG,%ax// code segment
+	jmp reloc_wr
+1:
+	cmp $-5,%ax        // S_FTEXT
+	jnz 2f
+
+	mov $REL_SYSSEG,%ax
+	add %dx,%ax        // skip code = far text segment
+	jmp reloc_wr
+2:
+	cmp $-3,%ax        // S_DATA
+	jnz sys_hdr_bad
+
+	mov -10(%bp),%ax   // far text size
+	mov $4,%cl
+	shr %cl,%ax        // skip far text
+	add %dx,%ax        // skip code
+	add $REL_SYSSEG,%ax// = data segment
+
+reloc_wr:
+	push %ax
+	mov $'[',%ax
+	call putc
+	mov %es,%ax
+	call hex4
+	mov $':',%ax
+	call putc
+	mov %di,%ax
+	call hex4
+	mov $'=',%ax
+	call putc
+	pop %ax
+	call hex4
+	push %ax
+	mov $']',%ax
+	call putc
+	pop %ax
+
+	mov %ax,%es:(%di)
+	ret
 
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Case for kernel in disk, no kernel relocation
@@ -674,6 +892,7 @@ sys_no_far_text:
 	mov $SYSSEG,%ax	// in ROM ds ist always set
 	mov %ax,%ds	// Get the header into DS
 	mov 8,%bx	// TSeg
+	xor %di,%di // far TSeg
 	mov 12,%si	// DSeg
 	mov 16,%dx	// BSeg
 	mov 20,%bp	// entry point

--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -26,6 +26,9 @@
 ! changes to support having setup + ELKS kernel as one single blob
 ! March 2020 https://github.com/tkchia
 !
+! changes to support .fartext headers and relocation
+! Sep 2020 Greg Haerr
+!
 ! The following data is passed to the main kernel (relative to INITSEG)
 !
 ! index
@@ -138,21 +141,12 @@ entry:
 	cmpw	$SIG1,setup_sig1
 	jne	no_sig
 	cmpw	$SIG2,setup_sig2
-	jne	no_sig
-	jmp	move_kernel     //;why double jmp
-	nop
+	je	move_kernel
 
-
-// Routine to print asciiz-string at DS:SI
-prts_1:	mov	$0x0007,%bx   //page 0
-	mov	$0x0e,%ah
-	int	$0x10
-
-prtstr:	lodsb
-	test	%al,%al
-	jnz	prts_1
-	ret
-
+no_sig:	lea	no_sig_mess,%si
+	call	puts
+1:                             // And halt
+	jmp	1b
 
 
 // If setup and kernel were loaded as a blob, we need to separate them out,
@@ -209,17 +203,7 @@ move_kernel_in_64ks:
 	rep
 	movsw
 	jmp	move_kernel_in_64ks
-#endif
 
-no_sig:
-	lea	no_sig_mess,%si
-	call	prtstr
-no_sig_loop:			// And halt
-	jmp	no_sig_loop
-
-
-//;------------------------------------------------
-#ifndef CONFIG_ROMCODE
 done_move_kernel:
 	cld
 	mov	$INITSEG,%ax
@@ -249,7 +233,7 @@ start_os:
 	push	%cs
 	pop	%ds
 	mov $hello_mess,%si
-	call prtstr
+	call puts
 
 	mov $INITSEG,%ax
 	mov	%ax,%ds
@@ -358,14 +342,18 @@ no_psmouse:
 	int	$0x12		// determine the size of the basememory
 	mov	%ax,0x2a
 
-//----------------------------
+//+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Case for ROM code
+//
+
 #ifdef CONFIG_ROMCODE
+// Case for kernel in ROM
 // We must now copy the kernel to RAM (SYSSEG)
 
 	mov %cs,%ax          //;string is in this codeseg
 	mov %ax,%ds
 	lea load_kernel,%si
-	call prtstr
+	call puts
 
    	mov $CONFIG_ROM_KERNEL_CODE,%ax   //;the ROM image
    	mov %ax,%ds
@@ -388,7 +376,7 @@ aouterr:
    	mov %cs,%ax
    	mov %ax,%ds
    	lea kernel_aouterr,%si
-   	call prtstr
+	call puts
 err_loop:
 	jmp err_loop
 
@@ -415,7 +403,7 @@ size_error:
    	mov %cs,%ax
    	mov %ax,%ds
    	lea kernel_to_big,%si
-   	call prtstr
+	call puts
    	jmp err_loop  //;and halt
 
 size_ok:
@@ -433,26 +421,6 @@ size_ok:
         cld
         rep
         movsw
-
-//; now ist the data and code ad the right position
-#endif
-
-/*
-!--------------------------------------------------------
-! We setup ds, es, and ss now
-!
-!
-!	For BCC generated code the rules are simple
-!
-!	ES=DS=SS. SP is at the top end of the segment, data at the bottom
-!	CS = DS is allowed (code then is start of data) or split.
-!
-
-!+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-! Case for kernel in ROM
-!
-*/
-#if defined(CONFIG_ROMCODE)
 
 // BX,CX,DX,SI,DI,DS,ES are expected in kernel crt0.S
 
@@ -542,120 +510,65 @@ _next1:
 	cmpw $0x0430,2   // i8086 - executable with separated I & D
 	jne sys_hdr_bad
 	mov 4,%bx        // BX = header size
-	cmp $0x20,%bx   // header size (no relocs)
+	cmp $0x20,%bx    // header size (no relocs)
 	je sys_hdr_good
-	cmp $0x40,%bx   // header size (relocs)
-	jne sys_hdr_bad
-	jmp sys_hdr_good
+	cmp $0x40,%bx    // header size (relocs)
+	je sys_hdr_good
 
 sys_hdr_bad:
 	mov %ss,%ax
-	mov	%ax,%ds
+	mov %ax,%ds
 	lea sys_hdr_msg,%si
-	call prtstr
-sys_hdr_loop:
-	jmp sys_hdr_loop
+	call puts
+1:                       // halt
+	jmp 1b
 sys_hdr_msg:
 	.ascii "Bad system header!"
 	.byte 0
 
-// Add AX to DS:SI and normalize segment
-add_ptr:
-	push %cx
-	add %si,%ax
-	mov	%ax,%si
-	and $15,%si
-	mov $4,%cl
-	shr %cl,%ax
-	mov %ds,%cx
-	add %cx,%ax
-	mov %ax,%ds
-	pop %cx
-	ret
-
-putc:
-	push %bx
-	push %cx
-	push %dx
-	mov   $0x0E,%ah
-	mov   $07,%bx
-	int   $0x10
-	pop %dx
-	pop %cx
-	pop %bx
-	ret
-
-hex1:
-	push %ax
-    and $0x0F,%al
-    add $'0',%al
-    cmp $'9',%al
-    jle 1f
-    add $('A'-'9'-1),%al
-1:  call putc
-	pop %ax
-	ret
-
-hex2:
-	push %ax
-	push %cx
-	push %dx
-    mov %al,%dl
-
-    mov $4,%cl
-    shr %cl,%al
-    call hex1
-    mov %dl,%al
-    call hex1
-	pop %dx
-	pop %cx
-	pop %ax
-	ret
-
-hex4:
-    push %ax
-    push %ax
-    mov %ah,%al
-    call hex2
-    pop %ax
-    call hex2
-	pop %ax
-	ret
-
-
 // System header is good
 
 sys_hdr_good:
-
 	mov %sp,%bp
-	mov 8,%dx     // code size -2(%bp)
+	mov 8,%dx     // -2(%bp) code size
 	push %dx
-	add $0xF,%dx     // align on next paragraph (issue #209)
-	mov	$4,%cl
+	add $15,%dx   // align on next paragraph (issue #209)
+	mov $4,%cl
 	shr %cl,%dx   // DX = code segment size in paragraph
 	shr %cl,%bx   // BX = header size in paragraphs
 
-	mov 12,%ax    // data size -(4%bp)
+	mov 12,%ax    // -4(%bp) data size
 	push %ax
-	mov 16,%ax    // bss size -6(%bp)
+	mov 16,%ax    // -6(%bp) bss size
 	push %ax
-	mov 20,%ax    // entry point -8(%bp)
+	mov 20,%ax    // -8(%bp) entry point
 	push %ax
+	xor %ax,%ax   // -10(%bp) far text size
+	push %ax
+	push %ax      // -12(%bp) text reloc size
+	push %ax      // -14(%bp) far text reloc size
+	push %ax      // -16(%bp) data reloc size
+	push %ax      // -18(%bp) kernel .text segment
+	push %ax      // -20(%bp) kernel .fartext segment
+	push %ax      // -22(%bp) kernel .data segment
 
 // Relocate kernel code
 
-	mov $'T',%ax
+	mov $'T',%ax     // display kernel .text segment
 	call putc
 
-	mov $SYSSEG,%ax
-	add %bx,%ax   // skip header
+	mov $SYSSEG,%ax  // start of a.out
+	add %bx,%ax      // skip header
 	mov %ax,%ds
-	xor	%si,%si
+	xor %si,%si
 
 	mov $REL_SYSSEG,%ax
 	mov %ax,%es
+	mov %ax,-18(%bp) // save .text segment
+	call hex4sp
+	add %dx,%ax      // add code paragraphs
+	mov %ax,-20(%bp) // save .data start in case no .fartext
 	xor %di,%di
-	call hex4
 
 	mov -2(%bp),%cx  // code size in bytes
 	cld
@@ -664,43 +577,38 @@ sys_hdr_good:
 
 // Relocate kernel far text
 
-	xor %ax,%ax   // far text size -10(%bp)
-	push %ax
-	push %ax      // text reloc size -12(%bp)
-	push %ax      // far text reloc size -14(%bp)
-	push %ax      // data reloc size -16(%bp)
-	cmp $0x04,%bx // extended header?
+	cmp $0x04,%bx    // extended header?
 	jne sys_no_far_text
-	mov $SYSSEG,%ax
+	mov $SYSSEG,%ax  // readdress a.out header
 	mov %ax,%ds
-	mov 0x20,%ax  // text reloc size
+	mov 0x20,%ax     // text reloc size
 	mov %ax,-12(%bp)
-	mov 0x32,%ax  // far text reloc size
+	mov 0x32,%ax     // far text reloc size
 	mov %ax,-14(%bp)
-	mov 0x24,%ax  // data reloc size
+	mov 0x24,%ax     // data reloc size
 	mov %ax,-16(%bp)
-	mov 0x30,%cx  // far text size
+	mov 0x30,%cx     // far text size
 	mov %cx,-10(%bp)
 	and %cx,%cx
 	jz sys_no_far_text
 
-	mov $'F',%ax
+	mov $'F',%ax      // display kernel .fartext segment
 	call putc
 
 	mov $SYSSEG,%ax
 	add %bx,%ax       // skip header
 	mov %ax,%ds
-	xor	%si,%si
+	xor %si,%si
 	mov -2(%bp),%ax   // skip code bytes
 	call add_ptr
 
-	mov $REL_SYSSEG,%ax
+	mov -18(%bp),%ax  // kernel .text segment
 	add %dx,%ax       // skip code paragraphs
 	mov %ax,%es
+	mov %ax,-20(%bp)  // save .fartext segment
 	xor %di,%di
-	call hex4
+	call hex4sp
 
-	cld
 	rep
 	movsb
 sys_no_far_text:
@@ -708,13 +616,10 @@ sys_no_far_text:
 // Relocate kernel data (not bss)
 // Kernel resets bss itself
 
-	mov $'f',%ax
-	call putc
-	mov -10(%bp),%ax // far text size
+	mov -10(%bp),%ax // conv far text size to paras
 	mov $4,%cl
 	shr %cl,%ax
 	mov %ax,%cx
-	call hex4
 
 	mov $'D',%ax
 	call putc
@@ -729,33 +634,30 @@ sys_no_far_text:
 	call add_ptr
 	push %si
 
-	mov $REL_SYSSEG,%ax
-	add %dx,%ax      // skip code paragraphs
+	mov -20(%bp),%ax // kernel .fartext segment
 	add %cx,%ax      // skip far text
 	mov %ax,%es
+	mov %ax,-22(%bp) // save .data segment
 	xor %di,%di
-	call hex4
+	call hex4sp
 
 	mov -4(%bp),%cx  // data size
-	cld
 	rep
 	movsb
 
 // Handle code/far text/data segment relocation
 
-	pop %si
+	pop %si          // get src ptr at fartext
 	mov -4(%bp),%ax  // skip data size
-	call add_ptr
+	call add_ptr     // now at relocation entries
 
-	push %es
 	mov -12(%bp),%cx // text reloc size
-
 text_reloc:
 	jcxz 1f
 	mov $'t',%ax
 	call putc
-	mov $REL_SYSSEG,%ax
-	mov %ax,%es      // ES -> text segment
+	mov -18(%bp),%ax // kernel .text segment
+	mov %ax,%es
 
 	call relocat
 	sub $8,%cx
@@ -768,9 +670,8 @@ ftext_reloc:
 	jcxz 2f
 	mov $'f',%ax
 	call putc
-	mov $REL_SYSSEG,%ax
-	add %dx,%ax      // skip code
-	mov %ax,%es      // ES -> far text segment
+	mov -20(%bp),%ax // kernel .fartext segment
+	mov %ax,%es
 
 	call relocat
 	sub $8,%cx
@@ -783,8 +684,8 @@ data_reloc:
 	jcxz 3f
 	mov $'d',%ax
 	call putc
-	pop %es          // ES -> data segment
-	push %es
+	mov -22(%bp),%ax   // kernel .data segment
+	mov %ax,%es
 
 	call relocat
 	sub $8,%cx
@@ -798,10 +699,9 @@ data_reloc:
 
 // Load registers as kernel expects
 
-	pop %es          // ES -> data segment
-	mov %es,%ax
+	mov -22(%bp),%ax   // kernel .data segment
+	mov %ax,%es
 	mov %ax,%ds
-
 	mov -2(%bp),%bx    // code size
 	mov -4(%bp),%si    // data size
 	mov -6(%bp),%dx    // bss size
@@ -810,31 +710,13 @@ data_reloc:
 
 // Jump to kernel entry point
 
-	mov $REL_SYSSEG,%ax
+	mov -18(%bp),%ax   // kernel .text segment
 	push %ax
 	push %cx
 	lret
 
 // Relocate segment at ES: from relocation record at DS:SI
-
 relocat:
-	mov (%si),%ax
-	call hex4
-	mov $' ',%ax
-	call putc
-	mov 2(%si),%ax
-	call hex4
-	mov $' ',%ax
-	call putc
-	mov 4(%si),%ax
-	call hex4
-	mov $' ',%ax
-	call putc
-	mov 6(%si),%ax
-	call hex4
-	mov $' ',%ax
-	call putc
-
 	mov (%si),%di      // get r_vaddr
 	mov 6(%si),%ax     // get r_type
 	cmp $80,%ax        // R_SEGWORD
@@ -843,27 +725,21 @@ relocat:
 	cmp $-2,%ax        // S_TEXT
 	jnz 1f
 
-	mov $REL_SYSSEG,%ax// code segment
-	jmp reloc_wr
+	mov -18(%bp),%ax   // kernel .text segment
+	jmp 3f
 1:
 	cmp $-5,%ax        // S_FTEXT
 	jnz 2f
 
-	mov $REL_SYSSEG,%ax
-	add %dx,%ax        // skip code = far text segment
-	jmp reloc_wr
+	mov -20(%bp),%ax   // kernel .fartext segment
+	jmp 3f
 2:
 	cmp $-3,%ax        // S_DATA
 	jnz sys_hdr_bad
 
-	mov -10(%bp),%ax   // far text size
-	mov $4,%cl
-	shr %cl,%ax        // skip far text
-	add %dx,%ax        // skip code
-	add $REL_SYSSEG,%ax// = data segment
-
-reloc_wr:
-	push %ax
+	mov -22(%bp),%ax   // kernel .data segment
+3:
+	push %ax           // display [seg:off=val]
 	mov $'[',%ax
 	call putc
 	mov %es,%ax
@@ -884,6 +760,20 @@ reloc_wr:
 	mov %ax,%es:(%di)
 	ret
 
+// Add AX to DS:SI and normalize segment
+add_ptr:
+	push %cx
+	add %si,%ax
+	mov	%ax,%si
+	and $15,%si
+	mov $4,%cl
+	shr %cl,%ax
+	mov %ds,%cx
+	add %cx,%ax
+	mov %ax,%ds
+	pop %cx
+	ret
+
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Case for kernel in disk, no kernel relocation
 //
@@ -892,7 +782,7 @@ reloc_wr:
 	mov $SYSSEG,%ax	// in ROM ds ist always set
 	mov %ax,%ds	// Get the header into DS
 	mov 8,%bx	// TSeg
-	xor %di,%di // far TSeg
+	xor %di,%di     // .fartext size
 	mov 12,%si	// DSeg
 	mov 16,%dx	// BSeg
 	mov 20,%bp	// entry point
@@ -909,98 +799,6 @@ reloc_wr:
 	retf
 
 #endif /* REL_SYS */
-
-/*
-!+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-!
-! This routine checks that the keyboard command queue is empty
-! (after emptying the output buffers)
-!
-! No timeout is used - if this hangs there is something wrong with
-! the machine, and we probably couldn't proceed anyway.
-
-! no call to this functions
-*/
-#if 0
-empty_8042:
-	call	delay
-	in	al,#0x64	! 8042 status port
-	test	al,#1		! output buffer?
-	jz	no_output
-	call	delay
-	in	al,#0x60	! read it
-	jmp	empty_8042
-no_output:
-	test	al,#2		! is input buffer full?
-	jnz	empty_8042	! yes - loop
-	ret
-!
-! Read a key and return the (US-)ascii code in al, scan code in ah
-!
-getkey:
-	xor	ah,ah
-	int	0x16
-	ret
-
-!
-! Read a key with a timeout of 30 seconds. The cmos clock is used to get
-! the time.
-!
-getkt:
-	call	gettime
-	add	al,#30		! wait 30 seconds
-	cmp	al,#60
-	jl	lminute
-	sub	al,#60
-lminute:
-	mov	cl,al
-again:	mov	ah,#0x01
-	int	0x16
-	jnz	getkey		! key pressed, so get it
-	call	gettime
-	cmp	al,cl
-	jne	again
-	mov	al,#0x20	! timeout, return default char `space'
-	ret
-
-!
-! Flush the keyboard buffer
-!
-flush:	mov	ah,#0x01
-	int	0x16
-	jz	empty
-	xor	ah,ah
-	int	0x16
-	jmp	flush
-empty:	ret
-
-!
-! Read the cmos clock. Return the seconds in al
-!
-
-gettime:
-	push	cx
-	mov	ah,#0x02
-	int	0x1a
-	mov	al,dh			! dh contains the seconds
-	and	al,#0x0f
-	mov	ah,dh
-	mov	cl,#0x04
-	shr	ah,cl
-	aad
-	pop	cx
-	ret
-
-!
-! Delay is needed after doing i/o
-!
-delay:
-	.word	0x00eb			! jmp $+2
-	ret
-#endif
-//;from never calls
-
-//form this position are calles code
 
 /*
 ! TODO: move probing to boot tools
@@ -1272,6 +1070,68 @@ f2880:	.word 2,36,80
 floppies: .word f360, f1200, f720, f1440, f2880, f2880
 #endif
 
+
+// Utility/debugging routines
+
+// Write DS:SI asciiz string to console
+1:	call	putc
+puts:	lodsb
+	test	%al,%al
+	jnz	1b
+	ret
+
+// Write AX to console
+putc:	push %bx
+	push %cx
+	push %dx
+	mov $0x0E,%ah
+	mov $7,%bx      // page 0
+	int $0x10
+	pop %dx
+	pop %cx
+	pop %bx
+	ret
+
+// Output hex nibble, byte and word. All registers saved.
+hex1:	push %ax
+	and $0x0F,%al
+	add $'0',%al
+	cmp $'9',%al
+	jle 1f
+	add $('A'-'9'-1),%al
+1:	call putc
+	pop %ax
+	ret
+
+hex2:	push %ax
+	push %cx
+	push %dx
+	mov %al,%dl
+	mov $4,%cl
+	shr %cl,%al
+	call hex1
+	mov %dl,%al
+	call hex1
+	pop %dx
+	pop %cx
+	pop %ax
+	ret
+
+hex4:	push %ax
+	push %ax
+	mov %ah,%al
+	call hex2
+	pop %ax
+	call hex2
+	pop %ax
+	ret
+
+hex4sp: call hex4
+	push %ax
+	mov $' ',%ax
+	call putc
+	pop %ax
+	ret
 
 //
 // The processor name must not be longer than 15 characters!

--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -733,10 +733,10 @@ sys_no_far_text:
 	add %dx,%ax      // skip code paragraphs
 	add %cx,%ax      // skip far text
 	mov %ax,%es
+	xor %di,%di
 	call hex4
 
 	mov -4(%bp),%cx  // data size
-	xor %di,%di
 	cld
 	rep
 	movsb

--- a/elks/arch/i86/lib/Makefile
+++ b/elks/arch/i86/lib/Makefile
@@ -36,6 +36,7 @@ SRCS1 = \
 	fmemcmpb.S fmemcmpw.S \
 	setupb.S setupw.S \
 	string.S \
+	ia16-far-call-thunks.S \
 #	farlist.S \
 	# end of list
 

--- a/elks/arch/i86/lib/ia16-far-call-thunks.S
+++ b/elks/arch/i86/lib/ia16-far-call-thunks.S
@@ -25,6 +25,7 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 //#include "ia16-preamble.h"
 
 	/* These routines must go into the near text segment, if at all.  */
+	.code16
 	.text
 
 	.global	__ia16_far_call_thunk.bx.si
@@ -32,6 +33,12 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 	.global	__ia16_far_call_thunk.bx.di
 	.type	__ia16_far_call_thunk.bx.di, @function
 __ia16_far_call_thunk.bx.si:
+	// fast version when si is zero
+	and	%si,%si
+	jnz	00f
+	call	%bx
+	retf
+00:
 	pushw	%bp			/* set up stack frame */
 	movw	%sp,	%bp
 	pushw	%bx			/* preserve %bx and %cx */
@@ -39,6 +46,12 @@ __ia16_far_call_thunk.bx.si:
 	movw	%si,	%cx		/* move stack args. size to %cx */
 	jmp	0f
 __ia16_far_call_thunk.bx.di:
+	// fast version when di is zero
+	and	%di,%di
+	jnz	00f
+	call	%bx
+	retf
+00:
 	pushw	%bp
 	movw	%sp,	%bp
 	pushw	%bx
@@ -50,7 +63,7 @@ __ia16_far_call_thunk.bx.di:
 	addw	%cx,	%bx
 	shrw	%cx
 1:
-	pushw	%ss:(%bx)
+	pushw	(%bx)			// SS: prefix removed
 	decw	%bx
 	decw	%bx
 	loop	1b

--- a/elks/arch/i86/lib/ia16-far-call-thunks.S
+++ b/elks/arch/i86/lib/ia16-far-call-thunks.S
@@ -1,0 +1,62 @@
+/* IA-16 far -> near call thunks without argument popping
+
+   Copyright (C) 2019 Free Software Foundation, Inc.
+   Written By TK Chia
+
+This file is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the
+Free Software Foundation; either version 3, or (at your option) any
+later version.
+
+This file is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+Under Section 7 of GPL version 3, you are granted additional
+permissions described in the GCC Runtime Library Exception, version
+3.1, as published by the Free Software Foundation.
+
+You should have received a copy of the GNU General Public License and
+a copy of the GCC Runtime Library Exception along with this program;
+see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+<http://www.gnu.org/licenses/>.  */
+
+//#include "ia16-preamble.h"
+
+	/* These routines must go into the near text segment, if at all.  */
+	.text
+
+	.global	__ia16_far_call_thunk.bx.si
+	.type	__ia16_far_call_thunk.bx.si, @function
+	.global	__ia16_far_call_thunk.bx.di
+	.type	__ia16_far_call_thunk.bx.di, @function
+__ia16_far_call_thunk.bx.si:
+	pushw	%bp			/* set up stack frame */
+	movw	%sp,	%bp
+	pushw	%bx			/* preserve %bx and %cx */
+	pushw	%cx
+	movw	%si,	%cx		/* move stack args. size to %cx */
+	jmp	0f
+__ia16_far_call_thunk.bx.di:
+	pushw	%bp
+	movw	%sp,	%bp
+	pushw	%bx
+	pushw	%cx
+	movw	%di,	%cx
+0:					/* re-push stack arguments */
+	jcxz	2f
+	leaw	4(%bp),	%bx
+	addw	%cx,	%bx
+	shrw	%cx
+1:
+	pushw	%ss:(%bx)
+	decw	%bx
+	decw	%bx
+	loop	1b
+2:
+	movw	-4(%bp), %cx		/* reload %cx for callee */
+	callw	*-2(%bp)		/* call function */
+	movw	%bp,	%sp		/* tear down stack frame and return */
+	popw	%bp
+	lretw

--- a/elks/arch/i86/mm/init.c
+++ b/elks/arch/i86/mm/init.c
@@ -69,11 +69,11 @@ void mm_stat(seg_t start, seg_t end)
 
 #endif
 
-    printk(".\nELKS kernel %s (%u text + %u data + %u bss + %u heap)\n"
+    printk(".\nELKS kernel %s (%u text, %u ftext, %u data, %u bss, %u heap)\n"
 	   "Kernel text at %x:0000, data at %x:0000, "
 	   "%uK for user processes.\n",
 	   system_utsname.release,
-	   (unsigned)_endtext, (unsigned)_enddata,
+	   (unsigned)_endtext, (unsigned)_endftext, (unsigned)_enddata,
 	   (unsigned)_endbss - (unsigned)_enddata,
 	   1 + ~ (unsigned) _endbss,
 	   kernel_cs, kernel_ds,

--- a/elks/arch/i86/tools/a.out.h
+++ b/elks/arch/i86/tools/a.out.h
@@ -18,10 +18,16 @@ struct exec {			/* a.out header */
     int32_t a_syms;		/* +28: size of symbol table */
 
     /* SHORT FORM ENDS HERE */
-    int32_t a_trsize;		/* text relocation size */
-    int32_t a_drsize;		/* data relocation size */
-    int32_t a_tbase;		/* text relocation base */
-    int32_t a_dbase;		/* data relocation base */
+    uint32_t a_trsize;		/* text relocation size */
+    uint32_t a_drsize;		/* data relocation size */
+    uint32_t a_tbase;		/* text relocation base */
+    uint32_t a_dbase;		/* data relocation base */
+    /* even more optional fields --- for ELKS medium memory model support */
+    uint16_t esh_ftseg;		/* far text size */
+    uint16_t esh_ftrsize;	/* far text relocation size */ //FIXME should be uint32
+    uint32_t esh_reserved1;
+	uint32_t esh_reserved2;
+    uint32_t esh_reserved3;
 };
 
 #define A_MAGIC0      (unsigned char) 0x01

--- a/elks/arch/i86/tools/build.c
+++ b/elks/arch/i86/tools/build.c
@@ -234,13 +234,15 @@ int main(int argc, char **argv)
     }
 
     lseek(id, 0, 0);
-#else
+#endif
+#if 1
     if (fstat(id, &sb)) {
 	perror("fstat");
 	die("Unable to stat 'system'");
     }
     sz = sb.st_size;
-    fprintf(stderr, "System is %d kB\n", sz / 1024);
+    //fprintf(stderr, "System is %d kB\n", sz / 1024);
+    fprintf(stderr, "System is %d B\n", sz);
 #endif
     sys_size = (sz + 15) / 16;
     fprintf(stderr, "System is %d\n", sz);

--- a/elks/arch/i86/tools/build.c
+++ b/elks/arch/i86/tools/build.c
@@ -40,7 +40,8 @@
 
 #include "a.out.h"
 
-#define MINIX_HEADER 32
+#define MINIX_HEADER 0x20
+#define SUPL_HEADER  0x40
 
 #define N_MAGIC_OFFSET 1024
 
@@ -104,7 +105,7 @@ void usage(void)
 
 int main(int argc, char **argv)
 {
-    int32_t i, c, id, sz;
+    int32_t i, c, id, sz, fsz;
     uint32_t sys_size;
     char buf[1024];
 
@@ -112,7 +113,7 @@ int main(int argc, char **argv)
     struct exec *ex = (struct exec *) buf;
 #endif
 
-    char major_root, minor_root;
+    unsigned char major_root, minor_root;
     struct stat sb;
     unsigned char setup_sectors;
 
@@ -217,32 +218,39 @@ int main(int argc, char **argv)
     if ((id = open(argv[3], O_RDONLY, 0)) < 0)
 	die("Unable to open 'system'");
 #ifndef __BFD__
-    if (read(id, buf, MINIX_HEADER) != MINIX_HEADER)
+    if (read(id, buf, SUPL_HEADER) != SUPL_HEADER)
 	die("Unable to read header of 'system'");
     if ((ex->a_magic[0] != 0x01) || (ex->a_magic[1] != 0x03)) {
 	die("Non-MINIX header of 'system'");
     }
-    fprintf(stderr, "System is %d B (%d B code, %d B data and %u B bss)\n",
-	    (intel_long(ex->a_text) + intel_long(ex->a_data) +
-	     intel_long(ex->a_bss)), intel_long(ex->a_text),
-	    intel_long(ex->a_data), (unsigned) intel_long(ex->a_bss));
-    sz = MINIX_HEADER + intel_long(ex->a_text) + intel_long(ex->a_data);
-
+    fsz = 0;
+    sz = intel_long(ex->a_text) + intel_long(ex->a_data) + intel_long(ex->a_bss);
+    if (ex->a_hdrlen == SUPL_HEADER) {
+	fsz = intel_short(ex->esh_ftseg);
+	sz += fsz;
+    }
+    fprintf(stderr, "System is %d B (%d B code, %d fartext, %d B data and %u B bss)\n",
+	sz, intel_long(ex->a_text), fsz,
+	intel_long(ex->a_data), (unsigned) intel_long(ex->a_bss));
+    sz = ex->a_hdrlen + intel_long(ex->a_text) + intel_long(ex->a_data);
+    if (ex->a_hdrlen == SUPL_HEADER) {
+	    sz += fsz;
+	    sz += intel_long(ex->a_trsize) + intel_long(ex->a_drsize)
+	       + intel_short(ex->esh_ftrsize);
+    }
     if (intel_long(ex->a_data) + intel_long(ex->a_bss) > 65535) {
 	fprintf(stderr, "Image too large.\n");
 	exit(1);
     }
 
     lseek(id, 0, 0);
-#endif
-#if 1
+#else
     if (fstat(id, &sb)) {
 	perror("fstat");
 	die("Unable to stat 'system'");
     }
     sz = sb.st_size;
-    //fprintf(stderr, "System is %d kB\n", sz / 1024);
-    fprintf(stderr, "System is %d B\n", sz);
+    fprintf(stderr, "System is %d kB\n", sz / 1024);
 #endif
     sys_size = (sz + 15) / 16;
     fprintf(stderr, "System is %d\n", sz);

--- a/elks/include/arch/segment.h
+++ b/elks/include/arch/segment.h
@@ -14,6 +14,6 @@ extern pid_t get_pid(void);
 
 /*@-namechecks@*/
 
-extern short *_endtext, *_enddata, *_endbss;
+extern short *_endtext, *_endftext, *_enddata, *_endbss;
 
 #endif /* !__ARCH_8086_SEGMENT_H */

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -48,6 +48,10 @@
  * in linux/version.h, and should only be used by linux/version.c
  */
 
+/* Compiler attribute and segment defines - here for now */
+#define FARPROC  __far __attribute__ ((far_section, noinline))
+#define INITPROC __far __attribute__ ((far_section, noinline, section (".fartext.init")))
+
 /* Don't touch these, unless you really know what you are doing. */
 #define DEF_INITSEG	0x0100	/* original 0x0100
 				 * for netboot use for example 0x5000, as

--- a/elks/include/linuxmt/minix.h
+++ b/elks/include/linuxmt/minix.h
@@ -44,15 +44,15 @@ struct elks_supl_hdr {
     unsigned long	msh_dbase;	/* data relocation base */
     /* even more optional fields --- for ELKS medium memory model support */
     unsigned short	esh_ftseg;	/* far text size */		// 0x30
-    unsigned long	esh_ftrsize;	/* far text relocation size */	// 0x34
+    unsigned long	esh_ftrsize;	/* far text relocation size */	// 0x32
     unsigned short	esh_reserved1;
     unsigned long	esh_reserved2, esh_reserved3;
 };
 
 struct minix_reloc {
     unsigned long	r_vaddr;	/* address of place within section */
-    unsigned short	r_symndx;	/* index into symbol table */
-    unsigned short	r_type;		/* relocation type */
+    unsigned short	r_symndx;	/* index into symbol table */	// 0x04
+    unsigned short	r_type;		/* relocation type */		// 0x06
 };
 
 /* r_type values */

--- a/elks/include/linuxmt/minix.h
+++ b/elks/include/linuxmt/minix.h
@@ -24,12 +24,12 @@
 
 struct minix_exec_hdr {
     unsigned long	type;
-    unsigned char	hlen;
+    unsigned char	hlen;			// 0x04
     unsigned char	reserved1;
     unsigned short	version;
-    unsigned short	tseg, reserved2;
-    unsigned short	dseg, reserved3;
-    unsigned short	bseg, reserved4;
+    unsigned short	tseg, reserved2;	// 0x08
+    unsigned short	dseg, reserved3;	// 0x0c
+    unsigned short	bseg, reserved4;	// 0x10
     unsigned long	entry;
     unsigned short	chmem;
     unsigned short	minstack;
@@ -38,13 +38,13 @@ struct minix_exec_hdr {
 
 struct elks_supl_hdr {
     /* optional fields */
-    unsigned long	msh_trsize;	/* text relocation size */
-    unsigned long	msh_drsize;	/* data relocation size */
+    unsigned long	msh_trsize;	/* text relocation size */	// 0x20
+    unsigned long	msh_drsize;	/* data relocation size */	// 0x24
     unsigned long	msh_tbase;	/* text relocation base */
     unsigned long	msh_dbase;	/* data relocation base */
     /* even more optional fields --- for ELKS medium memory model support */
-    unsigned short	esh_ftseg;	/* far text size */
-    unsigned long	esh_ftrsize;	/* far text relocation size */
+    unsigned short	esh_ftseg;	/* far text size */		// 0x30
+    unsigned long	esh_ftrsize;	/* far text relocation size */	// 0x34
     unsigned short	esh_reserved1;
     unsigned long	esh_reserved2, esh_reserved3;
 };

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -54,8 +54,6 @@ static void init_task(void);
 extern int run_init_process(char *cmd);
 extern int run_init_process_sptr(char *cmd, char *sptr, int slen);
 
-#define FARPROC __far  __attribute__ ((far_section, noinline))
-
 void FARPROC farproc()
 {
 	// call nearproc

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -56,18 +56,10 @@ extern int run_init_process_sptr(char *cmd, char *sptr, int slen);
 
 #define FARPROC __far  __attribute__ ((far_section, noinline))
 
-int a = 3;
-
-void FARPROC nearproc(void) // FIXME works only if FARPROC
-{
-	a = 2;
-}
-
 void FARPROC farproc()
 {
-	a = 1;
-	nearproc();
-    //printk("hello far kernel!!!\n");
+	// call nearproc
+    printk("hello far kernel!!!\n");
 }
 
 void start_kernel(void)
@@ -100,9 +92,6 @@ void start_kernel(void)
     serial_console_init();
 #endif
 
-	printk("BEFORE %d, ", a);
-	farproc();
-	printk("AFTER %d\n", a);
     device_setup();
 
 #ifdef CONFIG_SOCKET
@@ -116,6 +105,8 @@ void start_kernel(void)
 #endif
 
     mm_stat(base, end);
+
+	farproc();
 
     kfork_proc(init_task);
     wake_up_process(&task[1]);
@@ -143,8 +134,8 @@ static void init_task(void)
     if (strcmp(init_command, bininit) != 0) {
 	/* Set stdin/stdout/stderr to /dev/console if not running /bin/init*/
 	num = sys_open(s="/dev/console", O_RDWR, 0);
-	if (num < 0) /* FIXME w/o "s" below, sys_open fails, guessing string addr == DS:0*/
-	    printk("Unable to open %s (error %d)\n", s, num, "s");
+	if (num < 0)
+	    printk("Unable to open %s (error %d)\n", s, num);
 	sys_dup(num);		/* open stdout*/
 	sys_dup(num);		/* open stderr*/
     }

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -54,12 +54,6 @@ static void init_task(void);
 extern int run_init_process(char *cmd);
 extern int run_init_process_sptr(char *cmd, char *sptr, int slen);
 
-void FARPROC farproc()
-{
-	// call nearproc
-    printk("hello far kernel!!!\n");
-}
-
 void start_kernel(void)
 {
     seg_t base, end;
@@ -103,8 +97,6 @@ void start_kernel(void)
 #endif
 
     mm_stat(base, end);
-
-	farproc();
 
     kfork_proc(init_task);
     wake_up_process(&task[1]);

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -54,13 +54,20 @@ static void init_task(void);
 extern int run_init_process(char *cmd);
 extern int run_init_process_sptr(char *cmd, char *sptr, int slen);
 
-
 #define FARPROC __far  __attribute__ ((far_section, noinline))
-//#define FARPROC
 
-static void FARPROC test()
+int a = 3;
+
+void FARPROC nearproc(void) // FIXME works only if FARPROC
 {
-    printk("hello far kernel!!!\n");
+	a = 2;
+}
+
+void FARPROC farproc()
+{
+	a = 1;
+	nearproc();
+    //printk("hello far kernel!!!\n");
 }
 
 void start_kernel(void)
@@ -93,7 +100,9 @@ void start_kernel(void)
     serial_console_init();
 #endif
 
-	//test();
+	printk("BEFORE %d, ", a);
+	farproc();
+	printk("AFTER %d\n", a);
     device_setup();
 
 #ifdef CONFIG_SOCKET
@@ -158,7 +167,6 @@ static void init_task(void)
     run_init_process("/bin/sh");
     run_init_process("/bin/sash");
     panic("No init or sh found");
-	test();
 }
 
 #ifdef CONFIG_BOOTOPTS

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -54,9 +54,14 @@ static void init_task(void);
 extern int run_init_process(char *cmd);
 extern int run_init_process_sptr(char *cmd, char *sptr, int slen);
 
-/*
- *	For the moment this routine _MUST_ come first.
- */
+
+#define FARPROC __far  __attribute__ ((far_section, noinline))
+//#define FARPROC
+
+static void FARPROC test()
+{
+    printk("hello far kernel!!!\n");
+}
 
 void start_kernel(void)
 {
@@ -88,6 +93,7 @@ void start_kernel(void)
     serial_console_init();
 #endif
 
+	//test();
     device_setup();
 
 #ifdef CONFIG_SOCKET
@@ -152,6 +158,7 @@ static void init_task(void)
     run_init_process("/bin/sh");
     run_init_process("/bin/sash");
     panic("No init or sh found");
+	test();
 }
 
 #ifdef CONFIG_BOOTOPTS


### PR DESCRIPTION
This PR is meant to show progress and invite review of adding far text procedure capabilities to the ELKS kernel, in an effort to reduce .text code segment size for future enhancements. Code reviews welcome.

Technical discussion on #705.

Current status is kernel booting from normal and extended a.out header kernels.
Revised setup.S to read far text section if present.
Added thunking code to kernel library.
Fixed tools/build to allow supplemental header binaries.

Note done yet:
Relocation routines not done, coming.
Will display far text code size separately from near code size.
Any far text procedure added to kernel will be prototyped such that far text will be a configurable option.

Unsure yet how to handle CONFIG_ROMCODE and !REL_SYS configurations. Romcode depends on whether gcc can emit pre-relocated segment relocations for code at fixed addresses or not.

Also have concerns as to whether DEF_SYSSEG at 0x1000 may be overwritten by large kernel during REL_SYS copy. Suggest moving to 0x2000.
