### PR TITLE
[tools] Bump up gcc-ia16 version

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -97,7 +97,7 @@ $(DISTDIR)/$(MPC_DIST).tar.gz:
 
 # GCC for IA16
 
-GCC_VER=1b50b0dda4247d4fc5519d10a56d67af353dc438
+GCC_VER=17bd8a491ca31f8fd867b1f1a380cbbc5ef53b07
 GCC_DIST=gcc-ia16-$(GCC_VER)
 
 $(DISTDIR)/$(GCC_DIST).tar.gz:


### PR DESCRIPTION
The new `gcc-ia16` version, among other things, fixes a nasty bug which made GCC output incorrect code when compiling programs with `-mcmodel=medium -ffunction-sections`.  The bug caused some far tail calls, which should be `ljmp`s, to be wrongly "optimized" to near `jmp`s.

See https://github.com/tkchia/gcc-ia16/issues/73#issuecomment-810466108 et seq.