### PR TITLE
Enhancements to vi editor

### DIFF
--- a/elkscmd/elvis/config.h
+++ b/elkscmd/elvis/config.h
@@ -196,11 +196,11 @@ extern char *strchr();
 # define TMPNAME	"%s/elv%x%04x.%03x" /* temp file */
 # define CUTNAME	"%s/elv_%04x%.03x" /* cut buffer's temp file */
 # ifndef EXRC
-#  define EXRC		".exrc"		/* init file in current directory */
+#  define EXRC		".virc"		/* init file in current directory */
 # endif
 # define SCRATCHOUT	"%s/soXXXXXX"	/* temp file used as input to filter */
 # ifndef EXINIT
-#  define EXINIT	"EXINIT"
+#  define EXINIT	"VIINIT"
 # endif
 # ifndef SHELL
 #  define SHELL		"/bin/sh"	/* default shell */

--- a/elkscmd/elvis/tmp.c
+++ b/elkscmd/elvis/tmp.c
@@ -197,6 +197,7 @@ int tmpstart(filename)
 	sprintf(tmpname, TMPNAME, o_directory, sum, statb.st_ino, statb.st_dev);
 #endif
 
+#if 0	/* remove tmpfile busy check for ELKS*/
 	/* make sure nobody else is editing the same file */
 	if (access(tmpname, 0) == 0)
 	{
@@ -207,6 +208,9 @@ int tmpstart(filename)
 		}
 		FAIL("\"%s\" is busy", filename);
 	}
+#else
+	unlink(tmpname);					/* remove temp file before create*/
+#endif
 
 	/* create the temp file */
 #if ANY_UNIX


### PR DESCRIPTION
Changes to vi, discussed in #896.

- Remove 'file busy' check on startup.
- Rename .exrc -> .virc (will fix FAT filename issue by fixing VFAT long filenames in later commit).
- Rename EXINIT -> VIINIT.

@Mellvik, please test, thanks!