### PR TITLE
[kernel] Change a.out header tseg, dseg, bseg back to unsigned long

### DIFF
--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -583,7 +583,7 @@ sys_hdr_good:
 	mov %ax,%ds
 	mov 0x20,%ax     // text reloc size
 	mov %ax,-12(%bp)
-	mov 0x32,%ax     // far text reloc size
+	mov 0x32,%ax     // far text reloc size FIXME changing to 0x34
 	mov %ax,-14(%bp)
 	mov 0x24,%ax     // data reloc size
 	mov %ax,-16(%bp)

--- a/elks/arch/i86/tools/a.out.h
+++ b/elks/arch/i86/tools/a.out.h
@@ -10,12 +10,12 @@ struct exec {			/* a.out header */
     unsigned char a_hdrlen;	/* length of header */
     unsigned char a_unused;	/* reserved for future use */
     unsigned short a_version;	/* version stamp (not used at present) */
-    int32_t a_text;		/* +8:  size of text section in bytes */
-    int32_t a_data;		/* +12: size of data section in bytes */
-    int32_t a_bss;		/* +16: size of bss  section in bytes */
-    int32_t a_entry;	/* +20: entry point */
-    int32_t a_total;	/* +24: total memory allocated */
-    int32_t a_syms;		/* +28: size of symbol table */
+    uint32_t a_text;		/* +8:  size of text section in bytes */
+    uint32_t a_data;		/* +12: size of data section in bytes */
+    uint32_t a_bss;		/* +16: size of bss  section in bytes */
+    uint32_t a_entry;		/* +20: entry point */
+    uint32_t a_total;		/* +24: total memory allocated */
+    uint32_t a_syms;		/* +28: size of symbol table */
 
     /* SHORT FORM ENDS HERE */
     uint32_t a_trsize;		/* text relocation size */
@@ -23,10 +23,10 @@ struct exec {			/* a.out header */
     uint32_t a_tbase;		/* text relocation base */
     uint32_t a_dbase;		/* data relocation base */
     /* even more optional fields --- for ELKS medium memory model support */
-    uint16_t esh_ftseg;		/* far text size */
-    uint16_t esh_ftrsize;	/* far text relocation size */ //FIXME should be uint32
+    uint16_t esh_ftseg;		/* far text size */		//FIXME changing to long
+    uint16_t esh_ftrsize;	/* far text relocation size */	//FIXME changing to long
     uint32_t esh_reserved1;
-	uint32_t esh_reserved2;
+    uint32_t esh_reserved2;
     uint32_t esh_reserved3;
 };
 
@@ -55,8 +55,8 @@ struct exec {			/* a.out header */
 #define A_TOVLY	0x80	/* text overlay */	/* not used */
 
 /* Offsets of various things. */
-#define A_HEADERSIZ	32
-#define	A_TEXTPOS(X)	((int32_t)(X).a_hdrlen)
+#define A_MINHDR	32
+#define	A_TEXTPOS(X)	((uint32_t)(X).a_hdrlen)
 #define A_DATAPOS(X)	(A_TEXTPOS(X) + (X).a_text)
 #define	A_HASRELS(X)	((X).a_hdrlen > (unsigned char) A_MINHDR)
 #define A_HASEXT(X)	((X).a_hdrlen > (unsigned char) (A_MINHDR +  8))
@@ -68,7 +68,7 @@ struct exec {			/* a.out header */
   			((X).a_trsize + (X).a_drsize) : 0))
 
 struct reloc {
-    int32_t r_vaddr;		/* virtual address of reference */
+    uint32_t r_vaddr;		/* virtual address of reference */
     unsigned short r_symndx;	/* internal segnum or extern symbol num */
     unsigned short r_type;	/* relocation type */
 };

--- a/elks/arch/i86/tools/build.c
+++ b/elks/arch/i86/tools/build.c
@@ -226,17 +226,17 @@ int main(int argc, char **argv)
     fsz = 0;
     sz = intel_long(ex->a_text) + intel_long(ex->a_data) + intel_long(ex->a_bss);
     if (ex->a_hdrlen == SUPL_HEADER) {
-	fsz = intel_short(ex->esh_ftseg);
+	fsz = intel_short(ex->esh_ftseg);	//FIXME changing to long
 	sz += fsz;
     }
-    fprintf(stderr, "System is %d B (%d B code, %d fartext, %d B data and %u B bss)\n",
+    fprintf(stderr, "System is %d B (%d B code, %d B fartext, %d B data and %u B bss)\n",
 	sz, intel_long(ex->a_text), fsz,
 	intel_long(ex->a_data), (unsigned) intel_long(ex->a_bss));
     sz = ex->a_hdrlen + intel_long(ex->a_text) + intel_long(ex->a_data);
     if (ex->a_hdrlen == SUPL_HEADER) {
 	    sz += fsz;
 	    sz += intel_long(ex->a_trsize) + intel_long(ex->a_drsize)
-	       + intel_short(ex->esh_ftrsize);
+	       + intel_short(ex->esh_ftrsize);	//FIXME changing to long
     }
     if (intel_long(ex->a_data) + intel_long(ex->a_bss) > 65535) {
 	fprintf(stderr, "Image too large.\n");

--- a/elks/include/linuxmt/minix.h
+++ b/elks/include/linuxmt/minix.h
@@ -24,12 +24,12 @@
 
 struct minix_exec_hdr {
     unsigned long	type;
-    unsigned char	hlen;			// 0x04
+    unsigned char	hlen;		// 0x04
     unsigned char	reserved1;
     unsigned short	version;
-    unsigned short	tseg, reserved2;	// 0x08
-    unsigned short	dseg, reserved3;	// 0x0c
-    unsigned short	bseg, reserved4;	// 0x10
+    unsigned long	tseg;		// 0x08
+    unsigned long	dseg;		// 0x0c
+    unsigned long	bseg;		// 0x10
     unsigned long	entry;
     unsigned short	chmem;
     unsigned short	minstack;
@@ -43,7 +43,7 @@ struct elks_supl_hdr {
     unsigned long	msh_tbase;	/* text relocation base */
     unsigned long	msh_dbase;	/* data relocation base */
     /* even more optional fields --- for ELKS medium memory model support */
-    unsigned short	esh_ftseg;	/* far text size */		// 0x30
+    unsigned short	esh_ftseg;	/* far text size */		// 0x30 FIXME changing to long
     unsigned long	esh_ftrsize;	/* far text relocation size */	// 0x32
     unsigned short	esh_reserved1;
     unsigned long	esh_reserved2, esh_reserved3;

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,5 +1,5 @@
 ##
-console=ttyS0 net=eth 3 # condensed
+#console=ttyS0 net=eth 3 # condensed
 #init=/bin/init 3	# multiuser serial
 #init=/bin/sh		# singleuser shell
 #console=ttyS0		# serial console

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,5 +1,5 @@
 ##
-#console=ttyS0 net=eth 3 # condensed
+console=ttyS0 net=eth 3 # condensed
 #init=/bin/init 3	# multiuser serial
 #init=/bin/sh		# singleuser shell
 #console=ttyS0		# serial console


### PR DESCRIPTION
Cast to (size_t) for unsigned short usage in sys_exec.
In preparation for esh_ftseg changing to unsigned long, which will change the offset of esh_ftrsize.
Mark locations "FIXME changing to" for updating after compiler update: minix.h, setup.S, a.out.h, build.c.
Update build.c a.out header to correct dev86 version.