### PR TITLE
[ktcp] Fix ktcp socket return value corruption

### DIFF
--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -245,8 +245,8 @@ static int inet_read(register struct socket *sock, char *ubuf, int size,
     register struct tdb_read *cmd;
     int ret;
 
-    debug_net("inet_READ(socket: 0x%x size:%d nonblock: %d bufin %d)\n", sock, size,
-	   nonblock, bufin_sem);
+    debug_net("inet_READ(%d)(socket: 0x%x size:%d nonblock: %d bufin %d)\n",
+	   current->pid, sock, size, nonblock, bufin_sem);
 
     if (size > TCPDEV_MAXREAD)
 	size = TCPDEV_MAXREAD;

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -12,6 +12,7 @@
 #define DEBUG_CSLIP	0
 
 /* leave these off for now - too much info*/
+#define DEBUG_TCPDEV	0		/* tcpdev_ routines*/
 #define DEBUG_MEM	0		/* debug memory allocations*/
 #define DEBUG_CB	0		/* dump control blocks*/
 
@@ -37,6 +38,12 @@
 #define debug_cslip	printf
 #else
 #define debug_cslip(...)
+#endif
+
+#if DEBUG_TCPDEV
+#define debug_tcpdev	printf
+#else
+#define debug_tcpdev(...)
 #endif
 
 #if DEBUG_MEM


### PR DESCRIPTION
Fixes telnet localhost overwrite of tcpdev write buffer return value discussed in #747.
Fixes possible corruption during accept processing.
