### PR TITLE
[cmds] Add link capability to Applications installation

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -157,6 +157,8 @@ inet/telnet/telnet				:net
 inet/telnetd/telnetd			:net
 inet/tinyirc/tinyirc			:net
 inet/urlget/urlget				:net
+inet/urlget/urlget :::ftpget	:net
+inet/urlget/urlget :::httpget	:net
 #mtools/mcopy					:mtools					:1400k
 #mtools/mdel					:mtools					:1440k
 #mtools/mdir					:mtools					:1400k

--- a/elkscmd/Make.install
+++ b/elkscmd/Make.install
@@ -156,11 +156,18 @@ install:
 	do \
 		file=`echo $$line | cut -d" " -f 1`; \
 		dir=`echo $$line | cut -d" " -f 2`; \
-		if [ "$${dir:0:2}" == "::" ]; \
+		link=no; \
+		if [ "$${dir:0:3}" == ":::" ]; \
 		then \
-			instdir=$${dir:2}; \
+			instdir=$${dir:3}; \
+			link=yes; \
 		else \
-			instdir=bin; \
+			if [ "$${dir:0:2}" == "::" ]; \
+			then \
+				instdir=$${dir:2}; \
+			else \
+				instdir=bin; \
+			fi; \
 		fi; \
 		echo install $$file to $$instdir; \
 		if [ ! -e $$file ]; \
@@ -168,8 +175,14 @@ install:
 			echo "File specified in $(PACKAGE) not found: $$file"; \
 			exit 1; \
 		else \
-			[ ! -d $$file ] && mkdir -p $$(dirname $(DESTDIR)/$$instdir); \
-			[ -f $$file ] && $(INSTALL) $$file $(DESTDIR)/$$instdir; \
+			if [ "$$link" == "yes" ]; \
+			then \
+				echo ln -s $$(basename $$file) $$instdir; \
+				ln -s $$(basename $$file) $(DESTDIR)/bin/$$instdir; \
+			else \
+				[ ! -d $$file ] && mkdir -p $$(dirname $(DESTDIR)/$$instdir); \
+				[ -f $$file ] && $(INSTALL) $$file $(DESTDIR)/$$instdir; \
+			fi; \
 		fi \
 	done < Filelist
 	rm Filelist


### PR DESCRIPTION
Creates links from urlget to ftpget and httpget as requested in #750 

Use ":::" to specify linked file in Applications table.
Uses symlinks for now.
FAT filesystems will copy file separately.

@Mellvik, please test the build on Linux if possible, tested only on macOS. The mechanism creates a symlink rather than hard link on the disk image for now, there are some issues rewriting `mfs` to support hard links that will be done later. Things seem to work well, although I am noticing a possible bug in the usage display output when urlget is run from the shell as "/bin/ftpget" (and /bin/httpget).