### PR TITLE
[kernel] Expand buffer block numbers to 32 bits to support 500MB FAT filesystems

### DIFF
--- a/elks/arch/i86/drivers/block/ll_rw_blk.c
+++ b/elks/arch/i86/drivers/block/ll_rw_blk.c
@@ -248,14 +248,13 @@ static void add_request(struct blk_dev_struct *dev,
     set_irq();
 }
 
-static void make_request(unsigned short int major, int rw,
-			 register struct buffer_head *bh)
+static void make_request(unsigned short major, int rw, struct buffer_head *bh)
 {
-    register struct request *req;
+    struct request *req;
     sector_t sector, count;
     int max_req;
 
-    debug_blk("BLK %d %s\n", bh->b_blocknr, rw==READ? "read": "write");
+    debug_blk("BLK(%x) %lu %s\n", bh->b_dev, bh->b_blocknr, rw==READ? "read": "write");
     count = (sector_t) (BLOCK_SIZE >> 9);
     sector = bh->b_blocknr * count;
 

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -288,7 +288,7 @@ struct buffer_head *readbuf(register struct buffer_head *bh)
     return bh;
 }
 
-static struct buffer_head *find_buffer(kdev_t dev, block_t block)
+static struct buffer_head *find_buffer(kdev_t dev, block32_t block)
 {
     register struct buffer_head *bh = bh_llru;
 
@@ -302,7 +302,7 @@ struct buffer_head *get_hash_table(kdev_t dev, block_t block)
 {
     register struct buffer_head *bh;
 
-    if ((bh = find_buffer(dev, block)) != NULL) {
+    if ((bh = find_buffer(dev, (block32_t)block)) != NULL) {
 	INR_COUNT(bh);
 	wait_on_buffer(bh);
     }
@@ -320,7 +320,14 @@ struct buffer_head *get_hash_table(kdev_t dev, block_t block)
  * when the filesystem starts to get full of dirty blocks (I hope).
  */
 
+/* 16 bit block numbers for super blocks and MINIX filesystem driver*/
 struct buffer_head *getblk(kdev_t dev, block_t block)
+{
+	return getblk32(dev, (block32_t)block);
+}
+
+/* 32 bit block numbers for FAT filesystem driver*/
+struct buffer_head *getblk32(kdev_t dev, block32_t block)
 {
     register struct buffer_head *bh;
     register struct buffer_head *n_bh;
@@ -367,9 +374,16 @@ struct buffer_head *getblk(kdev_t dev, block_t block)
  * it. It returns NULL if the block was unreadable.
  */
 
+/* 16 bit block numbers for super blocks and MINIX filesystem driver*/
 struct buffer_head *bread(kdev_t dev, block_t block)
 {
     return readbuf(getblk(dev, block));
+}
+
+/* 32 bit block numbers for FAT filesystem driver*/
+struct buffer_head *bread32(kdev_t dev, block32_t block)
+{
+    return readbuf(getblk32(dev, block));
 }
 
 #if 0

--- a/elks/fs/msdos/fat.c
+++ b/elks/fs/msdos/fat.c
@@ -16,12 +16,12 @@ static struct fat_cache *fat_cache,cache[FAT_CACHE];
 /* Returns the this'th FAT entry, -1 if it is an end-of-file entry.
    If new_value is != -1, that FAT entry is replaced by it. */
 
-long FATPROC fat_access(register struct super_block *sb,long this,long new_value)
+cluster_t FATPROC fat_access(struct super_block *sb,cluster_t this,cluster_t new_value)
 {
 	struct buffer_head *bh,*bh2;
 	unsigned char *p_first,*p_last;
 	void *data,*data2;
-	long first,last,next;
+	cluster_t first,last,next;
 	int fatsz = MSDOS_SB(sb)->fat_bits;
 	//long copy;
 	//void *c_data, *c_data2;
@@ -148,7 +148,8 @@ void FATPROC cache_init(void)
 }
 
 
-void FATPROC cache_lookup(struct inode *inode,long cluster,long *f_clu,long *d_clu)
+void FATPROC cache_lookup(struct inode *inode,cluster_t cluster,
+	cluster_t *f_clu, cluster_t *d_clu)
 {
 	register struct fat_cache *walk;
 
@@ -180,7 +181,7 @@ static void FATPROC list_cache(void)
 #endif
 
 
-void FATPROC cache_add(struct inode *inode,long f_clu,long d_clu)
+void FATPROC cache_add(struct inode *inode, cluster_t f_clu, cluster_t d_clu)
 {
 	register struct fat_cache *walk,*last;
 
@@ -230,7 +231,7 @@ void FATPROC cache_inval_inode(struct inode *inode)
 }
 
 
-void FATPROC cache_inval_dev(int device)
+void FATPROC cache_inval_dev(kdev_t device)
 {
 	register struct fat_cache *walk;
 
@@ -239,9 +240,9 @@ void FATPROC cache_inval_dev(int device)
 }
 
 
-long FATPROC get_cluster(register struct inode *inode,long cluster)
+cluster_t FATPROC get_cluster(register struct inode *inode, cluster_t cluster)
 {
-	long this,count;
+	cluster_t this, count;
 
 	if (!(this = inode->u.msdos_i.i_start)) return 0;
 	if (!cluster) return this;
@@ -258,7 +259,7 @@ long FATPROC get_cluster(register struct inode *inode,long cluster)
 sector_t FATPROC msdos_smap(struct inode *inode, sector_t sector)
 {
 	register struct msdos_sb_info *sb;
-	long cluster;
+	cluster_t cluster;
 	int offset;
 
 	sb = MSDOS_SB(inode->i_sb);
@@ -280,9 +281,9 @@ sector_t FATPROC msdos_smap(struct inode *inode, sector_t sector)
 /* Free all clusters after the skip'th cluster. Doesn't use the cache,
    because this way we get an additional sanity check. */
 
-int FATPROC fat_free(register struct inode *inode,long skip)
+int FATPROC fat_free(register struct inode *inode, cluster_t skip)
 {
-	long this,last;
+	cluster_t this, last;
 
 	debug_fat("fat_free\n");
 	if (!(this = inode->u.msdos_i.i_start)) return 0;

--- a/elks/fs/msdos/file.c
+++ b/elks/fs/msdos/file.c
@@ -66,7 +66,7 @@ static size_t msdos_file_read(register struct inode *inode,register struct file 
 {
 	char *start;
 	size_t left,offset,size;
-	long sector;
+	sector_t sector;
 	struct buffer_head *bh;
 	void *data;
 
@@ -99,7 +99,7 @@ static size_t msdos_file_read(register struct inode *inode,register struct file 
 static size_t msdos_file_write(register struct inode *inode,register struct file *filp,char *buf,
     size_t count)
 {
-	long sector;
+	sector_t sector;
 	int offset,size,written;
 	int error;
 	char *start;
@@ -125,7 +125,7 @@ static size_t msdos_file_write(register struct inode *inode,register struct file
 	for (start = buf; count; count -= size) {
 		while (!(sector = msdos_smap(inode,filp->f_pos >> SECTOR_BITS)))
 			if ((error = msdos_add_cluster(inode)) < 0) break;
-		if (error) break;
+		if (error) break;	//FIXME check error return
 		offset = (int)filp->f_pos & (SECTOR_SIZE-1);
 		size = MIN(SECTOR_SIZE-offset,count);
 		if (!(bh = msdos_sread(inode->i_dev,sector,&data))) {
@@ -140,7 +140,7 @@ static size_t msdos_file_write(register struct inode *inode,register struct file
 			inode->i_size = filp->f_pos;
 			inode->i_dirt = 1;
 		}
-		debug_fat("file block write %d\n", bh->b_blocknr);
+		debug_fat("file block write %lu\n", bh->b_blocknr);
 		bh->b_dirty = 1;
 		unmap_brelse(bh);
 	}

--- a/elks/fs/msdos/file.c
+++ b/elks/fs/msdos/file.c
@@ -153,10 +153,10 @@ static size_t msdos_file_write(register struct inode *inode,register struct file
 
 void msdos_truncate(register struct inode *inode)
 {
-	int cluster;
+	cluster_t cluster;
 
 	debug_fat("truncate\n");
-	cluster = SECTOR_SIZE*MSDOS_SB(inode->i_sb)->cluster_size;
+	cluster = (cluster_t)SECTOR_SIZE*MSDOS_SB(inode->i_sb)->cluster_size;
 	(void)fat_free(inode,(inode->i_size + (cluster-1)) / cluster);
 	inode->u.msdos_i.i_attrs |= ATTR_ARCH;
 	inode->i_dirt = 1;

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -317,7 +317,7 @@ static void msdos_write_inode(register struct inode *inode)
 	raw_entry->start = (unsigned short)inode->u.msdos_i.i_start;
 	raw_entry->starthi = ((unsigned short *)&inode->u.msdos_i.i_start)[1];
 	date_unix2dos(inode->i_mtime,&raw_entry->time,&raw_entry->date);
-	debug_fat("write_inode block write %d\n", bh->b_blocknr);
+	debug_fat("write_inode block write %lu\n", bh->b_blocknr);
 	bh->b_dirty = 1;
 	unmap_brelse(bh);
 }

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -177,7 +177,7 @@ printk("FAT: me=%x,csz=%d,#f=%d,floc=%d,fsz=%d,rloc=%d,#d=%d,dloc=%d,#s=%ld,ts=%
 #ifdef BLOAT_FS
 static void msdos_statfs(struct super_block *sb,struct statfs *buf)
 {
-	long cluster_size,free,this;
+	cluster_t cluster_size,free,this;
 	struct statfs tmp;
 
 	cluster_size = MSDOS_SB(sb)->cluster_size;
@@ -202,7 +202,7 @@ void msdos_read_inode(register struct inode *inode)
 {
 	struct buffer_head *bh;
 	register struct msdos_dir_entry *raw_entry;
-	long this,nr;
+	cluster_t this, nr;
 	int fatsz = MSDOS_SB(inode->i_sb)->fat_bits;
 
 	//debug_fat("read_inode %ld\n", (unsigned long)inode->i_ino);
@@ -219,7 +219,7 @@ void msdos_read_inode(register struct inode *inode)
 			nr = inode->u.msdos_i.i_start = MSDOS_SB(inode->i_sb)->root_cluster;
 			if (nr) {
 				while (nr != -1) {
-					inode->i_size += (unsigned long)SECTOR_SIZE*MSDOS_SB(inode->i_sb)->cluster_size;
+					inode->i_size += (cluster_t)SECTOR_SIZE*MSDOS_SB(inode->i_sb)->cluster_size;
 					if (!(nr = fat_access(inode->i_sb,nr,-1L))) {
 						printk("FAT: can't read dir %ld\n", (unsigned long)inode->i_ino);
 						break;
@@ -273,7 +273,7 @@ void msdos_read_inode(register struct inode *inode)
 		inode->i_size = 0;
 		/* read FAT chain to set directory size */
 		for (this = inode->u.msdos_i.i_start; this && this != -1; this = fat_access(inode->i_sb,this,-1L))
-			inode->i_size += SECTOR_SIZE*MSDOS_SB(inode->i_sb)->cluster_size;
+			inode->i_size += (cluster_t)SECTOR_SIZE*MSDOS_SB(inode->i_sb)->cluster_size;
 	}
 	else {
 		inode->i_mode = MSDOS_MKMODE(raw_entry->attr,0755 & ~current->fs.umask) | S_IFREG;

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -12,15 +12,15 @@
 #include <linuxmt/stat.h>
 #include <linuxmt/debug.h>
 
-struct buffer_head * FATPROC msdos_sread(int dev,long sector,void **start)
+struct buffer_head * FATPROC msdos_sread(int dev, sector_t sector, void **start)
 {
 	register struct buffer_head *bh;
 
-	if (!(bh = bread(dev, (block_t)(sector >> 1) )))
+	if (!(bh = bread32(dev, sector >> 1)))
 		return NULL;
 
 	map_buffer(bh);
-	//debug_fat("msread sector %ld block %d\n", sector, bh->b_blocknr);
+	//debug_fat("msread sector %ld block %lu\n", sector, bh->b_blocknr);
 	*start = bh->b_data + (((int)sector & 1) << SECTOR_BITS);
 	return bh;
 }
@@ -50,7 +50,8 @@ int FATPROC msdos_add_cluster(register struct inode *inode)
 	static int lock = 0;
 	//FIXME: using previous on booted FAT volume with mounted FAT floppy won't work well
 	static long previous = 0; /* works best if one FS is being used */
-	long count,this,limit,last,current,sector;
+	long count,this,limit,last,current;
+	sector_t sector;
 	void *data;
 	struct buffer_head *bh;
 	int fatsz = MSDOS_SB(inode->i_sb)->fat_bits;
@@ -112,10 +113,10 @@ int FATPROC msdos_add_cluster(register struct inode *inode)
 	for (current = 0; current < MSDOS_SB(inode->i_sb)->cluster_size; current++) {
 		sector = MSDOS_SB(inode->i_sb)->data_start+(this-2) *
 			MSDOS_SB(inode->i_sb)->cluster_size+current;
-		debug("zeroing sector %d\r\n",sector);
+		debug("zeroing sector %lu\r\n", sector);
 
 		if (current < MSDOS_SB(inode->i_sb)->cluster_size-1 && !(sector & 1)) {
-			if (!(bh = getblk(inode->i_dev,(block_t)(sector >> 1))))
+			if (!(bh = getblk32(inode->i_dev, sector >> 1)))
 				printk("FAT: getblk fail\n");
 			else {
 				map_buffer(bh);
@@ -129,7 +130,7 @@ int FATPROC msdos_add_cluster(register struct inode *inode)
 			else memset(data,0,SECTOR_SIZE);
 		}
 		if (bh) {
-			debug_fat("add_cluster block write %d\n", bh->b_blocknr);
+			debug_fat("add_cluster block write %lu\n", bh->b_blocknr);
 			bh->b_dirty = 1;
 			unmap_brelse(bh);
 		}
@@ -208,7 +209,7 @@ void FATPROC date_unix2dos(long unix_date,unsigned short *time, unsigned short *
 ino_t FATPROC msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head **bh,
     struct msdos_dir_entry **de)
 {
-	long sector;
+	sector_t sector;
 	int offset;
 	void *data;
 
@@ -234,7 +235,7 @@ ino_t FATPROC msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head *
 
 	while (1) {
 		offset = *pos;
-		if ((sector = msdos_smap(dir,(long)(*pos >> SECTOR_BITS))) == -1)
+		if ((sector = msdos_smap(dir,(sector_t)(*pos >> SECTOR_BITS))) == -1)
 			return -1;
 		if (!sector)
 			return -1; /* FAT error ... */
@@ -252,7 +253,7 @@ ino_t FATPROC msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head *
 			return -1;
 		}
 #endif
-		//debug_fat("get entry %ld\n", sector);
+		//debug_fat("get entry %lu\n", sector);
 		return (sector << MSDOS_DPS_BITS)+((offset & (SECTOR_SIZE-1)) >> MSDOS_DIR_BITS);
 	}
 }
@@ -302,8 +303,8 @@ int FATPROC msdos_scan(struct inode *dir,char *name,struct buffer_head **res_bh,
    directory "inode". */
 
 /* Retrieve sectors sector */
-static long FATPROC raw_found(struct super_block *sb,long sector,char *name,long number,
-    ino_t *ino)
+static cluster_t FATPROC raw_found(struct super_block *sb,sector_t sector,
+	char *name,cluster_t number, ino_t *ino)
 {
 	struct buffer_head *bh;
 	struct msdos_dir_entry *data;
@@ -339,24 +340,25 @@ static long FATPROC raw_found(struct super_block *sb,long sector,char *name,long
 }
 
 /* Retrieve the root directory file */
-static long FATPROC raw_scan_root(register struct super_block *sb,char *name,long number,ino_t *ino)
+static cluster_t FATPROC raw_scan_root(register struct super_block *sb,
+	char *name, cluster_t number,ino_t *ino)
 {
 	int count;
-	long cluster = 0;
+	cluster_t cluster = 0;
 
 	for (count = 0; count < MSDOS_SB(sb)->dir_entries/MSDOS_DPS; count++) {
-		if ((cluster = raw_found(sb,(long)(MSDOS_SB(sb)->dir_start+count),name, number,
+		if ((cluster = raw_found(sb,(sector_t)(MSDOS_SB(sb)->dir_start+count),name, number,
 				ino)) >= 0) break;
 	}
 	return cluster;
 }
 
 /* Retrieve the normal directory file */
-static long FATPROC raw_scan_nonroot(register struct super_block *sb,long start,char *name,
-    long number,ino_t *ino)
+static cluster_t FATPROC raw_scan_nonroot(register struct super_block *sb,
+	cluster_t start, char *name, cluster_t number,ino_t *ino)
 {
 	int count;
-	long cluster;
+	cluster_t cluster;
 
 	do {
 		for (count = 0; count < MSDOS_SB(sb)->cluster_size; count++) {
@@ -375,7 +377,8 @@ static long FATPROC raw_scan_nonroot(register struct super_block *sb,long start,
 /* In the directory file (cluster start) within the name or cluster number number
  * to retrieve the file, return to its ino and cluster number
  */
-static long FATPROC raw_scan(struct super_block *sb,long start,char *name,long number, ino_t *ino)
+static cluster_t FATPROC raw_scan(struct super_block *sb,cluster_t start,
+	char *name, cluster_t number, ino_t *ino)
 {
     if (start)
 		return raw_scan_nonroot(sb,start,name,number,ino);

--- a/elks/fs/msdos/namei.c
+++ b/elks/fs/msdos/namei.c
@@ -180,7 +180,7 @@ static int FATPROC msdos_create_entry(register struct inode *dir,char *name,int 
 	de->start = 0;
 	date_unix2dos(CURRENT_TIME,&de->time,&de->date);
 	de->size = 0;
-	debug_fat("create_entry block write %d\n", bh->b_blocknr);
+	debug_fat("create_entry block write %lu\n", bh->b_blocknr);
 	bh->b_dirty = 1;
 	if ((*result = iget(dir->i_sb,ino)) != 0) msdos_read_inode(*result);
 	unmap_brelse(bh);
@@ -313,7 +313,7 @@ int msdos_rmdir(register struct inode *dir,const char *name,int len)
 	dir->i_mtime = CURRENT_TIME;
 	inode->i_dirt = dir->i_dirt = 1;
 	de->name[0] = DELETED_FLAG;
-	debug_fat("rmdir block write %d\n", bh->b_blocknr);
+	debug_fat("rmdir block write %lu\n", bh->b_blocknr);
 	bh->b_dirty = 1;
 	res = 0;
 rmdir_done:
@@ -353,7 +353,7 @@ int msdos_unlink(register struct inode *dir,const char *name,int len)
 	inode->i_dirt = 1;
 	de->name[0] = DELETED_FLAG;
 	dir->i_dirt = 1;
-	debug_fat("unlink block write %d\n", bh->b_blocknr);
+	debug_fat("unlink block write %lu\n", bh->b_blocknr);
 	bh->b_dirty = 1;
 unlink_done:
 	unmap_brelse(bh);

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -119,7 +119,7 @@
 
 struct buffer_head {
     char			*b_data;	/* Address if in L1 buffer area, else 0 */
-    block_t			b_blocknr;
+    block32_t			b_blocknr;	/* 32-bit block numbers required for FAT */
     kdev_t			b_dev;
     struct buffer_head		*b_next_lru;
     struct buffer_head		*b_prev_lru;
@@ -442,6 +442,7 @@ extern void close_filp(struct inode *, struct file *);
 
 extern struct buffer_head *get_hash_table(kdev_t,block_t);
 extern struct buffer_head *getblk(kdev_t,block_t);
+extern struct buffer_head *getblk32(kdev_t,block32_t);
 extern struct buffer_head *readbuf(struct buffer_head *);
 
 extern void ll_rw_blk(int,struct buffer_head *);
@@ -496,6 +497,7 @@ extern int _namei(char *,struct inode *,int,struct inode **);
 extern int sys_dup(unsigned int);
 
 extern struct buffer_head *bread(dev_t,block_t);
+extern struct buffer_head *bread32(dev_t,block32_t);
 
 extern int open_fd(int flags, struct inode *inode);
 

--- a/elks/include/linuxmt/genhd.h
+++ b/elks/include/linuxmt/genhd.h
@@ -19,8 +19,6 @@
 #define DOS_EXTENDED_PARTITION 5
 #define LINUX_EXTENDED_PARTITION 0x85
 
-typedef __u32 sector_t;
-
 struct partition
 {
     unsigned char boot_ind;	/* 0x80 - active */

--- a/elks/include/linuxmt/msdos_fs.h
+++ b/elks/include/linuxmt/msdos_fs.h
@@ -50,6 +50,8 @@
 
 #define MSDOS_FAT12 4078 /* maximum number of clusters in a 12 bit FAT */
 
+typedef sector_t cluster_t;
+
 struct msdos_boot_sector {
 	char ignored[13];		/*0*/
 	unsigned char cluster_size; /* sectors/cluster 13*/
@@ -109,8 +111,8 @@ struct slot_info {
 struct fat_cache {
 	int device; /* device number. 0 means unused. */
 	ino_t ino; /* inode number. */
-	long file_cluster; /* cluster number in the file. */
-	long disk_cluster; /* cluster number on disk. */
+	cluster_t file_cluster; /* cluster number in the file. */
+	cluster_t disk_cluster; /* cluster number on disk. */
 	struct fat_cache *next; /* next cache entry */
 };
 
@@ -124,7 +126,7 @@ struct fat_cache {
 
 /* misc.c */
 
-struct buffer_head * FATPROC msdos_sread(int dev,long sector,void **start);
+struct buffer_head * FATPROC msdos_sread(int dev, sector_t sector, void **start);
 void FATPROC lock_creation(void);
 void FATPROC unlock_creation(void);
 int  FATPROC msdos_add_cluster(struct inode *inode);
@@ -139,7 +141,7 @@ ino_t FATPROC msdos_parent_ino(struct inode *dir,int locked);
 /* fat.c */
 
 long FATPROC fat_access(struct super_block *sb,long this,long new_value);
-long FATPROC msdos_smap(struct inode *inode,long sector);
+sector_t FATPROC msdos_smap(struct inode *inode, sector_t sector);
 int  FATPROC fat_free(struct inode *inode,long skip);
 void FATPROC cache_init(void);
 void FATPROC cache_lookup(struct inode *inode,long cluster,long *f_clu,long *d_clu);

--- a/elks/include/linuxmt/msdos_fs.h
+++ b/elks/include/linuxmt/msdos_fs.h
@@ -50,7 +50,7 @@
 
 #define MSDOS_FAT12 4078 /* maximum number of clusters in a 12 bit FAT */
 
-typedef sector_t cluster_t;
+typedef long cluster_t;
 
 struct msdos_boot_sector {
 	char ignored[13];		/*0*/
@@ -109,7 +109,7 @@ struct slot_info {
 };
 
 struct fat_cache {
-	int device; /* device number. 0 means unused. */
+	kdev_t device; /* device number. 0 means unused. */
 	ino_t ino; /* inode number. */
 	cluster_t file_cluster; /* cluster number in the file. */
 	cluster_t disk_cluster; /* cluster number on disk. */
@@ -126,7 +126,7 @@ struct fat_cache {
 
 /* misc.c */
 
-struct buffer_head * FATPROC msdos_sread(int dev, sector_t sector, void **start);
+struct buffer_head * FATPROC msdos_sread(kdev_t dev, sector_t sector, void **start);
 void FATPROC lock_creation(void);
 void FATPROC unlock_creation(void);
 int  FATPROC msdos_add_cluster(struct inode *inode);
@@ -140,15 +140,16 @@ ino_t FATPROC msdos_parent_ino(struct inode *dir,int locked);
 
 /* fat.c */
 
-long FATPROC fat_access(struct super_block *sb,long this,long new_value);
+cluster_t FATPROC fat_access(struct super_block *sb,cluster_t this,cluster_t new_value);
 sector_t FATPROC msdos_smap(struct inode *inode, sector_t sector);
 int  FATPROC fat_free(struct inode *inode,long skip);
 void FATPROC cache_init(void);
-void FATPROC cache_lookup(struct inode *inode,long cluster,long *f_clu,long *d_clu);
-void FATPROC cache_add(struct inode *inode,long f_clu,long d_clu);
+void FATPROC cache_lookup(struct inode *inode,cluster_t cluster,
+	cluster_t *f_clu, cluster_t *d_clu);
+void FATPROC cache_add(struct inode *inode, cluster_t f_clu, cluster_t d_clu);
 void FATPROC cache_inval_inode(struct inode *inode);
-void FATPROC cache_inval_dev(int device);
-long FATPROC get_cluster(struct inode *inode,long cluster);
+void FATPROC cache_inval_dev(kdev_t device);
+cluster_t FATPROC get_cluster(struct inode *inode, cluster_t cluster);
 
 /* namei.c */
 

--- a/elks/include/linuxmt/types.h
+++ b/elks/include/linuxmt/types.h
@@ -17,6 +17,7 @@ typedef __u32			tcflag_t;
 
 typedef __u16			block_t;
 typedef __u32			block32_t;
+typedef __u32			sector_t;
 typedef __u16			dev_t;
 typedef __u16			flag_t;
 typedef __u16			gid_t;

--- a/elkscmd/rootfs_template/etc/rc.d/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sys
@@ -31,6 +31,7 @@ fi
 # mount 2nd filesystem
 #
 #mount -t msdos /dev/fd1 /mnt || true
+#mount -t msdos /dev/hda1 /mnt
 #mount /dev/hda /mnt
 
 #


### PR DESCRIPTION
Fixes FAT filesystem corruption error detailed in https://github.com/jbruchon/elks/issues/796#issuecomment-721218376.

Implements 32-bit block numbers in ELKS buffer system.

All FAT filesystems larger than 65MB suffered from this problem, causing incorrect data reads, and writing over incorrect portions of the disk when the sector number was greater than 65535.


To keep things small, since MINIX FS never uses block numbers greater than 16 bits, two new routines were introduced, called only by the FAT filesystem driver: `getblk32` and `bread32`, which take (unsigned long) block32_t types instead of their 16-bit counterparts, `getblk` and `bread` using block_t.

The FAT filesystem sector numbers were being silently truncated to 16-bit `block_t` values, which caused all block numbers to be effectively calculated mod 65536. When files were written with sector numbers just over 65535, the boot sector and FAT table was being overwritten. 

@Mellvik, this should work fine, please test. I have not yet fixed the FAT "multiple mount" problem, so test only from a single using a single FAT mount. I'm also not yet sure whether writing files (large or small) and running out of space is buggy or not. I suspect it could be, more testing needed.