### PR TITLE
[minixfs] Fix MINIX filesystem issues related to too many inodes

### DIFF
--- a/elks/fs/minix/inode.c
+++ b/elks/fs/minix/inode.c
@@ -149,6 +149,7 @@ struct super_block *minix_read_super(register struct super_block *s, char *data,
     static char *err1 = "minix: unable to read sb\n";
     static char *err2 = "minix: bad superblock or bitmaps\n";
     static char *err3 = "minix: get root inode failed\n";
+    static char *err4 = "minix: inode table too large\n";
 
     lock_super(s);
 	if (!(bh = bread(dev, (block_t) 1))) {
@@ -164,6 +165,11 @@ struct super_block *minix_read_super(register struct super_block *s, char *data,
 	    msgerr = err0;
 	    goto err_read_super_1;
 	}
+	if (ms->s_imap_blocks > MINIX_I_MAP_SLOTS) {
+	    msgerr = err4;
+	    goto err_read_super_1;
+	}
+
 	s->u.minix_sb.s_sbh = bh;
 	s->u.minix_sb.s_dirsize = 16;
 	s->u.minix_sb.s_namelen = 14;

--- a/elks/tools/mfs/minix_fs.h
+++ b/elks/tools/mfs/minix_fs.h
@@ -111,8 +111,8 @@ struct minix_dir_entry {
 #define MINIX_LINK_MAX	250
 #define MINIX2_LINK_MAX	65530
 
-#define MINIX_I_MAP_SLOTS	8
-#define MINIX_Z_MAP_SLOTS	64
+#define MINIX_I_MAP_SLOTS	4
+#define MINIX_Z_MAP_SLOTS	8
 
 #define MINIX2_ZONESZ	(BLOCK_SIZE/sizeof(u32))
 #define MINIX_ZONESZ	(BLOCK_SIZE/sizeof(u16))

--- a/elks/tools/mfs/mkfs.c
+++ b/elks/tools/mfs/mkfs.c
@@ -49,8 +49,8 @@ void parse_mkfs(int argc,char **argv,int *magic_p,int *nblks_p,int *inodes_p) {
   int c;
   int namelen = 14;
   int version = 1;
-  *nblks_p = 1440;
-  *inodes_p = 360;
+  *nblks_p = 0;
+  *inodes_p = 0;
     
   optind = 1;
   while (1) {
@@ -82,7 +82,7 @@ void parse_mkfs(int argc,char **argv,int *magic_p,int *nblks_p,int *inodes_p) {
       usage(argv[0]);
     }
   }
-  if (*nblks_p == -1)
+  if (*nblks_p == 0)
     fatalmsg("no filesystem size specified");
 
   //printf("MKFS v%d namelen %d inodes %d size %d\n", version, namelen, *inodes_p, *nblks_p);

--- a/elks/tools/mfs/super.c
+++ b/elks/tools/mfs/super.c
@@ -98,8 +98,11 @@ struct minix_fs_dat *new_fs(const char *fn,int magic,unsigned long fsize,int ino
    * Initialise bitmaps
    */
   IMAPS(fs) =UPPER(inodes + 1,BITS_PER_BLOCK);
-  ZMAPS(fs)=UPPER(fsize-(1+fs->msb.s_imap_blocks+INODE_BLOCKS(fs)), BITS_PER_BLOCK+1);
+  ZMAPS(fs)=UPPER(fsize-(1+IMAPS(fs)), BITS_PER_BLOCK);
   FIRSTZONE(fs) = NORM_FIRSTZONE(fs);
+//printf("IMAPS %u, ZMAPS %u, FIRST %u\n", IMAPS(fs), ZMAPS(fs), FIRSTZONE(fs));
+  if (IMAPS(fs) > MINIX_I_MAP_SLOTS)
+    fatalmsg("Too many inodes requested: max is 32736\n");
 
   fs->inode_bmap = domalloc(IMAPS(fs) * BLOCK_SIZE,0xff);
   fs->zone_bmap = domalloc(ZMAPS(fs) * BLOCK_SIZE,0xff);

--- a/elkscmd/disk_utils/mkfs.c
+++ b/elkscmd/disk_utils/mkfs.c
@@ -241,12 +241,16 @@ void setup_tables(void)
 	MAXSIZE = BLOCKS*1024L;
 	ZONES = BLOCKS;
 	INODES = BLOCKS/3;
+#if 0 /* FIXME: add ability to specify inode count rather than guess*/
 	if ( BLOCKS > 32768L ) INODES += (BLOCKS-32768)*4/3;
 	if ( INODES > 63424L ) INODES = 63424L;
 	if ((INODES & 8191) > 8188)
 		INODES -= 5;
 	if ((INODES & 8191) < 10)
 		INODES -= 20;
+#endif
+	if (INODES > 32736)		/* max inodes to fit in 4 imap blocks*/
+		INODES = 32736;
 	IMAPS = UPPER(INODES,BITS_PER_BLOCK);
 	ZMAPS = 0;
 	while (ZMAPS != UPPER(BLOCKS - NORM_FIRSTZONE,BITS_PER_BLOCK))
@@ -306,8 +310,8 @@ int main(int argc, char ** argv)
 		die("unable to open %s");
 	if (fstat(DEV,&statbuf)<0)
 		die("unable to stat %s");
-	else if (statbuf.st_rdev == 0x0300 || statbuf.st_rdev == 0x0340)
-		die("Will not try to make filesystem on '%s'");
+	//else if (statbuf.st_rdev == 0x0300 || statbuf.st_rdev == 0x0340)
+		//die("Will not try to make filesystem on '%s'");
 
 	setup_tables();
 	make_root_inode();

--- a/elkscmd/rootfs_template/etc/rc.d/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sys
@@ -31,6 +31,7 @@ fi
 # mount 2nd filesystem
 #
 #mount -t msdos /dev/fd1 /mnt || true
+#mount /dev/hda /mnt
 
 #
 # start networking


### PR DESCRIPTION
Fixes 2nd issue found in #796.

Currently, for space reasons, the ELKS kernel won't accept MINIX filesystems with inode bitmap table larger than 4 blocks. This translates to 32736 max inodes on any MINIX filesystem. The kernel didn't check for this limit when mounting a MINIX filesystem, which crashed the system due to kernel data corruption.

Kernel now refuses to mount a filesystem that has too many inodes.
Fixes mfs which was buggy in creating filesystems of max blocks (65535) (!).
Limits both mkfs and mfs to 32736 inodes, and uses reasonable defaults.
Allows mkfs to create /dev/hda or /dev/hdb filesystems (be careful!)


