### PR TITLE
[kernel] Improve disk I/O speed on non-720k drives

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -712,9 +712,11 @@ static void do_bioshd_request(void)
 	    head = (unsigned int) (tmp % (sector_t)drivep->heads);
 	    cylinder = (unsigned int) (tmp / (sector_t)drivep->heads);
 	    this_pass = drivep->sectors - sector + 1;
-	/* Fix for weird BIOS behavior with 720K floppy (issue #39) */
-	    if (this_pass < 3) this_pass = 1;
-	/* End of fix */
+
+	    /* Fix for weird BIOS behavior with 720K floppy (issue #39/44) */
+	    if (this_pass == 2 && drivep->sectors == 9) this_pass = 1;
+
+	    /* limit I/O to requested size*/
 	    if ((sector_t)this_pass > count) this_pass = (unsigned int) count;
 
 	    errs = MAX_ERRS;	/* BIOS disk reads should be retried at least three times */


### PR DESCRIPTION
Improves hard and floppy disk I/O speed on non-720k drives, requested by @Mellvik in https://github.com/jbruchon/elks/issues/521#issuecomment-716151094.

Improves previous four-year-old issue #39 and PR #44 by limiting the BIOS INT 13h hack for only those drives with 9 sectors per track, which is 720k floppies only.

IMO, it is questionable whether the fix should stay in, as the user reported they were running a non-standard BIOS. This BIOS apparently didn't work when requested to perform two-sector I/O starting on the 8th and 9th sector.

The fix stays in for now, and downgrades to single-sector BIOS I/O requests on the 8th and 9th sectors of 9-sectored disks only.