### PR TITLE
[cmds] Add errmsg on /etc/inittab open failure, have sys copy /etc files

### DIFF
--- a/elkscmd/rootfs_template/bin/sys
+++ b/elkscmd/rootfs_template/bin/sys
@@ -48,6 +48,8 @@ copy_bin_files()
 	cp /bin/sash	$MNT/bin
 	cp /bin/cp	$MNT/bin
 	cp /bin/init	$MNT/bin
+	cp /bin/getty	$MNT/bin
+	cp /bin/login	$MNT/bin
 	cp /bin/ls	$MNT/bin
 	cp /bin/mkdir	$MNT/bin
 	cp /bin/mount	$MNT/bin

--- a/elkscmd/rootfs_template/bin/sys
+++ b/elkscmd/rootfs_template/bin/sys
@@ -37,6 +37,7 @@ create_directories()
 {
 	echo "Creating directories..."
 	mkdir $MNT/bin
+	mkdir $MNT/etc
 	mkdir $MNT/mnt
 }
 
@@ -44,7 +45,9 @@ copy_bin_files()
 {
 	echo "Copying files from /bin..."
 	cp /bin/sh	$MNT/bin
+	cp /bin/sash	$MNT/bin
 	cp /bin/cp	$MNT/bin
+	cp /bin/init	$MNT/bin
 	cp /bin/ls	$MNT/bin
 	cp /bin/mkdir	$MNT/bin
 	cp /bin/mount	$MNT/bin
@@ -52,6 +55,16 @@ copy_bin_files()
 	cp /bin/pwd	$MNT/bin
 	cp /bin/sync	$MNT/bin
 	cp /bin/umount	$MNT/bin
+}
+
+copy_etc_files()
+{
+	echo "Copy files from /etc..."
+	cp /etc/inittab	$MNT/etc
+	cp /etc/passwd	$MNT/etc
+	cp /etc/profile	$MNT/etc
+	cp /etc/sashrc	$MNT/etc
+	cp /etc/issue	$MNT/etc
 }
 
 # sys script starts here
@@ -79,6 +92,9 @@ create_directories
 
 # copy some files from /bin
 copy_bin_files
+
+# copu some files from /etc
+copy_etc_files
 
 # done
 umount $1

--- a/elkscmd/sys_utils/init.c
+++ b/elkscmd/sys_utils/init.c
@@ -476,10 +476,6 @@ int main(int argc, char **argv)
 	while (*env)
 		printf("'%s'", *env++);
 	printf("\n");
-#else
-	close(0);
-	close(1);
-	close(2);
 #endif
 
 #if USE_UTMP
@@ -511,6 +507,11 @@ int main(int argc, char **argv)
 		scanFile(enterRunlevel);
 #if USE_UTMP
 		endutent();
+#endif
+#if !DEBUG
+		close(0);
+		close(1);
+		close(2);
 #endif
 		/* endless loop waiting for signals or child exit*/
 		while (1) {


### PR DESCRIPTION
Fixes problem in #853, which copied /bin/init, but init failed with no error message when no /etc/inittab.

/bin/init will give an error message when /etc/inittab can't be opened, rather than just exiting.
`sys` will copy /bin/init, login, getty and some /etc files, so that new filesystem will ask for login.

