### PR TITLE
[kernel] Add experimental display showing disk access

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -43,6 +43,7 @@
 #include <linuxmt/mm.h>
 #include <linuxmt/config.h>
 #include <linuxmt/debug.h>
+#include <linuxmt/timer.h>
 
 #include <arch/io.h>
 #include <arch/segment.h>
@@ -825,6 +826,7 @@ static void do_bioshd_request(void)
 	int drive, count;
 	char *buf;
 
+	spin_timer(1);
 	while (1) {
       next_block:
 
@@ -895,6 +897,7 @@ static void do_bioshd_request(void)
 	/* satisfied that request */
 	end_request(1);
     }
+    spin_timer(0);
 }
 
 #if 0			/* Currently not used, removing for size. */

--- a/elks/arch/i86/drivers/char/bioscon.c
+++ b/elks/arch/i86/drivers/char/bioscon.c
@@ -103,12 +103,7 @@ static void restart_timer(void)
 static void kbd_timer(int data)
 {
     int dav, extra = 0;
-#if 0
-    static int clk[4] = {0x072D, 0x075C, 0x077C, 0x072F,};
-    static int c = 0;
 
-    pokew((79+0*80)*2, 0xB800, clk[(c++)&0x03]);
-#endif
     if ((dav = bios_kbd_poll())) {
 	if (dav & 0xFF)
 	    Console_conin(dav & 0x7F);

--- a/elks/include/linuxmt/timer.h
+++ b/elks/include/linuxmt/timer.h
@@ -88,5 +88,7 @@ extern int del_timer(struct timer_list *);
 extern void timer_tick(int, struct pt_regs *, void *);
 extern void enable_timer_tick(void);
 extern void stop_timer(void);
+extern void do_timer(struct pt_regs *);
+extern void spin_timer(int);
 
 #endif


### PR DESCRIPTION
This PR adds a "spinning wheel" in the upper right corner of the display whenever disk I/O is occurring, kind of like the macOS "beachball" cursor when forced to wait.

I thought this might be useful, or fun, to visually see when the kernel is waiting for I/O to complete, especially now that the track cache is default on.

In general, QEMU I/O is too fast to see, so this is mostly for real hardware.

It might be possible to show TCP/IP activity as well, but need to think a bit more about it.