### PR TITLE
[boot] Enhance boot loader to boot ELKS on FAT32 filesystems

### DIFF
--- a/bootblocks/boot_sect_fat.h
+++ b/bootblocks/boot_sect_fat.h
@@ -139,6 +139,7 @@ bpb_vol_label:				// Volume label (11 bytes)
 bpb_fil_sys_type:			// Filesystem type (8 bytes)
 	.ascii "FAT12   "
 .endm
+	.set bpb_fat_sz_32,0x24		// FAT32 fat size, 32-bit
 
 .macro FAT_LOAD_AND_RUN_KERNEL
 	.set buf, entry + 0x200
@@ -146,7 +147,11 @@ bpb_fil_sys_type:			// Filesystem type (8 bytes)
 	// Load the first sector of the root directory
 	movb bpb_num_fats,%al
 	cbtw
-	mulw bpb_fat_sz_16
+	mov bpb_fat_sz_16,%bx		// check FAT16 fat size
+	and %bx,%bx
+	jnz 1f				// nonzero means FAT16 filesystem
+	mov bpb_fat_sz_32,%bx		// get loword FAT32 fat size instead
+1:	mulw %bx
 	addw bpb_rsvd_sec_cnt,%ax
 	push %ax
 	inc %dx				// Assume DX was 0 (from mulw); if

--- a/elks/include/linuxmt/msdos_fs.h
+++ b/elks/include/linuxmt/msdos_fs.h
@@ -63,16 +63,16 @@ struct msdos_boot_sector {
 	unsigned short fat_length;  /* sectors/FAT 22*/
 	unsigned short secs_track;  /* sectors per track (unused) 24*/
 	unsigned short heads;	    /* number of heads (unused) 26*/
-	unsigned long hidden;	    /* hidden sectors (unused) 28*/
+	unsigned long hidden;	    /* hidden sectors 28*/
 	unsigned long total_sect;   /* number of sectors (if sectors == 0) 32*/
 
 	/* The following fields are only used by FAT32 */
-	__u32	fat32_length;	/* sectors/FAT */
-	__u16	flags;		/* bit 8: fat mirroring, low 4: active fat */
-	__u8	version[2];	/* major, minor filesystem version */
-	__u32	root_cluster;	/* first cluster in root directory */
-	__u16	info_sector;	/* filesystem info sector */
-	__u16	backup_boot;	/* backup boot sector */
+	__u32	fat32_length;	/* sectors/FAT 36 */
+	__u16	flags;		/* bit 8: fat mirroring, low 4: active fat (unused) */
+	__u8	version[2];	/* major, minor filesystem version (unused) */
+	__u32	root_cluster;	/* first cluster of root directory 44 */
+	__u16	info_sector;	/* filesystem info sector (unused) */
+	__u16	backup_boot;	/* backup boot sector (unused) */
 	__u16	reserved2[6];	/* Unused */
 };
 

--- a/elkscmd/rootfs_template/bin/sys
+++ b/elkscmd/rootfs_template/bin/sys
@@ -2,12 +2,13 @@
 #
 # Usage: sys [-M] /dev/{fd0,fd1,hda1,hda2,etc}
 # -M will also transfer an MBR
+# -F will allow writing flat (non-MBR) hard drive
 #
 #set -x
 
 usage()
 {
-	echo "Usage: sys [-M] /dev/{fd0,fd1,hda1,hda2,etc}"
+	echo "Usage: sys [-M][-F] /dev/{fd0,fd1,hda1,hda2,etc}"
 	exit 1
 }
 
@@ -80,6 +81,7 @@ makeboot $1 $2 $3
 
 FSTYPE=$?
 if test "$1" = "-M"; then shift; fi
+if test "$1" = "-F"; then shift; fi
 case "$FSTYPE" in
 1) mount $1 $MNT ;;
 2) mount -t msdos $1 $MNT ;;


### PR DESCRIPTION
The ELKS FAT boot sector is enhanced to boot FAT12, FAT16 or FAT32 filesystems.

Works with `mkfat` and other FAT32 filesystem formatters and should allow booting from them after running `sys`.

Along with @tkchia's enhancement #857 relaxing the restriction of /linux having to be the first root directory entry, this change should allow booting from all freshly created FAT32 filesystems, including those made with ELKS mkfat and Windows 10.

The FAT boot sector code assumes that the root cluster will be at 2, which is always the first data cluster available. This will always be the case unless bad sectors are present, since the first data cluster (numbered 2) will always be allocated directly after the FAT tables. Checking for a root directory cluster other than 2 could be added after testing, but there are no known utilities that put the FAT32 root directory at another cluster location, so testing that is difficult, and likely unnecessary, given the other assumptions already made in the FAT boot code.

Also adds "sys -F" option to allow sys'ing flat (non-MBR) hard disks. This was required for my testing.
The msdos_fs.h header is updated with BPB offsets to help debugging.

Tested on QEMU with FAT16 and FAT32 filesystems of different sizes.

@toncho11, it would be interesting to try booting a FAT32 partition on your hardware, made using `mkfat` or Windows 10 format. I've attached updated 360k images with all the past few days sys fixes and the FAT32 boot sector.

[fd360-fat.bin.zip](https://github.com/jbruchon/elks/files/5534707/fd360-fat.bin.zip)
[fd360-minix.bin.zip](https://github.com/jbruchon/elks/files/5534708/fd360-minix.bin.zip)
