### PR TITLE
[kernel] Add global lock around network bind system call

### DIFF
--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -117,6 +117,7 @@ static int inet_bind(register struct socket *sock, struct sockaddr *addr,
 
     /* TODO : Check if the user has permision to bind the port */
 
+	down(&rwlock);
     cmd = (struct tdb_bind *)get_tdout_buf();
     cmd->cmd = TDC_BIND;
     cmd->sock = sock;
@@ -130,6 +131,8 @@ static int inet_bind(register struct socket *sock, struct sockaddr *addr,
 
     ret = ((struct tdb_return_data *)tdin_buf)->ret_value;
     tcpdev_clear_data_avail();
+	up(&rwlock);
+
     return (ret >= 0 ? 0 : ret);
 }
 

--- a/elkscmd/inet/httpd/httpd.c
+++ b/elkscmd/inet/httpd/httpd.c
@@ -148,7 +148,7 @@ int main(int argc, char **argv)
 	struct sockaddr_in localadr;
 
 	if ((listen_sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
-		fprintf(stderr, "httpd: Can't open socket (check if ktcp running)\n");
+		fprintf(stderr, "httpd: Can't open socket (check if ktcp is running)\n");
 		exit(-1);
 	}
 

--- a/elkscmd/inet/telnet/ttn.c
+++ b/elkscmd/inet/telnet/ttn.c
@@ -142,6 +142,10 @@ int main(int argc, char *argv[])
 	signal(SIGINT, finish);
 
 	tcp_fd = socket(AF_INET, SOCK_STREAM, 0);
+	if (tcp_fd < 0) {
+		fprintf(stderr, "Can't open socket (check if ktcp running)\n");
+		exit(1);
+	}
 	
 	locadr.sin_family = AF_INET;
 	locadr.sin_port = PORT_ANY;

--- a/elkscmd/inet/telnet/ttn.c
+++ b/elkscmd/inet/telnet/ttn.c
@@ -143,7 +143,7 @@ int main(int argc, char *argv[])
 
 	tcp_fd = socket(AF_INET, SOCK_STREAM, 0);
 	if (tcp_fd < 0) {
-		fprintf(stderr, "Can't open socket (check if ktcp running)\n");
+		fprintf(stderr, "Can't open socket (check if ktcp is running)\n");
 		exit(1);
 	}
 	

--- a/elkscmd/inet/telnetd/telnetd.c
+++ b/elkscmd/inet/telnetd/telnetd.c
@@ -189,7 +189,7 @@ int main(int argc, char **argv)
 	pid_t pid;
 
 	if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
-		fprintf(stderr, "telnetd: Can't open socket (check if ktcp running)\n");
+		fprintf(stderr, "telnetd: Can't open socket (check if ktcp is running)\n");
 		exit(-1);
 	}
 	memset(&addr_in, 0, sizeof(addr_in));


### PR DESCRIPTION
Fixes ktcp hang issue discovered by @pawosm-arm in https://github.com/jbruchon/elks/commit/a2f7374fac9f991b814fa6772c20f3dc4cbbe8e2#commitcomment-43349212.

Also adds initial check and error message to telnet if ktcp not running.