### PR TITLE
[kernel] Fix longstanding PTY bug requiring keypress to continue

### DIFF
--- a/elks/arch/i86/drivers/char/pty.c
+++ b/elks/arch/i86/drivers/char/pty.c
@@ -145,8 +145,6 @@ static void ttyp_release(struct tty *tty)
 
 static int ttyp_write(register struct tty *tty)
 {
-    if (tty->outq.len == tty->outq.size)
-	interruptible_sleep_on(&tty->outq.wait);
     return 0;
 }
 


### PR DESCRIPTION
Finally tracked down the bug which caused certain telnet sessions to stop displaying, which would start again on any keypress.

Initially seen years ago in #73, and temporarily fixed in #707.

PTY queues no longer have to be larger than the input queue, as stated in https://github.com/jbruchon/elks/issues/73#issuecomment-680274260, as the real problem was the PTY `ttyp_write` subdriver was blocking the process needlessly when the queue was full. The queue full check and required wait is already performed by the `ch_wait_wr` call in the master TTY `tty_write` routine.

This was tracked down using two nested `telnet localhost` connections and then a long "ls -lR /", which failed using the most recent networking code.