### PR TITLE
[kernel] Toggle debug display in kernel and applications with keystroke

### DIFF
--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -400,6 +400,7 @@ int tty_ioctl(struct inode *inode, struct file *file, int cmd, char *arg)
     case TCSETSW:
     case TCSETSF:
 	ret = verified_memcpy_fromfs(&tty->termios, arg, sizeof(struct termios));
+
 	/* Inform subdriver of new settings*/
 	if (ret == 0 && tty->ops->ioctl != NULL)
 	    ret = tty->ops->ioctl(tty, cmd, arg);

--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -81,6 +81,12 @@ int tty_intcheck(register struct tty *ttyp, unsigned char key)
 	    sig = SIGINT;
 	if (key == ttyp->termios.c_cc[VSUSP])
 	    sig = SIGTSTP;
+#if DEBUG_EVENT
+	if (key == ('P' & 0x1f)) {	/* ctrl-P*/
+	    debug_event();
+	    return 1;
+	}
+#endif
 	if (sig) {
 	    debug_tty("TTY signal %d to pgrp %d pid %d\n", sig, ttyp->pgrp, current->pid);
 	    kill_pg(ttyp->pgrp, sig, 1);
@@ -394,7 +400,6 @@ int tty_ioctl(struct inode *inode, struct file *file, int cmd, char *arg)
     case TCSETSW:
     case TCSETSF:
 	ret = verified_memcpy_fromfs(&tty->termios, arg, sizeof(struct termios));
-
 	/* Inform subdriver of new settings*/
 	if (ret == 0 && tty->ops->ioctl != NULL)
 	    ret = tty->ops->ioctl(tty, cmd, arg);

--- a/elks/arch/i86/drivers/char/pty.c
+++ b/elks/arch/i86/drivers/char/pty.c
@@ -115,10 +115,13 @@ size_t pty_write (struct inode *inode, struct file *file, char *data, size_t len
 		}
 
 		ret = get_user_char ((void *)(data++));
-		if (!tty_intcheck(tty, ret))
-			chq_addch (&tty->inq, ret);
-		count++;
+		if (!tty_intcheck(tty, ret)) {
+			chq_addch_nowakeup (&tty->inq, ret);
+			count++;
+		}
 	}
+	if (count > 0)
+		wake_up(&tty->inq.wait);
 
 	return count;
 }

--- a/elks/arch/i86/drivers/char/serial.c
+++ b/elks/arch/i86/drivers/char/serial.c
@@ -291,7 +291,8 @@ void rs_irq(int irq, struct pt_regs *regs, void *dev_id)
 	    chq_addch_nowakeup(q, c);
     } while (INB(io + UART_LSR) & UART_LSR_DR); /* while data available (for FIFOs)*/
 
-    wake_up(&q->wait);
+    if (q->len)		/* don't wakeup unless chars else EINTR result*/
+	wake_up(&q->wait);
 }
 #endif
 

--- a/elks/arch/i86/drivers/char/xt_key.c
+++ b/elks/arch/i86/drivers/char/xt_key.c
@@ -31,7 +31,6 @@
 #include <linuxmt/chqueue.h>
 #include <linuxmt/signal.h>
 #include <linuxmt/ntty.h>
-#include <linuxmt/debug.h>
 
 #include <arch/io.h>
 #include <arch/ports.h>
@@ -229,6 +228,7 @@ void keyboard_irq(int irq, struct pt_regs *regs, void *dev_id)
 	    ModeState &= ~mode;		/* key up: clear these and other modes*/
         } else
 	    ModeState |= mode;		/* key down: set mode bit */
+
         /* ModeState updated - now return */
         return;
     }

--- a/elks/arch/i86/drivers/char/xt_key.c
+++ b/elks/arch/i86/drivers/char/xt_key.c
@@ -31,6 +31,7 @@
 #include <linuxmt/chqueue.h>
 #include <linuxmt/signal.h>
 #include <linuxmt/ntty.h>
+#include <linuxmt/debug.h>
 
 #include <arch/io.h>
 #include <arch/ports.h>
@@ -228,7 +229,6 @@ void keyboard_irq(int irq, struct pt_regs *regs, void *dev_id)
 	    ModeState &= ~mode;		/* key up: clear these and other modes*/
         } else
 	    ModeState |= mode;		/* key down: set mode bit */
-
         /* ModeState updated - now return */
         return;
     }

--- a/elks/arch/i86/drivers/net/ne2k.c
+++ b/elks/arch/i86/drivers/net/ne2k.c
@@ -14,19 +14,12 @@
 #include <linuxmt/sched.h>
 #include <linuxmt/limits.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/debug.h>
 
 
 // Shared declarations between low and high parts
 
 #include "ne2k.h"
-
-#define DEBUG_ETH	0 /* set =1 for debugging*/
-
-#if DEBUG_ETH
-#define debug_eth   printk
-#else
-#define debug_eth(...)
-#endif
 
 // Static data
 struct wait_queue rxwait;
@@ -317,6 +310,14 @@ static struct file_operations eth_fops =
 #endif
 };
 
+#if DEBUG_ETH
+void eth_display_status(void)
+{
+	printk("\n---- Ethernet Stats ----\n");
+	printk("Skip Count %d\n", _ne2k_skip_cnt);
+}
+#endif
+
 /*
  * Ethernet main initialization (during boot)
  */
@@ -371,6 +372,9 @@ void eth_drv_init() {
 		memcpy(mac_addr, addr, 6);
 		ne2k_addr_set(addr);   /* Set NIC mac addr now so IOCTL works */
 
+#if DEBUG_ETH
+		debug_setcallback(eth_display_status);
+#endif
 		break;
 
 	}

--- a/elks/include/linuxmt/debug.h
+++ b/elks/include/linuxmt/debug.h
@@ -27,7 +27,10 @@
 /*
  * Kernel debug options, set =1 to turn on. Works across multiple files.
  */
+#define DEBUG_EVENT	1		/* generate debug events on CTRLP*/
+#define DEBUG_STARTDEF	0		/* default startup debug display*/
 #define DEBUG_BLK	0		/* block i/o*/
+#define DEBUG_ETH	0		/* ethernet*/
 #define DEBUG_FAT	0		/* FAT filesystem*/
 #define DEBUG_FILE	0		/* sys open and file i/o*/
 #define DEBUG_NET	0		/* networking*/
@@ -37,26 +40,44 @@
 #define DEBUG_TTY	0		/* tty driver*/
 #define DEBUG_WAIT	0		/* wait, exit*/
 
+#if DEBUG_EVENT
+void dprintk(char *, ...);		/* printk when debugging on*/
+void debug_event(void);			/* generate debug event*/
+void debug_setcallback(void (*cbfunc));	/* callback on debug event*/
+#define PRINTK		dprintk
+#else
+#define PRINTK		printk
+#define dprintk(...)
+#define debug_callback(...)
+#define debug_event(...)
+#endif
+
 #if DEBUG_BLK
-#define debug_blk	printk
+#define debug_blk	PRINTK
 #else
 #define debug_blk(...)
 #endif
 
+#if DEBUG_ETH
+#define debug_eth   PRINTK
+#else
+#define debug_eth(...)
+#endif
+
 #if DEBUG_FAT
-#define debug_fat	printk
+#define debug_fat	PRINTK
 #else
 #define debug_fat(...)
 #endif
 
 #if DEBUG_FILE
-#define debug_file	printk
+#define debug_file	PRINTK
 #else
 #define debug_file(...)
 #endif
 
 #if DEBUG_NET
-#define debug_net	printk
+#define debug_net	PRINTK
 #else
 #define debug_net(...)
 #endif
@@ -68,25 +89,25 @@
 #endif
 
 #if DEBUG_SIG
-#define debug_sig	printk
+#define debug_sig	PRINTK
 #else
 #define debug_sig(...)
 #endif
 
 #if DEBUG_SUP
-#define debug_sup	printk
+#define debug_sup	PRINTK
 #else
 #define debug_sup(...)
 #endif
 
 #if DEBUG_TTY
-#define debug_tty	printk
+#define debug_tty	PRINTK
 #else
 #define debug_tty(...)
 #endif
 
 #if DEBUG_WAIT
-#define debug_wait	printk
+#define debug_wait	PRINTK
 #else
 #define debug_wait(...)
 #endif
@@ -104,7 +125,7 @@
  */
 
 #ifdef DEBUG
-#	define	debug(...)	printk(__VA_ARGS__)
+#	define	debug(...)	PRINTK(__VA_ARGS__)
 #else
 #	define	debug(...)
 #endif

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -167,6 +167,7 @@ extern void up(short *);
 extern void wake_up_process(struct task_struct *);
 
 extern int kill_process(pid_t,sig_t,int);
+extern void kill_all(sig_t);
 
 extern void add_to_runqueue(struct task_struct *);
 

--- a/elks/include/linuxmt/signal.h
+++ b/elks/include/linuxmt/signal.h
@@ -34,6 +34,7 @@ typedef unsigned short sigset_t;	/* at least 16 bits */
 #define SIGPIPE		13
 #define SIGALRM		14
 #define SIGTERM		15
+#define SIGURG		16
 #define SIGTTIN		0		/* FIXME not implemented*/
 #define SIGUSR2		0		/* FIXME not implemented*/
 
@@ -129,10 +130,10 @@ typedef unsigned long sigset_t;	/* at least 32 bits */
 #define SM_SIGPIPE	(1 << (SIGPIPE - 1))
 #define SM_SIGALRM	(1 << (SIGALRM - 1))
 #define SM_SIGTERM	(1 << (SIGTERM - 1))
+#define SM_SIGURG	(1 << (SIGURG - 1))
 
 #define SM_SIGILL	0
 #define SM_SIGFPE	0
-#define SM_SIGURG	0
 #define SM_SIGTTIN	0
 #define SM_SIGTTOU	0
 #define SM_SIGTRAP	0

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -47,7 +47,6 @@ extern void Console_conout(dev_t, char);
 static void (*kputc)(dev_t, char) = Console_conout;
 #endif
 
-static int dprintk_on = DEBUG_STARTDEF;	/* toggled by debug events*/
 
 void set_console(dev_t dev)
 {
@@ -270,6 +269,7 @@ void panic(char *error, ...)
 }
 
 #if DEBUG_EVENT
+static int dprintk_on = DEBUG_STARTDEF;	/* toggled by debug events*/
 static void (*dprintk_cb)();		/* debug event callback function*/
 
 void debug_setcallback(void (*cbfunc))

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -31,6 +31,8 @@
 #include <linuxmt/kdev_t.h>
 #include <linuxmt/major.h>
 #include <linuxmt/ntty.h>
+#include <linuxmt/debug.h>
+#include <linuxmt/signal.h>
 #include <stdarg.h>
 
 dev_t dev_console;
@@ -44,6 +46,8 @@ static void (*kputc)(dev_t, char) = rs_conout;
 extern void Console_conout(dev_t, char);
 static void (*kputc)(dev_t, char) = Console_conout;
 #endif
+
+static int dprintk_on = DEBUG_STARTDEF;	/* toggled by debug events*/
 
 void set_console(dev_t dev)
 {
@@ -264,3 +268,31 @@ void panic(char *error, ...)
 
     halt();
 }
+
+#if DEBUG_EVENT
+static void (*dprintk_cb)();		/* debug event callback function*/
+
+void debug_setcallback(void (*cbfunc))
+{
+    dprintk_cb = cbfunc;
+}
+
+void debug_event(void)
+{
+    dprintk_on = !dprintk_on;
+    if (dprintk_cb)
+	dprintk_cb();
+    kill_all(SIGURG);
+}
+
+void dprintk(char *fmt, ...)
+{
+    va_list p;
+
+    if (!dprintk_on)
+	return;
+    va_start(p, fmt);
+    vprintk(fmt, p);
+    va_end(p);
+}
+#endif

--- a/elks/kernel/signal.c
+++ b/elks/kernel/signal.c
@@ -21,9 +21,11 @@ static void generate(sig_t sig, sigset_t msksig, register struct task_struct *p)
     register __sigdisposition_t sd;
 
     sd = p->sig.action[sig - 1].sa_dispose;
-    if ((sd == SIGDISP_IGN) || ((sd == SIGDISP_DFL) && (msksig &
-	    (SM_SIGCONT | SM_SIGCHLD | SM_SIGWINCH | SM_SIGURG)))) {
-	if (!(msksig & SM_SIGCHLD)) debug_sig("SIGNAL ignoring %d pid %d\n", sig, p->pid);
+    if ((sd == SIGDISP_IGN) ||
+       ((sd == SIGDISP_DFL) &&
+        (msksig & (SM_SIGCONT | SM_SIGCHLD | SM_SIGWINCH | SM_SIGURG)))) {
+	if (!(msksig & SM_SIGCHLD))
+	    debug_sig("SIGNAL ignoring %d pid %d\n", sig, p->pid);
 	return;
     }
     debug_sig("SIGNAL gen_sig %d mask %x action %x:%x pid %d\n", sig, msksig,
@@ -67,7 +69,7 @@ int kill_pg(pid_t pgrp, sig_t sig, int priv)
 	debug_sig("SIGNAL kill_pg 0 ignored\n");
 	return 0;
     }
-    debug_sig("SIGNAL kill_pg %d\n", pgrp);
+    debug_sig("SIGNAL kill_pg sig %d pgrp %d\n", sig, pgrp);
     for_each_task(p) {
 	if (p->pgrp == pgrp) {
 		if (p->state < TASK_ZOMBIE)
@@ -89,6 +91,16 @@ int kill_process(pid_t pid, sig_t sig, int priv)
 	if (p->pid == pid)
 	    return send_sig(sig, p, 0);
     return -ESRCH;
+}
+
+void kill_all(sig_t sig)
+{
+    register struct task_struct *p;
+
+    debug_sig("SIGNAL kill_all %d\n", sig);
+    for_each_task(p)
+	if (p->state < TASK_ZOMBIE)
+	    send_sig(sig, p, 0);
 }
 
 int sys_kill(pid_t pid, sig_t sig)

--- a/elkscmd/ash/linenoise_elks.c
+++ b/elkscmd/ash/linenoise_elks.c
@@ -285,9 +285,10 @@ static int enableRawMode(int fd) {
     /*raw.c_oflag &= ~(OPOST);*/
     /* control modes - set 8 bit chars */
     raw.c_cflag |= (CS8);
-    /* local modes - echo nothing, canonical off, no extended functions,
-     * no signal chars (^Z,^C) */
-    raw.c_lflag &= ~(ECHO | ECHONL | ICANON | IEXTEN | ISIG);
+    /* local modes - echo nothing, canonical off, no extended functions*/
+    raw.c_lflag &= ~(ECHO | ECHONL | ICANON | IEXTEN);
+    /* allow signal chars (^Z,^C,^P) */
+    raw.c_lflag |= ISIG;
     /* control chars - set return condition: min number of bytes and timer.
      * We want read to return every single byte, without timeout. */
     raw.c_cc[VMIN] = 1; raw.c_cc[VTIME] = 0; /* 1 byte, no timer */

--- a/elkscmd/inet/telnet/ttn.c
+++ b/elkscmd/inet/telnet/ttn.c
@@ -271,8 +271,10 @@ static void will_option (int optsrt)
 			struct termios termios;
 			tcgetattr(0, &termios);
 			termios.c_iflag &= ~(ICRNL|IGNCR|INLCR|IXON|IXOFF);
-			termios.c_oflag &= ~(OPOST);
-			termios.c_lflag &= ~(ECHO|ECHONL|ICANON|ISIG);
+			/*termios.c_oflag &= ~(OPOST);*/	/* leave OPOST|ONLCR on*/
+			termios.c_lflag &= ~(ECHO|ECHONL|ICANON);	/* leave ISIG on for ^P*/
+			termios.c_cc[VINTR] = 0;	/* turn ^C off*/
+			termios.c_cc[VSUSP] = 0;	/* turn ^Z off*/
 			tcsetattr(0, TCSANOW, &termios);
 			DO_echo= TRUE;
 			reply[0]= IAC;

--- a/elkscmd/inet/telnet/ttn.c
+++ b/elkscmd/inet/telnet/ttn.c
@@ -450,7 +450,7 @@ assert (iac == IAC);
 	case IAC_NOP:
 		break;
 	case IAC_DataMark:
-fprintf(stderr, "got a DataMark\r\n");
+//fprintf(stderr, "got a DataMark\r\n");
 		break;
 	case IAC_BRK:
 fprintf(stderr, "got a BRK\r\n");

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -5,7 +5,9 @@
 #define CSLIP		1	/* compile in CSLIP support*/
 
 /* turn these on for ELKS debugging*/
-#define DEBUG_TCP	0
+#define USE_DEBUG_EVENT 1	/* use CTRLP to toggle debug output*/
+#define DEBUG_STARTDEF	0	/* default startup debug display*/
+#define DEBUG_TCP	1
 #define DEBUG_IP	0
 #define DEBUG_ARP	0
 #define DEBUG_ETH	0
@@ -16,38 +18,46 @@
 #define DEBUG_MEM	0		/* debug memory allocations*/
 #define DEBUG_CB	0		/* dump control blocks*/
 
+#if USE_DEBUG_EVENT
+void dprintf(const char *, ...);
+#define PRINTF		dprintf
+#else
+#define PRINTF		printf
+#define dprintf(...)
+#endif
+
 #if DEBUG_TCP
-#define debug_tcp	printf
+#define debug_tcp	PRINTF
 #else
 #define debug_tcp(...)
 #endif
 
 #if DEBUG_IP
-#define debug_ip	printf
+#define debug_ip	PRINTF
 #else
 #define debug_ip(...)
 #endif
 
 #if DEBUG_ARP
-#define debug_arp	printf
+#define debug_arp	PRINTF
 #else
 #define debug_arp(...)
 #endif
 
 #if DEBUG_CSLIP
-#define debug_cslip	printf
+#define debug_cslip	PRINTF
 #else
 #define debug_cslip(...)
 #endif
 
 #if DEBUG_TCPDEV
-#define debug_tcpdev	printf
+#define debug_tcpdev	PRINTF
 #else
 #define debug_tcpdev(...)
 #endif
 
 #if DEBUG_MEM
-#define debug_mem	printf
+#define debug_mem	PRINTF
 #else
 #define debug_mem(...)
 #endif

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <getopt.h>
 #include <signal.h>
+#include <errno.h>
 #include <arpa/inet.h>
 #include "slip.h"
 #include "tcp.h"
@@ -94,8 +95,12 @@ printp();
 	FD_SET(intfd, &fdset);
 	FD_SET(tcpdevfd, &fdset);
 	count = select(intfd > tcpdevfd ? intfd + 1 : tcpdevfd + 1, &fdset, NULL, NULL, tv);
-	if (count < 0)
-		return;	//FIXME
+	if (count < 0) {
+		if (errno == EINTR)
+			continue;
+		printf("ktcp: select failed errno %d\n", errno);
+		return;
+	}
 
 	Now = timer_get_time();
 
@@ -121,9 +126,32 @@ printp();
     }
 }
 
+#if USE_DEBUG_EVENT
+static int dprintf_on = DEBUG_STARTDEF;
+
+void debug_toggle(int sig)
+{
+	dprintf_on = !dprintf_on;
+	printf("\nktcp: debug %s\n", dprintf_on? "on": "off");
+	signal(SIGURG, debug_toggle);
+}
+
+void dprintf(const char *fmt, ...)
+{
+	va_list ptr;
+
+	if (!dprintf_on)
+		return;
+	va_start(ptr, fmt);
+	vfprintf(stdout, fmt, ptr);
+	va_end(ptr);
+}
+#endif
+
 void catch(int sig)
 {
-    printf("ktcp: exit signal %d\n", sig);
+    printf("ktcp: exiting on signal %d\n", sig);
+	exit(1);
 }
 
 static void usage(void)
@@ -198,6 +226,9 @@ printp();
 
     signal(SIGHUP, catch);
     signal(SIGINT, catch);
+#if USE_DEBUG_EVENT
+    signal(SIGURG, debug_toggle);
+#endif
 
     /* become daemon now that tcpdev_inuse race condition over*/
     if (bflag) {

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -382,9 +382,10 @@ static void tcp_last_ack(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 /* called every ktcp run cycle*/
 void tcp_update(void)
 {
+    if (cbs_in_time_wait > 0 || cbs_in_user_timeout > 0) {
 debug_tcp("ktcp: update %x,%x\n", cbs_in_time_wait, cbs_in_user_timeout);
-    if (cbs_in_time_wait > 0 || cbs_in_user_timeout > 0)
 	tcpcb_expire_timeouts();
+    }
 
     //if (tcpcb_need_push > 0)
 	tcpcb_push_data();

--- a/elkscmd/sys_utils/getty.c
+++ b/elkscmd/sys_utils/getty.c
@@ -385,12 +385,13 @@ int main(int argc, char **argv)
 
     for (;;) {
 	state("login: ");
+	errno = 0;
 	n=read(STDIN_FILENO,Buffer,sizeof(Buffer)-1);
 	if (n < 1) {
 	    debug("read fail on stdin, errno %d\n", errno);
-	    if (errno != -EINTR)
-		exit(1);
-	    continue;
+	    if (errno == EINTR)
+		continue;
+	    exit(1);
 	}
 	Buffer[n] = '\0';
 	while (n > 0)

--- a/elkscmd/sys_utils/login.c
+++ b/elkscmd/sys_utils/login.c
@@ -104,7 +104,10 @@ int main(int argc, char ** argv)
 	for (;;) {
 		if (argc == 1) {
 			write(STDOUT_FILENO,"login: ",7);
+			errno = 0;
 			if (read(STDIN_FILENO, lbuf, sizeof(lbuf)) < 1) {
+				if (errno == EINTR)
+					continue;
 				exit(1);
 			}
 			p=strchr(lbuf,'\n');

--- a/libc/system/signal.c
+++ b/libc/system/signal.c
@@ -16,7 +16,7 @@ extern __attribute__((stdcall))
 #endif
     __far void _syscall_signal (int);
 
-Sig _sigtable[_NSIG-1];
+Sig _sigtable[_NSIG];
 
 /*
  * Signal handler.
@@ -42,7 +42,7 @@ Sig signal(int number, Sig pointer)
 {
    Sig old_sig;
    int rv;
-   if( number < 1 || number >= _NSIG ) { errno=EINVAL; return SIG_ERR; }
+   if( number < 1 || number > _NSIG ) { errno=EINVAL; return SIG_ERR; }
 
    if( pointer == SIG_DFL || pointer == SIG_IGN )
       rv = _signal(number, (__kern_sighandler_t) (long) (int) pointer);


### PR DESCRIPTION
This implements a general purpose event system for kernel and user mode, which by default uses Ctrl-P from the console or serial login to toggle debug display in ktcp and selected debug classes (from debug.h) in the kernel.

Communication with user mode processes is done using the SIGURG signal, which works well because the default processing for that signal is to ignore it. When Ctrl-P is typed, the kernel toggles its displays of debug_xxx calls, which are routed to dprintk, and a SIGURG signal is sent to all user processes, for them to control their own debug modes.

To test:
Boot normally, run "net start", then telnet. Use ^P to turn on and off kernel and user mode networking. By default, ktcp is compiled with DEBUG_TCP on, but all can be configured in ktcp/config.h.

Enabled by \#define DEBUG_EVENT in debug.h (default ON).
Allows kernel or user mode startup with debug on or off using DEBUG_STARTDEF.
Implements debug callbacks and dprintk in the kernel.
Fixes signal \#16, assigns it to SIGURG.
Fixes no wakeup on PTY or serial TTY unless non-signal characters received, which prevents EINTR returns.
Improves PTY execution speed by not calling wake_up on each received character.
Fixes getty/login EINTR return checks to stop exiting.
Fixes ktcp exiting on interrupted select call.
Fixes ash shell to allow ISIG processing in linenoise, allows ^C/^Z signals.
Fixes telnet to not turn off OPOST or ISIG processing for ^P, disallows ^C/^Z signals.
Moves DEBUG_ETH out of ne2k.c driver into debug.h (not yet done for wd.c)

Adds temporary demonstration code in ne2k.c to show both toggle display of debug_eth statements as well as debug event display of Skip Count when ^P pressed.