### PR TITLE
[nano-X] Improve mouse throughput on slow systems

### DIFF
--- a/elkscmd/nano-X/Makefile
+++ b/elkscmd/nano-X/Makefile
@@ -19,6 +19,8 @@ NANOXDEMOS += bin/nxdemo
 #NANOXDEMOS += bin/nxvgatest		# low-level vga routines test
 
 # mouse and kbd drivers
+# SLOW_CPU discards unprocessed mouse input for slow systems
+LOCALFLAGS += -DSLOW_CPU=1
 DRIVERS += drivers/mou_ser.o
 DRIVERS += drivers/kbd_tty.o
 

--- a/elkscmd/nano-X/drivers/mou_ser.c
+++ b/elkscmd/nano-X/drivers/mou_ser.c
@@ -267,6 +267,16 @@ MOU_Read(COORD *dx, COORD *dy, COORD *dz, BUTTON *bptr)
 			if(buttons & middle)
 				b |= MBUTTON;
 			*bptr = b;
+#if SLOW_CPU
+{
+			/* discard already-read mouse input on slow systems*/
+			int drop_bytes = (parse == ParseMS)? 3: 5;
+			while (nbytes >= drop_bytes) {
+				nbytes -= drop_bytes;
+				bp += drop_bytes;
+			}
+}
+#endif
 			return 1;
 		}
 	}


### PR DESCRIPTION
Fixes issue #815.

SLOW_CPU is always set, as most systems aren't very vast running Nano-X. Works for both PC and MS mice.

@pawosm-arm, this is the same fix you tested, except enhanced to work for both mouse types.
BTW, if you want to see what Nano-X / Microwindows is capable of these days, check out the screenshots here: https://github.com/ghaerr/microwindows. Unfortunately, it needs 32-bit systems for that kind of graphics, the last version of Nano-X I was able to port to ELKS was done back in 1999!
