### PR TITLE
[kernel] Remove send_buf double buffer in wd.c network driver

### DIFF
--- a/elks/arch/i86/drivers/net/wd.c
+++ b/elks/arch/i86/drivers/net/wd.c
@@ -18,14 +18,7 @@
 #include <linuxmt/sched.h>
 #include <linuxmt/limits.h>
 #include <linuxmt/mm.h>
-
-#define DEBUG_ETH	0	/* set =1 for debugging */
-
-#if DEBUG_ETH
-#define debug_eth	printk
-#else
-#define debug_eth(...)
-#endif
+#include <linuxmt/debug.h>
 
 /* I/O delay settings */
 #define INB	inb	/* use inb_p for 1us delay */

--- a/elks/arch/i86/drivers/net/wd.c
+++ b/elks/arch/i86/drivers/net/wd.c
@@ -439,6 +439,7 @@ static int wd_ioctl(struct inode * inode, struct file * file,
 	case IOCTL_ETH_ADDR_GET:
 		memcpy_tofs((char *)arg, mac_addr, 6U);
 		break;
+#if 0 /* unused*/
 	case IOCTL_ETH_ADDR_SET:
 		err = -ENOSYS;
 		break;
@@ -446,7 +447,7 @@ static int wd_ioctl(struct inode * inode, struct file * file,
 		/* Get the hardware address of the NIC,	which may be different
 		 * from the currently programmed address. Be careful with this,
 		 * it may interrupt ongoing send/receives.
-		 * arg must be a 32 bytes array.
+		 * arg must be a 6 word array.
 		 */
 		wd_get_hw_addr((word_t *)arg);
 		break;
@@ -464,6 +465,7 @@ static int wd_ioctl(struct inode * inode, struct file * file,
 		/* Get the current overflow skip counter. */
 		err = -ENOSYS;
 		break;
+#endif
 	default:
 		err = -EINVAL;
 	}
@@ -572,7 +574,7 @@ void wd_drv_init(void)
 {
 	int err;
 	unsigned u;
-	word_t hw_addr[16U];
+	word_t hw_addr[6U];
 
 	do {
 		err = request_irq(WD_IRQ, wd_int, NULL);


### PR DESCRIPTION
Hello @pawosm-arm,

Here's the second improvement to the wd.c driver. You can either apply the patch to your tree to test, or wait until the new toolchain build is done and apply this PR.

Thanks!


[wd2.patch.zip](https://github.com/jbruchon/elks/files/5287249/wd2.patch.zip)
