### PR TITLE
[kernel] bugfix: kfork_proc(NULL) corrupts early kernel stack

### DIFF
--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -92,7 +92,8 @@ void kfork_proc(char *addr)
 
     t->t_xregs.cs = kernel_cs;			/* Run in kernel space */
     t->t_regs.ds = t->t_regs.es = t->t_regs.ss = kernel_ds;
-    arch_build_stack(t, addr);
+    if (addr)
+	arch_build_stack(t, addr);
 }
 
 /*


### PR DESCRIPTION
Should fix https://github.com/jbruchon/elks/issues/756 .