### PR TITLE
[kernel] bugfix: buf. overflow in mapping kbd. scancode to action

### DIFF
--- a/elks/arch/i86/drivers/char/xt_key.c
+++ b/elks/arch/i86/drivers/char/xt_key.c
@@ -89,6 +89,8 @@ static unsigned char tb_state[] = {
     SSC, SSC, SSC, SSC, SSC, SSC, SSC, 'k', 'l' /*50->58, F11-F12*/
 };
 
+#define TB_STATE_MAX	(sizeof(tb_state) / sizeof(tb_state[0]) - 1)
+
 /*
  * Map CAPS|ALT|CTL|SHIFT into NORMAL,SHIFT,CAPS,CTL-ALT,
  * which are used to index into scan_tabs[].
@@ -192,7 +194,7 @@ static void keyboard_irq(int irq, struct pt_regs *regs, void *dev_id)
      *         10xx xxxxB, 0x80 Extended scan code
      *         11xx xxxxB, 0xC0 Simple Scan Code
      */
-    if (code >= 0x1C)
+    if (code >= 0x1C && code - 0x1C <= TB_STATE_MAX)
 	mode = tb_state[code - 0x1C]; /*is key a modifier key?*/
     else
         mode = SSC;


### PR DESCRIPTION
This bug may make ELKS "hang" at startup until the user presses some keys (https://github.com/jbruchon/elks/issues/909).

`set_leds()` causes the 8042 keyboard controller to return a `0xFA` (= KB_ACK) on the 8042 data port, and also issue an IRQ 1 for the `KB_ACK` (!).  Without this patch, the IRQ 1 handler may misinterpret the `0xFA` as a Caps Lock, Num Lock, or Scroll Lock key --- then it may erroneously invoke `set_leds()` again, leading to a spurious IRQ 1, leading to another spurious `set_leds()` call, etc.