### PR TITLE
[boot] Stamp start sector offset into boot sector for MBR boots

### DIFF
--- a/bootblocks/boot_sect.S
+++ b/bootblocks/boot_sect.S
@@ -548,19 +548,19 @@ msg_reboot:
 end_of_code:
 //------------------------------------------------------------------------------
 
-#ifndef BOOT_FAT
-	.org 0x1F3              // Fixed address of sect_offset for MINIX boot sector
-	.global sect_offset
-sect_offset:
-	.long 0
-#endif
-
 // ELKS disk parameter structure
 // For future expansion, fields should be added at the _front_ of structure
 
-	.org 0x1F7
-
 elks_parms_start:
+
+#ifdef BOOT_FAT
+	.org 0x1F7              // FAT boot sectors use older EPB for now
+#else
+	.org 0x1F3
+	.global sect_offset
+sect_offset:
+	.long 0                 // Partition start sector of MINIX boot block
+#endif
 
 // Disk geometry (CHS)
 

--- a/bootblocks/boot_sect.S
+++ b/bootblocks/boot_sect.S
@@ -551,12 +551,14 @@ end_of_code:
 // ELKS disk parameter structure
 // For future expansion, fields should be added at the _front_ of structure
 
-elks_parms_start:
-
 #ifdef BOOT_FAT
 	.org 0x1F7              // FAT boot sectors use older EPB for now
+elks_parms_start:
+
 #else
 	.org 0x1F3
+elks_parms_start:
+
 	.global sect_offset
 sect_offset:
 	.long 0                 // Partition start sector of MINIX boot block

--- a/bootblocks/boot_sect.S
+++ b/bootblocks/boot_sect.S
@@ -68,21 +68,6 @@ floppy_table:
 
 entry1:
 #endif
-
-	// instructions through _next0 not needed for floppy, only MBR boot
-	cld
-	cmp $0x4c65,%ax			// coming from ELKS MBR?
-	jnz _next0
-	mov 8(%si),%ax			// get MBR start sector from partion table at DS:SI
-	mov 10(%si),%si
-	push %cs
-	pop %es
-	mov $BOOTADDR+sect_offset,%di
-	stosw
-	xchg %ax,%si
-	stosw
-_next0:
-
 	// Get the memory size
 	// TODO: optional BIOS INT 12h
 
@@ -559,15 +544,16 @@ msg_error:
 msg_reboot:
 	.asciz "Press key\r\n"
 
+	.global end_of_code
+end_of_code:
+//------------------------------------------------------------------------------
+
 #ifndef BOOT_FAT
+	.org 0x1F3              // Fixed address of sect_offset for MINIX boot sector
 	.global sect_offset
 sect_offset:
 	.long 0
 #endif
-
-	.global last_code
-last_code:
-//------------------------------------------------------------------------------
 
 // ELKS disk parameter structure
 // For future expansion, fields should be added at the _front_ of structure

--- a/bootblocks/mbr.S
+++ b/bootblocks/mbr.S
@@ -110,7 +110,6 @@ sector_loaded:
 
 	mov	drive_num,%dh	// Restore DH drive number for VBR
 	mov	%si,%bp		// LILO says some BBs use bp rather than si
-	mov	$0x4c65,%ax	// 'eL' ELKS magic number
 
 	ljmp	$0,$BOOTADDR	// Jump to VBR boot sector
 

--- a/image/Makefile
+++ b/image/Makefile
@@ -138,11 +138,11 @@ hd32-fat:
 # MBR images
 hd32mbr-minix:
 	dd if=/dev/zero bs=512 count=63 | cat - hd32-minix.bin > hd32mbr-minix.bin
-	setboot hd32mbr-minix.bin -P63,16,63 $(HD_MBR_BOOT)
+	setboot hd32mbr-minix.bin -P63,16,63 -Sm $(HD_MBR_BOOT)
 
 hd32mbr-fat:
 	dd if=/dev/zero bs=512 count=63 | cat - hd32-fat.bin > hd32mbr-fat.bin
-	setboot hd32mbr-fat.bin -P63,16,63 $(HD_MBR_BOOT)
+	setboot hd32mbr-fat.bin -P63,16,63 -Sf $(HD_MBR_BOOT)
 
 # Clean target
 


### PR DESCRIPTION
Enhances the way ELKS uses MBR and boot sectors to boot from hard drives.

Use fixed (but currently different) locations in MINIX and FAT boot sectors to store starting sector offset for partition boots.
Updates `setboot` to stamp partition start offset into FAT and MINIX boot sectors.
Updates `makeboot` to use new fixed location for MINIX boot sectors.

Allows booting ELKS from any MBR, provided that the partition boot sector has the EPB, BPB and start sector offsets updated properly. The new sys/makeboot programs ensure that, and ELKS MBR images created using "make images" are updated properly with set boot.

Removes previous kluge code for determining when booting from an ELKS MBR; no longer required. This also frees up valuable space in the boot sector, which will be very useful should we decide to add FAT32 support to ELKS boot.

Tested on QEMU for all FD, HD MBR and HD flat images.

Currently, setboot.c and makeboot.c contain their own duplicate versions of boot sector offset information; this will be cleaned up in an upcoming boot cleanup PR, which will allow for EPB or MINIX-only offsets to be more easily changed if required.
