### PR TITLE
[fat] Fix hack in FAT add_cluster affecting multi mounted FAT filesystems

### DIFF
--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -109,6 +109,7 @@ static struct super_block *msdos_read_super(register struct super_block *s, char
 	MSDOS_SB(s)->clusters = MSDOS_SB(s)->cluster_size?
 		data_sectors/MSDOS_SB(s)->cluster_size : 0;
 	MSDOS_SB(s)->fat_bits = fat32 ? 32 : MSDOS_SB(s)->clusters > MSDOS_FAT12 ? 16 : 12;
+	MSDOS_SB(s)->previous_cluster = 0;
 	unmap_brelse(bh);
 
 printk("FAT: me=%x,csz=%d,#f=%d,floc=%d,fsz=%d,rloc=%d,#d=%d,dloc=%d,#s=%ld,ts=%ld\n",

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -48,13 +48,12 @@ int FATPROC msdos_add_cluster(register struct inode *inode)
 {
 	static struct wait_queue wait;
 	static int lock = 0;
-	//FIXME: using previous on booted FAT volume with mounted FAT floppy won't work well
-	static cluster_t previous = 0; /* works best if one FS is being used */
 	cluster_t count, this, limit, current, last;
 	sector_t sector;
 	void *data;
 	struct buffer_head *bh;
 	int fatsz = MSDOS_SB(inode->i_sb)->fat_bits;
+	cluster_t previous = MSDOS_SB(inode->i_sb)->previous_cluster;
 
 	debug_fat("add_cluster\n");
 #ifndef FAT_BITS_32
@@ -71,6 +70,7 @@ int FATPROC msdos_add_cluster(register struct inode *inode)
 	debug("free cluster: %d\r\n",this);
 
 	previous = (count+previous+1) % limit;
+	MSDOS_SB(inode->i_sb)->previous_cluster = previous;;
 	if (count >= limit) {
 		lock = 0;
 		wake_up(&wait);

--- a/elks/include/linuxmt/msdos_fs_sb.h
+++ b/elks/include/linuxmt/msdos_fs_sb.h
@@ -9,7 +9,7 @@ struct msdos_sb_info { /* space in struct super_block is 28 bytes */
 	unsigned short data_start;   /* first data sector */
 	unsigned long clusters;      /* number of clusters */
 	unsigned long root_cluster;
-
+	long previous_cluster;       /* used in add_cluster */
 # ifdef CONFIG_FS_DEV
 	ino_t dev_ino;               /* "/dev" ino */
 # endif


### PR DESCRIPTION
@Mellvik,

This should fix any issues with multiple FAT systems mounted, especially for large hard drives.

If you have time, please run some stress tests booting from FAT and copying files on another FAT (or both) filesystems.

Thanks!