### PR TITLE
[cmds] Fix mv command leaving new directory when linking files fails

### DIFF
--- a/elkscmd/file_utils/mv.c
+++ b/elkscmd/file_utils/mv.c
@@ -265,8 +265,10 @@ int main(int argc, char **argv)
 			}
 
 			/* only works if source directory has no subdirectories or symlinks!*/
-			if (!linkfiles(srcname, destname))
+			if (!linkfiles(srcname, destname)) {
+				rmdir(destname);	/* remove directory just created*/
 				return 1;
+			}
 
 			if (rmdir(srcname) < 0) {
 				perror(srcname);


### PR DESCRIPTION
Fixes problem found by @Mellvik in https://github.com/jbruchon/elks/pull/834#issuecomment-721696701 with `mv` leaving newly created destination directory when source directory contains subdirectories or symlinks.
