### PR TITLE
[boot] FAT12/16 boot: search entire root directory for /linux

### DIFF
--- a/bootblocks/boot_err.h
+++ b/bootblocks/boot_err.h
@@ -4,4 +4,4 @@
 #define ERR_PAYLOAD     2
 #define ERR_NO_SYSTEM   3
 #define ERR_BAD_SYSTEM  4
-
+#define ERR_FS_ODDITY   5


### PR DESCRIPTION
With this patch, `/linux` can now be anywhere in the root directory of a FAT12 or FAT16 filesystem.  However, `/linux`'s contents must still be laid out in contiguous sectors.

The bootloader now also checks that
  * it is not started from a FAT32 partition;
  * the root directory is not too large for it to process;
  * and that the `/linux` entry is not actually a volume label or part of a long file name.

If the bootloader detects either of the first two conditions, it will now say `5!`.