### PR TITLE
[kernel]][ktcp] Fine tune network buffer sizes for speed

### DIFF
--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -1178,7 +1178,7 @@ no_sig_mess:	.ascii	"No ELKS setup signature found ..."
 		.byte	0x00
 
 hello_mess:
-	.ascii "\r\nELKS Setup\r\n"
+	.ascii "\r\nELKS Setup "
 	.byte 0
 
 // variables in ROM are not very usefull

--- a/elks/arch/i86/drivers/char/pty.c
+++ b/elks/arch/i86/drivers/char/pty.c
@@ -93,9 +93,10 @@ size_t pty_read (struct inode *inode, struct file *file, char *data, size_t len)
 
 		put_user_char (tty_outproc (tty), (void *)(data++));
 		count++;
-		wake_up (&tty->outq.wait);  /* because tty_outproc does not */
 	}
 
+	if (count > 0)
+		 wake_up(&tty->outq.wait);  /* because ttyoutproc does not*/
 	return count;
 }
 

--- a/elks/arch/i86/drivers/char/tcpdev.c
+++ b/elks/arch/i86/drivers/char/tcpdev.c
@@ -24,8 +24,8 @@
 
 #ifdef CONFIG_INET
 
-unsigned char tdin_buf[TCPDEV_INBUFFERSIZE];
-unsigned char tdout_buf[TCPDEV_OUTBUFFERSIZE];
+unsigned char tdin_buf[TCPDEV_INBUFFERSIZE];	/* for reading tcpdev*/
+unsigned char tdout_buf[TCPDEV_OUTBUFFERSIZE];	/* for writing tcpdev*/
 
 short bufin_sem, bufout_sem;	/* Buffer semaphores */
 

--- a/elks/include/linuxmt/ntty.h
+++ b/elks/include/linuxmt/ntty.h
@@ -10,7 +10,7 @@
 #define OUTQ_SIZE	64	/* tty output queue size*/
 
 #define PTYINQ_SIZE	64	/* pty input queue size*/
-#define PTYOUTQ_SIZE	256	/* pty output queue size*/
+#define PTYOUTQ_SIZE	512	/* pty output queue size (=TDB_WRITE_MAX and telnetd buffer)*/
 
 #define RSINQ_SIZE	1024	/* serial input queue SLIP_MTU+128+8*/
 #define RSOUTQ_SIZE	64	/* serial output queue size*/

--- a/elks/include/linuxmt/tcpdev.h
+++ b/elks/include/linuxmt/tcpdev.h
@@ -10,8 +10,11 @@
 
 #define TCP_DEVICE_NAME	"tcpdev"
 
+/* should be equal to PTYOUTQ_SIZE and telnetd buffer size*/
+#define	TDB_WRITE_MAX		512	/* max data in tdb_write packet to ktcp*/
+
 #define TCPDEV_INBUFFERSIZE	1024
-#define TCPDEV_OUTBUFFERSIZE	128
+#define TCPDEV_OUTBUFFERSIZE	(TDB_WRITE_MAX + sizeof(struct tdb_write))
 
 #define TCPDEV_MAXREAD TCPDEV_INBUFFERSIZE - sizeof(struct tdb_return_data)
 
@@ -65,7 +68,6 @@ struct tdb_write {
     struct socket *sock;
     int size;
     int nonblock;
-#define	TDB_WRITE_MAX	100
     unsigned char data[TDB_WRITE_MAX];
 };
 

--- a/elkscmd/inet/telnetd/telnetd.c
+++ b/elkscmd/inet/telnetd/telnetd.c
@@ -20,7 +20,7 @@
 
 //#define RAWTELNET	/* set in telnet and telnetd for raw telnet without IAC*/
 
-#define MAX_BUFFER 100
+#define MAX_BUFFER 512		/* should be equal to TDB_WRITE_MAX and PTYOUTQ_SIZE*/
 static char buf_in  [MAX_BUFFER];
 static char buf_out [MAX_BUFFER];
 

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -15,7 +15,7 @@
 
 /* leave these off for now - too much info*/
 #define DEBUG_TCPDEV	0		/* tcpdev_ routines*/
-#define DEBUG_MEM0		/* debug memory allocations*/
+#define DEBUG_MEM	0		/* debug memory allocations*/
 #define DEBUG_CB	0		/* dump control blocks*/
 
 #if USE_DEBUG_EVENT

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -23,8 +23,10 @@
 #define IP_BUFSIZ	(TCP_BUFSIZ + sizeof(iphdr_t) + sizeof(struct ip_ll))
 
 /* control block input buffer size - max window size*/
-//#define CB_IN_BUF_SIZE	1024	/* must be power of 2*/
 #define CB_IN_BUF_SIZE	4096	/* must be power of 2*/
+
+/* max outstanding send window size*/
+#define TCP_SEND_WINDOW_MAX	1024	/* should be less than TCP_RETRANS_MAXMEM*/
 
 /* bytes to subtract from window size and when to force app write*/
 #define PUSH_THRESHOLD	512
@@ -39,7 +41,7 @@
 
 /* retransmit settings*/
 #define TCP_RTT_ALPHA			90
-#define TCP_RETRANS_MAXMEM		2048	/* max retransmit total memory (was 16384)*/
+#define TCP_RETRANS_MAXMEM		4096	/* max retransmit total memory*/
 #define TCP_RETRANS_MAXTRIES		3	/* max # retransmits*/
 /* timeout values in 1/16 seconds*/
 #define TCP_RETRANS_MAXWAIT		64	/* max retransmit wait (4 secs)*/


### PR DESCRIPTION
Fine tune the kernel and ktcp for faster networking speeds.
Achieves a maximum data size of 512 bytes/packet on telnet and httpd outbound transfers.
Fixes all issues in #755, with an emphasis for speed.

Testing on with @Mellvik's curl test, and 23.5M file shows the following results, almost halving the time to send the file:
```
Time    Speed    Packet Size
1:45    230k       128   (prior to this PR)
0:54    455k       512   (with this PR)
0:56    427k       512   (with this PR and ping -i 0.2 -s 1300 running)
```
For now, 512 bytes is the likely packet limit as PTY queue, tcpdev queues, kernel, ktcp and telnetd buffers all need to increase at the same time.

Tested on 386 desktop system. No system failures with simultaneous pings, inbound telnet and httpd transfer running.
Occasional retransmits and a few NIC receive buffer overruns seen, but all recovered with no data loss.
After testing, #755 can be closed if successful, unless RST issues seen.

Change PTY_OUTQSIZE = TDB_WRITE_MAX = telnetd buffer size.
Change PTY output queue size from 256 to 512: telnetd reads from pty out queue.
Change TDB max from 100 to 512: telnetd writes to ktcp and network.
Increase max retrans memory from 2048 to 4096: stops retrans limits exceeded on large httpd transfers.
Set receive window size < 255 when little space available.
Call wake_up once in pty_read for speed.

