### PR TITLE
[kernel] Get CONFIG_ROMCODE kernel build operational again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 .project
 *~
+.DS_Store
 
 #
 # Build ignores

--- a/bootblocks/boot_sect.S
+++ b/bootblocks/boot_sect.S
@@ -590,7 +590,7 @@ track_max:
 #elif defined(CONFIG_IMG_HD)
 	.word CONFIG_IMG_CYL
 #else
-	.error "Unknown number of disk tracks!"
+	.warning "Unknown number of disk tracks!"
 	.word 0
 #endif
 
@@ -610,7 +610,7 @@ sect_max:
 #elif defined(CONFIG_IMG_HD)
 	.byte CONFIG_IMG_SECT
 #else
-	.error "Unknown number of disk sectors per track!"
+	.warning "Unknown number of disk sectors per track!"
 	.byte 0
 #endif
 
@@ -624,7 +624,7 @@ head_max:
 #elif defined(CONFIG_IMG_HD)
 	.byte CONFIG_IMG_HEAD
 #else
-	.error "Unknown number of disk sides/heads!"
+	.warning "Unknown number of disk sides/heads!"
 	.byte 0
 #endif
 

--- a/config-emu86
+++ b/config-emu86
@@ -56,22 +56,25 @@ CONFIG_CPU_8086=y
 CONFIG_HW_VIDEO_LINES_PER_CHARACTER=8
 CONFIG_HW_VIDEO_LINES_PER_SCREEN=25
 # CONFIG_HW_259_USE_ORIGINAL_MASK is not set
-CONFIG_APM=y
+# CONFIG_HW_SERIAL_FIFO is not set
+CONFIG_APM=Y
 
 #
 # Kernel settings
 #
-
-#
-# Memory manager
-#
 CONFIG_SMALL_KERNEL=y
+# CONFIG_BOOTOPTS is not set
 CONFIG_SYS_VERSION=y
 # CONFIG_STRACE is not set
 CONFIG_IDLE_HALT=y
 CONFIG_ROMCODE=y
 CONFIG_EXPERIMENTAL=y
 # CONFIG_MODULES is not set
+# CONFIG_FARTEXT_KERNEL is not set
+
+#
+# Memory manager
+#
 
 #
 # ROM-CODE kernel-loader
@@ -118,7 +121,6 @@ CONFIG_ROM_CHECKSUM_SIZE=64
 CONFIG_SOCKET=y
 # CONFIG_NANO is not set
 CONFIG_INET=y
-CONFIG_CSLIP=y
 # CONFIG_UNIX is not set
 
 #
@@ -144,13 +146,14 @@ CONFIG_ROMFS_BASE=8000
 # CONFIG_ROOT_READONLY is not set
 # CONFIG_FS_RO is not set
 # CONFIG_FULL_VFS is not set
+CONFIG_32BIT_INODES=y
 CONFIG_FS_EXTERNAL_BUFFER=y
 CONFIG_PIPE=y
 
 #
 # Executable file formats
 #
-CONFIG_EXEC_ELKS=y
+# CONFIG_EXEC_MMODEL is not set
 
 #
 # Drivers
@@ -212,7 +215,7 @@ CONFIG_PSEUDO_TTY=y
 # Shell
 #
 # CONFIG_APP_ASH is not set
-# CONFIG_APP_SH_UTILS is not set
+CONFIG_APP_SH_UTILS=y
 
 #
 # sash as default shell
@@ -226,7 +229,7 @@ CONFIG_APP_SASH=y
 # CONFIG_APP_DBG_UTILS is not set
 # CONFIG_APP_DISK_UTILS is not set
 # CONFIG_APP_ELVIS is not set
-# CONFIG_APP_FILE_UTILS is not set
+CONFIG_APP_FILE_UTILS=y
 # CONFIG_APP_LEVEE is not set
 # CONFIG_APP_M4 is not set
 # CONFIG_APP_MINIX1 is not set
@@ -239,6 +242,7 @@ CONFIG_APP_SASH=y
 # CONFIG_APP_PRN_UTILS is not set
 # CONFIG_APP_SYS_UTILS is not set
 # CONFIG_APP_SCREEN is not set
+# CONFIG_APP_CRON is not set
 # CONFIG_APP_TEST is not set
 # CONFIG_APP_XVI is not set
 
@@ -258,4 +262,3 @@ CONFIG_APP_SASH=y
 # CONFIG_IMG_FAT is not set
 # CONFIG_IMG_RAW is not set
 CONFIG_IMG_ROM=y
-CONFIG_IMG_LINK=y

--- a/elks/arch/i86/boot/crt0.S
+++ b/elks/arch/i86/boot/crt0.S
@@ -34,7 +34,7 @@ _start:
 // Start cleaning BSS. Still using setup.S stack
 
 	mov	_enddata,%di	// start of BSS
-	mov	%dx,%cx       // CX = BSS size
+	mov	%dx,%cx		// CX = BSS size
 	xor	%ax,%ax
 	shr	$1,%cx
 	cld
@@ -48,12 +48,15 @@ _start:
 
 // Set SS:SP to task[0] kernel stack area
 
-	mov	%ds,%ax       // in ROMCODE stack is ready placed
-	mov	%ax,%ss       // SS=ES=DS
+	mov	%ds,%ax
+	mov	%ax,%ss		// SS=ES=DS
 	mov	$task + TASK_USER_AX,%sp
 
-	call	start_kernel	// Break point if it returns
-	int	$3
+	call	start_kernel	// fall through into breakpoint if returns
+
+	.global int3
+int3:	int	$3		// C breakpoint for emu86
+	ret
 
 early_printk:
 	push  %bp

--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -414,6 +414,9 @@ size_ok:
         mov 14,%cx	   //; Check data section size
         or %cx,%cx
         jnz size_error     //; .data section too big
+	mov 4,%cx	// check for no fartext header
+	cmp $0x20,%cx
+	jnz size_error
 
 //;and now copy the kerneldata
 // WARNING: Next code fails if code_size+data_size+32 > 64K
@@ -431,8 +434,7 @@ size_ok:
 	mov 0x10,%dx  // bss size
 	mov 0x0c,%si  // data size
 	mov 0x08,%bx  // text size
-	xor %di,%di   // far text size
-	mov 0x18,%ax  // entry point
+	mov 0x14,%ax  // entry point
 	mov %es,%cx   // data segment
 	mov %cx,%ds
 
@@ -443,6 +445,7 @@ size_ok:
 	mov $SYSSEG+2,%di
 	push %di
 	push %ax
+	xor %di,%di   // far text size
 	lret
 
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/elks/arch/i86/defconfig
+++ b/elks/arch/i86/defconfig
@@ -101,7 +101,6 @@ CONFIG_PIPE=y
 #
 # Executable file formats
 #
-CONFIG_EXEC_ELKS=y
 
 #
 # Drivers

--- a/elks/arch/i86/drivers/char/bioscon.c
+++ b/elks/arch/i86/drivers/char/bioscon.c
@@ -307,7 +307,6 @@ void console_init(void)
 
 	C++;
     }
-
     printk("BIOS console %ux%u"TERM_TYPE"(%u virtual consoles)\n",
 	   Width, Height, NumConsoles);
 }

--- a/elks/arch/i86/lib/unused/divmodsi3.s
+++ b/elks/arch/i86/lib/unused/divmodsi3.s
@@ -1,0 +1,93 @@
+
+ 	.code16
+
+ 	.text
+ 	.extern	ldivmod
+ 	.extern	ludivmod
+
+ 	.global	__divsi3
+ 	.align 1
+
+ __divsi3:
+ 	push	%bp
+ 	mov	%sp,%bp
+ 	push	%bx
+ 	push	%cx
+ 	push	%di
+ 	mov	4(%bp),%ax
+ 	mov	6(%bp),%bx
+ 	mov	8(%bp),%cx
+ 	mov	10(%bp),%di
+ 	call	ldivmod
+ 	mov	%di,%dx
+ 	mov	%cx,%ax
+ 	pop	%di
+ 	pop	%cx
+ 	pop	%bx
+ 	pop	%bp
+ 	ret
+
+ 	.global	__modsi3
+ 	.align 1
+
+ __modsi3:
+ 	push	%bp
+ 	mov	%sp,%bp
+ 	push	%bx
+ 	push	%cx
+ 	push	%di
+ 	mov	4(%bp),%ax
+ 	mov	6(%bp),%bx
+ 	mov	8(%bp),%cx
+ 	mov	10(%bp),%di
+ 	call	ldivmod
+ 	mov	%bx,%dx
+ 	pop	%di
+ 	pop	%cx
+ 	pop	%bx
+ 	pop	%bp
+ 	ret
+
+ 	.global	__udivsi3
+ 	.align 1
+
+ __udivsi3:
+ 	push	%bp
+ 	mov	%sp,%bp
+ 	push	%bx
+ 	push	%cx
+ 	push	%di
+ 	mov	4(%bp),%ax
+ 	mov	6(%bp),%bx
+ 	mov	8(%bp),%cx
+ 	mov	10(%bp),%di
+ 	call	ludivmod
+ 	mov	%di,%dx
+ 	mov	%cx,%ax
+ 	pop	%di
+ 	pop	%cx
+ 	pop	%bx
+ 	pop	%bp
+ 	ret
+
+ 	.global	__umodsi3
+ 	.align 1
+
+ __umodsi3:
+ 	push	%bp
+ 	mov	%sp,%bp
+ 	push	%bx
+ 	push	%cx
+ 	push	%di
+ 	mov	4(%bp),%ax
+ 	mov	6(%bp),%bx
+ 	mov	8(%bp),%cx
+ 	mov	10(%bp),%di
+ 	call	ludivmod
+ 	mov	%bx,%dx
+ 	pop	%di
+ 	pop	%cx
+ 	pop	%bx
+ 	pop	%bp
+ 	ret
+

--- a/elks/arch/i86/lib/unused/ldivmod.s
+++ b/elks/arch/i86/lib/unused/ldivmod.s
@@ -1,0 +1,200 @@
+/*
+ ! ldivmod.s - 32 over 32 to 32 bit division and remainder for 8086
+
+ ! ldivmod( dividend bx:ax, divisor di:cx )  [ signed quot di:cx, rem bx:ax ]
+ ! ludivmod( dividend bx:ax, divisor di:cx ) [ unsigned quot di:cx, rem bx:ax ]
+
+ ! dx is not preserved
+
+
+ ! NB negatives are handled correctly, unlike by the processor
+ ! divison by zero does not trap
+
+
+ ! let dividend = a, divisor = b, quotient = q, remainder = r
+ !	a = b * q + r  mod 2^32
+ ! where:
+
+ ! if b = 0, q = 0 and r = a
+
+ ! otherwise, q and r are uniquely determined by the requirements:
+ ! r has the same sign as b and absolute value smaller than that of b, i.e.
+ !	if b > 0, then 0 <= r < b
+ !	if b < 0, then 0 >= r > b
+ ! (the absoulute value and its comparison depend on signed/unsigned)
+
+ ! the rule for the sign of r means that the quotient is truncated towards
+ ! negative infinity in the usual case of a positive divisor
+
+ ! if the divisor is negative, the division is done by negating a and b,
+ ! doing the division, then negating q and r
+ */
+
+ 	.code16
+
+ 	.global	ldivmod
+ 	.text
+ 	.align 1
+
+ ldivmod:
+ 	mov	%di,%dx		// sign byte of b in dh
+ 	mov	%bh,%dl 	// sign byte of a in dl
+ 	test	%di,%di
+ 	jns	set_asign
+ 	neg	%di
+ 	neg	%cx
+ 	sbb	$0,%di
+
+ set_asign:
+ 	test	%bx,%bx
+ 	jns	got_signs	// leave r = a positive
+ 	neg	%bx
+ 	neg	%ax
+ 	sbb	$0,%bx
+ 	jmp	got_signs
+
+ 	.global	ludivmod
+ 	.align 1
+
+ ludivmod:
+ 	xor	%dx,%dx		// both sign bytes 0
+
+ got_signs:
+ 	push	%bp
+ 	push	%si
+ 	mov	%sp,%bp
+ 	push	%di		// remember b
+ 	push	%cx
+
+ b0	=	-4
+ b16	=	-2
+
+ 	test	%di,%di
+ 	jne	divlarge
+ 	test	%cx,%cx
+ 	je	divzero
+ 	cmp	%cx,%bx
+ 	jae	divlarge	// would overflow
+ 	xchg	%bx,%dx		// a in dx:ax, signs in bx
+ 	div	%cx
+ 	xchg	%ax,%cx		// q in di:cx, junk in ax
+ 	xchg	%bx,%ax		// signs in ax, junk in bx
+ 	xchg	%dx,%ax		// r in ax, signs back in dx
+ 	mov	%di,%bx		// r in bx:ax
+ 	jmp	zdivu1
+
+ divzero:			// return q = 0 and r = a
+ 	test	%dl,%dl
+ 	jns	return
+ 	jmp	negr		// a initially minus, restore it
+
+ divlarge:
+ 	push	%dx		// remember sign bytes
+ 	mov	%di,%si		// w in si:dx, initially b from di:cx
+ 	mov	%cx,%dx
+ 	xor	%cx,%cx		// q in di:cx, initially 0
+ 	mov	%cx,%di
+
+ // r in bx:ax, initially a
+ // use di:cx rather than dx:cx in order to
+ // have dx free for a byte pair later
+
+ 	cmp	%bx,%si
+ 	jb	loop1
+ 	ja	zdivu		// finished if b > r
+ 	cmp	%ax,%dx
+ 	ja	zdivu
+
+ // rotate w (= b) to greatest dyadic multiple of b <= r
+
+ loop1:
+ 	shl	$1,%dx		// w = 2*w
+ 	rcl	$1,%si
+ 	jc	loop1_exit	// w was > r counting overflow (unsigned)
+ 	cmp	%bx,%si		// while w <= r (unsigned)
+ 	jb	loop1
+ 	ja	loop1_exit
+ 	cmp	%ax,%dx
+ 	jbe	loop1		// else exit with carry clear for rcr
+
+ loop1_exit:
+ 	rcr	$1,%si
+ 	rcr	$1,%dx
+
+ loop2:
+ 	shl	$1,%cx		// q = 2*q
+ 	rcl	$1,%di
+ 	cmp	%bx,%si		// if w <= r
+ 	jb	loop2_over
+ 	ja	loop2_test
+ 	cmp	%ax,%dx
+ 	ja	loop2_test
+
+ loop2_over:
+ 	add	$1,%cx		// q++
+ 	adc	$0,%di
+ 	sub	%dx,%ax		// r = r-w
+ 	sbb	%si,%bx
+
+ loop2_test:
+ 	shr	$1,%si		// w = w/2
+ 	rcr	$1,%dx
+ 	cmp	b16(%bp),%si	// while w >= b
+ 	ja	loop2
+ 	jb	zdivu
+ 	cmp	b0(%bp),%dx
+ 	jae	loop2
+
+ zdivu:
+ 	pop	%dx		// sign bytes
+
+ zdivu1:
+ 	test	%dh,%dh
+ 	js	zbminus
+ 	test	%dl,%dl
+ 	jns	return		// else a initially minus, b plus
+ 	mov	%ax,%dx		// -a = b * q + r ==> a = b * (-q) + (-r)
+ 	or	%bx,%dx
+ 	je	negq		// use if r = 0
+ 	sub	b0(%bp),%ax	// use a = b * (-1 - q) + (b - r)
+ 	sbb	b16(%bp),%bx
+ 	not	%cx		// q = -1 - q (same as complement)
+ 	not	%di
+
+ negr:
+ 	neg	%bx
+ 	neg	%ax
+ 	sbb	$0,%bx
+ return:
+ 	mov	%bp,%sp
+ 	pop	%si
+ 	pop	%bp
+ 	ret
+
+ 	.align 1
+
+ zbminus:
+ 	test	%dl,%dl		// (-a) = (-b) * q + r ==> a = b * q + (-r)
+ 	js	negr		// use if initial a was minus
+ 	mov	%ax,%dx		// a = (-b) * q + r ==> a = b * (-q) + r
+ 	or	%bx,%dx
+ 	je	negq		// use if r = 0
+ 	sub	b0(%bp),%ax	// use a = b * (-1 - q) + (b + r) (b is now -b)
+ 	sbb	b16(%bp),%bx
+ 	not	%cx
+ 	not	%di
+ 	mov	%bp,%sp
+ 	pop	%si
+ 	pop	%bp
+ 	ret
+
+ 	.align 1
+
+ negq:
+ 	neg	%di
+ 	neg	%cx
+ 	sbb	$0,%di
+ 	mov	%bp,%sp
+ 	pop	%si
+ 	pop	%bp
+ 	ret

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -131,14 +131,14 @@ static void init_task(void)
     mount_root();
 
     /* Don't open /dev/console for /bin/init, 0-2 closed immediately and fragments heap*/
-    if (strcmp(init_command, bininit) != 0) {
+    //if (strcmp(init_command, bininit) != 0) {
 	/* Set stdin/stdout/stderr to /dev/console if not running /bin/init*/
 	num = sys_open(s="/dev/console", O_RDWR, 0);
 	if (num < 0)
 	    printk("Unable to open %s (error %d)\n", s, num);
 	sys_dup(num);		/* open stdout*/
 	sys_dup(num);		/* open stderr*/
-    }
+    //}
 
 #ifdef CONFIG_BOOTOPTS
     /* special handling if argc/argv array setup*/

--- a/emu86.sh
+++ b/emu86.sh
@@ -9,9 +9,9 @@
 # First run ELKS with kernel and root FS in ROM
 # Kernel image @ segment 0xE000 (top of 1024K address space)
 # Root filesystem @ segment 0x8000 (assumes 512K RAM & 512K ROM)
-# Skip the INT 19h bootstrap in the kernel image (+0x42)
+# Skip the INT 19h bootstrap in the kernel image (+0x32)
 
-emu86 -w 0xe0000 -f elks/arch/i86/boot/Image -w 0x80000 -f image/romfs.bin -x 0xe000:0x42 ${1+"$@"} &
+exec ../emu86/emu86 -w 0xe0000 -f elks/arch/i86/boot/Image -w 0x80000 -f image/romfs.bin -x 0xe000:0x32 ${1+"$@"}
 
 # Give time to EMU86 to emulate the serial port
 # and store the used PTY in 'emu86.pts'


### PR DESCRIPTION
Fixes to allow running latest ELKS kernel (no fartext) on emu86 emulator with ROM filesystem.

To use, copy config-emu86 to .config, make, then run emu86.sh. 
Requires updated emu86, which should be available shortly.

Adds back in __udivsi3 routines to arch/i86/lib/unused for testing, since emu86 requires updating for the SHR instruction used when replaced with libgcc functions in @tkchia's commit https://github.com/jbruchon/elks/commit/de499c25711319e0bbb9ee564589dc1e611c8ed6.

