### PR TITLE
[kernel] Optimize excessive buffer copying in filesystem read/write

### DIFF
--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -243,7 +243,7 @@ static void end_request(int uptodate)
     clr_irq();
     bh->b_uptodate = uptodate;
     set_irq();
-	unmap_buffer(bh);
+    //unmap_buffer(bh);
     unlock_buffer(bh);
 
 #ifdef BLOAT_FS

--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -243,7 +243,6 @@ static void end_request(int uptodate)
     clr_irq();
     bh->b_uptodate = uptodate;
     set_irq();
-    //unmap_buffer(bh);
     unlock_buffer(bh);
 
 #ifdef BLOAT_FS

--- a/elks/arch/i86/drivers/block/ll_rw_blk.c
+++ b/elks/arch/i86/drivers/block/ll_rw_blk.c
@@ -272,7 +272,7 @@ static void make_request(unsigned short int major, int rw,
 	return;
     /* Maybe the above fixes it, and maybe it doesn't boot. Life is interesting */
     lock_buffer(bh);
-    map_buffer(bh);
+    //map_buffer(bh);
 
     switch (rw) {
 
@@ -291,7 +291,7 @@ static void make_request(unsigned short int major, int rw,
 
     default:
 	debug("make_request: bad block dev cmd, must be R/W/RA/WA\n");
-	unmap_buffer(bh);
+	//unmap_buffer(bh);
 	unlock_buffer(bh);
 	return;
     }
@@ -320,8 +320,8 @@ static void make_request(unsigned short int major, int rw,
     /* fill up the request-info, and add it to the queue */
     req->rq_cmd = (__u8) rw;
     req->rq_sector = sector;
-    req->rq_buffer = bh->b_data;
     req->rq_seg = bh->b_seg;
+    req->rq_buffer = bh->b_data? bh->b_data: (char *)(bh->b_offset << BLOCK_SIZE_BITS);
     req->rq_bh = bh;
 
 #ifdef BLOAT_FS

--- a/elks/arch/i86/drivers/block/ll_rw_blk.c
+++ b/elks/arch/i86/drivers/block/ll_rw_blk.c
@@ -272,7 +272,6 @@ static void make_request(unsigned short int major, int rw,
 	return;
     /* Maybe the above fixes it, and maybe it doesn't boot. Life is interesting */
     lock_buffer(bh);
-    //map_buffer(bh);
 
     switch (rw) {
 
@@ -291,7 +290,6 @@ static void make_request(unsigned short int major, int rw,
 
     default:
 	debug("make_request: bad block dev cmd, must be R/W/RA/WA\n");
-	//unmap_buffer(bh);
 	unlock_buffer(bh);
 	return;
     }

--- a/elks/fs/block_dev.c
+++ b/elks/fs/block_dev.c
@@ -81,8 +81,8 @@ size_t block_read(struct inode *inode, register struct file *filp,
 	    //memcpy_tofs(buf, bh->b_data + (((size_t)(filp->f_pos)) & (BLOCK_SIZE - 1)),
                        //chars);
 	    char *data = bh->b_data? bh->b_data: (char *)(bh->b_offset << BLOCK_SIZE_BITS);
-	    fmemcpyb((byte_t *)buf, current->t_regs.ds,
-		(byte_t *)data + (((size_t)(filp->f_pos)) & (BLOCK_SIZE - 1)), bh->b_seg, chars);
+	    fmemcpyb(buf, current->t_regs.ds,
+		data + (((size_t)(filp->f_pos)) & (BLOCK_SIZE - 1)), bh->b_seg, chars);
 	    //unmap_brelse(bh);
 	    brelse(bh);
 	} else fmemsetb((word_t) buf, current->t_regs.ds, 0, (word_t) chars);
@@ -159,8 +159,7 @@ size_t block_write(struct inode *inode, register struct file *filp,
 	//map_buffer(bh);
 	//memcpy_fromfs((bh->b_data + offset), buf, chars);
 	char *data = bh->b_data? bh->b_data: (char *)(bh->b_offset << BLOCK_SIZE_BITS);
-	fmemcpyb((byte_t *)data + offset, bh->b_seg,
-	    (byte_t *)buf, current->t_regs.ds, chars);
+	fmemcpyb(data + offset, bh->b_seg, buf, current->t_regs.ds, chars);
 	mark_buffer_uptodate(bh, 1);
 	mark_buffer_dirty(bh, 1);
 	//unmap_brelse(bh);
@@ -217,8 +216,7 @@ static int blk_rw(struct inode *inode, register struct file *filp,
 	     */
 	    //memcpy_fromfs(bh->b_data + offset, buf, chars);
 	    char *data = bh->b_data? bh->b_data: (char *)(bh->b_offset << BLOCK_SIZE_BITS);
-	    fmemcpyb((byte_t *)data + offset, bh->b_seg,
-		(byte_t *)buf, current->t_regs.ds, chars);
+	    fmemcpyb(data + offset, bh->b_seg, buf, current->t_regs.ds, chars);
 	    bh->b_uptodate = bh->b_dirty = 1;
 	    /*
 	     *      Writing: queue physical I/O
@@ -237,9 +235,7 @@ static int blk_rw(struct inode *inode, register struct file *filp,
 	     */
 	    //memcpy_tofs(buf, bh->b_data + offset, chars);
 	    char *data = bh->b_data? bh->b_data: (char *)(bh->b_offset << BLOCK_SIZE_BITS);
-	    fmemcpyb((byte_t *)buf, current->t_regs.ds,
-		(byte_t *)data + offset,
-		bh->b_seg, chars);
+	    fmemcpyb(buf, current->t_regs.ds, data + offset, bh->b_seg, chars);
 	}
 	/*
 	 *      Move on and release buffer

--- a/elks/fs/block_dev.c
+++ b/elks/fs/block_dev.c
@@ -77,10 +77,14 @@ size_t block_read(struct inode *inode, register struct file *filp,
 		if (!read) read = -EIO;
 		break;
 	    }
-	    map_buffer(bh);
-	    memcpy_tofs(buf, bh->b_data + (((size_t)(filp->f_pos)) & (BLOCK_SIZE - 1)),
-			chars);
-	    unmap_brelse(bh);
+	    //map_buffer(bh);
+	    //memcpy_tofs(buf, bh->b_data + (((size_t)(filp->f_pos)) & (BLOCK_SIZE - 1)),
+                       //chars);
+	    char *data = bh->b_data? bh->b_data: (char *)(bh->b_offset << BLOCK_SIZE_BITS);
+	    fmemcpyb((byte_t *)buf, current->t_regs.ds,
+		(byte_t *)data + (((size_t)(filp->f_pos)) & (BLOCK_SIZE - 1)), bh->b_seg, chars);
+	    //unmap_brelse(bh);
+	    brelse(bh);
 	} else fmemsetb((word_t) buf, current->t_regs.ds, 0, (word_t) chars);
 	buf += chars;
 	filp->f_pos += chars;
@@ -152,11 +156,15 @@ size_t block_write(struct inode *inode, register struct file *filp,
 	/*
 	 *      Alter buffer, mark dirty
 	 */
-	map_buffer(bh);
-	memcpy_fromfs((bh->b_data + offset), buf, chars);
+	//map_buffer(bh);
+	//memcpy_fromfs((bh->b_data + offset), buf, chars);
+	char *data = bh->b_data? bh->b_data: (char *)(bh->b_offset << BLOCK_SIZE_BITS);
+	fmemcpyb((byte_t *)data + offset, bh->b_seg,
+	    (byte_t *)buf, current->t_regs.ds, chars);
 	mark_buffer_uptodate(bh, 1);
 	mark_buffer_dirty(bh, 1);
-	unmap_brelse(bh);
+	//unmap_brelse(bh);
+	brelse(bh);
 	buf += chars;
 	filp->f_pos += chars;
 	written += chars;
@@ -202,12 +210,15 @@ static int blk_rw(struct inode *inode, register struct file *filp,
 	    }
 	}
 
-	map_buffer(bh);
+	//map_buffer(bh);
 	if (wr == BLOCK_WRITE) {
 	    /*
 	     *      Alter buffer, mark dirty
 	     */
-	    memcpy_fromfs(bh->b_data + offset, buf, chars);
+	    //memcpy_fromfs(bh->b_data + offset, buf, chars);
+	    char *data = bh->b_data? bh->b_data: (char *)(bh->b_offset << BLOCK_SIZE_BITS);
+	    fmemcpyb((byte_t *)data + offset, bh->b_seg,
+		(byte_t *)buf, current->t_regs.ds, chars);
 	    bh->b_uptodate = bh->b_dirty = 1;
 	    /*
 	     *      Writing: queue physical I/O
@@ -215,7 +226,8 @@ static int blk_rw(struct inode *inode, register struct file *filp,
 	    ll_rw_blk(WRITE, bh);
 	    wait_on_buffer(bh);
 	    if (!bh->b_uptodate) { /* Write error. */
-		unmap_brelse(bh);
+		//unmap_brelse(bh);
+		brelse(bh);
 		if (!written) written = -EIO;
 		break;
 	    }
@@ -223,13 +235,18 @@ static int blk_rw(struct inode *inode, register struct file *filp,
 	    /*
 	     *      Empty buffer data. Buffer unchanged
 	     */
-	    memcpy_tofs(buf, bh->b_data + offset, chars);
+	    //memcpy_tofs(buf, bh->b_data + offset, chars);
+	    char *data = bh->b_data? bh->b_data: (char *)(bh->b_offset << BLOCK_SIZE_BITS);
+	    fmemcpyb((byte_t *)buf, current->t_regs.ds,
+		(byte_t *)data + offset,
+		bh->b_seg, chars);
 	}
 	/*
 	 *      Move on and release buffer
 	 */
 
-	unmap_brelse(bh);
+	//unmap_brelse(bh);
+	brelse(bh);
 
 	buf += chars;
 	filp->f_pos += chars;

--- a/elks/fs/block_dev.c
+++ b/elks/fs/block_dev.c
@@ -77,13 +77,9 @@ size_t block_read(struct inode *inode, register struct file *filp,
 		if (!read) read = -EIO;
 		break;
 	    }
-	    //map_buffer(bh);
-	    //memcpy_tofs(buf, bh->b_data + (((size_t)(filp->f_pos)) & (BLOCK_SIZE - 1)),
-                       //chars);
 	    char *data = bh->b_data? bh->b_data: (char *)(bh->b_offset << BLOCK_SIZE_BITS);
 	    fmemcpyb(buf, current->t_regs.ds,
 		data + (((size_t)(filp->f_pos)) & (BLOCK_SIZE - 1)), bh->b_seg, chars);
-	    //unmap_brelse(bh);
 	    brelse(bh);
 	} else fmemsetb((word_t) buf, current->t_regs.ds, 0, (word_t) chars);
 	buf += chars;
@@ -156,13 +152,10 @@ size_t block_write(struct inode *inode, register struct file *filp,
 	/*
 	 *      Alter buffer, mark dirty
 	 */
-	//map_buffer(bh);
-	//memcpy_fromfs((bh->b_data + offset), buf, chars);
 	char *data = bh->b_data? bh->b_data: (char *)(bh->b_offset << BLOCK_SIZE_BITS);
 	fmemcpyb(data + offset, bh->b_seg, buf, current->t_regs.ds, chars);
 	mark_buffer_uptodate(bh, 1);
 	mark_buffer_dirty(bh, 1);
-	//unmap_brelse(bh);
 	brelse(bh);
 	buf += chars;
 	filp->f_pos += chars;
@@ -209,12 +202,10 @@ static int blk_rw(struct inode *inode, register struct file *filp,
 	    }
 	}
 
-	//map_buffer(bh);
 	if (wr == BLOCK_WRITE) {
 	    /*
 	     *      Alter buffer, mark dirty
 	     */
-	    //memcpy_fromfs(bh->b_data + offset, buf, chars);
 	    char *data = bh->b_data? bh->b_data: (char *)(bh->b_offset << BLOCK_SIZE_BITS);
 	    fmemcpyb(data + offset, bh->b_seg, buf, current->t_regs.ds, chars);
 	    bh->b_uptodate = bh->b_dirty = 1;
@@ -224,7 +215,6 @@ static int blk_rw(struct inode *inode, register struct file *filp,
 	    ll_rw_blk(WRITE, bh);
 	    wait_on_buffer(bh);
 	    if (!bh->b_uptodate) { /* Write error. */
-		//unmap_brelse(bh);
 		brelse(bh);
 		if (!written) written = -EIO;
 		break;
@@ -233,7 +223,6 @@ static int blk_rw(struct inode *inode, register struct file *filp,
 	    /*
 	     *      Empty buffer data. Buffer unchanged
 	     */
-	    //memcpy_tofs(buf, bh->b_data + offset, chars);
 	    char *data = bh->b_data? bh->b_data: (char *)(bh->b_offset << BLOCK_SIZE_BITS);
 	    fmemcpyb(buf, current->t_regs.ds, data + offset, bh->b_seg, chars);
 	}
@@ -241,7 +230,6 @@ static int blk_rw(struct inode *inode, register struct file *filp,
 	 *      Move on and release buffer
 	 */
 
-	//unmap_brelse(bh);
 	brelse(bh);
 
 	buf += chars;

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -453,7 +453,6 @@ void map_buffer(register struct buffer_head *bh)
 {
     struct buffer_head *bmap;
     int i;
-static int in = 1, out = 1;
 
     /* If buffer is already mapped, just increase the refcount and return */
     if (bh->b_data /*|| bh->b_seg != kernel_ds*/) {
@@ -478,7 +477,6 @@ static int in = 1, out = 1;
 	if (!bmap->b_mapcount) {
 	    debug("UNMAP: %d <- %d\n", bmap->b_num, i);
 
-printk("copy L1 to L2 %d\n", out++);
 	    /* Unmap/copy L1 to L2 */
 	    fmemcpyw((byte_t *) (bmap->b_offset << BLOCK_SIZE_BITS), bmap->b_ds,
 		     bmap->b_data, kernel_ds, BLOCK_SIZE/2);
@@ -498,7 +496,6 @@ printk("copy L1 to L2 %d\n", out++);
     L1map[i] = bh;
     bh->b_data = (char *)L1buf + (i << BLOCK_SIZE_BITS);
     if (bh->b_uptodate) {
-printk("copy L2 to L1 %d\n", in++);
 	fmemcpyw(bh->b_data, kernel_ds,
 		 (byte_t *) (bh->b_offset << BLOCK_SIZE_BITS), bh->b_ds, BLOCK_SIZE/2);
     }

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -481,7 +481,7 @@ static int in = 1, out = 1;
 printk("copy L1 to L2 %d\n", out++);
 	    /* Unmap/copy L1 to L2 */
 	    fmemcpyw((byte_t *) (bmap->b_offset << BLOCK_SIZE_BITS), bmap->b_ds,
-		     (byte_t *) bmap->b_data, kernel_ds, BLOCK_SIZE/2);
+		     bmap->b_data, kernel_ds, BLOCK_SIZE/2);
 	    bmap->b_data = (char *)0;
 	    bmap->b_seg = bmap->b_ds;
 	    break;		/* success */
@@ -499,7 +499,7 @@ printk("copy L1 to L2 %d\n", out++);
     bh->b_data = (char *)L1buf + (i << BLOCK_SIZE_BITS);
     if (bh->b_uptodate) {
 printk("copy L2 to L1 %d\n", in++);
-	fmemcpyw((byte_t *) bh->b_data, kernel_ds,
+	fmemcpyw(bh->b_data, kernel_ds,
 		 (byte_t *) (bh->b_offset << BLOCK_SIZE_BITS), bh->b_ds, BLOCK_SIZE/2);
     }
     debug("MAP:   %d -> %d\n", bh->b_num, i);

--- a/elks/fs/minix/file.c
+++ b/elks/fs/minix/file.c
@@ -79,8 +79,8 @@ static size_t minix_file_read(struct inode *inode, register struct file *filp,
 	    //memcpy_tofs(buf, bh->b_data + (((size_t)(filp->f_pos)) & (BLOCK_SIZE - 1)),
 			//chars);
 	    char *data = bh->b_data? bh->b_data: (char *)(bh->b_offset << BLOCK_SIZE_BITS);
-	    fmemcpyb((byte_t *)buf, current->t_regs.ds,
-		(byte_t *)data + (((size_t)(filp->f_pos)) & (BLOCK_SIZE - 1)), bh->b_seg, chars);
+	    fmemcpyb(buf, current->t_regs.ds,
+		data + (((size_t)(filp->f_pos)) & (BLOCK_SIZE - 1)), bh->b_seg, chars);
 	    //unmap_brelse(bh);
 	    brelse(bh);
 	} else fmemsetb((word_t) buf, current->t_regs.ds, 0, (word_t) chars);
@@ -153,8 +153,7 @@ static size_t minix_file_write(struct inode *inode, register struct file *filp,
 	//map_buffer(bh);
 	//memcpy_fromfs((bh->b_data + offset), buf, chars);
 	char *data = bh->b_data? bh->b_data: (char *)(bh->b_offset << BLOCK_SIZE_BITS);
-	fmemcpyb((byte_t *)data + offset, bh->b_seg,
-	    (byte_t *)buf, current->t_regs.ds, chars);
+	fmemcpyb(data + offset, bh->b_seg, buf, current->t_regs.ds, chars);
 	mark_buffer_uptodate(bh, 1);
 	mark_buffer_dirty(bh, 1);
 	//unmap_brelse(bh);

--- a/elks/fs/minix/file.c
+++ b/elks/fs/minix/file.c
@@ -75,10 +75,14 @@ static size_t minix_file_read(struct inode *inode, register struct file *filp,
 		if (!read) read = -EIO;
 		break;
 	    }
-	    map_buffer(bh);
-	    memcpy_tofs(buf, bh->b_data + (((size_t)(filp->f_pos)) & (BLOCK_SIZE - 1)),
-			chars);
-	    unmap_brelse(bh);
+	    //map_buffer(bh);
+	    //memcpy_tofs(buf, bh->b_data + (((size_t)(filp->f_pos)) & (BLOCK_SIZE - 1)),
+			//chars);
+	    char *data = bh->b_data? bh->b_data: (char *)(bh->b_offset << BLOCK_SIZE_BITS);
+	    fmemcpyb((byte_t *)buf, current->t_regs.ds,
+		(byte_t *)data + (((size_t)(filp->f_pos)) & (BLOCK_SIZE - 1)), bh->b_seg, chars);
+	    //unmap_brelse(bh);
+	    brelse(bh);
 	} else fmemsetb((word_t) buf, current->t_regs.ds, 0, (word_t) chars);
 	buf += chars;
 	filp->f_pos += chars;
@@ -146,11 +150,15 @@ static size_t minix_file_write(struct inode *inode, register struct file *filp,
 	/*
 	 *      Alter buffer, mark dirty
 	 */
-	map_buffer(bh);
-	memcpy_fromfs((bh->b_data + offset), buf, chars);
+	//map_buffer(bh);
+	//memcpy_fromfs((bh->b_data + offset), buf, chars);
+	char *data = bh->b_data? bh->b_data: (char *)(bh->b_offset << BLOCK_SIZE_BITS);
+	fmemcpyb((byte_t *)data + offset, bh->b_seg,
+	    (byte_t *)buf, current->t_regs.ds, chars);
 	mark_buffer_uptodate(bh, 1);
 	mark_buffer_dirty(bh, 1);
-	unmap_brelse(bh);
+	//unmap_brelse(bh);
+	brelse(bh);
 	buf += chars;
 	filp->f_pos += chars;
 	written += chars;

--- a/elks/fs/minix/file.c
+++ b/elks/fs/minix/file.c
@@ -75,13 +75,9 @@ static size_t minix_file_read(struct inode *inode, register struct file *filp,
 		if (!read) read = -EIO;
 		break;
 	    }
-	    //map_buffer(bh);
-	    //memcpy_tofs(buf, bh->b_data + (((size_t)(filp->f_pos)) & (BLOCK_SIZE - 1)),
-			//chars);
 	    char *data = bh->b_data? bh->b_data: (char *)(bh->b_offset << BLOCK_SIZE_BITS);
 	    fmemcpyb(buf, current->t_regs.ds,
 		data + (((size_t)(filp->f_pos)) & (BLOCK_SIZE - 1)), bh->b_seg, chars);
-	    //unmap_brelse(bh);
 	    brelse(bh);
 	} else fmemsetb((word_t) buf, current->t_regs.ds, 0, (word_t) chars);
 	buf += chars;
@@ -150,13 +146,10 @@ static size_t minix_file_write(struct inode *inode, register struct file *filp,
 	/*
 	 *      Alter buffer, mark dirty
 	 */
-	//map_buffer(bh);
-	//memcpy_fromfs((bh->b_data + offset), buf, chars);
 	char *data = bh->b_data? bh->b_data: (char *)(bh->b_offset << BLOCK_SIZE_BITS);
 	fmemcpyb(data + offset, bh->b_seg, buf, current->t_regs.ds, chars);
 	mark_buffer_uptodate(bh, 1);
 	mark_buffer_dirty(bh, 1);
-	//unmap_brelse(bh);
 	brelse(bh);
 	buf += chars;
 	filp->f_pos += chars;

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -126,15 +126,14 @@
 #endif
 
 struct buffer_head {
-    char			*b_data;	/* Address in L1 buffer area */
+    char			*b_data;	/* Address if in L1 buffer area, else 0 */
     block_t			b_blocknr;
     kdev_t			b_dev;
-/*     struct buffer_head		*b_next; */
     struct buffer_head		*b_next_lru;
     struct buffer_head		*b_prev_lru;
     struct wait_queue		b_wait;
     block_t			b_count;
-    seg_t			b_seg;
+    seg_t			b_seg;		/* Current (L1 or L2) buffer segment*/
     char			b_lock;
     char			b_dirty;
     char			b_uptodate;

--- a/elks/include/linuxmt/memory.h
+++ b/elks/include/linuxmt/memory.h
@@ -19,8 +19,8 @@ void pokel (word_t off, seg_t seg, long_t val);
 void fmemsetb (word_t off, seg_t seg, byte_t val, word_t count);
 void fmemsetw (word_t off, seg_t seg, word_t val, word_t count);
 
-void fmemcpyb (byte_t * dst_off, seg_t dst_seg, byte_t * src_off, seg_t src_seg, word_t count);
-void fmemcpyw (byte_t * dst_off, seg_t dst_seg, byte_t * src_off, seg_t src_seg, word_t count);
+void fmemcpyb (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg, word_t count);
+void fmemcpyw (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg, word_t count);
 
 word_t fmemcmpb (word_t dst_off, seg_t dst_seg, word_t src_off, seg_t src_seg, word_t count);
 word_t fmemcmpw (word_t dst_off, seg_t dst_seg, word_t src_off, seg_t src_seg, word_t count);

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -171,7 +171,7 @@ inet/urlget/urlget :::httpget	:net
 #mtools/mtype					:mtools					:1440k
 #mtools/mwrite					:mtools					:1440k
 bc/bc							:other					:1440k
-prems/pres/pres					:other					:1440k
+prems/pres/pres					:other
 nano-X/bin/nxclock				:nanox					:1440k
 nano-X/bin/nxdemo				:nanox					:1440k
 nano-X/bin/nxlandmine			:nanox				:720k

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,5 +1,5 @@
 ##
-console=ttyS0 net=eth 3 # condensed
+#console=ttyS0 net=eth 3 # condensed
 #init=/bin/init 3	# multiuser serial
 #init=/bin/sh		# singleuser shell
 #console=ttyS0		# serial console

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,5 +1,5 @@
 ##
-#console=ttyS0 net=eth 3 # condensed
+console=ttyS0 net=eth 3 # condensed
 #init=/bin/init 3	# multiuser serial
 #init=/bin/sh		# singleuser shell
 #console=ttyS0		# serial console


### PR DESCRIPTION
Removes map_buffer / unmap_buffer calls for every disk I/O performed. 

For each buffer in external (main) memory, this saves copying 2048 bytes on each disk I/O operation.
All disk I/O is performed directly into L2 buffer (when CONFIG_FS_EXTERNAL_BUFFER enabled), otherwise L1.
Buffers are mapped into L1 buffers now only when necessary by filesystem drivers, but never for application file data.

This saves almost 200 memory-to-memory copies in just starting up the system alone. Should see another big speed jump in networking, as another buffer is now removed on each disk read or write.

This work is in preparation for multi-sector disk I/O coming soon.
