### PR TITLE
[tools] [kernel] [setup] Allow far text kernel support to work with ROM kernel

### DIFF
--- a/elks/arch/i86/Makefile
+++ b/elks/arch/i86/Makefile
@@ -40,6 +40,21 @@ SIBOFLAGS	=
 endif
 
 #########################################################################
+# ROM specific options.
+
+ifeq ($(CONFIG_ROMCODE), y)
+
+# Make sure that the a.out header & data segment values are prefixed with `0x'
+ROMPOSTLINKFLAGS = --aout-seg 0x$(CONFIG_ROM_KERNEL_CODE:0x%=%) \
+		   --data-seg 0x$(CONFIG_ROM_KERNEL_DATA:0x%=%)
+
+else
+
+ROMPOSTLINKFLAGS =
+
+endif
+
+#########################################################################
 # Objects to be compiled.
 
 AARCHIVES = kernel/akernel.a lib/lib86.a mm/mm.a
@@ -103,7 +118,7 @@ boot/system: $(XINCLUDE) $(AARCHIVES) $(ADRIVERS) sibo/crt1.o sibo/crt0.o
 		$(ARCH_DIR)/sibo/crt0.o $(ARCH_DIR)/sibo/crt1.o \
 		init/main.o $(ARCHIVES) $(DRIVERS) $(LIBGCC) \
 		-o $(ARCH_DIR)/boot/system > $(ARCH_DIR)/boot/system.tmp ; \
-		$(POSTLINK) $(ARCH_DIR)/boot/system ; \
+		$(POSTLINK) $(ROMPOSTLINKFLAGS) $(ARCH_DIR)/boot/system ; \
 		sort -k3,4 $(ARCH_DIR)/boot/system.tmp > $(ARCH_DIR)/boot/system.map ; \
 		rm -f $(ARCH_DIR)/boot/system.tmp )
 
@@ -121,7 +136,7 @@ boot/system:	$(XINCLUDE) $(AARCHIVES) $(ADRIVERS) boot/crt0.o
 		$(ARCH_DIR)/boot/crt0.o \
 		init/main.o '-(' $(ARCHIVES) $(DRIVERS) '-)' $(LIBGCC) \
 		-o $(ARCH_DIR)/boot/system > $(ARCH_DIR)/boot/system.map ; \
-		$(POSTLINK) $(ARCH_DIR)/boot/system)
+		$(POSTLINK) $(ROMPOSTLINKFLAGS) $(ARCH_DIR)/boot/system)
 #		sort -k3,4 $(ARCH_DIR)/boot/system.tmp > $(ARCH_DIR)/boot/system.map ; \
 #		rm -f $(ARCH_DIR)/boot/system.tmp )
 
@@ -139,12 +154,8 @@ ifeq ($(CONFIG_ROM_BOOTABLE_BY_RESET), y)
     RVECT = -r $(CONFIG_ROM_RESET_ADDRESS)   
 endif
 
-# Disable temporary the checksum to not overwrite the image
-# as it is actually not needed for execution in EMU86
-
 Image:	toolkit boot/setup boot/system  
-#	tools/mkbootloader $(RVECT) -c $(CONFIG_ROM_SETUP_CODE) $(CONFIG_ROM_CHECKSUM_SIZE) boot/Image $(CONFIG_ROM_BASE) -a boot/setup $(CONFIG_ROM_SETUP_CODE) -s boot/system $(CONFIG_ROM_KERNEL_CODE) $(CONFIG_ROM_BIOS_MODULE) $(CONFIG_ROM_BIOS_MODULE_ADDR)
-	tools/mkbootloader $(RVECT) boot/Image $(CONFIG_ROM_BASE) -a boot/setup $(CONFIG_ROM_SETUP_CODE) -s boot/system $(CONFIG_ROM_KERNEL_CODE) $(CONFIG_ROM_BIOS_MODULE) $(CONFIG_ROM_BIOS_MODULE_ADDR)
+	tools/mkbootloader $(RVECT) -c $(CONFIG_ROM_SETUP_CODE) $(CONFIG_ROM_CHECKSUM_SIZE) boot/Image $(CONFIG_ROM_BASE) -a boot/setup $(CONFIG_ROM_SETUP_CODE) -s boot/system $(CONFIG_ROM_KERNEL_CODE) $(CONFIG_ROM_BIOS_MODULE) $(CONFIG_ROM_BIOS_MODULE_ADDR)
 	$(CONFIG_ROM_SIMULATOR_PROGRAM)
 
 # End PC image build

--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -114,7 +114,7 @@ _start:
 // Entry point for non-EMU86 ROM systems
 
 	.byte 0x55,0xaa		// sign for ROM-Extension
-	.byte 0x04		// space for lengthcode (promsize/512)
+	.byte 2*CONFIG_ROM_CHECKSUM_SIZE // space for lengthcode (promsize/512)
 
 	push	%ds
 	xor	%ax,%ax		// DS = 0

--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -329,8 +329,7 @@ msg_too_big:
 
 aout_ok:
 	mov 10,%cx		// 10 = hiword hdr.a_text size
-	or %cx,%cx		// max 64k
-	jz 2f
+	jcxz 2f			// max 64k
 size_error:
    	mov %cs,%ax
    	mov %ax,%ds
@@ -338,25 +337,34 @@ size_error:
 	call puts
 	jmp err_loop		// and halt
 
-2:	mov 14,%cx		// 14 = hiword of hdr.a_data size
-	or %cx,%cx		// max 64jk
+2:	cmp %cx,14		// 14 = hiword of hdr.a_data size
+				// max 64k
+				// CX = 0
 	jnz size_error
-	mov 4,%cx		// 4 = hdr.a_hdrlen
-	cmp $0x20,%cx		// check for small 32 byte hdr
-	jnz size_error		// error, fartext present
+	cmpb $0x20,4		// 4 = hdr.a_hdrlen
+				// check for small 32 byte hdr
+	jnz size_error		// error, stray fartext or relocations present
 
 // Now copy kernel data segment to RAM
-// WARNING: Next code fails if code_size+data_size+32 > 64K
-	mov 4,%si		// 4 = hdr.a_hdrlen
-	add 8,%si		// 8 = add hdr.a_text size
+	mov 8,%ax		// 8 = hdr.a_text size
+	mov %ax,%si		// Build up normalized pointer to point to
+	and $0x000f,%si		// data contents to copy to RAM
+				// SI = offset
+	mov $4,%cl		// Compute segment
+	ror %cl,%ax
+	add $CONFIG_ROM_KERNEL_CODE+2,%ax
+	mov 0x0c,%cx		// 12 = hdr.a_data size
+	push %ds
+	mov %ax,%ds		// DS:SI -> contents to copy
 	mov $CONFIG_ROM_KERNEL_DATA,%ax	// ES = RAM kernel data segment
 	mov %ax,%es
-        xor %di,%di
-        mov 0x0c,%cx		// 12 = hdr.a_data size
-        shr $1,%cx		// copy words
-        cld
-        rep
-        movsw
+	xor %di,%di
+	inc %cx
+	shr $1,%cx		// copy words
+	cld
+	rep
+	movsw
+	pop %ds
 
 // BX,CX,DX,SI,DI,DS,ES are expected in kernel crt0.S
 
@@ -368,7 +376,7 @@ size_error:
 	mov %cx,%ds
 
 #ifdef CONFIG_ROM_DEBUG
-	int     $3               // break for debugger just before kernel
+	int $3			// break for debugger just before kernel
 #endif
 
 	mov $CONFIG_ROM_KERNEL_CODE+2,%di // a.out + 32 = kernel CS

--- a/elks/tools/elf2elks/elf2elks.c
+++ b/elks/tools/elf2elks/elf2elks.c
@@ -813,7 +813,7 @@ output_scn_stuff (Elf_Scn *scn, const Elf32_Shdr *shdr, uint32_t rels_start,
       for (ri = rels_start; ri != rels_start + n_rels; ++ri)
 	{
 	  struct minix_reloc *pmrel = &mrels[ri];
-	  uint16_t value, offset_in_scn;
+	  uint16_t value = 0, offset_in_scn;
 
 	  switch (pmrel->symndx)
 	    {


### PR DESCRIPTION
As suggested at https://github.com/tkchia/gcc-ia16/issues/66#issuecomment-732300514 .

I added
  * new options `--aout-seg` and `--data-seg` to `elks/tools/elf2elks/elf2elks.c`, to allow `elf2elks` to produce a kernel which uses a far text but can still be burnt into a ROM;
  * changes to `elks/arch/i86/Makefile` to get it
    * to use the new `elf2elks` options when building a ROMable kernel, and
    * to properly calculate a checksum for an output ROM image; and
 * changes to `elks/arch/i86/boot/setup.S` to allow the initial data contents of the kernel data to lie outside the `a.out`'s first 64 KiB (this may be useful if the ROM kernel becomes bigger in the future).

With appropriate configuration settings, the resulting ROM image can now be run as an option ROM under QEMU:

![20201127](https://user-images.githubusercontent.com/5507843/100469546-5b3f1d00-3111-11eb-9904-a677697e740f.png)

One minor problem is that, if the kernel is built as a ROM kernel with far text, then `setup.S` no longer passes the correct far text size to the kernel.  `elf2elks` effectively combines the near text and far text segments into one single blob, in order to output an `a.out` with a short header.