### PR TITLE
[fat] Expand FAT /dev from 16 to 28 entries, fix ttyS0 open

### DIFF
--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -15,26 +15,32 @@
 #include <linuxmt/debug.h>
 
 #ifdef CONFIG_FS_DEV
-/* max 16 entries in FAT device table*/
+/* FAT device table*/
 struct msdos_devdir_entry devnods[DEVDIR_SIZE] = {
     { "hda",	S_IFBLK | 0644, MKDEV(3, 0) },
     { "hda1",	S_IFBLK | 0644, MKDEV(3, 1) },
+    { "hda2",	S_IFBLK | 0644, MKDEV(3, 2) },
+    { "hdb",	S_IFBLK | 0644, MKDEV(3, 32) },
+    { "hdb1",	S_IFBLK | 0644, MKDEV(3, 33) },
+    { "hdb2",	S_IFBLK | 0644, MKDEV(3, 34) },
     { "fd0",	S_IFBLK | 0644, MKDEV(3, 128)},
     { "fd1",	S_IFBLK | 0644, MKDEV(3, 160)},
+    { "rd0",	S_IFBLK | 0644, MKDEV(1, 0) },
     { "kmem",	S_IFCHR | 0644, MKDEV(1, 2) },
     { "null",	S_IFCHR | 0644, MKDEV(1, 3) },
     { "zero",	S_IFCHR | 0644, MKDEV(1, 5) },
     { "tcpdev",	S_IFCHR | 0644, MKDEV(8, 0) },
     { "eth",	S_IFCHR | 0644, MKDEV(9, 0) },
-    { "ptyp0",	S_IFCHR | 0644, MKDEV(2,  8)},
-    { "ttyp0",	S_IFCHR | 0644, MKDEV(4,  8)},
     { "tty1",	S_IFCHR | 0644, MKDEV(4, 0) },
+    { "tty2",	S_IFCHR | 0644, MKDEV(4, 1) },
+    { "ttyp0",	S_IFCHR | 0644, MKDEV(4, 8) },
+    { "ttyp1",	S_IFCHR | 0644, MKDEV(4, 9) },
+    { "ptyp0",	S_IFCHR | 0644, MKDEV(2, 8) },
+    { "ptyp1",	S_IFCHR | 0644, MKDEV(2, 9) },
     { "ttyS0",	S_IFCHR | 0644, MKDEV(4, 64)},
     { "ttyS1",	S_IFCHR | 0644, MKDEV(4, 65)},
-    //{ "tty2",	S_IFCHR | 0644, MKDEV(4, 1) },
-    //{ "ttyS2",S_IFCHR | 0644, MKDEV(4, 66)},
     { "console",S_IFCHR | 0600, MKDEV(4, 254)},
-    { "tty",	S_IFCHR | 0666, MKDEV(4, 255) },
+    { "tty",	S_IFCHR | 0666, MKDEV(4, 255)}
 };
 #endif
 
@@ -158,10 +164,10 @@ printk("FAT: me=%x,csz=%d,#f=%d,floc=%d,fsz=%d,rloc=%d,#d=%d,dloc=%d,#s=%ld,ts=%
 	int i;
 	bh = NULL;
 
-	/* if /dev is first or second directory entry, turn on devfs filesystem */
-	for (i=0; i<2; i++) {
+	/* if /dev is found in first four directory entries, turn on devfs filesystem */
+	for (i=0; i<4; i++) {
 		ino = msdos_get_entry(s->s_mounted, &pos, &bh, &de); 
-		if (ino < 0) break;
+		if (ino == -1) break;
 		if (de->attr == ATTR_DIR && !strncmp(de->name, "DEV        ", 11)) {
 				MSDOS_SB(s)->dev_ino = ino;
 				break;

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -15,14 +15,18 @@
 #include <linuxmt/debug.h>
 
 #ifdef CONFIG_FS_DEV
-/* FAT device table*/
+/* FAT device table, increase DEVDIR_SIZE to add entries*/
 struct msdos_devdir_entry devnods[DEVDIR_SIZE] = {
     { "hda",	S_IFBLK | 0644, MKDEV(3, 0) },
     { "hda1",	S_IFBLK | 0644, MKDEV(3, 1) },
     { "hda2",	S_IFBLK | 0644, MKDEV(3, 2) },
+    { "hda3",	S_IFBLK | 0644, MKDEV(3, 3) },
+    { "hda4",	S_IFBLK | 0644, MKDEV(3, 4) },
     { "hdb",	S_IFBLK | 0644, MKDEV(3, 32) },
     { "hdb1",	S_IFBLK | 0644, MKDEV(3, 33) },
     { "hdb2",	S_IFBLK | 0644, MKDEV(3, 34) },
+    { "hdb3",	S_IFBLK | 0644, MKDEV(3, 35) },
+    { "hdb4",	S_IFBLK | 0644, MKDEV(3, 36) },
     { "fd0",	S_IFBLK | 0644, MKDEV(3, 128)},
     { "fd1",	S_IFBLK | 0644, MKDEV(3, 160)},
     { "rd0",	S_IFBLK | 0644, MKDEV(1, 0) },

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -225,7 +225,7 @@ ino_t FATPROC msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head *
 			*de = &deventry;
 			memset(deventry.name, ' ', MSDOS_NAME);
 			for (j = strlen(devnods[i].name); --j >= 0; )
-			    deventry.name[j] = toupper(devnods[i].name[j]);
+			    deventry.name[j] = devnods[i].name[j];
 
 			i += DEVINO_BASE;
 			return i;

--- a/elks/include/linuxmt/msdos_fs_sb.h
+++ b/elks/include/linuxmt/msdos_fs_sb.h
@@ -17,7 +17,7 @@ struct msdos_sb_info { /* space in struct super_block is 28 bytes */
 
 # ifdef CONFIG_FS_DEV
 #define DEVINO_BASE MSDOS_DPB
-#define DEVDIR_SIZE 24
+#define DEVDIR_SIZE 28
 
 struct msdos_devdir_entry {
     char    *name;

--- a/elks/include/linuxmt/msdos_fs_sb.h
+++ b/elks/include/linuxmt/msdos_fs_sb.h
@@ -17,7 +17,7 @@ struct msdos_sb_info { /* space in struct super_block is 28 bytes */
 
 # ifdef CONFIG_FS_DEV
 #define DEVINO_BASE MSDOS_DPB
-#define DEVDIR_SIZE 16
+#define DEVDIR_SIZE 24
 
 struct msdos_devdir_entry {
     char    *name;


### PR DESCRIPTION
Various small fixes and enhancements for FAT filesystem.

Expands /dev with 8 more entries, including /dev/hda2 and /dev/hdb, /dev/hdb1.

Allows activation of "fake" /dev if /dev is in first four entries in root directory, rather than two. This, along with a possible future relaxation of the requirement of /linux to be the first entry in the root directory, will help booting off filesystems created using Windows 10 format.

Fixes inability to open /dev/ttyS0 when booted from FAT because of MSDOS upper -> lower case filename conversions. The new code treats /dev entries specially.
