### PR TITLE
[kernel] fmemcpy / fmemset parameter cleanup

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -767,7 +767,7 @@ static void do_bioshd_request(void)
 		    out_ax = BD_AX;
 		    reset_bioshd(drive); /* controller should be reset upon error detection */
 		} else if (need_dma_seg && req->rq_cmd == READ)
-		    fmemcpyw(buff, seg, NULL, DMASEG, (word_t)(this_pass << 8));
+		    fmemcpyw(buff, seg, NULL, DMASEG, this_pass << 8);
 
 		dma_avail = 1;
 		wake_up(&dma_wait);

--- a/elks/arch/i86/drivers/block/rd.c
+++ b/elks/arch/i86/drivers/block/rd.c
@@ -175,8 +175,8 @@ static int rd_ioctl(register struct inode *inode, struct file *file,
 		       j, rd_segment[j].sectors, size);
 
 		debug("RD: fmemsetw(0, 0x%x, 0, 0x%x)\n",
-			rd_segment[j].seg, (word_t) (size >> 1));
-		fmemsetw(0, rd_segment[j].seg, 0, (word_t) (size >> 1));
+			rd_segment[j].seg, (size_t) (size >> 1));
+		fmemsetw(0, rd_segment[j].seg, 0, (size_t) (size >> 1));
 
 		if (k != -1)
 		    rd_segment[k].next = j;	/* set link to next index */
@@ -245,7 +245,7 @@ static void do_rd_request(void)
 	debug("entry %d, seg %x, offset %d\n", index, rd_segment[index].seg, offset);
 
 	if (CURRENT->rq_cmd == WRITE) {
-	    fmemcpyw((byte_t *) (offset * SECTOR_SIZE), rd_segment[index].seg,
+	    fmemcpyw((char *) (offset * SECTOR_SIZE), rd_segment[index].seg,
 		buff, CURRENT->rq_seg, 1024/2);
 	} else {
 	    fmemcpyw(buff, CURRENT->rq_seg,

--- a/elks/arch/i86/drivers/char/cgatext.c
+++ b/elks/arch/i86/drivers/char/cgatext.c
@@ -55,10 +55,7 @@ cgatext_read(struct inode *inode, struct file *f, char *data, size_t len)
 
   if(len)
   {
-    fmemcpyb
-      ((byte_t *)data, current->t_regs.ds,
-      (byte_t *)f->f_pos, (seg_t)cgatext_mem_SEG,
-      (word_t)len);
+    fmemcpyb(data, current->t_regs.ds, (char *)f->f_pos, cgatext_mem_SEG, len);
 
     f->f_pos += len;
   }
@@ -73,10 +70,7 @@ cgatext_write(struct inode *inode, register struct file *f, char *data, size_t l
 
   if(len)
   {
-    fmemcpyb(
-      (byte_t *)f->f_pos, (seg_t)cgatext_mem_SEG,
-      (byte_t *)data, current->t_regs.ds,
-      (word_t)len);
+    fmemcpyb((char *)f->f_pos, cgatext_mem_SEG, data, current->t_regs.ds, len);
 
     f->f_pos += len;
   }

--- a/elks/arch/i86/drivers/char/dircon.c
+++ b/elks/arch/i86/drivers/char/dircon.c
@@ -133,8 +133,7 @@ static void ScrollUp(register Console * C, int y)
 
     vp = (__u16 *)((__u16)(y * Width) << 1);
     if ((unsigned int)y < MaxRow)
-	fmemcpyb((byte_t *)vp, (seg_t) C->vseg,
-		(byte_t *)(vp + Width), (seg_t) C->vseg, (MaxRow - y)*(Width << 1));
+	fmemcpyb(vp, C->vseg, vp + Width, C->vseg, (MaxRow - y) * (Width << 1));
     ClearRange(C, 0, MaxRow, MaxCol, MaxRow);
 }
 
@@ -146,8 +145,7 @@ static void ScrollDown(register Console * C, int y)
 
     vp = (__u16 *)((__u16)(yy * Width) << 1);
     while (--yy >= y) {
-	fmemcpyb((byte_t *)vp, (seg_t) C->vseg,
-		(byte_t *)(vp - Width), (seg_t) C->vseg, (Width << 1));
+	fmemcpyb(vp, C->vseg, vp - Width, C->vseg, Width << 1);
 	vp -= Width;
     }
     ClearRange(C, 0, y, MaxCol, y);

--- a/elks/arch/i86/drivers/char/lp.c
+++ b/elks/arch/i86/drivers/char/lp.c
@@ -287,7 +287,7 @@ void lp_init(void)
     /* only ports 0, 1, 2 and 3 may exist according to RB's intlist */
     for (i = 0; i < LP_PORTS; i++) {
 	/* 8 is offset for LPT info, 2 bytes for each entry */
-	lp->io = (char *)peekw((word_t) (2 * i + 8), 0x40);
+	lp->io = (char *)peekw(2 * i + 8, 0x40);
 	/* returns 0 if port wasn't detected by BIOS at bootup */
 	if (!lp->io)
 	    break;		/* there can be no more ports */

--- a/elks/arch/i86/drivers/char/mem.c
+++ b/elks/arch/i86/drivers/char/mem.c
@@ -110,7 +110,7 @@ size_t full_write(struct inode *inode, struct file *filp, char *data, size_t len
 size_t zero_read(struct inode *inode, struct file *filp, char *data, size_t len)
 {
     debugmem("zero_read()\n");
-    fmemsetb((word_t)data, current->t_regs.ds, 0, (word_t) len);
+    fmemsetb(data, current->t_regs.ds, 0, len);
     filp->f_pos += len;
     return (size_t)len;
 }

--- a/elks/arch/i86/drivers/net/wd.c
+++ b/elks/arch/i86/drivers/net/wd.c
@@ -272,8 +272,8 @@ static int wd_pack_get(char *data, size_t len)
 		} else {
 			res = rxhdr->count - sizeof(e8390_pkt_hdr);
 			if (res > len) res = len;
-			fmemcpyb((byte_t *)data, current->t_regs.ds,
-				(byte_t *)hdr_start + sizeof(e8390_pkt_hdr),
+			fmemcpyb(data, current->t_regs.ds,
+				(char *)hdr_start + sizeof(e8390_pkt_hdr),
 				WD_SHMEMSEG, res);
 		}
 		OUTB(current_rx_page - 1U, WD_8390_PORT + EN0_BOUNDARY);
@@ -316,7 +316,7 @@ static size_t wd_pack_put(char *data, size_t len)
 			len = MAX_PACKET_ETH;
 		if (len < 64U) len = 64U;  /* issue #133 */
 		fmemcpyb((byte_t *)((WD_FIRST_TX_PG - WD_START_PG) << 8U),
-			WD_SHMEMSEG, (byte_t *)data, current->t_regs.ds, len);
+			WD_SHMEMSEG, data, current->t_regs.ds, len);
 		OUTB(E8390_NODMA | E8390_PAGE0, WD_8390_PORT + E8390_CMD);
 		if (INB(WD_8390_PORT + E8390_CMD) & E8390_TRANS) {
 			printk("eth: attempted send with the tr busy.\n");

--- a/elks/arch/i86/lib/fmemory.S
+++ b/elks/arch/i86/lib/fmemory.S
@@ -20,8 +20,8 @@
 	.global fmemcmpb
 	.global fmemcmpw
 
-// void fmemcpyb (byte_t * dst_off, seg_t dst_seg, byte_t * src_off, seg_t src_seg,
-//		word_t count)
+// void fmemcpyb (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg,
+//		size_t count)
 
 fmemcpyb:
 	mov    %si,%ax
@@ -48,8 +48,8 @@ fmemcpyb:
 	mov    %ax,%ds
 	ret
 
-// void fmemcpyw (byte * dst_off, seg_t dst_seg, byte * src_off, seg_t src_seg,
-//		word_t count)
+// void fmemcpyw (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg,
+//		size_t count)
 
 fmemcpyw:
 	mov    %es,%bx
@@ -69,7 +69,7 @@ fmemcpyw:
 	mov    %bx,%es
 	ret
 
-// void fmemsetb (word_t off, seg_t seg, byte_t val, word_t count)
+// void fmemsetb (void * off, seg_t seg, byte_t val, size_t count)
 // compiler pushes byte_t as word_t
 
 fmemsetb:
@@ -94,7 +94,7 @@ fmemsetb:
 	mov    %dx,%di
 	ret
 
-// void fmemsetw (word_t off, seg_t seg, word_t val, word_t count)
+// void fmemsetw (void * off, seg_t seg, word_t val, size_t count)
 
 fmemsetw:
 	mov    %es,%bx
@@ -110,8 +110,8 @@ fmemsetw:
 	mov    %bx,%es
 	ret
 
-// int fmemcmpb (word_t dst_off, seg_t dst_seg, word_t src_off, seg_t src_seg,
-//		word_t count)
+// int fmemcmpb (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg,
+//		size_t count)
 
 fmemcmpb:
 	mov    %es,%bx
@@ -138,8 +138,8 @@ fmemcmpb_exit:
 	mov    %bx,%es
 	ret
 
-// int fmemcmpw (word_t dst_off, seg_t dst_seg, word_t src_off, seg_t src_seg,
-//		word_t count)
+// int fmemcmpw (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg,
+//		size_t count)
 
 fmemcmpw:
 	mov    %es,%bx

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -188,7 +188,7 @@ segment_s * seg_dup (segment_s * src)
 {
 	segment_s * dst = seg_free_get (src->size, src->flags);
 	if (dst)
-		fmemcpyw(NULL, dst->base, 0, src->base, src->size << 3);
+		fmemcpyw(0, dst->base, 0, src->base, src->size << 3);
 
 	return dst;
 }

--- a/elks/fs/block_dev.c
+++ b/elks/fs/block_dev.c
@@ -81,7 +81,7 @@ size_t block_read(struct inode *inode, register struct file *filp,
 	    fmemcpyb(buf, current->t_regs.ds,
 		data + (((size_t)(filp->f_pos)) & (BLOCK_SIZE - 1)), bh->b_seg, chars);
 	    brelse(bh);
-	} else fmemsetb((word_t) buf, current->t_regs.ds, 0, (word_t) chars);
+	} else fmemsetb(buf, current->t_regs.ds, 0, chars);
 	buf += chars;
 	filp->f_pos += chars;
 	read += chars;

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -478,7 +478,7 @@ void map_buffer(register struct buffer_head *bh)
 	    debug("UNMAP: %d <- %d\n", bmap->b_num, i);
 
 	    /* Unmap/copy L1 to L2 */
-	    fmemcpyw((byte_t *) (bmap->b_offset << BLOCK_SIZE_BITS), bmap->b_ds,
+	    fmemcpyw((char *) (bmap->b_offset << BLOCK_SIZE_BITS), bmap->b_ds,
 		     bmap->b_data, kernel_ds, BLOCK_SIZE/2);
 	    bmap->b_data = (char *)0;
 	    bmap->b_seg = bmap->b_ds;
@@ -497,7 +497,7 @@ void map_buffer(register struct buffer_head *bh)
     bh->b_data = (char *)L1buf + (i << BLOCK_SIZE_BITS);
     if (bh->b_uptodate) {
 	fmemcpyw(bh->b_data, kernel_ds,
-		 (byte_t *) (bh->b_offset << BLOCK_SIZE_BITS), bh->b_ds, BLOCK_SIZE/2);
+		 (char *) (bh->b_offset << BLOCK_SIZE_BITS), bh->b_ds, BLOCK_SIZE/2);
     }
     debug("MAP:   %d -> %d\n", bh->b_num, i);
   end_map_buffer:
@@ -532,3 +532,17 @@ void unmap_brelse(register struct buffer_head *bh)
     }
 }
 #endif /* CONFIG_FS_EXTERNAL_BUFFER*/
+
+void memcpy_buf_touser(char *buf, size_t offset, size_t len, struct buffer_head *bh)
+{
+	char *data = bh->b_data? bh->b_data: (char *)(bh->b_offset << BLOCK_SIZE_BITS);
+
+	fmemcpyb(buf, current->t_regs.ds, data + offset, bh->b_seg, len);
+}
+
+void memcpy_buf_fromuser(size_t offset, char *buf, size_t len, struct buffer_head *bh)
+{
+	char *data = bh->b_data? bh->b_data: (char *)(bh->b_offset << BLOCK_SIZE_BITS);
+
+	fmemcpyb(data + offset, bh->b_seg, buf, current->t_regs.ds, len);
+}

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -412,7 +412,7 @@ int sys_execve(char *filename, char *sptr, size_t slen)
 	: currentp->t_endseg) - slen;
     currentp->t_begstack &= ~1;		/* force even stack pointer and argv/envp*/
     currentp->t_regs.sp = (__u16)currentp->t_begstack;
-    fmemcpyb((byte_t *)currentp->t_begstack, seg_data->base, (byte_t *)sptr, ds, (word_t) slen);
+    fmemcpyb((char *)currentp->t_begstack, seg_data->base, sptr, ds, slen);
     currentp->t_minstack = stack;
 
     /* From this point, the old code and data segments are not needed anymore */
@@ -429,7 +429,7 @@ int sys_execve(char *filename, char *sptr, size_t slen)
     currentp->t_regs.es = currentp->t_regs.ss = seg_data->base;
 
     /* Wipe the BSS */
-    fmemsetb((seg_t)(size_t)mh.dseg + base_data, seg_data->base, 0, (word_t)(size_t)mh.bseg);
+    fmemsetb((char *)(size_t)mh.dseg + base_data, seg_data->base, 0, (size_t)mh.bseg);
     {
 	register int i = 0;
 

--- a/elks/fs/minix/file.c
+++ b/elks/fs/minix/file.c
@@ -79,7 +79,7 @@ static size_t minix_file_read(struct inode *inode, register struct file *filp,
 	    fmemcpyb(buf, current->t_regs.ds,
 		data + (((size_t)(filp->f_pos)) & (BLOCK_SIZE - 1)), bh->b_seg, chars);
 	    brelse(bh);
-	} else fmemsetb((word_t) buf, current->t_regs.ds, 0, (word_t) chars);
+	} else fmemsetb(buf, current->t_regs.ds, 0, chars);
 	buf += chars;
 	filp->f_pos += chars;
 	read += chars;

--- a/elks/include/linuxmt/memory.h
+++ b/elks/include/linuxmt/memory.h
@@ -16,14 +16,14 @@ void pokeb (word_t off, seg_t seg, byte_t val);
 void pokew (word_t off, seg_t seg, word_t val);
 void pokel (word_t off, seg_t seg, long_t val);
 
-void fmemsetb (word_t off, seg_t seg, byte_t val, word_t count);
-void fmemsetw (word_t off, seg_t seg, word_t val, word_t count);
+void fmemsetb (void * off, seg_t seg, byte_t val, size_t count);
+void fmemsetw (void * off, seg_t seg, word_t val, size_t count);
 
-void fmemcpyb (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg, word_t count);
-void fmemcpyw (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg, word_t count);
+void fmemcpyb (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg, size_t count);
+void fmemcpyw (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg, size_t count);
 
-word_t fmemcmpb (word_t dst_off, seg_t dst_seg, word_t src_off, seg_t src_seg, word_t count);
-word_t fmemcmpw (word_t dst_off, seg_t dst_seg, word_t src_off, seg_t src_seg, word_t count);
+word_t fmemcmpb (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg, size_t count);
+word_t fmemcmpw (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg, size_t count);
 
 /* macros for far pointers (a la Turbo C++ and Open Watcom) */
 #define _FP_SEG(fp)	((unsigned)((unsigned long)(void __far *)(fp) >> 16))


### PR DESCRIPTION
Revise function definitions to use `void *` and `size_t` to allow less casting, more readability.