### PR TITLE
Handle AltGr key mode with FR keyboard

### DIFF
--- a/elks/arch/i86/drivers/char/xt_key.c
+++ b/elks/arch/i86/drivers/char/xt_key.c
@@ -199,7 +199,7 @@ static void keyboard_irq(int irq, struct pt_regs *regs, void *dev_id)
 
     /* --------------Process status keys-------------- */
     if (!(mode & 0xC0)) {  		/* Not a simple scancode or fnkey*/
-#if defined(CONFIG_KEYMAP_DE) || defined(CONFIG_KEYMAP_SE) /* || defined(CONFIG_KEYMAP_ES) */
+#if defined(CONFIG_KEYMAP_DE) || defined(CONFIG_KEYMAP_SE) || defined(CONFIG_KEYMAP_FR) /* || defined(CONFIG_KEYMAP_ES) */
 	if ((mode == ALT) && E0key)	/* ALT_GR has a E0 prefix*/
 	    mode = ALT_GR;
 #endif


### PR DESCRIPTION
Without this the AltGr don't work as expected with the french
azerty keyboard, for example the AltGr+" key generates a graphical
character and not #.

Tested on a IBM XT/286 and a french Model M AT keyboard.