### PR TITLE
[kernel] Fix ROMFS readdir routine

### DIFF
--- a/elks/include/linuxmt/romfs_fs.h
+++ b/elks/include/linuxmt/romfs_fs.h
@@ -7,7 +7,7 @@
 #define ROMFS_MAGIC_STR "ROMFS"
 #define ROMFS_MAGIC_LEN 6  /* even length for word compare */
 
-#define ROMFS_NAME_MAX 256
+#define ROMFS_NAME_MAX 14  /* was 255, made compatible with MINIX*/
 
 
 /* In-memory superblock */


### PR DESCRIPTION
Fixes bug evidenced by `pwd` not working under emu86 with ROMFS filesystem.

Also shortens allowed ROMFS directory name entries to 14, to be compatible with MINIX fs.
The ROMFS driver has an auto buffer which would need to be static if ROMFS_NAME_MAX is increased to prevent unintentional kernel stack overflow.