### PR TITLE
[kernel] Allow legacy v0 a.out programs to run with minimal stack

### DIFF
--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -66,6 +66,7 @@ void stack_check(void)
     {
 	/* optional: check stack over min stack*/
 	if (currentp->t_regs.sp < currentp->t_begstack - currentp->t_minstack) {
+	  if (currentp->t_minstack)	/* display if protected stack*/
 	    printk("(%d)STACK OVER MINSTACK by %u BYTES\n", currentp->pid,
 		currentp->t_begstack - currentp->t_minstack - currentp->t_regs.sp);
 	}

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -278,10 +278,11 @@ int sys_execve(char *filename, char *sptr, size_t slen)
 	    }
 	    heap = len - min_len;
 	    if (heap < INIT_STACK) {			/* check space for stack*/
-		retval = -EINVAL;
-		goto error_exec3;
+		stack = heap - slen;			/* allow minimal non-std stack*/
+		debug("EXEC v0: len %d min_len %d heap %d stack %d\n",
+			len, min_len, heap, stack);
 	    }
-	    heap -= INIT_STACK;
+	    heap -= stack;
 	    if (heap < slen) {				/* check space for environment*/
 		retval = -E2BIG;
 		goto error_exec3;

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -269,25 +269,20 @@ int sys_execve(char *filename, char *sptr, size_t slen)
 	debug("EXEC: stack %u heap %u env %u total %u\n", stack, heap, slen, len);
 	break;
     case 0:
-	stack = INIT_STACK;
 	len = mh.chmem;
 	if (len) {
 	    if (len <= min_len) {			/* check bad chmem*/
 		retval = -EINVAL;
 		goto error_exec3;
 	    }
+	    stack = 0;					/* no protected stack space*/
 	    heap = len - min_len;
-	    if (heap < INIT_STACK) {			/* check space for stack*/
-		stack = heap - slen;			/* allow minimal non-std stack*/
-		debug("EXEC v0: len %d min_len %d heap %d stack %d\n",
-			len, min_len, heap, stack);
-	    }
-	    heap -= stack;
 	    if (heap < slen) {				/* check space for environment*/
 		retval = -E2BIG;
 		goto error_exec3;
 	    }
 	} else {
+	    stack = INIT_STACK;
 	    len = min_len;
 #ifdef CONFIG_EXEC_LOW_STACK
 	    if (base_data) {


### PR DESCRIPTION
Fixes kernel to be able to run legacy ELKS (v0 header) programs that allocated less memory than INIT_STACK bytes for stack.
Runs programs produced by [Alfonso Marton's](http://www.alfonsomartone.itb.it/fhlvnr.html) `exe2elks` Turbo-C DOS to ELKS conversion program.

Incompatibility found by @toncho11 in https://github.com/jbruchon/elks/issues/871#issuecomment-729857520.
