### PR TITLE
[kernel tty] Fix ICRNL to work when ICANON off

### DIFF
--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -345,32 +345,32 @@ again:
 	    ch = chq_getch(&tty->inq);
 	}
 
-	    if (icanon) {
-		if (ch == tty->termios.c_cc[VERASE]) {
-		    if (i > 0) {
-			i--;
-			k = ((get_user_char((void *)(--data))
-			    == '\t') ? TAB_SPACES : 1);
-			do {
-			    tty_echo(tty, ch);
-			} while (--k);
-		    }
-		    continue;
-		}
-		if ((tty->termios.c_iflag & ICRNL) && (ch == '\r'))
-		    ch = '\n';
+	if ((tty->termios.c_iflag & ICRNL) && (ch == '\r'))
+	    ch = '\n';
 
-		if (ch == tty->termios.c_cc[VEOF])
-		    break;
-	    } else {
-		if (vtime && vmin)	/* start timeout after first character*/
-		    nonblock = 1;
+	if (icanon) {
+	    if (ch == tty->termios.c_cc[VERASE]) {
+		if (i > 0) {
+		    i--;
+		    k = ((get_user_char((void *)(--data)) == '\t') ? TAB_SPACES : 1);
+		    do {
+			tty_echo(tty, ch);
+		    } while (--k);
+		}
+		continue;
 	    }
-	    put_user_char(ch, (void *)(data++));
-	    tty_echo(tty, ch);
-	    i++;
-	    if (icanon && ((ch == '\n') || (ch == tty->termios.c_cc[VEOL])))
+
+	    if (ch == tty->termios.c_cc[VEOF])
 		break;
+	} else {
+	    if (vtime && vmin)	/* start timeout after first character*/
+		nonblock = 1;
+	}
+	put_user_char(ch, (void *)(data++));
+	tty_echo(tty, ch);
+	i++;
+	if (icanon && ((ch == '\n') || (ch == tty->termios.c_cc[VEOL])))
+	    break;
     }
     return i;
 }

--- a/elkscmd/inet/tinyirc/tinyirc.c
+++ b/elkscmd/inet/tinyirc/tinyirc.c
@@ -87,7 +87,8 @@ struct passwd *userinfo;
 #ifdef	POSIX
 struct termios _tty;
 tcflag_t _res_oflg, _res_lflg;
-#define raw() (_tty.c_lflag &= ~(ICANON | ECHO | ICRNL | ISIG), \
+#define raw() (_tty.c_lflag &= ~(ICANON | ECHO | ISIG), \
+	_tty.c_iflag &= ~ICRNL, \
 	_tty.c_oflag &= ~ONLCR, tcsetattr(my_tty, TCSANOW, &_tty))
 #define savetty() ((void) tcgetattr(my_tty, &_tty), \
 	_res_oflg = _tty.c_oflag, _res_lflg = _tty.c_lflag)

--- a/elkscmd/ktcp/slip.c
+++ b/elkscmd/ktcp/slip.c
@@ -109,6 +109,7 @@ int slip_init(char *fdev, speed_t baudrate)
      */
     ioctl(devfd, TCGETS, &tios);
     tios.c_lflag &= ~(ISIG | ICANON | ECHO | ECHOE);
+	tios.c_iflag &= ~(ICRNL);
     tios.c_oflag &= ~ONLCR;
     if (baud)
 	tios.c_cflag = baud;

--- a/elkscmd/misc_utils/miniterm.c
+++ b/elkscmd/misc_utils/miniterm.c
@@ -469,6 +469,7 @@ int main(int argc, char **argv)
 		tcgetattr(0, &stdin_termio);
 		tcgetattr(0, &new);
 		new.c_lflag &= ~(ICANON | ECHO);
+		new.c_iflag &= ~(ICRNL);
 		tcsetattr(0, TCSANOW, &new);
 	}
 

--- a/elkscmd/sys_utils/sercat.c
+++ b/elkscmd/sys_utils/sercat.c
@@ -59,6 +59,7 @@ int main(int argc, char **argv)
 	if (tcgetattr(fd, &org) >= 0) {
 		new = org;
 		new.c_lflag &= ~(ICANON | ISIG | ECHO | ECHOE | ECHONL);
+		new.c_iflag &= ~(ICRNL);
 		new.c_cflag |= CS8 | CREAD;
 		new.c_cc[VMIN] = 255;			/* min bytes to read if VTIME = 0*/
 		new.c_cc[VTIME] = 1;			/* intercharacter timeout if VMIN > 0, timeout if VMIN = 0*/


### PR DESCRIPTION
This PR fixes the ICRNL termios setting to work when ICANON is off, to match Linux/standard operation.

This bug was found when porting Minix editor `mined` (coming shortly).

All ELKS applications were examined to correctly work with the changed behavior, with fixes included in this PR.
Fix `tinyirc` which incorrectly included ICRNL in the incorrect termios field.