### PR TITLE
[cmds] Create sys tool for making boot disks from ELKS

### DIFF
--- a/bootblocks/boot_sect.S
+++ b/bootblocks/boot_sect.S
@@ -560,6 +560,7 @@ msg_reboot:
 	.asciz "Press key\r\n"
 
 #ifndef BOOT_FAT
+	.global sect_offset
 sect_offset:
 	.long 0
 #endif

--- a/bootblocks/boot_sect_fat.h
+++ b/bootblocks/boot_sect_fat.h
@@ -117,6 +117,7 @@ bpb_num_heads:				// Number of heads
 head_max:
 	.word FAT_NUM_HEADS
 bpb_hidd_sec:				// Hidden sectors
+	.global sect_offset
 sect_offset:
 	.long 0
 bpb_tot_sec_32:				// Total number of sectors, 32-bit

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -654,11 +654,10 @@ static int bioshd_ioctl(struct inode *inode,
     case HDIO_GETGEO:
 	err = verify_area(VERIFY_WRITE, (void *) arg, sizeof(struct hd_geometry));
 	if (!err) {
-	    put_user((__u16) drivep->heads, (__u16 *) &loc->heads);
-	    put_user((__u16) drivep->sectors, (__u16 *) &loc->sectors);
-	    put_user((__u16) drivep->cylinders, (__u16 *) &loc->cylinders);
-	    put_user((__u16) hd[MINOR(inode->i_rdev)].start_sect,
-		    (__u16 *) &loc->start);
+	    put_user_char(drivep->heads, &loc->heads);
+	    put_user_char(drivep->sectors, &loc->sectors);
+	    put_user(drivep->cylinders, &loc->cylinders);
+	    put_user_long(hd[MINOR(inode->i_rdev)].start_sect, &loc->start);
 	}
     }
     return err;
@@ -703,13 +702,15 @@ static int do_bios_readwrite(struct drive_infot *drivep, sector_t start, char *b
 		BD_DX = (head << 8) | drive;
 		BD_ES = seg;
 		BD_BX = (unsigned) buf;
-		debug_bios("bioshd: drive %d cmd %d CHS %d/%d/%d count %d\n",
+		debug_bios("bioshd(%d): cmd %d CHS %d/%d/%d count %d\n",
 		    drive, cmd, cylinder, head, sector, this_pass);
 		in_ax = BD_AX;
 		out_ax = 0;
 
 		set_ddpt(drivep->sectors);
 		if (call_bios(&bdt)) {
+			printk("bioshd(%d): cmd %d retry #%d sector %d count %d\n",
+				drive, cmd, MAX_ERRS - errs + 1, sector, this_pass);
 		    out_ax = BD_AX;
 		    reset_bioshd(drive);
 		}
@@ -732,29 +733,43 @@ static void bios_readtrack(struct drive_infot *drivep, sector_t start)
 {
 	unsigned int cylinder, head, sector, num_sectors;
 	int drive = drivep - drive_info;
+	int errs = 0;
+	unsigned short out_ax;
 
 	drive = hd_drive_map[drive];
 	get_chst(drivep, start, &cylinder, &head, &sector, &num_sectors);
 
 	if (num_sectors > (DMASEGSZ >> 9)) num_sectors = DMASEGSZ >> 9;
 
-	BD_AX = BIOSHD_READ | num_sectors;
-	BD_CX = (unsigned int) ((cylinder << 8) | ((cylinder >> 2) & 0xc0) | sector);
-	BD_DX = (head << 8) | drive;
-	BD_ES = DMASEG;
-	BD_BX = 0;
+	do {
+		BD_AX = BIOSHD_READ | num_sectors;
+		BD_CX = (unsigned int) ((cylinder << 8) | ((cylinder >> 2) & 0xc0) | sector);
+		BD_DX = (head << 8) | drive;
+		BD_ES = DMASEG;
+		BD_BX = 0;
+		out_ax = 0;
+		debug_bios("bioshd(%d): track read CHS %d/%d/%d count %d\n",
+			drive, cylinder, head, sector, num_sectors);
 
-	set_ddpt(drivep->sectors);
-	if (call_bios(&bdt)) {
-		printk("bioshd: track read error sector %d count %d\n", sector, num_sectors);
+		set_ddpt(drivep->sectors);
+		if (call_bios(&bdt)) {
+			printk("bioshd(%d): track read retry #%d sector %d count %d\n",
+				drive, errs + 1, sector, num_sectors);
+		    out_ax = BD_AX;
+		    reset_bioshd(drive);
+		}
+	} while (out_ax && ++errs < 1);	/* no track retries, for testing only*/
+
+	if (out_ax) {
 		set_cache_invalid();
 		return;
 	}
+
 	cache_drive = drivep;
 	cache_startsector = start;
 	cache_endsector = start + num_sectors - 1;
 	debug_bios("bioshd(%d): track read lba %ld to %ld count %d\n",
-		drivep-drive_info, cache_startsector, cache_endsector, num_sectors);
+		drive, cache_startsector, cache_endsector, num_sectors);
 }
 
 /* check whether cache is valid for one sector*/

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -54,7 +54,7 @@ sh_utils/test			:boot	:shutil
 sh_utils/true			:boot	:be-shutil
 sh_utils/echo			:boot	:be-shutil
 file_utils/cat			:boot	:be-fileutil
-file_utils/chgrp				:be-fileutil		:720k
+file_utils/chgrp				:be-fileutil			:1440k
 file_utils/chmod				:be-fileutil	:360k
 file_utils/chown				:be-fileutil		:720k
 file_utils/cmp					:be-fileutil			:1440k
@@ -62,7 +62,7 @@ file_utils/cp					:be-fileutil	:360k
 file_utils/df					:be-fileutil			:1440k
 file_utils/dd					:be-fileutil			:1440k
 file_utils/mkdir				:fileutil		:360k
-file_utils/mknod				:fileutil				:1440k
+file_utils/mknod				:fileutil		:360k
 file_utils/mkfifo				:fileutil				:1440k
 file_utils/more					:fileutil			:720k
 file_utils/mv					:fileutil		:360k
@@ -76,6 +76,7 @@ sys_utils/chmem					:sysutil			:720k
 sys_utils/kill					:sysutil			:720k
 sys_utils/ps					:sysutil		:360k
 sys_utils/reboot				:sysutil		:360k
+sys_utils/makeboot				:sysutil		:360k
 sys_utils/man					:sysutil				:1440k
 sys_utils/meminfo				:sysutil				:1440k
 sys_utils/mouse					:sysutil				:1440k

--- a/elkscmd/ash/Makefile
+++ b/elkscmd/ash/Makefile
@@ -30,7 +30,7 @@ OBJS=	builtins.o cd.o dirent.o error.o eval.o exec.o expand.o input.o \
 	bltin/echo.o bltin/expr.o bltin/regexp.o bltin/operators.o \
 	linenoise_elks.o autocomplete.o
 
-LDFLAGS += -maout-heap=6144 -maout-stack=2048
+LDFLAGS += -maout-heap=8192 -maout-stack=2048
 
 #
 # Set READLINE in shell.h and add -ledit to LIBS if you want to use the

--- a/elkscmd/rootfs_template/bin/sys
+++ b/elkscmd/rootfs_template/bin/sys
@@ -1,0 +1,83 @@
+# sys - System Transfer Script
+#
+# Usage: sys /dev/{fd0,fd1,hda1,hda2,etc}
+#
+#set -x
+
+usage()
+{
+	echo "Usage: sys /dev/{fd0,fd1,hda1,hda2,etc}"
+	exit 1
+}
+
+create_dev_dir()
+{
+	echo "Creating /dev entries..."
+	mkdir $MNT/dev
+	mknod $MNT/dev/hda	b 3 0
+	mknod $MNT/dev/hda1	b 3 1
+	mknod $MNT/dev/fd0	b 3 128
+	mknod $MNT/dev/fd1	b 3 160
+	mknod $MNT/dev/kmem	c 1 2
+	mknod $MNT/dev/null	c 1 3
+	mknod $MNT/dev/zero	c 1 5
+	mknod $MNT/dev/tcpdev	c 8 0
+	mknod $MNT/dev/eth	c 9 0
+	mknod $MNT/dev/ptyp0	c 2 8
+	mknod $MNT/dev/ttyp0	c 4 8
+	mknod $MNT/dev/tty1	c 4 0
+	mknod $MNT/dev/ttys0	c 4 64
+	mknod $MNT/dev/ttys1	c 4 65
+	mknod $MNT/dev/console	c 4 254
+	mknod $MNT/dev/tty	c 4 255
+}
+
+create_directories()
+{
+	echo "Creating directories..."
+	mkdir $MNT/bin
+	mkdir $MNT/mnt
+}
+
+copy_bin_files()
+{
+	echo "Copying files from /bin..."
+	cp /bin/sh	$MNT/bin
+	cp /bin/cp	$MNT/bin
+	cp /bin/ls	$MNT/bin
+	cp /bin/mkdir	$MNT/bin
+	cp /bin/mount	$MNT/bin
+	cp /bin/ps	$MNT/bin
+	cp /bin/pwd	$MNT/bin
+	cp /bin/sync	$MNT/bin
+	cp /bin/umount	$MNT/bin
+}
+
+# sys script starts here
+MNT=/mnt
+
+# sys script requires target argument
+if test "$#" -lt 1; then usage; fi
+
+# makeboot returns filesystem type, 1=MINIX, 2=FAT
+makeboot $1
+FSTYPE=$?
+case "$FSTYPE" in
+1) mount $1 $MNT ;;
+2) mount -t msdos $1 $MNT ;;
+*) exit 1 ;;
+esac
+
+# if MINIX, create /dev entries
+if test "$FSTYPE" = "1"; then create_dev_dir; fi
+
+# create important directories
+create_directories
+
+# copy some files from /bin
+copy_bin_files
+
+# done
+umount $1
+
+exit 0

--- a/elkscmd/sys_utils/.gitignore
+++ b/elkscmd/sys_utils/.gitignore
@@ -7,6 +7,7 @@ init
 kill
 knl
 login
+makeboot
 man
 meminfo
 mouse

--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -34,6 +34,7 @@ PRGS = \
 	mouse \
 	sercat \
 	console \
+	makeboot \
 	# EOL
 
 init: init.o
@@ -98,6 +99,9 @@ sercat: sercat.o
 
 console: console.o
 	$(LD) $(LDFLAGS) -o console console.o $(LDLIBS)
+
+makeboot: makeboot.o
+	$(LD) $(LDFLAGS) -o makeboot makeboot.o $(LDLIBS)
 
 unreal16: unreal16.o
 	$(LD) -melks-libc -mcmodel=small -c unreal16.S -o unreal16.o

--- a/elkscmd/sys_utils/makeboot.c
+++ b/elkscmd/sys_utils/makeboot.c
@@ -1,0 +1,365 @@
+/*
+ * makeboot - make a bootable image
+ * Part of /bin/sys script for creating ELKS images from ELKS
+ *
+ * Usage: makeboot /dev/{fd0,fd1,hda1,hda2,etc}
+ *
+ * Copies boot sector from root device to target device
+ * Sets EPB and BPB parameters in boot sector
+ * Copies /linux and /bootopts for MINIX
+ * Copies /linux and creates /dev for FAT
+ *
+ * Nov 2020 Greg Haerr
+ */
+
+#include <stdio.h>
+#include <dirent.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <utime.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/mount.h>
+#include <linuxmt/hdreg.h>
+#include <linuxmt/minix_fs.h>
+
+#define BUF_SIZE	1024 
+
+#define MOUNTDIR	"/tmp/mnt"
+
+#define SYSFILE1	"/linux"		/* copied for MINIX and FAT*/
+#define SYSFILE2	"/bootopts"		/* copied for MINIX only */
+#define DEVDIR		"/dev"			/* created for FAT only */
+
+/* See bootblocks/minix.map for the offsets, these used for MINIX and FAT */
+#define ELKS_BPB_NumTracks	0x1F7		/* offset of number of tracks (word)*/
+#define ELKS_BPB_SecPerTrk	0x1F9		/* offset of sectors per track (byte)*/
+#define ELKS_BPB_NumHeads	0x1FA		/* offset of number of heads (byte)*/
+
+/* MINIX-only offsets, FIXME - SectOffset not yet standard*/
+#define MINIX_SectOffset	0x1B5		/* offset of partition start sector FIXME */
+
+/* FAT BPB start and end offsets*/
+#define FATBPB_START	11				/* start at bytes per sector*/
+#define FATBPB_END		61				/* through end of file system type*/
+
+/* FAT-only offsets */
+#define FAT_BPB_SecPerTrk	0x18		/* offset of sectors per track (word) */
+#define FAT_BPB_NumHeads	0x1A		/* offset of number of heads (word) */
+#define FAT_BPB_SectOffset	0x1C		/* offset of partition start sector (long) */
+
+unsigned int SecPerTrk, NumHeads, NumTracks;
+unsigned long Start_sector;
+
+int bootsecsize;
+char bootblock[1024];				/* 1024 for MINIX, 512 for FAT */
+
+/* return name of root device*/
+char *devname(dev_t dev)
+{
+	DIR *dp;
+	struct dirent *d;
+	struct stat st;
+	static char devdir[] = "/dev";
+	static char name[16];
+
+	dp = opendir(devdir);
+	if (dp == 0) {
+		perror("/dev");
+		return NULL;
+	}
+	strcpy(name, devdir);
+	strcat(name, "/");
+
+	while ((d = readdir(dp)) != NULL) {
+		if (d->d_name[0] == '.')
+ 			continue;
+		strcpy(name + sizeof(devdir), d->d_name);
+		if (stat(name, &st) == 0) {
+			if (S_ISBLK(st.st_mode) && st.st_rdev == dev) {
+				closedir(dp);
+				return name;
+			}
+		}
+	}
+	closedir(dp);
+	fprintf(stderr, "Can't find root device\n");
+	return NULL;
+}
+
+/* determine and return filesystem type*/
+int get_fstype(int fd)
+{
+	struct minix_super_block *sb;
+	char superblock[512];
+
+	lseek(fd, 1024L, SEEK_SET);
+	if (read(fd, superblock, 512) != 512) {
+		fprintf(stderr, "Can't read superblock\n");
+		return 0;
+	}
+	sb = (struct minix_super_block *)superblock;
+	printf("magic %x\n", sb->s_magic);
+	if (sb->s_magic == MINIX_SUPER_MAGIC)
+		return FST_MINIX;
+	return FST_MSDOS;		/* guess FAT if not MINIX*/
+}
+
+/* get device geometry*/
+int get_geometry(int fd)
+{
+	struct hd_geometry geom;
+
+	if (ioctl(fd, HDIO_GETGEO, &geom) < 0) {
+		fprintf(stderr, "Can't get boot drive geometry\n");
+		return 0;
+	}
+
+	NumTracks = geom.cylinders;
+	NumHeads = geom.heads;
+	SecPerTrk = geom.sectors;
+	Start_sector = geom.start;
+	printf("Boot drive geometry CHS %d/%d/%d offset %ld\n",
+		NumTracks, NumHeads, SecPerTrk, Start_sector);
+
+	return 1;	// success
+}
+
+/* set ELKS EPB track, head, sector and start_offset values in buffer*/
+void setEPBparms(char *buf)
+{
+	buf[ELKS_BPB_SecPerTrk] = (unsigned char)SecPerTrk;
+	buf[ELKS_BPB_NumHeads] = (unsigned char)NumHeads;
+	buf[ELKS_BPB_NumTracks] = (unsigned char)NumTracks;
+	buf[ELKS_BPB_NumTracks+1] = (unsigned char)(NumTracks >> 8);
+}
+
+/* set MINIX SectorOffset in buffer*/
+void setMINIXparms(char *buf)
+{
+	*(unsigned long *)&buf[MINIX_SectOffset] = Start_sector;
+}
+
+/* set FAT BPB values from target in buffer*/
+int setFATparms(int fd, char *buf)
+{
+	int n;
+	char BPB[512];
+
+	lseek(fd, 0L, SEEK_SET);
+	n = read(fd, BPB, 512);
+	if (n != 512) {
+		fprintf(stderr, "Can't read target boot sector\n");
+		return 0;
+	}
+
+	/* copy FAT BPB*/
+	for (n = FATBPB_START; n <= FATBPB_END; n++)
+		buf[n] = BPB[n];
+
+#if 0
+	*(unsigned short *)&buf[FAT_BPB_SecPerTrk] = SecPerTrk;
+	*(unsigned short *)&buf[FAT_BPB_NumHeads] = NumHeads;
+	*(unsigned long *)&buf[FAT_BPB_SectOffset] = Start_sector;
+#endif
+	return 1;
+}
+
+int copyfile(char *srcname, char *destname, int setmodes)
+{
+	int		rfd;
+	int		wfd;
+	int		rcc;
+	int		wcc;
+	char		*bp;
+	struct	stat	statbuf1;
+	struct	stat	statbuf2;
+	struct	utimbuf	times;
+	static char buf[BUF_SIZE];
+
+	printf("Copying %s to %s\n", srcname, destname);
+	if (stat(srcname, &statbuf1) < 0) {
+		perror(srcname);
+		return 0;
+	}
+
+	if (stat(destname, &statbuf2) < 0) {
+		statbuf2.st_ino = -1;
+		statbuf2.st_dev = -1;
+	}
+
+	rfd = open(srcname, 0);
+	if (rfd < 0) {
+		perror(srcname);
+		return 0;
+	}
+
+	wfd = creat(destname, statbuf1.st_mode);
+	if (wfd < 0) {
+		perror(destname);
+		close(rfd);
+		return 0;
+	}
+
+	while ((rcc = read(rfd, buf, BUF_SIZE)) > 0) {
+		bp = buf;
+		while (rcc > 0) {
+			wcc = write(wfd, bp, rcc);
+			if (wcc < 0) {
+				perror(destname);
+				goto error_exit;
+			}
+			bp += wcc;
+			rcc -= wcc;
+		}
+	}
+
+	if (rcc < 0) {
+		perror(srcname);
+		goto error_exit;
+	}
+
+	close(rfd);
+	if (close(wfd) < 0) {
+		perror(destname);
+		return 0;
+	}
+
+	if (setmodes) {
+		chmod(destname, statbuf1.st_mode);
+		chown(destname, statbuf1.st_uid, statbuf1.st_gid);
+		times.actime = statbuf1.st_atime;
+		times.modtime = statbuf1.st_mtime;
+		utime(destname, &times);
+	}
+
+	return 1;	// success
+
+error_exit:
+	close(rfd);
+	close(wfd);
+
+	return 0;	// fail
+}
+
+int main(int ac, char **av)
+{
+	char *rootdevice, *targetdevice;
+	int rootfstype, fstype, fd, n;
+	struct stat sbuf;
+
+	if (ac != 2) {
+		fprintf(stderr, "Usage: makeboot /dev/{fd0,fd1,hda1,hda2,etc}\n");
+		return -1;
+	}
+	targetdevice = av[1];
+
+	if (stat("/", &sbuf) < 0) {
+		perror("/");
+		return -1;
+	}
+	rootdevice = devname(sbuf.st_dev);
+	printf("root device %s\n", rootdevice);
+
+	fd = open(rootdevice, O_RDONLY);
+	if (fd < 0) {
+		fprintf(stderr, "Can't open root device %s\n", rootdevice);
+		return -1;
+	}
+	if (!get_geometry(fd)) {
+		fprintf(stderr, "Can't get geometry for root device %s\n", rootdevice);
+		close(fd);
+		return -1;
+	}
+	rootfstype = get_fstype(fd);
+	if (rootfstype == 0) {
+		fprintf(stderr, "Unknown root device filesystem format\n");
+		close(fd);
+		return -1;
+	}
+	printf("root type %d\n", rootfstype);
+
+	bootsecsize = (rootfstype == FST_MINIX)? 1024: 512;
+	lseek(fd, 0L, SEEK_SET);
+	n = read(fd, bootblock, bootsecsize);
+	if (n != bootsecsize) {
+		fprintf(stderr, "Can't read root boot sector\n");
+		close(fd);
+		return -1;
+	}
+	close(fd);
+
+	fd = open(targetdevice, O_RDWR);
+	if (fd < 0) {
+		fprintf(stderr, "Can't open target device %s\n", targetdevice);
+		return -1;
+	}
+	if (!get_geometry(fd)) {	/* gets ELKS CHS parameters for bootblock write*/
+		fprintf(stderr, "Can't get geometry for target device %s\n", targetdevice);
+		close(fd);
+		return -1;
+	}
+	setEPBparms(bootblock);		/* sets ELKS CHS parameters in bootblock*/
+	fstype = get_fstype(fd);
+	if (fstype == 0) {
+		fprintf(stderr, "Unknown target device filesystem format\n");
+		close(fd);
+		return -1;
+	}
+	if (fstype == FST_MINIX) setMINIXparms(bootblock);
+	if (fstype == FST_MSDOS) {
+		if (!setFATparms(fd, bootblock)) {
+			close(fd);
+			return -1;
+		}
+	}
+	printf("target type %d\n", fstype);
+
+	lseek(fd, 0L, SEEK_SET);
+	n = write(fd, bootblock, n);
+	if (n != bootsecsize) {
+		fprintf(stderr, "Can't write target boot sector\n");
+		close(fd);
+		return -1;
+	}
+	close(fd);
+
+	if (rootfstype != fstype) {
+		fprintf(stderr, "Root and new system device must be same filesystem format\n");
+		return -1;
+	}
+
+	if (mkdir(MOUNTDIR, 0777) < 0) {
+		fprintf(stderr, "Can't create temp mount point %s\n", MOUNTDIR);
+		return -1;
+	}
+	if (mount(targetdevice, MOUNTDIR, fstype, 0) < 0) {
+		fprintf(stderr, "Can't mount %s on %s\n", targetdevice, MOUNTDIR);
+		rmdir(MOUNTDIR);
+		return -1;
+	}
+	if (!copyfile(SYSFILE1, MOUNTDIR SYSFILE1, 1)) {
+		fprintf(stderr, "Error copying %s\n", SYSFILE1);
+		goto errout;
+	}
+
+	if (fstype == FST_MSDOS) {
+		if (mkdir(MOUNTDIR DEVDIR, 0777) < 0)
+			fprintf(stderr, "/dev directory may already exist on target\n");
+	} else {
+		if (!copyfile(SYSFILE2, MOUNTDIR SYSFILE2, 1))
+			fprintf(stderr, "Not copying %s file\n", SYSFILE2);
+	}
+
+	if (umount(targetdevice) < 0)
+		fprintf(stderr, "Unmount error\n");
+	rmdir(MOUNTDIR);
+
+	return fstype;		/* return filesystem type (1=MINIX, 2=FAT */
+
+errout:
+	umount(targetdevice);
+	rmdir(MOUNTDIR);
+	return 0;
+}


### PR DESCRIPTION
Creates `sys` script and helper tool `makeboot` requested in #835 to create ELKS disk images from ELKS.

Usage: sys /dev/{target drive}

Tested only on QEMU for /dev/fd1 and /dev/hda1.
Temporarily only creates bootable disk with /bin/sh and a few other utilities to test. More files can be automatically copied once the basic ability to sys various targets is tested.

Needs testing on both MINIX and FAT floppies and hard drives on real systems.
Requires that boot filesystem type is the same type as target drive (MINIX or FAT).
Full debug output is currently on.

Added more debug code to bioshd driver, as some funny things are happening in QEMU when trying to sys a 360k floppy from a 1.44M floppy, which isn't working.