### PR TITLE
[kernel] Reduce kernel stack usage on symlinks to FAT filesystem

### DIFF
--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -99,7 +99,8 @@ int FATPROC msdos_get_entry_long(
 	off_t oldpos = *pos;	/* location of next directory entry start*/
 	int is_long;
 	unsigned char alias_checksum = 0;
-	unsigned char unicodename[52+2];		/* Limited to two long entries */
+	/* static not reentrant: conserve stack usage*/
+	static unsigned char unicodename[52+2];		/* Limited to two long entries */
 
 	if ((int)*pos & (sizeof(struct msdos_dir_entry) - 1)) return -ENOENT;
 	is_long = 0;
@@ -156,7 +157,7 @@ int FATPROC msdos_get_entry_long(
 			int i,i2,last;
 			int long_len = 0;
 			unsigned char c;
-			char longname[14];
+			static char longname[14]; /* static not reentrant: conserve stack usage*/
 
 			if (is_long) {
 				unsigned char sum;

--- a/elks/fs/msdos/namei.c
+++ b/elks/fs/msdos/namei.c
@@ -91,8 +91,9 @@ static int FATPROC msdos_find_long(struct inode *dir, const char *name, int len,
 {
 	int i, entry_len, res;
 	off_t dirpos, pos = 0;
-	char entry_name[14];
-	char msdos_name[14];
+	/* static not reentrant: conserve stack usage*/
+	static char entry_name[14];
+	static char msdos_name[14];
 
 	for (i=0; i<len; i++)
 		msdos_name[i] = get_fs_byte(name++);

--- a/elks/fs/stat.c
+++ b/elks/fs/stat.c
@@ -17,7 +17,7 @@
 
 static int cp_stat(register struct inode *inode, struct stat *statbuf)
 {
-    struct stat tmp;
+    static struct stat tmp;		/* static not reentrant: conserve stack usage*/
 
     memset(&tmp, 0, sizeof(tmp));
 


### PR DESCRIPTION
This should fix issue #776 and the kernel stack overflow mentioned in passing regarding cp /bin/\* in #742.

Instead of increasing kernel stack size from 512 to 600, several large stack buffers were found in various FAT functions, which could be converted to static to conserve stack space, as the routines are not required to be reentrant.

Looking further into the reason for #776, I find that the MINIX symlink follow code is recursive, which uses too much stack space. This is already documented as a FIXME in minix/symlink.c. That will have to be fixed at a later time.

Testing with CONFIG_STRACE shows that the current high kernel stack usage marker is 426 bytes with this fix, instead of the 524 earlier which caused stack overflow.