### PR TITLE
[ktcp] updated debug output, mostly for acks and seq numbers.

### DIFF
--- a/elkscmd/ktcp/icmp.c
+++ b/elkscmd/ktcp/icmp.c
@@ -46,7 +46,7 @@ void icmp_process(struct iphdr_s *iph,unsigned char *packet)
 	apair.daddr = iph->saddr;
 	apair.saddr = iph->daddr;
 	apair.protocol = PROTO_ICMP;
-	ip_sendpacket(packet, len, &apair);
+	ip_sendpacket(packet, len, &apair, NULL);
 	netstats.icmpsndcnt++;
 	break;
    case ICMP_TYPE_DST_UNRCH:

--- a/elkscmd/ktcp/ip.c
+++ b/elkscmd/ktcp/ip.c
@@ -94,7 +94,7 @@ static void ip_print(struct iphdr_s *head, int size)
     debug_ip("tos:%d len:%u ", head->tos, ntohs(head->tot_len));
     debug_ip("id:%u ", ntohs(head->id));
     debug_ip("offs:%d ", ntohs(head->frag_off));	//FIXME add FM_ flags
-    debug_ip("chk:0x%x ", head->check);
+    debug_ip("chk:0x%x ", ip_calc_chksum((char *)head, 4 * IP_HLEN(head)));
     debug_ip("ttl:%d ", head->ttl);
     debug_ip("prot:%d\n", head->protocol);
 #if DEBUG_IP > 1

--- a/elkscmd/ktcp/ip.c
+++ b/elkscmd/ktcp/ip.c
@@ -93,7 +93,8 @@ static void ip_print(struct iphdr_s *head, int size)
     debug_ip("v%d hl:%d ", IP_VERSION(head), IP_HLEN(head));
     debug_ip("tos:%d len:%u ", head->tos, ntohs(head->tot_len));
     debug_ip("id:%u ", ntohs(head->id));
-    debug_ip("offs:%d ", ntohs(head->frag_off));	//FIXME add FM_ flags
+    debug_ip("fl:0x%x ", ntohs(head->id)>>13);
+    debug_ip("fo:%d ", ntohs(head->frag_off)&0x1fff);
     debug_ip("chk:0x%x ", ip_calc_chksum((char *)head, 4 * IP_HLEN(head)));
     debug_ip("ttl:%d ", head->ttl);
     debug_ip("prot:%d\n", head->protocol);

--- a/elkscmd/ktcp/ip.c
+++ b/elkscmd/ktcp/ip.c
@@ -93,8 +93,8 @@ static void ip_print(struct iphdr_s *head, int size)
     debug_ip("v%d hl:%d ", IP_VERSION(head), IP_HLEN(head));
     debug_ip("tos:%d len:%u ", head->tos, ntohs(head->tot_len));
     debug_ip("id:%u ", ntohs(head->id));
-    debug_ip("fo:%x ", ntohs(head->frag_off));	//FIXME add FM_ flags
-    debug_ip("chk:%x ", ip_calc_chksum((char *)head, 4 * IP_HLEN(head)));
+    debug_ip("offs:%d ", ntohs(head->frag_off));	//FIXME add FM_ flags
+    debug_ip("chk:0x%x ", head->check);
     debug_ip("ttl:%d ", head->ttl);
     debug_ip("prot:%d\n", head->protocol);
 #if DEBUG_IP > 1
@@ -108,7 +108,7 @@ static void ip_print(struct iphdr_s *head, int size)
 #endif
 }
 
-void ip_recvpacket(unsigned char *packet,int size)
+void ip_recvpacket(unsigned char *packet, int size)
 {
     register struct iphdr_s *iphdr = (struct iphdr_s *)packet;
     int len;
@@ -116,7 +116,7 @@ void ip_recvpacket(unsigned char *packet,int size)
 
     ip_print(iphdr, size);
 
-    if (IP_VERSION(iphdr) != 4){
+    if (IP_VERSION(iphdr) != 4) {
         debug_ip("IP: Bad IP version\n");
 	netstats.ipbadhdr++;
 	return;
@@ -137,14 +137,14 @@ void ip_recvpacket(unsigned char *packet,int size)
 
     switch (iphdr->protocol) {
     case PROTO_ICMP:
-        debug_ip("IP: recv icmp packet\n");
+        //debug_ip("IP: recv icmp packet\n");
 	data = packet + 4 * IP_HLEN(iphdr);
 	icmp_process(iphdr, data);
 	netstats.icmprcvcnt++;
 	break;
 
     case PROTO_TCP:
-        debug_ip("IP: recv tcp packet\n");
+        //debug_ip("IP: recv tcp packet\n");
 	tcp_process(iphdr);
 	netstats.tcprcvcnt++;
 	break;
@@ -152,7 +152,7 @@ void ip_recvpacket(unsigned char *packet,int size)
     netstats.iprcvcnt++;
 }
 
-void ip_sendpacket(unsigned char *packet, int len, struct addr_pair *apair)
+void ip_sendpacket(unsigned char *packet, int len, struct addr_pair *apair, struct tcpcb_s *cb)
 {
     /*
      * save space for possible ethernet header before ip packet
@@ -179,11 +179,13 @@ void ip_sendpacket(unsigned char *packet, int len, struct addr_pair *apair)
 
     ip_print(iph, 0);
 #if DEBUG_TCP
-    struct iptcp_s iptcp;
-    iptcp.iph = iph;
-    iptcp.tcph = (struct tcphdr_s *)(((char *)iph) + 4 * IP_HLEN(iph));
-    iptcp.tcplen = ntohs(iph->tot_len) - 4 * IP_HLEN(iph);
-    tcp_print(&iptcp, 0);
+    if (iph->protocol == PROTO_TCP && cb) {	/* really - one of them is enough */
+	struct iptcp_s iptcp;
+	iptcp.iph = iph;
+	iptcp.tcph = (struct tcphdr_s *)(((char *)iph) + 4 * IP_HLEN(iph));
+	iptcp.tcplen = ntohs(iph->tot_len) - 4 * IP_HLEN(iph);
+	tcp_print(&iptcp, 0, cb);
+    }
 #endif
 
     /* route packet using src and dst address*/

--- a/elkscmd/ktcp/ip.h
+++ b/elkscmd/ktcp/ip.h
@@ -36,6 +36,7 @@ struct iphdr_s {
 };
 
 typedef struct iphdr_s iphdr_t;
+struct tcpcb_s;		/* defined in tcp.h */
 
 extern ipaddr_t local_ip;
 extern ipaddr_t gateway_ip;
@@ -51,7 +52,7 @@ extern unsigned int MTU;
 int ip_init(void);
 __u16 ip_calc_chksum(char *data, int len);
 void ip_recvpacket(unsigned char *packet, int size);
-void ip_sendpacket(unsigned char *packet, int len, struct addr_pair *apair);
+void ip_sendpacket(unsigned char *packet, int len, struct addr_pair *apair, struct tcpcb_s *cb);
 void ip_route(unsigned char *packet, int len, struct addr_pair *apair);
 
 #endif

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -45,7 +45,7 @@ void tcp_print(struct iptcp_s *head, int recv, struct tcpcb_s *cb)
  	debug_tcp("ack:%ld ", ntohl(head->tcph->acknum) - cb->irs);
     }
     debug_tcp("win:%u urg:%d ", ntohs(head->tcph->window), head->tcph->urgpnt);
-    debug_tcp("chk:0x%x len:%u\n", head->tcph->chksum, head->tcplen);
+    debug_tcp("chk:0x%x len:%u\n", tcp_chksum(head), head->tcplen);
 #endif
 }
 

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -191,7 +191,7 @@ struct tcpcb_list_s *tcpcb_find_by_sock(void *sock);
 
 __u16 tcp_chksum(struct iptcp_s *h);
 __u16 tcp_chksumraw(struct tcphdr_s *h, __u32 saddr, __u32 daddr, __u16 len);
-void tcp_print(struct iptcp_s *head, int recv);
+void tcp_print(struct iptcp_s *head, int recv, struct tcpcb_s *cb);
 void tcp_output(struct tcpcb_s *cb);
 void tcp_update(void);
 int tcp_init(void);

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -288,7 +288,7 @@ void tcp_reoutput(struct tcp_retrans_list_s *n)
 	n->rto = TCP_RETRANS_MAXWAIT;
     n->next_retrans = Now + n->rto;
 printf("retrans retry: #%d rto %ld (cnt %d, mem %u)\n", n->retrans_num, n->rto, tcp_timeruse, tcp_retrans_memory);
-    ip_sendpacket((unsigned char *)n->tcphdr, n->len, &n->apair);
+    ip_sendpacket((unsigned char *)n->tcphdr, n->len, &n->apair, n->cb);
     netstats.tcpretranscnt++;
 }
 
@@ -383,6 +383,6 @@ void tcp_output(struct tcpcb_s *cb)
     apair.protocol = PROTO_TCP;
 
     add_for_retrans(cb, th, len, &apair);
-    ip_sendpacket((unsigned char *)th, len, &apair);
+    ip_sendpacket((unsigned char *)th, len, &apair, cb);
     netstats.tcpsndcnt++;
 }


### PR DESCRIPTION
Changed ktcp debug output per #841 and #839 (comment):

- removed ICMP debug output from debug_tcp
- changed presentation of sequence numbers and acks to be easier to read (always starting @ 0)
- now displays checksums from the packets in stead of calculating them
- hex output nor preceded with 0x in order to distinguish from decimal
- some seemingly extraneous debug messages commented out for now

Tested on qemu & physical.
