### PR TITLE
[kernel] Limit size of /dev/hda to max filesize (2^31)-1

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -496,7 +496,10 @@ static int bioshd_open(struct inode *inode, struct file *filp)
 	probe_floppy(target, hdp);
 #endif
 
-    inode->i_size = (hdp->nr_sects) << 9;
+    inode->i_size = hdp->nr_sects << 9;
+    /* limit inode size to max filesize for CHS >= 4MB (2^22)*/
+    if (hdp->nr_sects >= 0x00400000L)	/* 2^22*/
+	inode->i_size = 0x7ffffffL;	/* 2^31 - 1*/
     return 0;
 }
 

--- a/elkscmd/disk_utils/mkfs.c
+++ b/elkscmd/disk_utils/mkfs.c
@@ -316,5 +316,6 @@ int main(int argc, char ** argv)
 	setup_tables();
 	make_root_inode();
 	write_tables();
+	sync();
 	return 0;
 }


### PR DESCRIPTION
Fixes issue in https://github.com/jbruchon/elks/issues/835#issuecomment-724827503.
Also adds sync to mkfs.

@toncho11, try this, it should fix your fdisk problem on /dev/hda with a HD size > 2GB.

[fd360-fat.bin.zip](https://github.com/jbruchon/elks/files/5519374/fd360-fat.bin.zip)
[fd360-minix.bin.zip](https://github.com/jbruchon/elks/files/5519375/fd360-minix.bin.zip)



