### PR TITLE
[kernel] Improve kernel speed copying words rather than bytes

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -745,7 +745,7 @@ static void do_bioshd_request(void)
 
 		if (need_dma_seg) {
 		    if (req->rq_cmd == WRITE)
-			fmemcpyb(NULL, DMASEG, buff, seg, (this_pass << 9));
+			fmemcpyw(NULL, DMASEG, buff, seg, (this_pass << 8));
 		    BD_BX = 0;
 		    BD_ES = DMASEG;
 		} else {
@@ -765,7 +765,7 @@ static void do_bioshd_request(void)
 		    out_ax = BD_AX;
 		    reset_bioshd(drive); /* controller should be reset upon error detection */
 		} else if (need_dma_seg && req->rq_cmd == READ)
-		    fmemcpyb(buff, seg, NULL, DMASEG, (word_t)(this_pass << 9));
+		    fmemcpyw(buff, seg, NULL, DMASEG, (word_t)(this_pass << 8));
 
 		dma_avail = 1;
 		wake_up(&dma_wait);

--- a/elks/arch/i86/drivers/block/rd.c
+++ b/elks/arch/i86/drivers/block/rd.c
@@ -329,13 +329,13 @@ static void do_rd_request(void)
 	     buff);
 	if (CURRENT->rq_cmd == WRITE) {
 	    debug("RD: request writing to %ld\n", (long) start);
-	    fmemcpyb((byte_t *) (offset * SECTOR_SIZE), rd_segment[segnum].segment,
-			buff, CURRENT->rq_seg, 1024);
+	    fmemcpyw((byte_t *) (offset * SECTOR_SIZE), rd_segment[segnum].segment,
+			buff, CURRENT->rq_seg, 1024/2);
 	}
 	if (CURRENT->rq_cmd == READ) {
 	    debug("RD_REQUEST reading from %ld\n", start);
-	    fmemcpyb(buff, CURRENT->rq_seg,
-			(byte_t *) (offset * SECTOR_SIZE), rd_segment[segnum].segment, 1024);
+	    fmemcpyw(buff, CURRENT->rq_seg,
+			(byte_t *) (offset * SECTOR_SIZE), rd_segment[segnum].segment, 1024/2);
 	}
 	end_request(1);
     }

--- a/elks/arch/i86/drivers/char/meta.c
+++ b/elks/arch/i86/drivers/char/meta.c
@@ -102,8 +102,8 @@ static void do_meta_request(kdev_t device)
 #if 0
 	    verified_memcpy_tofs(driver->udd_data, buff, BLOCK_SIZE);
 /* FIXME FIXME	*/
-	    fmemcpyb(driver->udd_data, driver->udd_task->mm.dseg,
-	    		buff, kernel_ds, 1024);
+	    fmemcpyw(driver->udd_data, driver->udd_task->mm.dseg,
+	    		buff, kernel_ds, 1024/2);
 #endif
 	}
 	printk("8");
@@ -128,8 +128,8 @@ static void do_meta_request(kdev_t device)
 #if 0
 	    verified_memcpy_fromfs(buff, driver->udd_data, BLOCK_SIZE);
 /* FIXME FIXME */
-	    fmemcpyb(buff, kernel_ds,
-	    		driver->udd_data, driver->udd_task->mm.dseg, 1024);
+	    fmemcpyw(buff, kernel_ds,
+	    		driver->udd_data, driver->udd_task->mm.dseg, 1024/2);
 #endif
 	}
 	end_request(1, req->rq_dev);

--- a/elks/arch/i86/lib/fmemcpyb.S
+++ b/elks/arch/i86/lib/fmemcpyb.S
@@ -15,7 +15,7 @@ fmemcpyb:
 	mov    %si,%ax
 	mov    %di,%dx
 	mov    %sp,%si
-	mov    10(%si),%cx  // arg4:   word count
+	mov    10(%si),%cx  // arg4:   byte count
 	les    2(%si),%di   // arg0+1: far destination pointer
 	lds    6(%si),%si   // arg2+3: far source pointer
 	cld

--- a/elks/arch/i86/lib/fmemcpyw.S
+++ b/elks/arch/i86/lib/fmemcpyw.S
@@ -1,4 +1,4 @@
-// void fmemcpyw (word_t dst_off, seg_t dst_seg, word_t src_off, seg_t src_seg, word_t count)
+// void fmemcpyw (byte * dst_off, seg_t dst_seg, byte * src_off, seg_t src_seg, word_t count)
 // segment after offset to allow LDS & LES from the stack
 // assume DS=ES=SS (not ES for GCC-IA16)
 
@@ -15,9 +15,9 @@ fmemcpyw:
 	mov    %si,%ax
 	mov    %di,%dx
 	mov    %sp,%si
-	mov    10(%si),%cx  //; arg4:   word count
-	les    2(%si),%di   //; arg0+1: far destination pointer
-	lds    6(%si),%si   //; arg2+3: far source pointer
+	mov    10(%si),%cx  // arg4:   word count
+	les    2(%si),%di   // arg0+1: far destination pointer
+	lds    6(%si),%si   // arg2+3: far source pointer
 	cld
 	rep
 	movsw

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -188,7 +188,7 @@ segment_s * seg_dup (segment_s * src)
 {
 	segment_s * dst = seg_free_get (src->size, src->flags);
 	if (dst)
-		fmemcpyb (NULL, dst->base, 0, src->base, src->size << 4);
+		fmemcpyw(NULL, dst->base, 0, src->base, src->size << 3);
 
 	return dst;
 }

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -477,8 +477,8 @@ void map_buffer(register struct buffer_head *bh)
 	    debug("UNMAP: %d <- %d\n", bmap->b_num, i);
 
 	    /* Unmap/copy L1 to L2 */
-	    fmemcpyb((byte_t *) (bmap->b_offset << BLOCK_SIZE_BITS), bmap->b_ds,
-		     (byte_t *) bmap->b_data, kernel_ds, BLOCK_SIZE);
+	    fmemcpyw((byte_t *) (bmap->b_offset << BLOCK_SIZE_BITS), bmap->b_ds,
+		     (byte_t *) bmap->b_data, kernel_ds, BLOCK_SIZE/2);
 	    bmap->b_data = 0;
 	    break;		/* success */
 	}
@@ -494,8 +494,8 @@ void map_buffer(register struct buffer_head *bh)
     L1map[i] = bh;
     bh->b_data = (char *)L1buf + (i << BLOCK_SIZE_BITS);
     if (bh->b_uptodate) {
-	fmemcpyb((byte_t *) bh->b_data, kernel_ds,
-		 (byte_t *) (bh->b_offset << BLOCK_SIZE_BITS), bh->b_ds, BLOCK_SIZE);
+	fmemcpyw((byte_t *) bh->b_data, kernel_ds,
+		 (byte_t *) (bh->b_offset << BLOCK_SIZE_BITS), bh->b_ds, BLOCK_SIZE/2);
     }
     debug("MAP:   %d -> %d\n", bh->b_num, i);
   end_map_buffer:

--- a/elks/include/linuxmt/memory.h
+++ b/elks/include/linuxmt/memory.h
@@ -14,7 +14,7 @@ extern void pokew (word_t off, seg_t seg, word_t val);
 extern void fmemsetb (word_t off, seg_t seg, byte_t val, word_t count);
 extern void fmemsetw (word_t off, seg_t seg, word_t val, word_t count);
 
-extern void fmemcpyb (byte_t * dst_ptr, seg_t dst_seg, byte_t * src_off, seg_t src_seg, word_t count);
+extern void fmemcpyb (byte_t * dst_off, seg_t dst_seg, byte_t * src_off, seg_t src_seg, word_t count);
 extern void fmemcpyw (byte_t * dst_off, seg_t dst_seg, byte_t * src_off, seg_t src_seg, word_t count);
 
 extern word_t fmemcmpb (word_t dst_off, seg_t dst_seg, word_t src_off, seg_t src_seg, word_t count);


### PR DESCRIPTION
Use fmemcpyw rather than fmemcpyb when possible.

Improvements made in BIOS floppy/hard disk driver, kernel buffer copying, fork data segment duplication and ramdisk copying.
