### PR TITLE
[cmds] Enhance mv to overwrite target and move directories

### DIFF
--- a/libc/system/out.mk
+++ b/libc/system/out.mk
@@ -34,6 +34,7 @@ OBJS = \
 	mkfifo.o \
 	opendir.o \
 	readdir.o \
+	rewinddir.o \
 	setjmp.o \
 	setpgrp.o \
 	signal.o \

--- a/libc/system/rewinddir.c
+++ b/libc/system/rewinddir.c
@@ -1,0 +1,9 @@
+#include <dirent.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+void
+rewinddir(DIR *dirp)
+{
+   lseek(dirp->dd_fd, 0L, SEEK_SET);
+}


### PR DESCRIPTION
Provides workaround for broken kernel rename problem identified in issue #583.

`mv` can now be used to rename a directory. This takes @toncho11's idea from https://github.com/jbruchon/elks/issues/583#issuecomment-720961426 and uses links instead of copying.

Also enhances `mv` to overwrite the target file, if it's not a directory.

This version will fail midway should the source directory contain subdirectories or symlinks (like /bin, but renames /bin without httpget and ftpget). Will probably add some error checking code in a further commit.