### PR TITLE
[ktcp] TCP retransmit cleanup and fixes, socket write throttling

### DIFF
--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -658,8 +658,8 @@ sys_no_far_text:
 	mov -12(%bp),%cx // text reloc size
 text_reloc:
 	jcxz 1f
-	mov $'t',%ax
-	call putc
+//	mov $'t',%ax
+//	call putc
 	mov -18(%bp),%ax // kernel .text segment
 	mov %ax,%es
 
@@ -672,8 +672,8 @@ text_reloc:
 	mov -14(%bp),%cx // far text reloc size
 ftext_reloc:
 	jcxz 2f
-	mov $'f',%ax
-	call putc
+//	mov $'f',%ax
+//	call putc
 	mov -20(%bp),%ax // kernel .fartext segment
 	mov %ax,%es
 
@@ -686,8 +686,8 @@ ftext_reloc:
 	mov -16(%bp),%cx // data reloc size
 data_reloc:
 	jcxz 3f
-	mov $'d',%ax
-	call putc
+//	mov $'d',%ax
+//	call putc
 	mov -22(%bp),%ax   // kernel .data segment
 	mov %ax,%es
 

--- a/elks/arch/i86/drivers/net/ne2k-asm.S
+++ b/elks/arch/i86/drivers/net/ne2k-asm.S
@@ -8,6 +8,7 @@
 //-----------------------------------------------------------------------------
 
 #include "arch/ports.h"
+#include <arch/asm-offsets.h>
 
 	.code16
 
@@ -34,6 +35,7 @@ io_ne2k_dma_len1   = base+0x0A  // page 0 - write
 io_ne2k_dma_len2   = base+0x0B  // page 0 - write
 
 io_ne2k_rx_stat    = base+0x0C  // page 0 - read
+io_ne2k_tx_stat    = base+0x04  // page 0 - read
 
 io_ne2k_rx_conf    = base+0x0C  // page 0 - write
 io_ne2k_tx_conf    = base+0x0D  // page 0 - write
@@ -61,6 +63,7 @@ rx_last            = 0x80
 
 //-----------------------------------------------------------------------------
 	.data
+	.extern current
 
 _ne2k_next_pk:
 	.word 0	// being used as byte ...
@@ -68,6 +71,10 @@ _ne2k_next_pk:
 	.global _ne2k_skip_cnt
 _ne2k_skip_cnt:
 	.word 0	// # of packets to skip if buffer overrun, default is all (0)
+
+	.global _ne2k_has_data
+_ne2k_has_data:
+	.word 0 
 
 	.text
 
@@ -115,14 +122,11 @@ ems_loop:
 //-----------------------------------------------------------------------------
 // DMA initialization - Prepare for internal NIC DMA transfer
 //-----------------------------------------------------------------------------
-
+// Uses: DX, AX
 // BX : chip memory address (4000h...8000h)
 // CX : byte count
 
 dma_init:
-
-	push    %ax
-	push    %dx
 
 	// set DMA start address
 
@@ -144,8 +148,6 @@ dma_init:
 	mov     %ch,%al
 	out     %al,%dx
 
-	pop     %dx
-	pop     %ax
 	ret
 
 //-----------------------------------------------------------------------------
@@ -159,9 +161,9 @@ dma_init:
 
 dma_write:
 
-	push    %ax
 	push    %cx
-	push    %dx
+	push	%bx	// TODO check if this is required (2)
+	push	%ds
 	push    %si
 
 	cli		// Experimental
@@ -179,6 +181,8 @@ dma_write:
 
 	// I/O write loop
 
+	mov	current,%bx		// setup for far memory xfer
+	mov	TASK_USER_DS(%bx),%ds
 	mov     $io_ne2k_data_io,%dx
 	cld
 
@@ -198,14 +202,13 @@ check_dma_w:
 
 	mov     $0x40,%al       //clear DMA intr bit in ISR
 	out     %al,%dx
-	clc
 
 
 	sti		// Experimental
 	pop     %si
-	pop     %dx
+	pop	%ds
+	pop	%bx
 	pop     %cx
-	pop     %ax
 	ret
 
 #if 0
@@ -254,29 +257,36 @@ rlp_ret:
 	
 //-----------------------------------------------------------------------------
 // Read block from chip with internal DMA
-//
-// FIXME: The first read operation should get a full page (256 bytes)
-// instead of just the first 4 bytes. That way a single DMA read operation will cover
-// most incoming packets in interactive sessions.
 //-----------------------------------------------------------------------------
-
+//
 // BX    : chip memory to read from
 // CX    : byte count
 // ES:DI : host memory to write to
+// AL:	 : 0: buffer is local, <>0: buffer is far
 
 dma_read:
 
-	push    %ax
-	push    %cx
-	push    %dx
 	push    %di
-	push    %es  // compiler scratch
+	push    %es
+	push	%bx
+	push	%ax
 
 	cli		//Experimental
 	inc     %cx     // make byte count even
 	and     $0xfffe,%cx
 	call    dma_init
 	shr     %cx     // half -> word size transf
+
+	mov     %ds,%bx
+	mov     %bx,%es
+	pop	%ax
+	cmp	$0,%al		// Use local buffer if zero
+	jz	buf_local
+	mov	current,%bx	// Normal: read directly into the (far) buffer
+	mov	TASK_USER_DS(%bx),%es
+buf_local:
+	pop	%bx
+	push	%bx
 
 	// start DMA read
 
@@ -286,12 +296,8 @@ dma_read:
 
 	// I/O read loop
 
-	mov     %ds,%ax
-	mov     %ax,%es
-
 	mov     $io_ne2k_data_io,%dx
 	cld
-
 emr_loop:
 	in      %dx,%ax
 	stosw
@@ -305,15 +311,15 @@ check_dma_r:
 	test    $0x40,%al       // dma done?
 	jz      check_dma_r     // loop if not
 
+	//mov	$0xabcd,%ax	// TEST
+	//mov	%ax,10(%di)
 	mov     $0x40,%al       // reset ISR (RDC bit only)
 	out     %al,%dx
 	sti		//Experimental
 
+	pop	%bx
 	pop	%es
 	pop     %di
-	pop     %dx
-	pop     %cx
-	pop     %ax
 
 	ret
 
@@ -322,11 +328,12 @@ check_dma_r:
 // ne2k_getpage -- return current ring buffer page numbers in AX:
 // AH = CURRENT - where the next received packet will be stored,
 // AL = BOUNDARY - where the next read from the buffer will start
+//-----------------------------------------------------------------------
 // NOTE: BOUNDARY is always one behind where the next read will start, the real 
 // 	read point is in the variable _NE2K_NEXT_PK. This trick is necessary
 //	because the internal logic in the NIC will trogger an overrun interrupt
 //	if the BOUNDARY pointer matches or exceeds the CURRENT pointer.
-// Used internally, exposed externally for debuggin purposes.
+// Used internally, exposed externally for debugging purposes.
 //
 	.global ne2k_getpage
 
@@ -337,7 +344,7 @@ ne2k_getpage:
 
 	mov     $io_ne2k_rx_put,%dx     // CURRENT
 	in      %dx,%al
-	mov     %al,%cl
+	mov     %al,%ah
 
 	mov	$0x02,%al		// page 0
 	mov	$io_ne2k_command,%dx
@@ -345,7 +352,6 @@ ne2k_getpage:
 
 	mov     $io_ne2k_rx_get,%dx     // BOUNDARY
 	in      %dx,%al
-	mov     %cl,%ah
 
 	ret
 
@@ -362,14 +368,14 @@ ne2k_getpage:
 ne2k_rx_stat:
 
 	// get RX put pointer
-
+#if 0
 	mov	$0x42,%al	// page 1
 	mov	$io_ne2k_command,%dx
 	out	%al,%dx
 
 	mov     $io_ne2k_rx_put,%dx
 	in      %dx,%al
-	mov     %al,%cl
+	mov     %al,%ah
 
 	mov	$0x02,%al	// back to page 0
 	mov	$io_ne2k_command,%dx
@@ -377,12 +383,11 @@ ne2k_rx_stat:
 
 	// get RX get pointer
 
-	//call	ne2k_getpage	// get current page pointers
-	mov	_ne2k_next_pk,%al // but ignore BOUNDARY, use the 'real' one.
-
-	cmp     %al,%cl		// The ring is empty if they are equal.
+	mov	_ne2k_next_pk,%al 
+	cmp     %al,%ah		// The ring is empty if they are equal.
 	jz      nrs_empty
-
+	cmp	$0,%ax
+	jz	nrs_empty
 	mov     $1,%ax		// Yes, we have data
 	jmp     nrs_exit
 
@@ -390,6 +395,12 @@ nrs_empty:
 	xor     %ax,%ax
 
 nrs_exit:
+
+#else
+	// sep2020: keep ring buffer status in a variable
+	// instead of accessing the NIC registers continuously.
+	movw	_ne2k_has_data,%ax	// TEST !!!!!
+#endif
 	ret
 
 //-----------------------------------------------------------------------------
@@ -397,9 +408,11 @@ nrs_exit:
 //-----------------------------------------------------------------------------
 // arg1 : packet buffer to receive the data. The buffer must be 4 bytes to hold 
 //	the NIC header plus the mac Ethernet frame size.
+// arg2: int - requested read size (max buffer)
+// arg3: int array [2] (return) containing the NIC packet header.
 //
 // returns:
-// AX : error code [currently unused since we don't accept packets with errors].
+// AX : < 0 if error, >0 is length read
 
 	.global ne2k_pack_get
 
@@ -407,27 +420,39 @@ ne2k_pack_get:
 
 	push    %bp
 	mov     %sp,%bp
-	push    %di		// used by compiler
+	push    %di
+	//push	%es
+
+	//sub 	$4,%sp		// temp space
+	//mov	%sp,%di
+	mov	8(%bp),%di	// get the hdr into arg3
 
 	// get RX_put pointer
 
 	mov	_ne2k_next_pk,%bh
 	xor	%bl,%bl		// Next pkt to read in BX
 
-	// get first page (256 bytes) which may be the entire packet
-
-	mov	4(%bp),%di	// Buffer address to receive data.
-	mov	$256,%cx	// Get entire page
+	mov	$4,%cx
+	//mov     %ds,%ax
+	//mov     %ax,%es		// local address space
+	xor	%al,%al		// local address space
 	call	dma_read
 
-	mov	0(%di),%ax  // AH : next record, AL : status
-	mov	2(%di),%cx  // packet size (without CRC)
+	mov	0(%di),%ax	// AH : next record, AL : status
+	mov	2(%di),%cx	// packet size (without CRC)
+
+	//add	$4,%sp
+	mov	4(%bp),%di	// Buffer address to receive data.
+	mov	6(%bp),%dx	// read len
+	cmp	%cx,%dx		// choose the shorter
+	jnb	npg_cont0
+	mov	%dx,%cx		
 
 #if 0
 	// -------------------------------------------------------------
-	// Check packet size - not really required since the NIC will not
-	// accept such packets per our initialization. Also, in order to handle error-
-	// packets, we would have to update the rx_get (BOUNDARY) pointer.
+	// Check packet size - not required since the NIC will not
+	// accept such packets per our initialization. Note, in order to handle
+	// erroneous packets, rx_get (BOUNDARY) pointer must be updated.
 	// -------------------------------------------------------------
 	or      %cx,%cx		// zero length
 	jz      npg_err2
@@ -435,60 +460,90 @@ ne2k_pack_get:
 	cmp     $1528,%cx	// max - head - crc
 	jnc     npg_err
 #endif
-	sub	$252,%cx	// Got entire packet?
-	jle	npg_cont
-				// If not, get rest of packet.
-	inc	%bh		// next page and onwards
-	cmp	$rx_last,%bh	// check wraparound
-	jnz	npg_cont0
-	mov	$rx_first,%bh
+	//sub	$252,%cx	// Got entire packet?
+	//jle	npg_cont
+				// If not, get rest.
+	//inc	%bh		// Point to next page
+	//cmp	$rx_last,%bh	// check wraparound
+	//jnz	npg_cont0
+	//mov	$rx_first,%bh
 npg_cont0:
-	add	$256,%di	// Destination memory address (keep NIC header)
-
+	//add	$256,%di	// Update destination memory address 
+				// (keep the 4 byte NIC header)
+	push	%cx		// save length
 	push	%ax
-	push	%cx
+	add	$4,%bx
+	//mov	%bx,%ax
+	//mov	current,%bx	// Read directly into the (far) buffer
+	//mov	TASK_USER_DS(%bx),%es
+	//mov	%ax,%bx
+	
 
-	// get packet body
-
+	mov	$1,%al		// use far transfer
 	call    dma_read
-	pop     %cx
-
-	// update RX_get pointer
-
 	pop     %ax
+
+	// update RX_get pointer (BOUNDARY, end of ring)
+
 npg_cont:
-	xchg    %al,%ah			// get next pointer to %al
-	mov	%al,_ne2k_next_pk	// save 'real' next ptr
+	xchg    %al,%ah		// get pointer to %al
+	mov	%al,_ne2k_next_pk  // save 'real' next ptr
+	mov	%al,%bl		// save for later
 	dec	%al
 	cmp	$rx_first,%al
-	jnb	npg_next		// if the decrement sent us outside the ring..
-	mov	$rx_last-1,%al		// make it right ...
+	jnb	npg_next	// if the decrement sent us outside the ring..
+	mov	$rx_last-1,%al	// make it right ...
 
 npg_next:
 
-	mov     $io_ne2k_rx_get,%dx	// update read_ptr reg (BOUNDARY)
+	mov     $io_ne2k_rx_get,%dx	// update RX_get (BOUNDARY)
 	out     %al,%dx
 
+#if 0	/* error processing - not used */
 	xor     %ax,%ax
 	jmp     npg_exit
-#if 0
 npg_err:
 	mov     $-1,%ax		// Packet too big
 	jmp	npg_exit
 
 npg_err2:
 	mov	$-2,%ax		// zero length packet
-#endif
+#endif  /* ---------------------------- */
 
 npg_exit:
-	// clear RX bit in ISR
-	//mov     %ax,%bx 		// save return value
-	//mov     $io_ne2k_int_stat,%dx   // reset the interrupt bit
-	//mov     $1,%al  		// NE2K_STAT_RX 
-	//out     %al,%dx
-	//mov     %bx,%ax 		// unsave
+#if 0	/* Handle ring buffer overflow - not used */
+        /* OFLOW handled by its interrupt handler */
 
+	mov     $io_ne2k_int_stat,%dx  
+	in	%dx,%al			// get the status bits
+	test	$0x10,%al
+	jz	npg_no_oflw
+	push	%bx
+	call	ne2k_clr_oflow
+	pop	%bx
+
+npg_no_oflw:
+#endif
+	// The is effectively the replacement for the rx_stat routine,
+	// clear the has_data flag if ring buffer is empty.
+	cli
+	//mov	_ne2k_has_data,%ax
+	//dec	%ax	// TESTING
+	//cmp	$0,%ax
+	//jz	npg_zero	// don't set to zero unless sure (TESTING)
+	//mov	%ax,_ne2k_has_data
+npg_zero:
+	call	ne2k_getpage
+	cmp	%ah,%bl		// ring buffer empty?
+	jnz	npg_more_data
+	movw	$0,_ne2k_has_data
+npg_more_data:
+
+	sti
+	pop	%ax	// return byte count (from %cx)
+	//pop	%es
 	pop     %di
+	mov	%bp,%sp	// restore stack pointer
 	pop     %bp
 	ret
 
@@ -539,14 +594,14 @@ ne2k_pack_put:
 
 	push    %bp
 	mov     %sp,%bp
-	push    %si  // used by compiler
+	push    %si
 
 	// write packet to chip memory
 
-	mov     6(%bp),%cx	// arg2
+	mov     6(%bp),%cx	// arg2 - count
 	xor     %bl,%bl
 	mov     $tx_first,%bh
-	mov     4(%bp),%si	// arg1
+	mov     4(%bp),%si	// arg1 - buffer
 	call    dma_write	// copy the data
 
 	// set TX pointer and length
@@ -556,24 +611,33 @@ ne2k_pack_put:
 	mov     $tx_first,%al
 	out     %al,%dx
 
-	inc     %dx  // io_ne2k_tx_len1
+	inc     %dx		// io_ne2k_tx_len1
 	mov     %cl,%al
 	out     %al,%dx
-	inc     %dx  // = io_ne2k_tx_len2
+	inc     %dx		// = io_ne2k_tx_len2
 	mov     %ch,%al
 	out     %al,%dx
 
 	// start TX
 
+tx_rdy_wait:
 	mov     $io_ne2k_command,%dx
+	in	%dx,%al
+	test	$0x4,%al	// Check that previous transmit competed.
+	jnz	tx_rdy_wait
 	mov	$6,%al		// Set TX bit, starts transfer...
 	out	%al,%dx
 
 	//mov	$io_ne2k_int_stat,%dx	// reset tx intr bit
 	//mov	$2,%al		// Test, should not make any difference
 	//out	%al,%dx
-				// Not waiting for completion
-	xor     %ax, %ax	// always zero return
+
+1:	mov     $io_ne2k_command,%dx
+	in      %dx,%al
+	test    $4,%al		// Wait for completion
+	jnz	1b
+
+	xor     %ax, %ax	// Always zero return
 
 	pop     %si
 	pop     %bp
@@ -600,19 +664,44 @@ ne2k_int_stat:
 	mov     $io_ne2k_int_stat,%dx
 	in      %dx,%al
 	test    $0x13,%al	// ring buffer overflow, tx, rx
-				// Don't reset RDC intr here, it will break 
-				// the dma_read/write routines
 	jz      nis_next
 
-	// clear TX interrupt only
-	push	%ax	
-	mov	$3,%al		// removing this for test, reset all ints see what happens ..
-				// 3 is experimental
+	mov	%al,%bl		// save return value
+	and	$3,%al		// Reset TX & RX bits here, otherwise traffic 
+				// will stop. DO NOT reset the RDC & OFLOW 
+				// interrupts, it will disturb dma rd/wr.
 	out     %al,%dx
-	pop	%ax
+	xor	%ax,%ax
+	mov	%bl,%al		// unsave
 
 nis_next:
 
+	ret
+
+//--------------------------------------------------------------
+// Initialization operations common to several internal routines
+// Uses: AX, DX
+//--------------------------------------------------------------
+ne2k_base_init:
+
+	mov     $io_ne2k_command,%dx
+
+	mov	$0x21,%al	// page 0 + Abort DMA; STOP
+	out     %al,%dx
+
+	// data I/O in words for PC/AT and higher
+
+	mov     $io_ne2k_data_conf,%dx
+	mov     $0x49,%al	// set word access
+	out     %al,%dx
+
+	// clear DMA length 
+
+	xor     %al,%al
+	mov     $io_ne2k_dma_len1,%dx
+	out     %al,%dx
+	inc     %dx  		// = io_ne2k_dma_len2
+	out     %al,%dx
 	ret
 
 //-----------------------------------------------------------------------------
@@ -622,26 +711,7 @@ nis_next:
 	.global ne2k_init
 
 ne2k_init:
-
-	// Stop DMA and MAC
-
-	mov     $io_ne2k_command,%dx
-	mov	$0x21,%al	// page 0 + Abort DMA; STOP
-	out     %al,%dx
-
-	// data I/O in words for PC/AT and higher
-
-	mov     $io_ne2k_data_conf,%dx
-	mov     $0x49,%al
-	out     %al,%dx
-
-	// clear DMA length - Important!
-
-	xor     %al,%al
-	mov     $io_ne2k_dma_len1,%dx
-	out     %al,%dx
-	inc     %dx  // = io_ne2k_dma_len2
-	out     %al,%dx
+	call	ne2k_base_init	// basic initialization
 
 	// Accept only packets without errors.
 	// Unicast & broadcast, no promiscuous, no multicast
@@ -688,7 +758,8 @@ ne2k_init:
 	// TX & RX & OFLW, no error interrupts
 
 	mov     $io_ne2k_int_mask,%dx
-	mov     $0x13,%al	// 53 = Overflow, RX, TX + RDC (debug only)
+	mov     $0x13,%al	// 0x53 = RDC, Overflow, RX, TX 
+				// 0x13 = Overflow, RX, TX
 	out     %al,%dx
 
 	mov	$0x42,%al	// page 1
@@ -780,8 +851,6 @@ ne2k_stop:
 
 ne2k_term:
 
-	// assume page 0
-
 	// mask all interrrupts
 
 	mov     $io_ne2k_int_mask,%dx
@@ -793,31 +862,29 @@ ne2k_term:
 //-----------------------------------------------------------------------------
 // NE2K probe
 //-----------------------------------------------------------------------------
-
-// Read few registers at supposed I/O addresses
-// and check their values for NE2K presence
+//
+// Access the command register, check that the changes stick
 
 // returns:
-
 // AX: 0=found 1=not found
 
 	.global ne2k_probe
 
 ne2k_probe:
 
-	// query command register
-	// MAC & DMA should be stopped
-	// and no TX in progress
+	// Poke then peek at the base address of the interface.
+	// If something is there, return 0.
+	// No attempt is made to get details about the i/f.
 
-	// register not initialized in QEMU
-	// so do not rely on this one
-
-	//mov     $io_ne2k_command,%dx
-	//in      %dx,%al
-	//and     $0x3F,%al
-	//cmp     $0x21,%al
-	//jnz     np_err
-
+	mov     $io_ne2k_command,%dx
+	mov	$0x20,%al	// set page 0
+	out	%al,%dx
+	in	%dx,%al
+	cmp	$0xff,%al	// cannot be FF
+	jz	np_err
+	cmp	0,%al		// cannot be 0
+	jz	np_err
+	
 	xor     %ax,%ax
 	jmp     np_exit
 
@@ -886,25 +953,15 @@ ne2k_get_hw_addr:
 	// NOTE: Since we're reading the entire PROM, we also have the opportunity to
 	// detect the type of card. The caller can do this since the entire dataset 
 	// is being returned.
-	// FIXME: Some of this code is identical to init() and clr_oflw((),
-	//	 move to its own function.
 
 w_reset:
-	mov	$io_ne2k_command,%dx
-	mov	$0x21,%al	// pg 0, stop, reset DMA
-	out	%al,%dx
-	mov     $io_ne2k_data_conf,%dx
-	mov     $0x49,%al	//word access
-	out     %al,%dx
-	mov	$io_ne2k_dma_len1, %dx
-	xor	%al,%al		// clear count regs
-	out	%al,%dx
-	inc	%dx
-	out	%al,%dx
+	call	ne2k_base_init	// basic initialization
+
+	xor	%al,%al
 	mov	$io_ne2k_int_mask,%dx
 	out	%al,%dx         // mask completion irq
 	mov	$io_ne2k_int_stat,%dx
-	mov	$0xff,%al
+	mov	$0x7f,%al
 	out	%al,%dx		// clear interrupt status reg, required
 
 	mov	$io_ne2k_rx_conf,%dx
@@ -917,6 +974,7 @@ w_reset:
 	// Now read the PROM
 	mov	$32,%cx		// bytes to read
 	xor	%bx,%bx		// read from 0:0
+	xor	%al,%al		// AL = 0 : local xfer
 	call	dma_read
 
 	mov	$io_ne2k_tx_conf,%dx	// set tx back to normal
@@ -941,25 +999,22 @@ ne2k_clr_oflow:
 
 	push	%di
 	push	%bp
-
-        mov	$io_ne2k_command,%dx
-        mov	$0x21,%al       // pg 0, stop, reset DMA
-        out	%al,%dx
-	
-	mov	$io_ne2k_dma_len1,%dx
-	xor	%al,%al
-	out	%al,%dx
-	inc	%dx
-	out	%al,%dx	// clear dma counter
-
-	mov	_ne2k_skip_cnt,%bx	// get # of packets to discard
 	mov	%sp,%bp
-	sub	$4,%sp		// make temp space
+
+	sub	$4,%sp		// get temp space on the stack
 	mov	%sp,%di
+
+	mov	$io_ne2k_command,%dx
+of_chk_tx:	// Ensure no transmit is in progress
+	in	%dx,%al
+	test	4,%al
+	//jnz	of_chk_tx
+
+	call	ne2k_base_init	// stop & soft reset
 
 	mov	$io_ne2k_int_stat,%dx
 
-of_reset:	// May need a timeout counter here to avoid being stuck if something goes wrong ...
+of_reset:
 	in	%dx,%al		// wait for reset to complete
 	test	$0x80,%al
 	jz	of_reset
@@ -972,31 +1027,16 @@ of_reset:	// May need a timeout counter here to avoid being stuck if something g
 	out	%al,%dx
 	
 	// NIC has stopped, now clear out the ring buffer
-	// -- either the given # of frames or the whole shebang -
-        // by manipulating the BOUNDARY pointer to discard packets.
 
 	call	ne2k_getpage    // get BOUNDARY (AL) and CURRENT (AH) pointers
-
-	cmp	$0,%bx		// zero - just empty the ring buffer
-	jnz	of_drop_packets	// not zero - dicard %bx packets
-
-	mov	%ah,%al         // set BOUNDARY = CURRENT
-	cmp	$rx_first,%ah   // if CURRENT is at the beginning of the ring (!)
-	jnz	of_clr_pk
-	mov	$rx_last+1,%al  // do the 'one behind' trickery
-
-of_clr_pk:
-	mov	%ah,_ne2k_next_pk // save real boundary ptr
-	dec	%al
-	mov	$io_ne2k_rx_get,%dx     // fake BOUNDARY ptr
-	out	%al,%dx
-	jmp	of_drop_ok
 
 of_drop_packets:
 	// loop through the number of packets given by %bx
 	// terminate if we reach the head of the buffer before the # of packets
+	// if cnt = 0, just keep the oldest packet in the ring.
 	mov	%ax,%cx		// save BOUNDARY & CURRENT
 	mov	_ne2k_next_pk,%ah
+	mov	_ne2k_skip_cnt,%bx	// get # of packets to discard
 of_drop_loop1:
 	push	%cx
 	push	%bx
@@ -1005,12 +1045,32 @@ of_drop_loop1:
 
 	// get header
 	mov	$4,%cx		// 4 bytes only
+	mov	$0,%al		// local xfer
 	call	dma_read
 
 	mov	0(%di),%ax	// AH : next record, AL : status
 	pop	%bx		// packet counter
 	pop	%cx		// need CURRENT (front of queue)
-	cmp	%ch,%ah		// has the tail caught up with the head yet?
+	cmp	$0,%bx		// Zero = keep the oldest packet, skip the rest.
+	jnz	of_drop_loop2
+
+	mov	%cl,%al		// save BOUNDARY for return
+	push	%ax
+	mov	$0x42,%al	// page 1
+	mov	$io_ne2k_command,%dx
+	out	%al,%dx
+
+	mov     $io_ne2k_rx_put,%dx
+	mov	%ah,%al		// set CURRENT to the beginning of the next pkt,
+	out	%al,%dx		// effectively clearing everything but the 
+				// first pkt in the buffer.
+	mov	$io_ne2k_command,%dx
+	mov	$2,%al
+	out	%al,%dx		// page 0
+	pop	%ax
+	jmp	of_drop_ok
+of_drop_loop2:
+	cmp	%ch,%ah		// Has the tail caught up with the head yet?
 	jz	of_wraparound
 	dec	%bx	
 	jnz	of_drop_loop1
@@ -1026,11 +1086,12 @@ of_drop_ok:
 
 	xor	%al,%al
 	out	%al,%dx
-	mov	$io_ne2k_int_stat,%dx	// clear interrupt
-	in	%dx,%al			// (all active bits, this is effectively a reset)
+	mov	$io_ne2k_int_stat,%dx	// clear all interrupt bits
+	in	%dx,%al
 	out	%al,%dx
 
-	pop	%ax	// return value as if we'd callet get_page() (for debugging)
+	pop	%ax	// return value as if we'd called 
+			// getpage() (for debugging)
 	mov	%bp,%sp
 	pop	%bp
 	pop	%di
@@ -1070,8 +1131,8 @@ ne2k_rdc:
 
 ne2k_get_errstat:
 
-// not currently useful: Needs a regime to regularly collect and accumulate 
-// the numbers in order to be of value.
+// Currently useful only 4 debugging: Needs a regime to regularly collect 
+// and accumulate the numbers in order to be of value.
 #if 0
 	push	%bp
 	mov	%si,%bp
@@ -1096,6 +1157,23 @@ ne2k_get_errstat:
 	pop	%bp
 #endif
 	xor	%ax,%ax
+	ret
+
+//---------------------------------------------------------------------------
+// Ne2k - get TX error status
+// return the content of the TX status register in AX
+//---------------------------------------------------------------------------
+
+	.global ne2k_get_tx_stat
+
+ne2k_get_tx_stat:
+	mov	$io_ne2k_int_stat,%dx
+	mov	$0x08,%al	// Clear TXE bit in ISR
+	out	%al,%dx
+
+	mov	$io_ne2k_tx_stat,%dx
+	in	%dx,%al
+	xor	%ah,%ah
 	ret
 
 //-----------------------------------------------------------------------------

--- a/elks/arch/i86/drivers/net/ne2k.c
+++ b/elks/arch/i86/drivers/net/ne2k.c
@@ -16,7 +16,6 @@
 #include <linuxmt/mm.h>
 #include <linuxmt/debug.h>
 
-
 // Shared declarations between low and high parts
 
 #include "ne2k.h"
@@ -27,11 +26,10 @@ struct wait_queue txwait;
 
 static byte_t eth_inuse = 0;
 
-static byte_t def_mac_addr [6] = {0x52, 0x54, 0x00, 0x12, 0x34, 0x56};  /* QEMU default */
+//static byte_t def_mac_addr [6] = {0x52, 0x54, 0x00, 0x12, 0x34, 0x56};  /* QEMU default */
 static byte_t mac_addr [6]; /* Current MAC address, from HW or default */
 
-static byte_t recv_buf [MAX_PACKET_ETH+4];
-static byte_t send_buf [MAX_PACKET_ETH];
+extern word_t _ne2k_has_data;
 extern word_t _ne2k_skip_cnt;	/* In case the NIC ring buffer overflows, skip this # of packets,
 				 * zero means 'all'. */
 
@@ -39,10 +37,10 @@ extern word_t _ne2k_skip_cnt;	/* In case the NIC ring buffer overflows, skip thi
  * Get packet
  */
 
-static size_t eth_read(struct inode * inode, struct file * filp,
-	char * data, size_t len)
+static size_t eth_read(struct inode * inode, struct file * filp, char * data, size_t len)
 {
 	size_t res;
+	word_t nhdr[2];	/* packet header from the NIC, for debugging */
 
 	while (1) {
 		size_t size;  // actual packet size
@@ -60,17 +58,16 @@ static size_t eth_read(struct inode * inode, struct file * filp,
 				break;
 			}
 		}
-
-		if (ne2k_pack_get(recv_buf)) {
+		if ((size = ne2k_pack_get(data, len, nhdr)) < 0) {
 			res = -EIO;
 			break;
 		}
 
-		size = *((word_t *) (recv_buf + 2));
-		if (len > size) len = size;
-		memcpy_tofs(data, recv_buf + 4, len);	/* +4: Discard NIC header. */
+		debug_eth("eth read: req %d, got %d real %d\n", len, size, nhdr[1]);
+		if (nhdr[1] > size)
+			printk("eth: truncated read - %d %d\n", nhdr[1], size);
 
-		res = len;
+		res = size;
 		break;
 	}
 
@@ -82,8 +79,7 @@ static size_t eth_read(struct inode * inode, struct file * filp,
  * Pass packet to driver for send
  */
 
-static size_t eth_write (struct inode * inode, struct file * file,
-	char * data, size_t len)
+static size_t eth_write (struct inode * inode, struct file * file, char * data, size_t len)
 {
 	size_t res;
 
@@ -103,10 +99,9 @@ static size_t eth_write (struct inode * inode, struct file * file,
 		}
 
 		if (len > MAX_PACKET_ETH) len = MAX_PACKET_ETH;
-		memcpy_fromfs(send_buf, data, len);
 
 		if (len < 64) len = 64;  /* issue #133 */
-		if (ne2k_pack_put(send_buf, len)) {
+		if (ne2k_pack_put(data, len)) {
 			res = -EIO;
 			break;
 		}
@@ -129,7 +124,7 @@ int eth_select(struct inode * inode, struct file * filp, int sel_type)
 
 	switch (sel_type) {
 		case SEL_OUT:
-			if (ne2k_tx_stat () != NE2K_STAT_TX) {
+			if (ne2k_tx_stat() != NE2K_STAT_TX) {
 				select_wait(&txwait);
 				break;
 			}
@@ -137,7 +132,7 @@ int eth_select(struct inode * inode, struct file * filp, int sel_type)
 			break;
 
 		case SEL_IN:
-			if (ne2k_rx_stat () != NE2K_STAT_RX) {
+			if (ne2k_rx_stat() != NE2K_STAT_RX) {
 				select_wait(&rxwait);
 				break;
 			}
@@ -160,24 +155,28 @@ static void ne2k_int(int irq, struct pt_regs * regs, void * dev_id)
 {
 	word_t stat, page;
 
-	stat = ne2k_int_stat ();
+	stat = ne2k_int_stat();
 #if 0
         page = ne2k_getpage();
-        printk("$%02x$B%02x$", (page>>8)&0xff, page&0xff);
+        printk("|%04x|", page);
 #endif
-	debug_eth("/%02X",stat&0xff);
 
         if (stat & NE2K_STAT_OF) {
-		printk("eth: NIC ring buffer overflow, skipping ");
+		printk("eth: NIC receive oflow (0x%x), ", stat);
 		if (_ne2k_skip_cnt) 
-			printk("%d packets.\n", _ne2k_skip_cnt);
+			printk("skipping %d packets.\n", _ne2k_skip_cnt);
 		else
-			printk("all packets.\n");
+			printk("clearing buffer.\n");
 		page = ne2k_clr_oflow(); 
-		debug_eth("/C%02x|B%02x/ ", (page>>8)&0xff, page&0xff);
+		debug_eth("/CB%04x/ ", page);
+		/* The clr_oflow routine effectively resets the NIC, clears
+		 * the ISR, so more processing of interrupt status bits is
+		 * meaningless. */
+		return;
 	}
 
 	if (stat & NE2K_STAT_RX) {
+		_ne2k_has_data = 1; 
 		wake_up(&rxwait);
 	}
 
@@ -185,7 +184,7 @@ static void ne2k_int(int irq, struct pt_regs * regs, void * dev_id)
 		wake_up(&txwait);
 	}
 	if (stat & NE2K_STAT_RDC) {
-		printk("eth: Warning - RDC intr.\n");
+		printk("eth: Warning - RDC intr. (0x%x)\n", stat);
 		/* The RDC interrupt should be disabled in the low level driver.
 		 * When real DMA transfer from NIC til system RAM is enabled, this is where
 		 * we handle transfer completion.
@@ -194,6 +193,12 @@ static void ne2k_int(int irq, struct pt_regs * regs, void * dev_id)
 		 */
 		ne2k_rdc();
 	}
+	if (stat & NE2K_STAT_TXE) { 	
+		/* transmit error detected, this should not happen. */
+		printk("eth: TX-error, status 0x%x\n", ne2k_get_tx_stat());
+		/* ne2k_get_tx_stat resets this int in the ISR */
+	}
+	debug_eth("%02X/%d/",stat,_ne2k_has_data);
 	stat = page; /* to keep compiler happy */
 }
 
@@ -210,6 +215,7 @@ static int eth_ioctl(struct inode * inode, struct file * file, unsigned int cmd,
 			memcpy_tofs((char *) arg, mac_addr, 6);
 			break;
 
+#if 0 /* unused*/
 		case IOCTL_ETH_ADDR_SET:
 			memcpy_fromfs(mac_addr, (char *) arg, 6);
 			ne2k_addr_set(mac_addr);
@@ -241,7 +247,7 @@ static int eth_ioctl(struct inode * inode, struct file * file, unsigned int cmd,
 			/* Get the current overflow skip counter. */
 			arg = _ne2k_skip_cnt;
 			break;
-
+#endif
 		default:
 			err = -EINVAL;
 
@@ -320,9 +326,11 @@ void eth_display_status(void)
 
 /*
  * Ethernet main initialization (during boot)
+ * FIXME: Needs return value to signal that initalization failed.
  */
 
-void eth_drv_init() {
+void eth_drv_init(void)
+{
 	int err;
 	word_t prom[16];	/* PROM containing HW MAC address and more 
 				 * (aka SAPROM, Station Address PROM).
@@ -359,33 +367,36 @@ void eth_drv_init() {
 		//i=0;while (i < 16) printk("%02X ", prom[i++]);
 
 		/* If there is no prom (i.e. emulator), use default */
-		if ((hw_addr[0] == 0xff) && (hw_addr[1] == 0xff))
-		        addr = def_mac_addr;
-		else
-		        addr = hw_addr; 
+       if ((hw_addr[0] == 0xff) && (hw_addr[1] == 0xff)) {
+               //addr = def_mac_addr;
+           err = -1;
+       } else {
+                addr = hw_addr;
+           err = 0;
+       }
 
-		printk ("eth: NE2K at 0x%x, irq %d, MAC %02X", NE2K_PORT, NE2K_IRQ, addr[0]);
-		i = 1;
-		while (i < 6) printk(":%02X", addr[i++]);
-		printk("\n");
+       if (!err) {
+           printk ("eth: NE2K at 0x%x, irq %d, MAC %02x", NE2K_PORT, NE2K_IRQ, addr[0]);
+           i = 1;
+           while (i < 6) printk(":%02x", addr[i++]);
+           printk("\n");
 
-		memcpy(mac_addr, addr, 6);
-		ne2k_addr_set(addr);   /* Set NIC mac addr now so IOCTL works */
-
+           memcpy(mac_addr, addr, 6);
+           ne2k_addr_set(addr);   /* Set NIC mac addr now so IOCTL works */
 #if DEBUG_ETH
 		debug_setcallback(eth_display_status);
 #endif
+       } else
+           printk("eth: Cannot access NE2K interface.\n");
+
 		break;
 
 	}
+	_ne2k_has_data = 0;
 	_ne2k_skip_cnt = 0;	/* # of packets to discard if the NIC buffer overflows. 
-				 * Zero is the default, discard entire buffer.
+                 		 * Zero is the default, discard entire buffer less one pkt.
 				 * May be changed via ioctl.
-				 * A big # will have the same effect.
+				 * A big # will elar the entire bnuffer.
 				 * On a floppy based system, anything else is useless.
 				 */
-	return;
 }
-
-
-//-----------------------------------------------------------------------------

--- a/elks/arch/i86/drivers/net/ne2k.h
+++ b/elks/arch/i86/drivers/net/ne2k.h
@@ -9,12 +9,13 @@
 #define NE2K_STAT_TX    0x0002  // packet sent
 #define NE2K_STAT_OF    0x0010  // RX ring overflow
 #define NE2K_STAT_RDC   0x0040  // Remote DMA complete
+#define NE2K_STAT_TXE	0x0080	// TX error
 
 
 // From low level NE2K PHY
 
-extern word_t ne2k_phy_get (word_t reg, word_t * val);
-extern word_t ne2k_phy_set (word_t reg, word_t val);
+extern word_t ne2k_phy_get (word_t, word_t *);
+extern word_t ne2k_phy_set (word_t, word_t);
 
 
 // From low level NE2K MAC
@@ -31,13 +32,13 @@ extern void   ne2k_term ();
 extern void   ne2k_start ();
 extern void   ne2k_stop ();
 
-extern void   ne2k_addr_set (byte_t *addr);
+extern void   ne2k_addr_set (byte_t *);
 
 extern word_t ne2k_rx_stat ();
 extern word_t ne2k_tx_stat ();
 
-extern word_t ne2k_pack_get (byte_t * pack);
-extern word_t ne2k_pack_put (byte_t * pack, word_t len);
+extern word_t ne2k_pack_get (char *, word_t, word_t *);
+extern word_t ne2k_pack_put (char *, word_t);
 
 extern word_t ne2k_test ();
 
@@ -47,5 +48,6 @@ extern void ne2k_get_hw_addr(word_t *);
 extern word_t ne2k_clr_oflow(void);
 extern void ne2k_rdc(void);
 extern void ne2k_get_errstat(byte_t *);
+extern word_t ne2k_get_tx_stat(void);
 
 #endif /* !NE2K_H */

--- a/elks/include/arch/ports.h
+++ b/elks/include/arch/ports.h
@@ -35,9 +35,6 @@
 #define CONFIG_NEED_IRQ1
 #endif
 
-/* unused*/
-//#define CONFIG_NEED_IRQ2		/* only available on XT, slave PIC on AT*/
-
 #ifdef CONFIG_CHAR_DEV_RS
 //#define CONFIG_FAST_IRQ4		/* COM1 very fast serial driver, no ISIG handling*/
 //#define CONFIG_FAST_IRQ3		/* COM2 very fast serial driver, no ISIG handling*/
@@ -47,24 +44,21 @@
 //#define CONFIG_NEED_IRQ2		/* COM4, XT only*/
 #endif
 
-/* unused*/
-//#define CONFIG_NEED_IRQ6
-//#define CONFIG_NEED_IRQ7
-//#define CONFIG_NEED_IRQ8
-
 #ifdef CONFIG_ETH_NE2K
-//#define CONFIG_NEED_IRQ9
+//#define CONFIG_NEED_IRQ9		/* ensure NE2K_IRQ set properly below also*/
 #define CONFIG_NEED_IRQ12
 #endif
 
 #ifdef CONFIG_ETH_WD
-#define CONFIG_NEED_IRQ2
+#define CONFIG_NEED_IRQ2		/* only available on XT, slave PIC on AT*/
 #endif
 
 /* unused*/
+//#define CONFIG_NEED_IRQ6
+//#define CONFIG_NEED_IRQ7
+//#define CONFIG_NEED_IRQ8
 //#define CONFIG_NEED_IRQ10
 //#define CONFIG_NEED_IRQ11
-//#define CONFIG_NEED_IRQ12
 //#define CONFIG_NEED_IRQ13
 
 /* obsolete - driver won't compile*/
@@ -103,6 +97,7 @@
 #define COM4_IRQ	2		/* unregistered unless COM4_PORT found*/
 
 /* ne2k, ne2k.c */
+//#define NE2K_IRQ	9		/* ensure CONFIG_NEED_IRQxx set properly above*/
 #define NE2K_IRQ	12
 #define NE2K_PORT	0x300
 

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -348,7 +348,7 @@ static int inet_write(register struct socket *sock, char *ubuf, int size,
 
 	if (ret < 0) {
             if (ret == -ERESTARTSYS) {
-printk("inet_write: RESTARTSYS\n");
+//printk("inet_write: retry\n");
                 schedule();
             } else
                 return ret;

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -18,6 +18,7 @@
 #include <linuxmt/stat.h>
 #include <linuxmt/debug.h>
 #include <linuxmt/fcntl.h>
+#include <linuxmt/sched.h>
 #include <linuxmt/net.h>
 #include <linuxmt/tcpdev.h>
 #include <linuxmt/debug.h>
@@ -349,6 +350,9 @@ static int inet_write(register struct socket *sock, char *ubuf, int size,
 	if (ret < 0) {
             if (ret == -ERESTARTSYS) {
 //printk("inet_write: retry\n");
+		/* delay process 10ms*/
+		current->state = TASK_INTERRUPTIBLE;
+		current->timeout = jiffies + 10;
                 schedule();
             } else
                 return ret;

--- a/elkscmd/inet/httpd/httpd.c
+++ b/elkscmd/inet/httpd/httpd.c
@@ -42,7 +42,7 @@ extern pid_t waitpid(pid_t, int *, int);
 #define WS(c)	( ((c) == ' ') || ((c) == '\t') || ((c) == '\r') || ((c) == '\n') )
 
 int listen_sock;
-#define BUF_SIZE	2048
+#define BUF_SIZE	1024
 char buf[BUF_SIZE];
 
 char* get_mime_type(char *name)
@@ -86,8 +86,8 @@ void send_error(int fd, int errnum, char *str)
 
 void process_request(int fd)
 {
-	int fin, size;
-	int ret;
+	int fin, ret;
+	off_t size;
 	char *c, *file, fullpath[128];
 	struct stat st;
 	
@@ -129,13 +129,13 @@ void process_request(int fd)
 	size = lseek(fin, (off_t)0, SEEK_END);
 	lseek(fin, (off_t)0, SEEK_SET);
 	send_header(fd, get_mime_type(fullpath));
-	sprintf(buf,"Content-Length: %d\r\n\r\n",size);
+	sprintf(buf,"Content-Length: %ld\r\n\r\n", size);
 	write(fd, buf, strlen(buf));
 	
 	do {
 		ret = read(fin, buf, BUF_SIZE);
 		if (ret > 0)
-			write(fd, buf, ret);
+			ret = write(fd, buf, ret);
 	} while (ret == BUF_SIZE);
 	
 	close(fin);

--- a/elkscmd/ktcp/arp.c
+++ b/elkscmd/ktcp/arp.c
@@ -114,15 +114,15 @@ char *mac_ntoa(eth_addr_t eth_addr)
 static void arp_print(register struct arp *arp)
 {
 #if DEBUG_ARP
-    printf("ARP: ");
-    printf("op:%d ", ntohs(arp->op));
-    printf("ll:%s->", mac_ntoa(arp->ll_eth_src));
-    printf("%s ", mac_ntoa(arp->ll_eth_dest));
-    printf("%s->", in_ntoa(arp->ip_src));
-    printf("%s ", in_ntoa(arp->ip_dest));
-    printf("eth:%s->", mac_ntoa(arp->eth_src));
-    printf("%s", mac_ntoa(arp->eth_dest));
-    printf("\n");
+    DPRINTF("ARP: ");
+    DPRINTF("op:%d ", ntohs(arp->op));
+    DPRINTF("ll:%s->", mac_ntoa(arp->ll_eth_src));
+    DPRINTF("%s ", mac_ntoa(arp->ll_eth_dest));
+    DPRINTF("%s->", in_ntoa(arp->ip_src));
+    DPRINTF("%s ", in_ntoa(arp->ip_dest));
+    DPRINTF("eth:%s->", mac_ntoa(arp->eth_src));
+    DPRINTF("%s", mac_ntoa(arp->eth_dest));
+    DPRINTF("\n");
 #endif
 }
 

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -15,49 +15,49 @@
 
 /* leave these off for now - too much info*/
 #define DEBUG_TCPDEV	0		/* tcpdev_ routines*/
-#define DEBUG_MEM	0		/* debug memory allocations*/
+#define DEBUG_MEM0		/* debug memory allocations*/
 #define DEBUG_CB	0		/* dump control blocks*/
 
 #if USE_DEBUG_EVENT
 void dprintf(const char *, ...);
-#define PRINTF		dprintf
+#define DPRINTF		dprintf
 #else
-#define PRINTF		printf
+#define DPRINTF		printf
 #define dprintf(...)
 #endif
 
 #if DEBUG_TCP
-#define debug_tcp	PRINTF
+#define debug_tcp	DPRINTF
 #else
 #define debug_tcp(...)
 #endif
 
 #if DEBUG_IP
-#define debug_ip	PRINTF
+#define debug_ip	DPRINTF
 #else
 #define debug_ip(...)
 #endif
 
 #if DEBUG_ARP
-#define debug_arp	PRINTF
+#define debug_arp	DPRINTF
 #else
 #define debug_arp(...)
 #endif
 
 #if DEBUG_CSLIP
-#define debug_cslip	PRINTF
+#define debug_cslip	DPRINTF
 #else
 #define debug_cslip(...)
 #endif
 
 #if DEBUG_TCPDEV
-#define debug_tcpdev	PRINTF
+#define debug_tcpdev	DPRINTF
 #else
 #define debug_tcpdev(...)
 #endif
 
 #if DEBUG_MEM
-#define debug_mem	PRINTF
+#define debug_mem	DPRINTF
 #else
 #define debug_mem(...)
 #endif

--- a/elkscmd/ktcp/deveth.c
+++ b/elkscmd/ktcp/deveth.c
@@ -158,14 +158,14 @@ void eth_write(unsigned char *packet, int len)
 #if DEBUG_ETH
 void eth_printhex(unsigned char *packet, int len)
 {
-  unsigned char *p = packet;
-  int i = 0;
-  printf("eth: write %d bytes: ", len);
-  if (len > 128) len = 128;
-  while (len--) {
-	printf("%02X ", *p++);
-	if ((i++ & 15) == 15) printf("\n");
-  }
-  printf("\n");
+	unsigned char *p = packet;
+	int i = 0;
+	DPRINTF("eth: write %d bytes: ", len);
+	if (len > 128) len = 128;
+	while (len--) {
+		DPRINTF("%02X ", *p++);
+		if ((i++ & 15) == 15) DPRINTF("\n");
+	}
+	DPRINTF("\n");
 }
 #endif

--- a/elkscmd/ktcp/icmp.c
+++ b/elkscmd/ktcp/icmp.c
@@ -16,6 +16,7 @@
 #include <arpa/inet.h>
 #include "config.h"
 #include "ip.h"
+#include "tcp.h"
 #include "icmp.h"
 #include "netconf.h"
 

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -60,7 +60,7 @@ void setp(unsigned char **p)
 }
 
 char *zero;
-void printp()
+void printp(void)
 {
 unsigned char *p;
 //int i;

--- a/elkscmd/ktcp/netconf.h
+++ b/elkscmd/ktcp/netconf.h
@@ -56,8 +56,8 @@ extern struct packet_stats_s netstats;
 #define NS_NETSTATS	3
 #define NS_ARP		4
 
-void netconf_init();
-void netconf_send();
-void netconf_request();
+void netconf_init(void);
+void netconf_send(struct tcpcb_s *cb);
+void netconf_request(struct stat_request_s *sr);
 
 #endif

--- a/elkscmd/ktcp/slip.c
+++ b/elkscmd/ktcp/slip.c
@@ -19,6 +19,7 @@
 #include <termios.h>
 
 #include "ip.h"
+#include "tcp.h"
 #include "slip.h"
 #include "vjhc.h"
 #include "netconf.h"

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -16,6 +16,7 @@
 #include <arpa/inet.h>
 #include "slip.h"
 #include "ip.h"
+#include "icmp.h"
 #include "tcp.h"
 #include "tcp_cb.h"
 #include "tcpdev.h"
@@ -30,12 +31,20 @@ extern int cbs_in_user_timeout;
 
 void tcp_print(struct iptcp_s *head, int recv)
 {
-    debug_tcp("TCP: %s ", recv? "recv": "send");
+#if DEBUG_TCP
+    char *prot;
+    switch (head->iph->protocol) {
+    case PROTO_TCP: prot = "TCP"; break;
+    case PROTO_ICMP: prot = "ICMP"; break;
+    default: prot = "???";
+    }
+    debug_tcp("%s: %s ", prot, recv? "recv": "send");
     debug_tcp("src:%u dst:%u ", ntohs(head->tcph->sport), ntohs(head->tcph->dport));
     debug_tcp("flags:%x ",head->tcph->flags);
     debug_tcp("seq:%lx ack:%lx ", ntohl(head->tcph->seqnum), ntohl(head->tcph->acknum));
     debug_tcp("win:%u urg:%d ", ntohs(head->tcph->window), head->tcph->urgpnt);
     debug_tcp("chk:%x len:%u\n", tcp_chksum(head), head->tcplen);
+#endif
 }
 
 int tcp_init(void)

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -37,15 +37,21 @@
 //#define TIMEOUT_INITIAL_RTT	4	/* initial RTT before retransmit*/
 #define TIMEOUT_INITIAL_RTT	1	/* initial RTT before retransmit*/
 
-/* following timeout is in 1/16 ticks, not seconds*/
-#define TIMEOUT_MIN_SLIP	8	/* minimum retrans timeout for slip/cslip (1/2 sec)*/
-
-#define PROTO_TCP	0x06
+/* retransmit settings*/
+#define TCP_RTT_ALPHA			90
+#define TCP_RETRANS_MAXMEM		2048	/* max retransmit total memory (was 16384)*/
+#define TCP_RETRANS_MAXTRIES		3	/* max # retransmits*/
+/* timeout values in 1/16 seconds*/
+#define TCP_RETRANS_MAXWAIT		64	/* max retransmit wait (4 secs)*/
+#define TCP_RETRANS_MINWAIT_SLIP	8	/* minimum retrans timeout for slip/cslip (1/2 sec)*/
+#define TCP_RETRANS_MINWAIT_ETH		4	/* minimum retrans timeout for ethernet (1/4 sec)*/
 
 #define SEQ_LT(a,b)	((long)((a)-(b)) < 0)
 #define SEQ_LEQ(a,b)	((long)((a)-(b)) <= 0)
 #define SEQ_GT(a,b)	((long)((a)-(b)) > 0)
 #define SEQ_GEQ(a,b)	((long)((a)-(b)) >= 0)
+
+#define PROTO_TCP	0x06
 
 #define	TF_FIN	0x01
 #define TF_SYN	0x02
@@ -173,23 +179,18 @@ struct	tcp_retrans_list_s {
 
 };
 
-int tcp_timeruse;
 int tcpcb_need_push;
+int tcp_timeruse;		/* # retransmits alloced*/
+int tcp_retrans_memory;		/* total retransmit memory*/
 
-#define TCP_RTT_ALPHA		90
-//#define TCP_RETRANS_MAXMEM	8192*2
-#define TCP_RETRANS_MAXMEM	2048
-int tcp_retrans_memory;
-
-struct tcpcb_list_s *tcpcb_new();
+struct tcpcb_list_s *tcpcb_new(void);
 struct tcpcb_list_s *tcpcb_find(__u32 addr, __u16 lport, __u16 rport);
 struct tcpcb_list_s *tcpcb_find_by_sock(void *sock);
-void tcpcb_remove();
 
 __u16 tcp_chksum(struct iptcp_s *h);
 __u16 tcp_chksumraw(struct tcphdr_s *h, __u32 saddr, __u32 daddr, __u16 len);
 void tcp_print(struct iptcp_s *head, int recv);
-void tcp_output();
+void tcp_output(struct tcpcb_s *cb);
 void tcp_update(void);
 int tcp_init(void);
 void tcp_process(struct iphdr_s *iph);

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -15,6 +15,7 @@
 
 #include "config.h"
 #include "tcp.h"
+#include "tcp_cb.h"
 #include "tcpdev.h"
 #include "tcp_output.h"
 
@@ -98,6 +99,17 @@ struct tcpcb_list_s *tcpcb_clone(struct tcpcb_s *cb)
 	memcpy(&n->tcpcb, cb, sizeof(struct tcpcb_s));
 
     return n;
+}
+
+void tcpcb_remove_cb(struct tcpcb_s *cb)
+{
+    struct tcpcb_list_s *n;
+
+    for (n=tcpcbs; n; n=n->next)
+	if (&n->tcpcb == cb) {
+	    tcpcb_remove(n);
+	    return;
+	}
 }
 
 void tcpcb_remove(struct tcpcb_list_s *n)

--- a/elkscmd/ktcp/tcp_cb.h
+++ b/elkscmd/ktcp/tcp_cb.h
@@ -5,6 +5,8 @@ extern int tcpcb_num;
 
 void tcpcb_init(void);
 struct tcpcb_list_s *tcpcb_clone(struct tcpcb_s *cb);
+void tcpcb_remove(struct tcpcb_list_s *n);
+void tcpcb_remove_cb(struct tcpcb_s *cb);
 void tcpcb_buf_read(struct tcpcb_s *cb, __u8 *data, __u16 len);
 void tcpcb_buf_write(struct tcpcb_s *cb, __u8 *data, __u16 len);
 void tcpcb_expire_timeouts(void);

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -342,7 +342,7 @@ static void tcpdev_write(void)
 	return;
     }
 
-debug_tcp("tcpdev write: window %ld retrans cnt %d\n", cb->send_nxt - cb->send_una, tcp_timeruse);
+debug_tcpdev("tcpdev write: window %ld retrans cnt %d\n", cb->send_nxt - cb->send_una, tcp_timeruse);
 #if 1
 #define SEND_WINDOW_MAX	1024	/* should be less than TCP_RETRANS_MAXMEM*/
     if (cb->send_nxt - cb->send_una > SEND_WINDOW_MAX) {

--- a/elkscmd/rootfs_template/bin/net
+++ b/elkscmd/rootfs_template/bin/net
@@ -15,6 +15,8 @@
 # default IP address, gateway and network mask
 localip=10.0.2.15
 gateway=10.0.2.2
+#localip=10.0.0.15
+#gateway=10.0.0.127
 netmask=255.255.255.0
 
 # default link layer [eth|slip|cslip]

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -6,4 +6,4 @@
 #console=tty2		# alt2 console
 #root=bda1			# hd partition 1
 #ro					# read-only root
-#net=slip
+#net=eth


### PR DESCRIPTION
Cleanup and fixes to ktcp retransmit routines. Should fix most issues in #755.

Fix major memory corruption bug in calling tcpcb_remove with bad parms due to lax function prototyping.
Limit retransmit waits to 1/4 second min, 4 seconds max, and 3 retransmits max.
Add experimental code to ktcp's tcpdev write handler to delay/throttle writes after SEND_WINDOW_MAX (1024) bytes unacked data outstanding.
Cleanup tcpdev handling for writing closed socket an retrans limit exceeded (returns -EPIPE and -ENOMEM).
Reduce httpd's buffer to 1024, fix file size bug, checks write return value.
Fine tuned ^P debug display.
Add comments in ports.h for IRQ selection.
Removed fartext relocation debug display at boot.

Tested on NE2K driver on real hardware.

@Mellvik - give this a try to test issues discussed in #755. I'm still seeing infrequent long loops when writes are delayed at times, with display "limiting write to max send window".
Also, the NE2K driver doesn't always work on first try, sometimes gets "NIC ring buffer overflow, skip all packets", and "RDC intr" quite a bit. Not sure why RDC intr is enabled, once it happens the driver is toast. I think the NE2K driver may still be buggy (at least on my faster 386).
I'm also having problems with telnet from Linux into ELKS - seems to work first time only with ^P debugging ON; timing related.
The send window size throttling can be changed or turned off entirely in tcpdev.c: line 346.
