### PR TITLE
[networking] Fix repeated quick reconnections with ktcp

### DIFF
--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -62,7 +62,7 @@ static __u32 choose_seq(void)
 }
 
 /* abruptly terminate connection*/
-static void tcp_reset_connection(struct tcpcb_s *cb)
+static void tcp_reset_connection(struct tcpcb_s *cb)	//FIXME remove
 {
 	tcp_send_reset(cb);
 	tcpcb_remove_cb(cb);	/* deallocate*/
@@ -123,10 +123,9 @@ static void tcp_syn_sent(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 printf("SYN sent, wrong ACK (listen port not expired)\n");
 	    /* Send RST */
 	    cb->send_nxt = h->acknum;
-	    cb->state = TS_CLOSED;	//FIXME not needed
-	    //tcp_reset_connection(cb);	/* deallocate*/
 	    //tcp_send_reset(cb);
-	    tcpcb_remove_cb(cb);
+	    retval_to_sock(cb->sock, -ECONNREFUSED);
+	    tcpcb_remove_cb(cb);	/* deallocate*/
 	    return;
 	}
 

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -116,7 +116,7 @@ void tcpcb_remove(struct tcpcb_list_s *n)
 {
     struct tcpcb_list_s *next = n->next;
 
-    debug_tcp("tcp: REMOVING control block\n");
+    debug_tcp("tcp: REMOVING control block %x\n", n);
     tcpcb_num--;	/* for netstat*/
 
     if (n->prev)

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -72,17 +72,11 @@ static void tcpdev_bind(void)
 
     port = ntohs(db->addr.sin_port);
     if (port == 0) {
-	if (next_port < 1024)
+	if (++next_port < 1024)
 	    next_port = 1024;
 	while (tcpcb_check_port(next_port) != NULL)
 	    next_port++;
 	port = next_port;
-
-/* TODO : Handle the case when no port is available
- * Just to be right, I don't think it is posible to run out
- * of ports in 8086!!!
- */
-
     } else {
 	if (tcpcb_check_port(port) != NULL) {	/* Port already bound */
 	    tcpcb_remove(n);
@@ -369,8 +363,8 @@ static void tcpdev_release(void)
     struct tcpcb_s *cb;
     void * sock = db->sock;
 
-debug_tcp("tcpdev: got close from ELKS process\n");
     n = tcpcb_find_by_sock(sock);
+    debug_tcp("tcpdev: got close from ELKS process, %x\n", n);
     if (n) {
 	cb = &n->tcpcb;
 	switch(cb->state){


### PR DESCRIPTION
Fixes problem of connecting via telnet, then ^D, then quick telnet again, which used to cause "SYN sent, wrong ACK (listen port not expired)".

This was one of the last remaining big bugs in networking - the inability to reconnect quickly. The problem came down to ktcp ultimately not incrementing the locally bound port number properly.