### PR TITLE
[/dev] Rename /dev/bd[a1...] -> /dev/hd[a1...], /dev/hd -> /dev/dhd

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -128,7 +128,7 @@ static void bioshd_geninit(void);
 
 static struct gendisk bioshd_gendisk = {
     MAJOR_NR,			/* Major number */
-    "bd",			/* Major name */
+    "hd",			/* Major name */
     MINOR_SHIFT,		/* Bits to shift to get real from partition */
     1 << MINOR_SHIFT,		/* Number of partitions per real */
     NUM_DRIVES,			/* maximum number of real */
@@ -168,14 +168,14 @@ static unsigned short int INITPROC bioshd_gethdinfo(void) {
 	    /* NOTE: some BIOS may underreport cylinders by 1*/
 	    drivep->cylinders = (((BD_CX & 0xc0) << 2) | (BD_CX >> 8)) + 1;
 	    drivep->fdtype = -1;
-	    printk("bioshd: bd%c BIOS CHS %d,%d,%d\n", 'a'+drive, drivep->cylinders,
+	    printk("bioshd: hd%c BIOS CHS %d,%d,%d\n", 'a'+drive, drivep->cylinders,
 		drivep->heads, drivep->sectors);
 	}
 #ifdef IDE_PROBE_ENABLE
 	if (arch_cpu > 5) {	/* Do this only if AT or higher */
 	    if (!get_ide_data(drive, drivep)) {	/* get CHS from the drive itself */
 		/* sanity checks already done, accepting data */
-		printk("bioshd: bd%c IDE CHS %d,%d,%d\n", 'a'+drive, drivep->cylinders,
+		printk("bioshd: hd%c  IDE CHS %d,%d,%d\n", 'a'+drive, drivep->cylinders,
 		drivep->heads, drivep->sectors);
 	    }
 	}

--- a/elks/arch/i86/drivers/block/directhd.c
+++ b/elks/arch/i86/drivers/block/directhd.c
@@ -74,7 +74,7 @@ static void directhd_geninit();
 
 static struct gendisk directhd_gendisk = {
     MAJOR_NR,			/* major number */
-    "hd",			/* device name */
+    "dhd",			/* device name */
     6,
     1 << 6,
     4,
@@ -367,7 +367,7 @@ int directhd_init(void)
     for (i = 0; i < 4; i++)
 	/* sanity check */
 	if (drive_info[i].heads != 0) {
-	    printk("athd: /dev/hd%c: %d heads, %d cylinders, %d sectors\n",
+	    printk("athd: /dev/dhd%c: %d heads, %d cylinders, %d sectors\n",
 		   (i + 'a'),
 		   drive_info[i].heads,
 		   drive_info[i].cylinders, drive_info[i].sectors);

--- a/elks/arch/i86/drivers/block/idequery.c
+++ b/elks/arch/i86/drivers/block/idequery.c
@@ -91,7 +91,7 @@ int INITPROC get_ide_data(int drive, struct drive_infot *drive_info) {
 		    drive++;
 		    continue;
 		}
-		debug("bd%c: drive at port 0x%x not found\n", 'a'+drive, port);
+		debug("hd%c: drive at port 0x%x not found\n", 'a'+drive, port);
 
 		retval = -1;
 		break;
@@ -126,13 +126,13 @@ int INITPROC get_ide_data(int drive, struct drive_infot *drive_info) {
 	    	drive_info->sectors = ide_buffer[56];
 
 		/* Note: If the 3rd drive is slave, not master, it will be reported as
-		 * bdd, not bdc here. */
-		debug("bd%c: %d heads, %d cylinders, %d sectors\n", 'a'+drive,
+		 * hdd, not hdc here. */
+		debug("hd%c: %d heads, %d cylinders, %d sectors\n", 'a'+drive,
 			drive_info->heads, drive_info->cylinders, drive_info->sectors);
 	    } else {
 		retval = -2;
 #if IDE_DEBUG
-		printk("bd%c: Error in IDE device data.\n", 'a'+drive);
+		printk("hd%c: Error in IDE device data.\n", 'a'+drive);
 		dump_ide(ide_buffer, 256);
 #endif
 	    }

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -17,8 +17,8 @@
 #ifdef CONFIG_FS_DEV
 /* max 16 entries in FAT device table*/
 struct msdos_devdir_entry devnods[DEVDIR_SIZE] = {
-    { "bda",	S_IFBLK | 0644, MKDEV(3, 0) },
-    { "bda1",	S_IFBLK | 0644, MKDEV(3, 1) },
+    { "hda",	S_IFBLK | 0644, MKDEV(3, 0) },
+    { "hda1",	S_IFBLK | 0644, MKDEV(3, 1) },
     { "fd0",	S_IFBLK | 0644, MKDEV(3, 128)},
     { "fd1",	S_IFBLK | 0644, MKDEV(3, 160)},
     { "kmem",	S_IFCHR | 0644, MKDEV(1, 2) },

--- a/elks/include/linuxmt/directhd.h
+++ b/elks/include/linuxmt/directhd.h
@@ -27,7 +27,7 @@
 #define MAX_DRIVES 4		/* 2 per i/o channel and 2 i/o channels */
 
 #if 0
-#define DIRECTHD_DEVICE_NAME	"hd"
+#define DIRECTHD_DEVICE_NAME	"dhd"
 #endif
 
 #endif

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -166,9 +166,9 @@ static struct dev_name_struct {
 	int num;
 } devices[] = {
 	/* root_dev_name needs first 5 in order*/
-	{ "bda",     0x0300 },
-	{ "bdb",     0x0320 },
-	{ "bdc",     0x0340 },
+	{ "hda",     0x0300 },
+	{ "hdb",     0x0320 },
+	{ "hdc",     0x0340 },
 	{ "fd0",     0x0380 },
 	{ "fd1",     0x03a0 },
 	{ "ttyS",    0x0440 },

--- a/elkscmd/disk_utils/fdisk.c
+++ b/elkscmd/disk_utils/fdisk.c
@@ -44,7 +44,7 @@ struct geometry {
     unsigned long start;
 };
 
-#define DEFAULT_DEV			"/dev/bda"
+#define DEFAULT_DEV			"/dev/hda"
 #define PARTITION_TYPE		0x80	/* ELKS, Old Minix*/
 
 #define PARTITION_START		0x01be	/* offset of partition table in MBR*/

--- a/elkscmd/disk_utils/partype.c
+++ b/elkscmd/disk_utils/partype.c
@@ -13,15 +13,15 @@
  *
  *	  0	No partition with the specified type was found.
  *
- *	  1	Partition /dev/bda1 has the specified type.
- *	  2	Partition /dev/bda2 has the specified type.
- *	  3	Partition /dev/bda3 has the specified type.
- *	  4	Partition /dev/bda4 has the specified type.
+ *	  1	Partition /dev/hda1 has the specified type.
+ *	  2	Partition /dev/hda2 has the specified type.
+ *	  3	Partition /dev/hda3 has the specified type.
+ *	  4	Partition /dev/hda4 has the specified type.
  *
- *	 65	Partition /dev/hda1 has the specified type.
- *	 66	Partition /dev/hda2 has the specified type.
- *	 67	Partition /dev/hda3 has the specified type.
- *	 68	Partition /dev/hda4 has the specified type.
+ *	 65	Partition /dev/dhda1 has the specified type.
+ *	 66	Partition /dev/dhda2 has the specified type.
+ *	 67	Partition /dev/dhda3 has the specified type.
+ *	 68	Partition /dev/dhda4 has the specified type.
  *
  *	129	Partition /dev/sda1 has the specified type.
  *	130	Partition /dev/sda2 has the specified type.
@@ -29,7 +29,7 @@
  *	132	Partition /dev/sda4 has the specified type.
  *
  *	251	The raw drive is not seekable.
- *	252	Neither /dev/hda nor /dev/bda is available.
+ *	252	Neither /dev/dhda nor /dev/hda is available.
  *	253	The minimum size specified was larger than the
  *		maximum size specified.
  *	254	An invalid partition type was specified.
@@ -135,20 +135,20 @@ int main(int argc,char **argv)
 	    exit(253);
 	}
     }
-    strcpy(drive, "/dev/bda");
+    strcpy(drive, "/dev/hda");
     if ((fp = fopen(drive,"rb")) == NULL) {
-	drive[5] = 'h';
+	strcpy(drive, "/dev/dhda");
 	if ((fp = fopen(drive,"rb")) == NULL) {
-	    drive[5] = 's';
+	    strcpy(drive, "/dev/shda");
 	    if ((fp = fopen(drive,"rb")) == NULL) {
 		fprintf(stderr, "ERROR 3: Can't open raw drive.\n");
-		fprintf(stderr, "         Searched /dev/bda - /dev/hda - /dev/sda only.\n");
+		fprintf(stderr, "         Searched /dev/hda - /dev/dhda - /dev/sda only.\n");
 		exit(252);
 	    }
 	}
     }
     if (fseek(fp,0x1be,SEEK_SET)) {
-	fprintf(stderr, "ERROR 4: Can't seek to partition table in /dev/bda\n"
+	fprintf(stderr, "ERROR 4: Can't seek to partition table in /dev/hda\n"
 			"         ");
 	perror("Reason");
 	exit(251);

--- a/elkscmd/sys_utils/mount.8
+++ b/elkscmd/sys_utils/mount.8
@@ -27,7 +27,7 @@ Specify the type of filesystem to be mounted. Default is
 .B minix .
 .SH EXAMPLES
 .IP
-mount \-t minix /dev/bda1 /mnt
+mount \-t minix /dev/hda1 /mnt
 .LP
 .SH EXIT STATUS
 .TP

--- a/image/Make.devices
+++ b/image/Make.devices
@@ -44,23 +44,23 @@ devices:
 # BIOS hard and floppy disks.
 # Limit to 4 primary partitions per disk (MBR).
 
-	$(MKDEV) /dev/bda  b 3 0
-	$(MKDEV) /dev/bda1 b 3 1
-	$(MKDEV) /dev/bda2 b 3 2
-	$(MKDEV) /dev/bda3 b 3 3
-	$(MKDEV) /dev/bda4 b 3 4
-	$(MKDEV) /dev/bda5 b 3 5
-	$(MKDEV) /dev/bda6 b 3 6
-	$(MKDEV) /dev/bda7 b 3 7
-	$(MKDEV) /dev/bda8 b 3 8
-	$(MKDEV) /dev/bdb  b 3 32
-	$(MKDEV) /dev/bdb1 b 3 33
-	$(MKDEV) /dev/bdb2 b 3 34
-	$(MKDEV) /dev/bdb3 b 3 35
-	$(MKDEV) /dev/bdb4 b 3 36
-	$(MKDEV) /dev/bdc  b 3 64
-	$(MKDEV) /dev/bdc1 b 3 65
-	$(MKDEV) /dev/bdd  b 3 96
+	$(MKDEV) /dev/hda  b 3 0
+	$(MKDEV) /dev/hda1 b 3 1
+	$(MKDEV) /dev/hda2 b 3 2
+	$(MKDEV) /dev/hda3 b 3 3
+	$(MKDEV) /dev/hda4 b 3 4
+	$(MKDEV) /dev/hda5 b 3 5
+	$(MKDEV) /dev/hda6 b 3 6
+	$(MKDEV) /dev/hda7 b 3 7
+	$(MKDEV) /dev/hda8 b 3 8
+	$(MKDEV) /dev/hdb  b 3 32
+	$(MKDEV) /dev/hdb1 b 3 33
+	$(MKDEV) /dev/hdb2 b 3 34
+	$(MKDEV) /dev/hdb3 b 3 35
+	$(MKDEV) /dev/hdb4 b 3 36
+	$(MKDEV) /dev/hdc  b 3 64
+	$(MKDEV) /dev/hdc1 b 3 65
+	$(MKDEV) /dev/hdd  b 3 96
 	$(MKDEV) /dev/fd0  b 3 128
 	$(MKDEV) /dev/fd1  b 3 160
 
@@ -113,15 +113,15 @@ devices:
 # Direct PATA / IDE disks. (Not working)
 # Limit to 4 primary partitions per disk (MBR).
 
-#	$(MKDEV) /dev/hda b 5  0    # Currently.
-#	$(MKDEV) /dev/hda b 5  0 4  # Currently.
-#	$MKSET   0 15 $(MKDEV) /dev/hda b 5	# Currently.
-#	$(MKDEV) /dev/hdb b 5 64    # Currently.
-#	$(MKDEV) /dev/hdb b 5 64 4  # Currently.
-#	$MKSET  64 15 $(MKDEV) /dev/hdb b 5	# Currently.
+#	$(MKDEV) /dev/dhda b 5  0    # Currently.
+#	$(MKDEV) /dev/dhda b 5  0 4  # Currently.
+#	$MKSET   0 15 $(MKDEV) /dev/dhda b 5	# Currently.
+#	$(MKDEV) /dev/dhdb b 5 64    # Currently.
+#	$(MKDEV) /dev/dhdb b 5 64 4  # Currently.
+#	$MKSET  64 15 $(MKDEV) /dev/dhdb b 5	# Currently.
 
-#	$MKSET   0 63 $(MKDEV) /dev/hda b 3	# Ought to be.
-#	$MKSET  64 63 $(MKDEV) /dev/hdb b 3	# Ought to be.
+#	$MKSET   0 63 $(MKDEV) /dev/dhda b 3	# Ought to be.
+#	$MKSET  64 63 $(MKDEV) /dev/dhdb b 3	# Ought to be.
 
 ##############################################################################
 # Virtual consoles, pseudo-tty slaves and serial ports.


### PR DESCRIPTION
Rename bios hd driver /dev/bda etc to /dev/hda, for ease of understanding of ELKS devices by newbies.
The original direct hd driver /dev/hda etc is renamed to /dev/dhda (but remains commented out in images/Make.devices due to it not working).

Common devices:
/dev/fd0 - floppy
/dev/hda - first hard disk
/dev/hdb - second hard disk
/dev/hda1 - first hard disk partition 1
etc...

Wiki will be updated shortly.
