### PR TITLE
[fat] Fix get_parent_ino on FAT32, fixes pwd

### DIFF
--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -398,6 +398,9 @@ ino_t FATPROC msdos_parent_ino(register struct inode *dir,int locked)
 	} else if (!current) this = MSDOS_ROOT_INO;
 	else {
 		if ((prev = raw_scan(dir->i_sb,current,MSDOS_DOTDOT,0L,NULL)) < 0) {
+			if (MSDOS_SB(dir->i_sb)->fat_bits == 32 &&
+			    current == MSDOS_SB(dir->i_sb)->root_cluster)
+					this = MSDOS_ROOT_INO;
 		} else {
 			if (prev == 0 
 #ifndef FAT_BITS_32

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -62,7 +62,7 @@ file_utils/cp					:be-fileutil	:360k
 file_utils/df					:be-fileutil			:1440k
 file_utils/dd					:be-fileutil			:1440k
 file_utils/mkdir				:fileutil		:360k
-file_utils/mknod				:fileutil				:1440k
+file_utils/mknod				:fileutil		:360k
 file_utils/mkfifo				:fileutil				:1440k
 file_utils/more					:fileutil			:720k
 file_utils/mv					:fileutil		:360k

--- a/elkscmd/rootfs_template/bin/sys
+++ b/elkscmd/rootfs_template/bin/sys
@@ -40,6 +40,7 @@ create_directories()
 	mkdir $MNT/bin
 	mkdir $MNT/etc
 	mkdir $MNT/mnt
+	mkdir $MNT/root
 }
 
 copy_bin_files()
@@ -48,15 +49,20 @@ copy_bin_files()
 	cp /bin/sh	$MNT/bin
 	cp /bin/sash	$MNT/bin
 	cp /bin/cp	$MNT/bin
+	cp /bin/echo	$MNT/bin
 	cp /bin/init	$MNT/bin
 	cp /bin/getty	$MNT/bin
 	cp /bin/login	$MNT/bin
 	cp /bin/ls	$MNT/bin
+	cp /bin/makeboot $MNT/bin
 	cp /bin/mkdir	$MNT/bin
+	cp /bin/mknod	$MNT/bin
 	cp /bin/mount	$MNT/bin
 	cp /bin/ps	$MNT/bin
 	cp /bin/pwd	$MNT/bin
 	cp /bin/sync	$MNT/bin
+	cp /bin/sys	$MNT/bin
+	cp /bin/test	$MNT/bin
 	cp /bin/umount	$MNT/bin
 }
 

--- a/elkscmd/rootfs_template/etc/rc.d/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sys
@@ -32,7 +32,7 @@ fi
 #
 #mount -t msdos /dev/fd1 /mnt || true
 #mount -t msdos /dev/hda1 /mnt
-#mount /dev/hda /mnt
+#mount -t msdos /dev/hda /mnt
 
 #
 # start networking

--- a/elkscmd/sh_utils/pwd.c
+++ b/elkscmd/sh_utils/pwd.c
@@ -6,7 +6,7 @@ int main(int ac, char **av)
 	char wd[255];
 	
 	if (getcwd(wd,255) == NULL) {
-		write(STDOUT_FILENO, "Cannot get current directory\n", 28);
+		write(STDOUT_FILENO, "Cannot get current directory\n", 29);
 		return 1;
 	}
 	strcat(wd, "\n");


### PR DESCRIPTION
Fixes #860.

Also copies enough files with sys to enable a sys from the new system.

@toncho11,

Here's a system for confirmation testing, thanks.

[fd360-fat.bin.zip](https://github.com/jbruchon/elks/files/5539198/fd360-fat.bin.zip)
