### PR TITLE
[cmd] Functional enhancements to fdtest

### DIFF
--- a/elkscmd/misc_utils/fdtest.c
+++ b/elkscmd/misc_utils/fdtest.c
@@ -27,7 +27,6 @@ struct biosparms bdt;
 #define MAX		30		/* max # of sectors per read */
 #define SECSIZE		512		/* sector size*/
 
-unsigned char user_buf[MAX * SECSIZE];
 unsigned char kernel_buf[MAX * SECSIZE];
 int verbose = 0;
 int out = 0;
@@ -50,12 +49,8 @@ int read_disk(unsigned short drive, unsigned short cylinder, unsigned short head
 		return(1);
 	}
 
-	/* then memcpy to "user" buffer*/
-	//fmemcpyw(user_buf, _FP_SEG(user_buf), kernel_buf, _FP_SEG(kernel_buf),
-	//	(count * SECSIZE) >> 1);
 	if (out)
 		write(1, kernel_buf, count*512);
-	fprintf(stderr, ".");
 	return(0);
 }
 
@@ -67,7 +62,6 @@ int main(int ac, char **av)
 	int i, max, direct = 0;
 	unsigned short bs = 1;
 	time_t t, tt;
-	//time_t ttt;
 
 	/* setup starting CHS*/
 	drive = 0;		/* 0-1*/
@@ -140,7 +134,7 @@ int main(int ac, char **av)
 		fprintf(stderr, "Testing entire drive %d, max %d incr %d\n", drive, max, bs);
 		cylinder = 0;
 		t = time(NULL);
-		/* we're not concerned with track boundaries, the BIOS handles it just fine */
+
 		while (read_disk(drive, cylinder, head, sector, bs) == 0) {
 			blocks++; 
 			if (sector + bs <= max) sector += bs;
@@ -172,6 +166,7 @@ int main(int ac, char **av)
 					}
 				}
 			}
+			if (!verbose) fprintf(stderr, ".");
 		}
 		fprintf(stderr, "\nRead %d blocks in %ld seconds\n", blocks, time(NULL) - t);
 		return(0);
@@ -193,9 +188,6 @@ int main(int ac, char **av)
 	t = time(NULL);
 	(void)read_disk(drive, cylinder, head, sector, max);
 	tt = time(NULL);
-	//if (!head) (void)read_disk(drive, cylinder, head+1, sector, max);
-	//ttt = time(NULL);
 	fprintf(stderr, "%ld secs\n", tt-t);
-	//if (!head) fprintf(stderr, "%ld secs (both heads)\n", ttt-t);
 	
 }

--- a/elkscmd/misc_utils/fdtest.c
+++ b/elkscmd/misc_utils/fdtest.c
@@ -3,6 +3,9 @@
  */
 #include <stdio.h>
 #include <time.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <unistd.h>
 #include <linuxmt/bioshd.h>
 #include <linuxmt/biosparm.h>
 #include <linuxmt/memory.h>
@@ -21,29 +24,39 @@ struct biosparms bdt;
 #define BD_ES bdt.es
 #define BD_FL bdt.fl
 
-#define MAX		18		/* # sectors per track*/
+#define MAX		30		/* max # of sectors per read */
 #define SECSIZE		512		/* sector size*/
 
 unsigned char user_buf[MAX * SECSIZE];
 unsigned char kernel_buf[MAX * SECSIZE];
+int verbose = 0;
+int out = 0;
 
-void read_disk(unsigned short drive, unsigned short cylinder, unsigned short head,
+int read_disk(unsigned short drive, unsigned short cylinder, unsigned short head,
 	unsigned short sector, unsigned short count)
 {
 	if (count > MAX) count = MAX;
+	if (verbose)
+		fprintf(stderr, "d %d c %d h %d s %d cnt %d\n", drive, cylinder, head, sector, count);
 
 	/* BIOS disk read into "kernel" buffer*/
 	BD_AX = BIOSHD_READ | count;
 	BD_BX = _FP_OFF(kernel_buf);	/* note: 64k DMA boundary ignored here*/
 	BD_ES = _FP_SEG(kernel_buf);
-	BD_CX = (unsigned short) ((cylinder << 8) | ((cylinder >> 2) & 0xc0) | sector);
+	BD_CX = (unsigned short) (((cylinder&0xff) << 8) | ((cylinder&0x300) >> 2) | sector);
 	BD_DX = (head << 8) | drive;
-	if (call_bios(&bdt))
-		printf("READ ERROR at CHS %d,%d,%d\n", cylinder, head, sector);
+	if (call_bios(&bdt)) {
+		fprintf(stderr, "READ ERROR at CHS %d,%d,%d\n", cylinder, head, sector);
+		return(1);
+	}
 
 	/* then memcpy to "user" buffer*/
-	fmemcpyw(user_buf, _FP_SEG(user_buf), kernel_buf, _FP_SEG(kernel_buf),
-		(count * SECSIZE) >> 1);
+	//fmemcpyw(user_buf, _FP_SEG(user_buf), kernel_buf, _FP_SEG(kernel_buf),
+	//	(count * SECSIZE) >> 1);
+	if (out)
+		write(1, kernel_buf, count*512);
+	fprintf(stderr, ".");
+	return(0);
 }
 
 int main(int ac, char **av)
@@ -51,38 +64,138 @@ int main(int ac, char **av)
 	unsigned short drive, cylinder, head, sector;
 	unsigned short start_dma_page, end_dma_page;
 	unsigned long normalized_seg;
-	int i;
-	time_t t;
+	int i, max, direct = 0;
+	unsigned short bs = 1;
+	time_t t, tt;
+	//time_t ttt;
 
 	/* setup starting CHS*/
 	drive = 0;		/* 0-1*/
-	cylinder = 3;		/* 1-79*/
+	cylinder = 3;		/* 0-79*/
 	head = 0;		/* 0-1*/
-	sector = 1;		/* 1-18 on 1.44M floppies*/
+	sector = 1;		/* 1-18, 18 on 1.44M floppies */
+	max = 18;		/* sectors per track on device */
+
+	while (--ac) {
+		av++;
+		switch ((*av)[1]) {
+		case 'd':	/* select drive, 0 or 1 */
+			drive = atoi(*(++av));
+			ac--;
+			break;
+		case 'c':	/* select (starting) cylinder, 0 - 79 */
+			cylinder = atoi(*(++av));
+			ac--;
+			break;
+		case 'h':	/* select start head, 0 or 1 */
+			head = atoi(*(++av));
+			ac--;
+			break;
+		case 's':	/* select staring sector, 1 to MAX or max */
+			sector = atoi(*(++av));
+			ac--;
+			break;
+		case 't':	/* set sectors per track */
+			max = atoi(*(++av));
+			if (max > MAX) max = MAX;
+			ac--;
+			break;
+		case 'D':	/* Direct: Read entore disk from the given starting point */
+			direct++;
+			break;
+		case 'b':	/* blocksize, only in Direct Mode */
+			bs = atoi(*(++av));
+			ac--;
+			if (bs < 1 || bs > MAX) bs = 1;
+			break;
+		case 'v':	/* verbose, show debug messages */
+			verbose++;
+			break;
+		case 'o':	/* send read data to stdout */
+			out++;
+			break;
+		case 'u':
+		default:
+			fprintf(stderr, "usage: fdtest [-D] [-v] [-o] [-d drive] [-c cylinder] [-h head]\n[-s sector] [-t sectors per track] [-b blocksize]\n");
+			fprintf(stderr, "-D: Read entire device, -v: verbose, -o: send data to stdout\n");
+			return(1);
+		}	
+	}
 
 	/* dma start/end pages must be equal to ensure I/O within 64k DMA boundary for INT 13h*/
-	start_dma_page = (_FP_SEG(kernel_buf) + ((__u16) kernel_buf >> 4)) >> 12;
-	end_dma_page = (_FP_SEG(kernel_buf) + ((__u16) (kernel_buf + MAX * 512 - 1) >> 4)) >> 12;
-	normalized_seg = (((__u32)_FP_SEG(kernel_buf) + (_FP_OFF(kernel_buf) >> 4)) << 16) +
-		(_FP_OFF(kernel_buf) & 15);
-	printf("dma start page %x, dma end page %x, buffer at %x:%x - ",
-		start_dma_page, end_dma_page, _FP_SEG(normalized_seg), _FP_OFF(normalized_seg));
-	printf(start_dma_page == end_dma_page? "OK\n": "ERROR\n");
+	if (verbose) {
+		start_dma_page = (_FP_SEG(kernel_buf) + ((__u16) kernel_buf >> 4)) >> 12;
+		end_dma_page = (_FP_SEG(kernel_buf) + ((__u16) (kernel_buf + max * 512 - 1) >> 4)) >> 12;
+		normalized_seg = (((__u32)_FP_SEG(kernel_buf) + (_FP_OFF(kernel_buf) >> 4)) << 16) +
+			(_FP_OFF(kernel_buf) & 15);
+		fprintf(stderr, "dma start page %x, dma end page %x, buffer at %x:%x - ",
+			start_dma_page, end_dma_page, _FP_SEG(normalized_seg), _FP_OFF(normalized_seg));
+		fprintf(stderr, start_dma_page == end_dma_page? "OK\n": "ERROR\n");
+	}
 
-	printf("Reading %d sectors individually\n", MAX);
+	signal(SIGINT, SIG_IGN);	/* any signal here will likely crash the system */
+	if (direct) {
+		int  blocks = 0;
+
+		fprintf(stderr, "Testing entire drive %d, max %d incr %d\n", drive, max, bs);
+		cylinder = 0;
+		t = time(NULL);
+		/* we're not concerned with track boundaries, the BIOS handles it just fine */
+		while (read_disk(drive, cylinder, head, sector, bs) == 0) {
+			blocks++; 
+			if (sector + bs <= max) sector += bs;
+			else {
+				if (bs <= max) {
+					sector = sector + bs - max;
+					if (!head)
+						head++;
+					else {
+						head--;
+						cylinder++;
+					}
+				} else {
+					int j;
+					for (j = bs; j > max; j -= max) {
+						if (head) {
+							head--;
+							cylinder++;
+						} else head++;
+					}
+					sector += bs%max;
+					if (sector > max) {
+						sector -= max;
+						if (head) {
+							head--;
+							cylinder++;
+						} else 
+							head++;
+					}
+				}
+			}
+		}
+		fprintf(stderr, "\nRead %d blocks in %ld seconds\n", blocks, time(NULL) - t);
+		return(0);
+	}
+
+	fprintf(stderr, "Reading %d sectors individually\n", max);
 	t = time(NULL);
-	for (i=0; i < MAX; i++)
-		read_disk(drive, cylinder, head, sector+i, 1);
-	printf("%ld secs\n", time(NULL) - t);
+	for (i=0; i < max; i++)
+		(void)read_disk(drive, cylinder, head, sector+i, 1);
+	fprintf(stderr, "%ld secs\n", time(NULL) - t);
 	
-	printf("Reading %d sectors as %d 1024-byte blocks\n", MAX, MAX/2);
+	fprintf(stderr, "Reading %d sectors as %d 1024-byte blocks\n", max, max/2);
 	t = time(NULL);
-	for (i=0; i < MAX; i += 2)
-		read_disk(drive, cylinder, head, sector+i, 2);
-	printf("%ld secs\n", time(NULL) - t);
+	for (i=0; (sector+i) < max-1; i += 2)
+		(void)read_disk(drive, cylinder, head, sector+i, 2);
+	fprintf(stderr, "%ld secs\n", time(NULL) - t);
 	
-	printf("Reading %d sectors at once\n", MAX);
+	fprintf(stderr, "Reading %d sectors at once\n", max);
 	t = time(NULL);
-	read_disk(drive, cylinder, head, sector, MAX);
-	printf("%ld secs\n", time(NULL) - t);
+	(void)read_disk(drive, cylinder, head, sector, max);
+	tt = time(NULL);
+	//if (!head) (void)read_disk(drive, cylinder, head+1, sector, max);
+	//ttt = time(NULL);
+	fprintf(stderr, "%ld secs\n", tt-t);
+	//if (!head) fprintf(stderr, "%ld secs (both heads)\n", ttt-t);
+	
 }


### PR DESCRIPTION
Adding functionality to @ghaerr's `fdtest` program - expanding speed tests to cover BIOS and drive testing.

`fdtest` now has two modes: 
- Standard mode: Runs (and reports elapsed time) 3 tests on the selected drive (single block, double block, entire track), with selectable starting points.
- Direct mode: Reads (and reports time consumption) the entire drive using default or command line parameters

`fdtest` reports errors and continues until the requested test has completed. Thus is is possible to stress-test the BIOS in one or a few runs.

The command line parameters are:
```
-d <device> Read from device 0 or 1, default 0
-D Enter direct mode, read entire drive, ignore parameters adjusting the starting point
-b <blocksize> Read <blocksize> sectors per operation, max 25, default 1, intentionally not checked against SPT
-h <head> Starting head, 0 or 1, default 0, ignored in direct mode
-u Print usage and exit
-t <spt> Set sectors per track, default is 18
-s <sector> Starting sector (normal mode)
-v Verbose output
-c <cyl> Starting cylinder (normal mode)
-o Send read data to stdout - remember to redirect
```
Interrupts (^C) are disabled - a forced exit will hang or seriously screw up there system. Similarly, `fdtest` must be run on a totally quiet system. If preempted by a context switch, the system will most likely hang hard.