### PR TITLE
[kernel] Add CR before NL on serial printk display

### DIFF
--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -37,9 +37,9 @@
 
 dev_t dev_console;
 
+extern void rs_conout(dev_t, char);
 #ifdef CONFIG_CONSOLE_SERIAL
 #define DEVCONSOLE  MKDEV(TTY_MAJOR,RS_MINOR_OFFSET)	/* /dev/ttyS0*/
-extern void rs_conout(dev_t, char);
 static void (*kputc)(dev_t, char) = rs_conout;
 #else
 #define DEVCONSOLE  MKDEV(TTY_MAJOR,TTY_MINOR_OFFSET)	/* /dev/tty1*/
@@ -62,8 +62,13 @@ void set_console(dev_t dev)
 
 void kputchar(int ch)
 {
-	if (kputc)
+	if (kputc) {
+#ifdef CONFIG_CHAR_DEV_RS
+		if (ch == '\n' && kputc == rs_conout)
+			(*kputc)(dev_console, '\r');
+#endif
 		(*kputc)(dev_console, ch);
+	}
 }
 
 static void kputs(register char *buf)

--- a/elkscmd/sys_utils/login.c
+++ b/elkscmd/sys_utils/login.c
@@ -96,7 +96,7 @@ int main(int argc, char ** argv)
 {
 	struct passwd *pwd;
 	struct utmp *entryp = NULL;
-	char lbuf[UT_NAMESIZE], *pbuf, salt[3];
+	char lbuf[64], *pbuf, salt[3];
 	char *p;
 
 


### PR DESCRIPTION
Fixes kernel printk on serial windows on Linux.

Also fixes problem of network logins asking for Password: after 8 characters typed.