### PR TITLE
[ktcp] Cleanup and remove unused debug cruft from ktcp

### DIFF
--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -349,7 +349,6 @@ static int inet_write(register struct socket *sock, char *ubuf, int size,
 
 	if (ret < 0) {
             if (ret == -ERESTARTSYS) {
-//printk("inet_write: retry\n");
 		/* delay process 10ms*/
 		current->state = TASK_INTERRUPTIBLE;
 		current->timeout = jiffies + 10;

--- a/elkscmd/ktcp/deveth.c
+++ b/elkscmd/ktcp/deveth.c
@@ -67,7 +67,6 @@ void eth_process(void)
 	if (len < 0) printf("ktcp: eth_process error %d (errno %d), discarding packet\n", len, errno); //FIXME
 	return;
   }
-  if (len > (int)sizeof(sbuf)) { printf("ktcp: eth_process OVERFLOW\n"); exit(1); }
 
   eth_head = (eth_head_t *) sbuf;
 

--- a/elkscmd/ktcp/ip.h
+++ b/elkscmd/ktcp/ip.h
@@ -54,6 +54,4 @@ void ip_recvpacket(unsigned char *packet, int size);
 void ip_sendpacket(unsigned char *packet, int len, struct addr_pair *apair);
 void ip_route(unsigned char *packet, int len, struct addr_pair *apair);
 
-#define memcpy	xxmemcpy
-extern void *xxmemcpy(void *,const void *,int);
 #endif

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -38,8 +38,6 @@ ipaddr_t local_ip;
 ipaddr_t gateway_ip;
 ipaddr_t netmask_ip;
 
-char foo[] = "/dev/eth";	// FIXME remove after memory errors
-
 #define DEFAULT_IP		"10.0.2.15"
 #define DEFAULT_GATEWAY		"10.0.2.2"
 #define DEFAULT_NETMASK		"255.255.255.0"
@@ -53,23 +51,6 @@ speed_t baudrate = 	57600;
 
 int dflag;
 static int intfd;	/* interface fd*/
-
-void setp(unsigned char **p)
-{
-	*p = 0;
-}
-
-char *zero;
-void printp(void)
-{
-unsigned char *p;
-//int i;
-setp(&p);
-
-//printf(zero="ZERO\n");
-//for (i=0; i<16; i++) printf("%d (%c) ", p[i], p[i]);
-//printf("\n");
-}
 
 void ktcp_run(void)
 {
@@ -88,8 +69,6 @@ extern int cbs_in_user_timeout;
 	    timeint.tv_usec = 0;
 	    tv = &timeint;
 	} else tv = NULL;
-
-printp();
 
 	FD_ZERO(&fdset);
 	FD_SET(intfd, &fdset);
@@ -165,8 +144,6 @@ int main(int argc,char **argv)
     int ch;
     int bflag = 0;
     static char *linknames[3] = { "ethernet", "slip", "cslip" };
-printp();
-//printf("ZERO is at %x\n", zero);
 
     while ((ch = getopt(argc, argv, "bdm:p:s:l:")) != -1) {
 	switch (ch) {
@@ -246,7 +223,7 @@ printp();
 	setsid();
     }
 
-    arp_init ();
+    arp_init();
     ip_init();
     icmp_init();
     tcp_init();
@@ -254,5 +231,5 @@ printp();
 
     ktcp_run();
 
-    exit(0);
+    return 0;
 }

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -70,10 +70,10 @@ struct tcpcb_list_s *tcpcb_new(void)
 
     n = (struct tcpcb_list_s *) malloc(sizeof(struct tcpcb_list_s));
     if (n == NULL) {
-	debug_tcp("ktcp: Out of memory 3\n");
+	debug_tcp("ktcp: Out of memory 2\n");
 	return NULL;
     }
-debug_mem("Alloc CB %d bytes\n", sizeof(struct tcpcb_list_s));
+    debug_mem("Alloc CB %d bytes\n", sizeof(struct tcpcb_list_s));
 
     memset(&n->tcpcb, 0, sizeof(struct tcpcb_s));
     n->tcpcb.rtt = TIMEOUT_INITIAL_RTT << 4;
@@ -116,7 +116,7 @@ void tcpcb_remove(struct tcpcb_list_s *n)
 {
     struct tcpcb_list_s *next = n->next;
 
-debug_tcp("tcp: REMOVING control block\n");
+    debug_tcp("tcp: REMOVING control block\n");
     tcpcb_num--;	/* for netstat*/
 
     if (n->prev)
@@ -128,7 +128,7 @@ debug_tcp("tcp: REMOVING control block\n");
 	n->prev = NULL;
 
 	rmv_all_retrans(tcpcbs);
-debug_mem("Free CB\n");
+	debug_mem("Free CB\n");
 	free(tcpcbs);
 	tcpcbs = n;
 
@@ -140,7 +140,7 @@ debug_mem("Free CB\n");
 
     rmv_all_retrans(n);
     free(n);
-debug_mem("Free CB\n");
+    debug_mem("Free CB\n");
 }
 
 struct tcpcb_list_s *tcpcb_check_port(__u16 lport)
@@ -260,7 +260,6 @@ void tcpcb_buf_read(struct tcpcb_s *cb, __u8 *data, __u16 len)
 {
     register int head = cb->buf_head, i;
 
-if (len > cb->buf_len) printf("tcpcb_buf_read: BAD READ\n"); //FIXME
     for (i=0; i<len; i++)
 	*(data + i) = cb->in_buf[head++ & (CB_IN_BUF_SIZE - 1)];
     cb->buf_head = head & (CB_IN_BUF_SIZE - 1);

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -48,6 +48,7 @@ __u16 tcp_chksum(struct iptcp_s *h)
 	sum = (sum & 0xffff) + (sum >> 16);
     return ~(__u16)sum;
 }
+
 /*** __u16 tcp_chksum(struct iptcp_s *h)
 	.text
 	.globl _tcp_chksum
@@ -120,6 +121,7 @@ __u16 tcp_chksumraw(struct tcphdr_s *h, __u32 saddr, __u32 daddr, __u16 len)
 	sum = (sum & 0xffff) + (sum >> 16);
     return ~(__u16)sum;
 }
+
 /*** __u16 tcp_chksumraw(struct tcphdr_s *h, __u32 saddr, __u32 daddr, __u16 len)
 	.text
 	.globl _tcp_chksumraw
@@ -270,10 +272,10 @@ void add_for_retrans(struct tcpcb_s *cb, struct tcphdr_s *th, __u16 len,
     n->rto = cb->rtt << 1;
     if (linkprotocol == LINK_ETHER) {
 	if (n->rto < TCP_RETRANS_MINWAIT_ETH)
-	    n->rto = TCP_RETRANS_MINWAIT_ETH;		/* 1/4 sec min retrans timeout on ethernet*/
+	    n->rto = TCP_RETRANS_MINWAIT_ETH;	/* 1/4 sec min retrans timeout on ethernet*/
     } else {
 	if (n->rto < TCP_RETRANS_MINWAIT_SLIP)
-	    n->rto = TCP_RETRANS_MINWAIT_SLIP;		/* 1/2 sec min retrans timeout on slip/cslip*/
+	    n->rto = TCP_RETRANS_MINWAIT_SLIP;	/* 1/2 sec min retrans timeout on slip/cslip*/
     }
     n->next_retrans = Now + n->rto;
 }

--- a/elkscmd/ktcp/vjhc.c
+++ b/elkscmd/ktcp/vjhc.c
@@ -155,7 +155,7 @@ int ip_vjhc_init(void)
 			free(xmit_state);
 		xmit_state= calloc(ip_snd_vjhc_state_nr, sizeof(snd_state_ut));
 		if (!xmit_state) {
-			printf("ktcp: Out of memory 4\n");
+			printf("ktcp: Out of memory 3\n");
 			return -1;
 		}
 
@@ -174,7 +174,7 @@ int ip_vjhc_init(void)
 			free(rcv_state);
 		rcv_state= calloc(ip_rcv_vjhc_state_nr, sizeof(snd_state_ut));
 		if (!rcv_state) {
-			printf("ktcp: Out of memory 5\n");
+			printf("ktcp: Out of memory 4\n");
 			return -1;
 		}
 	}
@@ -214,18 +214,18 @@ int ip_vjhc_compress(pkt_ut *pkt)
 	tcp_hdr_len= TCP_DATAOFF(tcp_hdr);	/* !!! */
 	tot_len= ip_hdr_len + tcp_hdr_len;
 #if DEBUG_CSLIP
-	printf("cslip compress: packet with size %d\n\t", pkt->p_size);
+	DPRINTF("cslip compress: packet with size %d\n\t", pkt->p_size);
 	for (cp= (__u8 *)pkt->p_data+pkt->p_offset;
 		 cp < (__u8 *)pkt->p_data + pkt->p_offset + ip_hdr_len; cp++) {
-		printf("%x ", *cp);
+		DPRINTF("%x ", *cp);
 	}
-	printf("\n\t");
+	DPRINTF("\n\t");
 	for (; cp < (__u8 *)pkt->p_data + pkt->p_offset + tot_len; cp++)
-		printf("%x ", *cp);
-	printf("\n\t");
+		DPRINTF("%x ", *cp);
+	DPRINTF("\n\t");
 	for (; cp < (__u8 *)pkt->p_data + pkt->p_offset + pkt->p_size; cp++)
-		printf("%x ", *cp);
-	printf("\n");
+		DPRINTF("%x ", *cp);
+	DPRINTF("\n");
 #endif
 	for (prev = NULL, state = xmit_head;;) {
 		if (ip_hdr->saddr == state->s_src_ip &&
@@ -513,18 +513,18 @@ void ip_vjhc_arr_compr(pkt_ut *pkt)
 	ip_hdr->check= 0;
 	ip_hdr->check= ip_calc_chksum((char *)ip_hdr, state->s_ip_hdr_len);
 #if DEBUG_CSLIP
-	printf("cslip arr_compr: packet with size %d\n\t", pkt->p_size);
+	DPRINTF("cslip arr_compr: packet with size %d\n\t", pkt->p_size);
 	for (cp= (__u8 *)pkt->p_data+pkt->p_offset;
 		 cp < (__u8 *)pkt->p_data + pkt->p_offset + state->s_ip_hdr_len; cp++) {
-		printf("%x ", *cp);
+		DPRINTF("%x ", *cp);
 	}
-	printf("\n\t");
+	DPRINTF("\n\t");
 	for (; cp < (__u8 *)pkt->p_data + pkt->p_offset + tot_len; cp++)
-		printf("%x ", *cp);
-	printf("\n\t");
+		DPRINTF("%x ", *cp);
+	DPRINTF("\n\t");
 	for (; cp < (__u8 *)pkt->p_data + pkt->p_offset + pkt->p_size; cp++)
-		printf("%x ", *cp);
-	printf("\n");
+		DPRINTF("%x ", *cp);
+	DPRINTF("\n");
 #endif
 }
 

--- a/elkscmd/rootfs_template/etc/rc.d/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sys
@@ -44,7 +44,7 @@ slip)
 	net start slip
 	;;
 cslip)
-	net start clsip
+	net start cslip
 	;;
 *)
 	# normal network start


### PR DESCRIPTION
Removes lots of older unused debug cruft, along with source code cleanup of ktcp. No operational changes, other than the real memcpy will be used rather than the error-checking slower C xxmemcpy version.