### PR TITLE
[fat] Relax requirement of FAT /dev directory placement

### DIFF
--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -168,8 +168,8 @@ printk("FAT: me=%x,csz=%d,#f=%d,floc=%d,fsz=%d,rloc=%d,#d=%d,dloc=%d,#s=%ld,ts=%
 	int i;
 	bh = NULL;
 
-	/* if /dev is found in first four directory entries, turn on devfs filesystem */
-	for (i=0; i<4; i++) {
+	/* if /dev is found in first eight directory entries, turn on devfs filesystem */
+	for (i=0; i<8; i++) {
 		ino = msdos_get_entry(s->s_mounted, &pos, &bh, &de); 
 		if (ino == -1) break;
 		if (de->attr == ATTR_DIR && !strncmp(de->name, "DEV        ", 11)) {


### PR DESCRIPTION
Fix likely problem of `sys` run on Windows 10 formatted volumes failing to open /dev/console at boot, discussed in https://github.com/jbruchon/elks/pull/858#issuecomment-726578626.

@toncho11, try this system image for sys'ing a freshly formatted Windows 10 image, thanks!

[fd360-fat.bin.zip](https://github.com/jbruchon/elks/files/5537782/fd360-fat.bin.zip)
