### PR TITLE
[kernel] Use word rather than byte copy in kernel memcpy routines

### DIFF
--- a/elks/arch/i86/lib/fmemory.S
+++ b/elks/arch/i86/lib/fmemory.S
@@ -24,21 +24,28 @@
 //		word_t count)
 
 fmemcpyb:
-	mov    %es,%bx
 	mov    %si,%ax
 	mov    %di,%dx
 	mov    %sp,%si
+	push   %es
 	mov    ARG4(%si),%cx  // byte count
 	les    ARG0(%si),%di  // far destination pointer
 	lds    ARG2(%si),%si  // far source pointer
+	mov    %cx,%bx
 	cld
+	shr    $1,%cx         // copy words
+	jz     1f
 	rep
+	movsw
+1:	mov    %bx,%cx        // then possibly final byte
+	and    $1,%cx
+	jz     2f
 	movsb
+2:	pop    %es
 	mov    %ax,%si
 	mov    %dx,%di
 	mov    %ss,%ax
 	mov    %ax,%ds
-	mov    %bx,%es
 	ret
 
 // void fmemcpyw (byte * dst_off, seg_t dst_seg, byte * src_off, seg_t src_seg,
@@ -66,17 +73,25 @@ fmemcpyw:
 // compiler pushes byte_t as word_t
 
 fmemsetb:
-	mov    %es,%bx
 	mov    %di,%dx
 	mov    %sp,%di
+	push   %es
 	mov    ARG2(%di),%ax  // value
 	mov    ARG3(%di),%cx  // byte count
 	les    ARG0(%di),%di  // far pointer
+	mov    %cx,%bx
 	cld
+	shr    $1,%cx         // store words
+	jz     1f
+	mov    %al,%ah
 	rep
+	stosw
+1:	mov    %bx,%cx        // then possibly final byte
+        and    $1,%cx
+	jz     2f
 	stosb
+2:	pop    %es
 	mov    %dx,%di
-	mov    %bx,%es
 	ret
 
 // void fmemsetw (word_t off, seg_t seg, word_t val, word_t count)

--- a/elks/arch/i86/mm/memcpyfs.S
+++ b/elks/arch/i86/mm/memcpyfs.S
@@ -25,19 +25,27 @@ memcpy_fromfs:
 	mov	%si,%ax
 	mov	%di,%dx
 	mov	%sp,%bx
+	push    %ds
+	push	%es
 	mov	ARG0(%bx),%di		// daddr
 	mov	ARG1(%bx),%si		// saddr
 	mov	ARG2(%bx),%cx		// len
 	mov	current,%bx
 	mov	TASK_USER_DS(%bx),%ds
 	mov	%ss,%bx
-	push	%es
 	mov	%bx,%es
+	mov	%cx,%bx
 	cld
+	shr	$1,%cx			// copy words
+	jz	1f
 	rep
+	movsw
+1:	mov	%bx,%cx			// then possibly final byte
+	and	$1,%cx
+	jz	2f
 	movsb
-	pop	%es
-	mov	%bx,%ds
+2:	pop	%es
+	pop     %ds
 	mov	%dx,%di
 	mov	%ax,%si
 	ret
@@ -47,17 +55,24 @@ memcpy_fromfs:
 memcpy_tofs:
 	mov	%si,%ax
 	mov	%di,%dx
-	mov	%es,%bx
+	mov	%sp,%bx
+	push	%es
 	mov	current,%si
 	mov	TASK_USER_DS(%si),%es
-	mov	%sp,%si
-	mov	ARG0(%si),%di		// daddr
-	mov	ARG2(%si),%cx		// len
-	mov	ARG1(%si),%si		// saddr
+	mov	ARG0(%bx),%di		// daddr
+	mov	ARG2(%bx),%cx		// len
+	mov	ARG1(%bx),%si		// saddr
+	mov	%cx,%bx
 	cld
+	shr	$1,%cx			// copy words
+	jz	1f
 	rep
+	movsw
+1:	mov	%bx,%cx			// then possibly final byte
+	and	$1,%cx
+	jz	2f
 	movsb
-	mov	%bx,%es
+2:	pop	%es
 	mov	%dx,%di
 	mov	%ax,%si
 	ret


### PR DESCRIPTION
Rewrite fmemcpyb, fmemsetb, memcpy_tofs and memcpy_fromfs to use word moves rather than byte moves for speed. These routines are already written in 8086 assembly to use the 8086 `rep movb` instruction.

This should be the final tuneup for easily speeding up the ELKS kernel for networking. 

The memcpy_tofs routine is used for all read system calls to transfer data to an application, and memcpy_fromfs is used when writing. The fmemcpyb function is used for copying NIC packet data to and from the kernel, and fmemsetb is used to clear the .bss segment when loading applications.

These now use `rep movsw` rather than `rep movsb` for speed, so throughput should be increased on 8086 systems.

I have not yet tested whether odd addresses are used for word copies. That shouldn't happen much at all, but if so there will be one further tuneup.