### PR TITLE
[kernel][fat] Move FAT filesystem code to far text section

### DIFF
--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -68,7 +68,7 @@ struct inode_operations msdos_dir_inode_operations = {
 
 /*@+type@*/
 
-static int
+static int FATPROC
 unicode_to_ascii(char *ascii, unsigned char *uni)
 {
 	char *op = ascii;
@@ -86,7 +86,7 @@ unicode_to_ascii(char *ascii, unsigned char *uni)
  *	returns 1 on short filename
  *	returns 2 on long filename
  */
-int msdos_get_entry_long(
+int FATPROC msdos_get_entry_long(
 	struct inode *dir,		/* scan this directory*/
 	off_t *pos,				/* starting at this offset*/
 	struct buffer_head **bh,/* using this buffer*/

--- a/elks/fs/msdos/fat.c
+++ b/elks/fs/msdos/fat.c
@@ -16,7 +16,7 @@ static struct fat_cache *fat_cache,cache[FAT_CACHE];
 /* Returns the this'th FAT entry, -1 if it is an end-of-file entry.
    If new_value is != -1, that FAT entry is replaced by it. */
 
-long fat_access(register struct super_block *sb,long this,long new_value)
+long FATPROC fat_access(register struct super_block *sb,long this,long new_value)
 {
 	struct buffer_head *bh,*bh2;
 	unsigned char *p_first,*p_last;
@@ -133,7 +133,7 @@ long fat_access(register struct super_block *sb,long this,long new_value)
 }
 
 
-void cache_init(void)
+void FATPROC cache_init(void)
 {
 	static int initialized = 0;
 	int count;
@@ -148,7 +148,7 @@ void cache_init(void)
 }
 
 
-void cache_lookup(struct inode *inode,long cluster,long *f_clu,long *d_clu)
+void FATPROC cache_lookup(struct inode *inode,long cluster,long *f_clu,long *d_clu)
 {
 	register struct fat_cache *walk;
 
@@ -168,7 +168,7 @@ printk("cache hit: %ld (%ld)\r\n",walk->file_cluster,*d_clu);
 
 
 #ifdef DEBUG
-static void list_cache(void)
+static void FATPROC list_cache(void)
 {
 	struct fat_cache *walk;
 
@@ -182,7 +182,7 @@ static void list_cache(void)
 #endif
 
 
-void cache_add(struct inode *inode,long f_clu,long d_clu)
+void FATPROC cache_add(struct inode *inode,long f_clu,long d_clu)
 {
 	register struct fat_cache *walk,*last;
 
@@ -223,7 +223,7 @@ list_cache();
 /* Cache invalidation occurs rarely, thus the LRU chain is not updated. It
    fixes itself after a while. */
 
-void cache_inval_inode(struct inode *inode)
+void FATPROC cache_inval_inode(struct inode *inode)
 {
 	register struct fat_cache *walk;
 
@@ -233,7 +233,7 @@ void cache_inval_inode(struct inode *inode)
 }
 
 
-void cache_inval_dev(int device)
+void FATPROC cache_inval_dev(int device)
 {
 	register struct fat_cache *walk;
 
@@ -242,7 +242,7 @@ void cache_inval_dev(int device)
 }
 
 
-long get_cluster(register struct inode *inode,long cluster)
+long FATPROC get_cluster(register struct inode *inode,long cluster)
 {
 	long this,count;
 
@@ -258,7 +258,7 @@ long get_cluster(register struct inode *inode,long cluster)
 }
 
 
-long msdos_smap(struct inode *inode,long sector)
+long FATPROC msdos_smap(struct inode *inode,long sector)
 {
 	register struct msdos_sb_info *sb;
 	long cluster;
@@ -283,7 +283,7 @@ long msdos_smap(struct inode *inode,long sector)
 /* Free all clusters after the skip'th cluster. Doesn't use the cache,
    because this way we get an additional sanity check. */
 
-int fat_free(register struct inode *inode,long skip)
+int FATPROC fat_free(register struct inode *inode,long skip)
 {
 	long this,last;
 

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -12,7 +12,7 @@
 #include <linuxmt/stat.h>
 #include <linuxmt/debug.h>
 
-struct buffer_head *msdos_sread(int dev,long sector,void **start)
+struct buffer_head * FATPROC msdos_sread(int dev,long sector,void **start)
 {
 	register struct buffer_head *bh;
 
@@ -30,21 +30,21 @@ static struct wait_queue creation_wait;
 static int creation_lock = 0;
 
 
-void lock_creation(void)
+void FATPROC lock_creation(void)
 {
 	while (creation_lock) sleep_on(&creation_wait);
 	creation_lock = 1;
 }
 
 
-void unlock_creation(void)
+void FATPROC unlock_creation(void)
 {
 	creation_lock = 0;
 	wake_up(&creation_wait);
 }
 
 
-int msdos_add_cluster(register struct inode *inode)
+int FATPROC msdos_add_cluster(register struct inode *inode)
 {
 	static struct wait_queue wait;
 	static int lock = 0;
@@ -163,7 +163,7 @@ static int day_n[] = { 0,31,59,90,120,151,181,212,243,273,304,334,0,0,0,0 };
 
 /* Convert a MS-DOS time/date pair to a UNIX date (seconds since 1 1 70). */
 
-long date_dos2unix(unsigned short time,unsigned short date)
+long FATPROC date_dos2unix(unsigned short time,unsigned short date)
 {
 	int month,year;
 
@@ -178,7 +178,7 @@ long date_dos2unix(unsigned short time,unsigned short date)
 
 /* Convert linear UNIX date to a MS-DOS time/date pair. */
 
-void date_unix2dos(long unix_date,unsigned short *time, unsigned short *date)
+void FATPROC date_unix2dos(long unix_date,unsigned short *time, unsigned short *date)
 {
 	int day,year,nl_day,month;
 
@@ -213,7 +213,7 @@ void date_unix2dos(long unix_date,unsigned short *time, unsigned short *date)
    non-NULL, it is brelse'd before. Pos is incremented. The buffer header is
    returned in bh. */
 
-ino_t msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head **bh,
+ino_t FATPROC msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head **bh,
     struct msdos_dir_entry **de)
 {
 	long sector;
@@ -268,7 +268,7 @@ ino_t msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head **bh,
 /* Scans a directory for a given file (name points to its formatted name) or
    for an empty directory slot (name is NULL). Returns the inode number. */
 
-int msdos_scan(struct inode *dir,char *name,struct buffer_head **res_bh,
+int FATPROC msdos_scan(struct inode *dir,char *name,struct buffer_head **res_bh,
     struct msdos_dir_entry **res_de,ino_t *ino)
 {
 	off_t pos;
@@ -310,7 +310,7 @@ int msdos_scan(struct inode *dir,char *name,struct buffer_head **res_bh,
    directory "inode". */
 
 /* Retrieve sectors sector */
-static long raw_found(struct super_block *sb,long sector,char *name,long number,
+static long FATPROC raw_found(struct super_block *sb,long sector,char *name,long number,
     ino_t *ino)
 {
 	struct buffer_head *bh;
@@ -347,7 +347,7 @@ static long raw_found(struct super_block *sb,long sector,char *name,long number,
 }
 
 /* Retrieve the root directory file */
-static long raw_scan_root(register struct super_block *sb,char *name,long number,ino_t *ino)
+static long FATPROC raw_scan_root(register struct super_block *sb,char *name,long number,ino_t *ino)
 {
 	int count;
 	long cluster = 0;
@@ -360,7 +360,7 @@ static long raw_scan_root(register struct super_block *sb,char *name,long number
 }
 
 /* Retrieve the normal directory file */
-static long raw_scan_nonroot(register struct super_block *sb,long start,char *name,
+static long FATPROC raw_scan_nonroot(register struct super_block *sb,long start,char *name,
     long number,ino_t *ino)
 {
 	int count;
@@ -383,14 +383,14 @@ static long raw_scan_nonroot(register struct super_block *sb,long start,char *na
 /* In the directory file (cluster start) within the name or cluster number number
  * to retrieve the file, return to its ino and cluster number
  */
-static long raw_scan(struct super_block *sb,long start,char *name,long number, ino_t *ino)
+static long FATPROC raw_scan(struct super_block *sb,long start,char *name,long number, ino_t *ino)
 {
     if (start)
 		return raw_scan_nonroot(sb,start,name,number,ino);
     return raw_scan_root(sb,name,number,ino);
 }
 
-ino_t msdos_parent_ino(register struct inode *dir,int locked)
+ino_t FATPROC msdos_parent_ino(register struct inode *dir,int locked)
 {
 	long current,prev;
 	ino_t this = (ino_t)-1L;

--- a/elks/fs/msdos/namei.c
+++ b/elks/fs/msdos/namei.c
@@ -16,7 +16,7 @@
 #include <linuxmt/mm.h>
 #include <linuxmt/debug.h>
 
-unsigned char get_fs_byte(const void *dv)
+unsigned char FATPROC get_fs_byte(const void *dv)
 {
     unsigned char retv;
 
@@ -26,7 +26,7 @@ unsigned char get_fs_byte(const void *dv)
 
 /* Formats an MS-DOS file name. Rejects invalid names. */
 /* Converted to 11 bytes of msdos 8.3 file name */
-static int msdos_format_name(register const char *name,int len,char *res)
+static int FATPROC msdos_format_name(register const char *name,int len,char *res)
 {
 	register char *walk;
 	unsigned char c;
@@ -64,7 +64,7 @@ static int msdos_format_name(register const char *name,int len,char *res)
 
 
 /* Locates a shortname directory entry. */
-static int msdos_find(struct inode *dir,const char *name,int len,
+static int FATPROC msdos_find(struct inode *dir,const char *name,int len,
     struct buffer_head **bh,struct msdos_dir_entry **de,ino_t *ino)
 {
 	int res;
@@ -77,7 +77,7 @@ static int msdos_find(struct inode *dir,const char *name,int len,
 	return res;
 }
 
-static int compare(char *s1, char *s2, int len)
+static int FATPROC compare(char *s1, char *s2, int len)
 {
 	while (len--)
 		if (*s1++ != *s2++)
@@ -86,7 +86,7 @@ static int compare(char *s1, char *s2, int len)
 }
 
 /* Locate a long or shortname directory entry*/
-static int msdos_find_long(struct inode *dir, const char *name, int len,
+static int FATPROC msdos_find_long(struct inode *dir, const char *name, int len,
     struct buffer_head **bh, ino_t *ino)
 {
 	int i, entry_len, res;
@@ -156,7 +156,7 @@ int msdos_lookup(register struct inode *dir,char *name,size_t len,
 
 /* Create a new directory entry (name is already formatted). */
 
-static int msdos_create_entry(register struct inode *dir,char *name,int is_dir,
+static int FATPROC msdos_create_entry(register struct inode *dir,char *name,int is_dir,
     register struct inode **result)
 {
 	struct buffer_head *bh;

--- a/elks/include/linuxmt/msdos_fs.h
+++ b/elks/include/linuxmt/msdos_fs.h
@@ -8,11 +8,10 @@
 #include <linuxmt/fs.h>
 #include <linuxmt/ctype.h>
 
-#ifndef toupper
-extern char toupper(char c);
-#endif
-#ifndef tolower
-extern char tolower(char c);
+#ifdef CONFIG_FARTEXT_KERNEL
+#define FATPROC __far __attribute__ ((far_section, noinline, section (".fartext.fatfs")))
+#else
+#define FATPROC
 #endif
 
 #define MSDOS_ROOT_INO  1 /* == MINIX_ROOT_INO */
@@ -123,33 +122,31 @@ struct fat_cache {
 
 #define MSDOS_MKATTR(m) (!(m & 0200) ? ATTR_RO : ATTR_NONE)
 
-extern struct buffer_head *msdos_sread(int dev,long sector,void **start);
-
 /* misc.c */
 
-extern void lock_creation(void);
-extern void unlock_creation(void);
-extern int msdos_add_cluster(struct inode *inode);
-extern long date_dos2unix(unsigned short time,unsigned short date);
-extern void date_unix2dos(long unix_date,unsigned short *time,
-    unsigned short *date);
-extern ino_t msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head **bh,
+struct buffer_head * FATPROC msdos_sread(int dev,long sector,void **start);
+void FATPROC lock_creation(void);
+void FATPROC unlock_creation(void);
+int  FATPROC msdos_add_cluster(struct inode *inode);
+long FATPROC date_dos2unix(unsigned short time,unsigned short date);
+void FATPROC date_unix2dos(long unix_date,unsigned short *time, unsigned short *date);
+ino_t FATPROC msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head **bh,
     struct msdos_dir_entry **de);
-extern int msdos_scan(struct inode *dir,char *name,struct buffer_head **res_bh,
+int  FATPROC msdos_scan(struct inode *dir,char *name,struct buffer_head **res_bh,
     struct msdos_dir_entry **res_de,ino_t *ino);
-extern ino_t msdos_parent_ino(struct inode *dir,int locked);
+ino_t FATPROC msdos_parent_ino(struct inode *dir,int locked);
 
 /* fat.c */
 
-extern long fat_access(struct super_block *sb,long this,long new_value);
-extern long msdos_smap(struct inode *inode,long sector);
-extern int fat_free(struct inode *inode,long skip);
-extern void cache_init(void);
-void cache_lookup(struct inode *inode,long cluster,long *f_clu,long *d_clu);
-void cache_add(struct inode *inode,long f_clu,long d_clu);
-void cache_inval_inode(struct inode *inode);
-void cache_inval_dev(int device);
-long get_cluster(struct inode *inode,long cluster);
+long FATPROC fat_access(struct super_block *sb,long this,long new_value);
+long FATPROC msdos_smap(struct inode *inode,long sector);
+int  FATPROC fat_free(struct inode *inode,long skip);
+void FATPROC cache_init(void);
+void FATPROC cache_lookup(struct inode *inode,long cluster,long *f_clu,long *d_clu);
+void FATPROC cache_add(struct inode *inode,long f_clu,long d_clu);
+void FATPROC cache_inval_inode(struct inode *inode);
+void FATPROC cache_inval_dev(int device);
+long FATPROC get_cluster(struct inode *inode,long cluster);
 
 /* namei.c */
 
@@ -165,28 +162,19 @@ extern int msdos_rename(struct inode *old_dir,const char *old_name,int old_len,
 
 /* inode.c */
 
-extern void msdos_put_inode(struct inode *inode);
-extern void msdos_put_super(struct super_block *sb);
-extern struct super_block *msdos_read_super(register struct super_block *s,char *data, int silent);
-extern void msdos_statfs(struct super_block *sb,struct statfs *buf);
-extern long msdos_bmap(struct inode *inode,long block);
 extern void msdos_read_inode(struct inode *inode);
-extern void msdos_write_inode(struct inode *inode);
 extern int init_msdos_fs(void);
 
 /* dir.c */
 
-//extern struct file_operations msdos_dir_operations;
 extern struct inode_operations msdos_dir_inode_operations;
-extern int msdos_get_entry_long(struct inode *dir, off_t *pos, struct buffer_head **bh,
+int FATPROC msdos_get_entry_long(struct inode *dir, off_t *pos, struct buffer_head **bh,
     char *name, int *namelen, off_t *dirpos, ino_t *ino);
 
 /* file.c */
 
-//extern struct file_operations msdos_file_operations;
 extern struct inode_operations msdos_file_inode_operations;
 extern struct inode_operations msdos_file_inode_operations_no_bmap;
-
 extern void msdos_truncate(struct inode *inode);
 
 #endif

--- a/elkscmd/rootfs_template/etc/rc.d/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sys
@@ -1,6 +1,8 @@
 # This file performs system initialization
 
 echo Running $0 script
+# uncomment to display script execution
+#set -x
 
 umask 022
 export PATH=/bin
@@ -24,6 +26,11 @@ then
 #	uncomment next line to check minix HD filesystem, will fail on msdos fat
 #	check_filesystem
 fi
+
+#
+# mount 2nd filesystem
+#
+#mount -t msdos /dev/fd1 /mnt || true
 
 #
 # start networking


### PR DESCRIPTION
This PR moves the FAT filesystem code out of the kernel .text section, into a far section named .fartext.fatfs.
System tested with various FAT filesystem mounts and seems to work well. This is not yet as efficient as possible, but the kernel is now at 48k code, with 11k far text. This is now a considerable savings and provides much more breathing room for kernel expansion.

It is intended to commit this PR, but I desire to show and get comments on various code efficiency issues for a short period.

The FAT (and other) filesystem function entry points continue to be near text. More .text space could be saved by moving to far function pointers in the various kernel file_ops structures in the future, but this has too many ramifications for now.

The FAT and INIT far text code continues to be selectable using Far Text Kernel config option. The FAT section can be turned off individually in the header file linuxmt/msdos_fs.h, if desired.

