### PR TITLE
[kernel] Rewrite wait system call, fixes cron

### DIFF
--- a/Documentation/html/user/cron.html
+++ b/Documentation/html/user/cron.html
@@ -47,8 +47,8 @@
 			run ELKS on qemu, the hardware time will be UTC or Greenich mean
 			time.<BR>Therefore the jobs will not be executed at the local time
 			if you do not set<BR>the ELKS time to your local time. If you
-			schedule a lot of jobs you may<BR>run out of slots. Increase
-			POLL_MAX in the limits.h file then.<BR><BR>To display the contents
+			schedule a lot of jobs you may<BR>run out of task slots.
+			<BR><BR>To display the contents
 			of the crontab file call the crontab program<BR>with the &quot;-l&quot;
 			parameter:<BR><BR><FONT FACE="Courier New, monospace">$ crontab
 			-l</FONT><BR><BR>To edit the cron jobs, do:<BR><BR><FONT FACE="Courier New, monospace">$

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -486,7 +486,9 @@ int sys_execve(char *filename, char *sptr, size_t slen)
      */
     arch_setup_user_stack(currentp, (word_t) mh.entry);
 
+#if 0	/* used only for vfork()*/
     wake_up(&currentp->p_parent->child_wait);
+#endif
 
     /* Done */
 

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -71,9 +71,11 @@ struct task_struct {
     pid_t			pgrp;
     struct tty			*tty;
     struct task_struct		*p_parent;
+#if BLOAT
     struct task_struct		*p_prevsib;
     struct task_struct		*p_nextsib;
     struct task_struct		*p_child;
+#endif
     struct wait_queue		child_wait;
     int				exit_status;	/* process exit status*/
     struct inode		*t_inode;

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -38,7 +38,7 @@ struct task_struct *find_empty_process(void)
     register struct task_struct *currentp = current;
 
     if (task_slots_unused <= 1) {
-        printk("Only %d slots\n", task_slots_unused);
+        printk("Only %d task slots\n", task_slots_unused);
         if (!task_slots_unused || currentp->uid)
             return NULL;
     }
@@ -109,14 +109,16 @@ pid_t do_fork(int virtual)
 
     t->exit_status = 0;
 
-    /* Set up our family tree */
     t->ppid = currentp->pid;
     t->p_parent = currentp;
+#if BLOAT
+    /* Set up our family tree */
     t->p_nextsib = t->p_child = NULL;
     if ((t->p_prevsib = currentp->p_child) != NULL) {
 	currentp->p_child->p_nextsib = t;
     }
     currentp->p_child = t;
+#endif
 
     /*
      *      Build a return stack for t.

--- a/elks/kernel/signal.c
+++ b/elks/kernel/signal.c
@@ -88,7 +88,7 @@ int kill_process(pid_t pid, sig_t sig, int priv)
 
     debug_sig("SIGNAL kill_proc sig %d pid %d\n", sig, pid);
     for_each_task(p)
-	if (p->pid == pid)
+	if (p->pid == pid && p->state < TASK_ZOMBIE)
 	    return send_sig(sig, p, 0);
     return -ESRCH;
 }
@@ -116,7 +116,7 @@ int sys_kill(pid_t pid, sig_t sig)
     count = retval = 0;
     if (pid == -1) {
 	for_each_task(p)
-	    if (p->pid > 1 && p != pcurrent) {
+	    if (p->pid > 1 && p != pcurrent && p->state < TASK_ZOMBIE) {
 		count++;
 		if ((err = send_sig(sig, p, 0)) != -EPERM)
 		    retval = err;

--- a/elks/kernel/sleepwake.c
+++ b/elks/kernel/sleepwake.c
@@ -140,6 +140,8 @@ void _wake_up(register struct wait_queue *q, unsigned short int it)
     register struct task_struct *p;
 
     for_each_task(p) {
+	if (p->state == TASK_UNUSED)
+		continue;
 	if ((p->waitpt == q) || ((p->waitpt == &select_queue) && select_poll (p, q)))
 	    if (p->state == TASK_INTERRUPTIBLE ||
 		(it && p->state == TASK_UNINTERRUPTIBLE)) {

--- a/elks/kernel/sys.c
+++ b/elks/kernel/sys.c
@@ -215,7 +215,7 @@ int sys_setpgid(pid_t pid, pid_t pgid)
 	return -EINVAL;
 
     for_each_task(p) {
-	if (p->pid == pid) {
+	if (p->pid == pid && p->state != TASK_UNUSED) {
 
 	    if (p->p_pptr == current || p->p_opptr == current) {
 
@@ -235,7 +235,7 @@ int sys_setpgid(pid_t pid, pid_t pgid)
 		struct task_struct *tmp;
 
 		for_each_task(tmp) {
-		    if ((tmp->pgrp == pgid)
+		    if ((tmp->pgrp == pgid && tmp->state != TASK_UNUSED)
 			&& (tmp->session == current->session)) {
 			goto ok_pgid:
 		    }
@@ -259,7 +259,7 @@ int sys_getpgid(pid_t pid)
     if (!pid)
 	return current->pgrp;
     for_each_task(p)
-	if (p->pid == pid)
+	if (p->pid == pid && p->state != TASK_UNUSED)
 	    return p->pgrp;
     return -ESRCH;
 }
@@ -276,7 +276,7 @@ int sys_getsid(pid_t pid)
     if (!pid)
 	return current->session;
     for_each_task(p)
-	if (p->pid == pid)
+	if (p->pid == pid && p->state != TASK_UNUSED)
 	    return p->session;
     return -ESRCH;
 

--- a/elkscmd/cron/Makefile
+++ b/elkscmd/cron/Makefile
@@ -7,7 +7,6 @@ BASEDIR=..
 include $(BASEDIR)/Make.defs
 
 LOCALFLAGS = -Wno-implicit-int -Wno-return-type $(OPTIONS)
-CRONFLAGS = -maout-heap=0x3800
 
 ###############################################################################
 #
@@ -26,10 +25,10 @@ all: $(progs)
 install: $(progs)
 
 cron: cron.o runjob.o $(common)
-	$(CC) $(CFLAGS) $(CRONFLAGS) -o $@ cron.o runjob.o $(common)
+	$(CC) $(CFLAGS) -maout-heap=14336 -o $@ cron.o runjob.o $(common)
 
 crontab: crontab.o $(common)
-	$(CC) $(CFLAGS) -o $@ crontab.o $(common)
+	$(CC) $(CFLAGS) -maout-heap=14336 -o $@ crontab.o $(common)
 
 clean:
 	rm -f $(progs) *.o

--- a/elkscmd/cron/config.h
+++ b/elkscmd/cron/config.h
@@ -5,6 +5,7 @@
 #ifndef __AC_CRON_D
 #define __AC_CRON_D 1
 
+#define TEST		0	/* =1 to debug/test sleep timer*/
 
 #define OS_LINUX 1
 #define while(x) while( (x) != 0 )

--- a/elkscmd/cron/cron.c
+++ b/elkscmd/cron/cron.c
@@ -169,7 +169,9 @@ securepath(char *path)
 	if ( sb.st_uid != 0 ) fatal("%s: not user 0", part);
 	if ( sb.st_gid != 0 ) fatal("%s: not group 0", part);
 	if ( !S_ISDIR(sb.st_mode) ) fatal("%s: not a directory", part);
+#if 0
 	if ( sb.st_mode & (S_IWGRP|S_IWOTH) ) fatal("%s: group or world writable", part);
+#endif
     }
     if ( stat(path, &sb) != 0 ) fatal("%s: can't stat", path);
     if ( stat(".", &sb1) != 0 ) fatal(".: can't stat");

--- a/elkscmd/cron/cron.c
+++ b/elkscmd/cron/cron.c
@@ -37,7 +37,8 @@ eat(int sig)
 {
     int status;
 
-    waitpid(-1, &status, 0);
+    while (waitpid(-1, &status, 0) != -1)
+		continue;
     signal(SIGCHLD,eat);
 }
 
@@ -354,6 +355,14 @@ main(int argc, char **argv)
 	struct tm *tm;
 	int adjust;
 
+#if TEST
+	int n = 2;
+	do {
+		printf("cron: sleep start %d\n", n);
+		n = sleep(n);
+		printf("cron: sleep return %d\n", n);
+	} while (n > 0);
+#else
 	time(&ticks);
 	tm = localtime(&ticks);
 	adjust = (30 - tm->tm_sec) % 60;
@@ -380,6 +389,7 @@ main(int argc, char **argv)
 	    else
 		delay = left;
 	}
+#endif
 
 	checkcrondir();
 
@@ -389,7 +399,10 @@ main(int argc, char **argv)
 
 	for (i=0; i < nrtabs; i++)
 	    for (j=0; j < tabs[i].nrl; j++) {
-		    if ( (tabs[i].flags & ACTIVE) && triggered(&Now, &(tabs[i].list[j].trigger)) ) {
+#if !TEST
+		    if ( (tabs[i].flags & ACTIVE) && triggered(&Now, &(tabs[i].list[j].trigger)))
+#endif
+			{
 		      runjob(&tabs[i], &tabs[i].list[j]); 
             }
         }

--- a/elkscmd/cron/crontab.c
+++ b/elkscmd/cron/crontab.c
@@ -26,7 +26,7 @@
 
 char *pgm = "crontab";
 FILE *in_tmp;
-#define CRONTMP "crontmp.tmp"
+#define CRONTMP "/tmp/crontab.tmp"
 extern int interactive;
 
 void
@@ -180,9 +180,9 @@ visual(struct passwd *pwd)
     int save_euid = geteuid();
 
     xchdir(pwd->pw_dir ? pwd->pw_dir : "/tmp");
-    strcpy(vitemp, "/tmp/.crontab.XXXXXX");
+    strcpy(vitemp, "/tmp/cronedit.tmp");
     seteuid(getuid());
-    mktemp(vitemp);
+    //mktemp(vitemp);
 
     atexit(nomorevitemp);
 

--- a/elkscmd/cron/lib.c
+++ b/elkscmd/cron/lib.c
@@ -231,8 +231,12 @@ xis_crondir (void)
             error("can't create crontab template: %s", strerror(errno));
             return -1;
         }  
+#if TEST
+        fprintf(ftmp,"0-59 * * * * echo Message 1 by cron >>cron.out\n");
+#else
         fprintf(ftmp,"* * * * * echo Hello! Here is cron >>cron.out\n");
-        fprintf(ftmp,"10,20,30,40,50 * * * * echo Message by cron >>cron.out\n");
+        fprintf(ftmp,"10,20,30,40,50 * * * * echo Message 10 by cron >>cron.out\n");
+#endif
         fclose(ftmp);
     }
 }

--- a/elkscmd/cron/runjob.c
+++ b/elkscmd/cron/runjob.c
@@ -37,6 +37,9 @@ runjobprocess(crontab *tab,cron *job,struct passwd *usr)
     char *shell;
     input[0] = input[1] = 0;
 
+#if TEST
+	printf("cron: running '%s'\n", job->command);
+#endif
     if ( (shell=jobenv(tab, "SHELL")) == 0 )
 	shell = _PATH_BSHELL;
 
@@ -64,6 +67,7 @@ runjobprocess(crontab *tab,cron *job,struct passwd *usr)
 
 	execle(shell, "sh", "-c", job->command, (char*)0, tab->env);
 	perror(shell);
+	exit(1);
     }
     else {					/* runjobprocess() */
 	close(input[0]);
@@ -90,9 +94,8 @@ runjobprocess(crontab *tab,cron *job,struct passwd *usr)
 	}
 #endif        
 	/* wait for all subprocesses to finish */
-	//while ( wait(&status) != -1 )
-    while ( waitpid(-1, &status, 0) != -1 )
-	    ;
+	while (wait(&status) != -1)
+	    continue;
     }
     exit(0);
 }


### PR DESCRIPTION
Fixes #892.

There was a race condition between reaping process exit status and re-using unused task structures, which caused `cron` to fail. `sys_wait4` was rewritten to eliminate this problem. Handling of orphans is now performed at process exit time, rather than in wait, which fixes the race problem. Also previously, orphaned zombies were reparented to init, for reaping exit status. Now, the task structure entry is marked unused, for better use of the limited task structure during fast task creation periods.

Fixed a number of kernel problems where the `for_each_task` define was used to iterate through all tasks; it is an error to check task structure fields without examining whether the task state is TASK_UNUSED or not, as values are never cleared. 

Removed unused task "family" fields: p_child, p_nextsib, p_prevsib.

Finally, testing on QEMU has proved to be a real problem: for some reason, it seems QEMU limits process usage and greatly slows executing instructions, including the timer interrupt, after several minutes, or until console I/O. This causes the `sleep` wait in cron to linger well past its requested real time and thus cron jobs don't execute when they should. I've added a "TEST" define in cron's config.h that shows this happening with debug output of jobs. Thus, cron's timing itself of job execution has not been tested. I plan on further investigation of QEMU's instruction throttling when I have time.
