### PR TITLE
[boot] Add console=ttyS0,19200 option for setting serial baud rate

### DIFF
--- a/elks/arch/i86/drivers/char/serial.c
+++ b/elks/arch/i86/drivers/char/serial.c
@@ -470,26 +470,18 @@ void INITPROC rs_setbaud(dev_t dev, unsigned long baud)
     register struct tty *tty = ttys + NR_CONSOLES + MINOR(dev) - RS_MINOR_OFFSET;
     unsigned int b;	/* use smaller 16-bit width to reduce code*/
 
-    switch (baud) {
-        case 50: b = B50; break;
-        case 75: b = B75; break;
-        case 110: b = B110; break;
-        case 134: b = B134; break;
-        case 150: b = B150; break;
-        case 200: b = B200; break;
-        case 300: b = B300; break;
-        case 600: b = B600; break;
-        case 1200: b = B1200; break;
-        case 1800: b = B1800; break;
-        case 2400: b = B2400; break;
-        case 4800: b = B4800; break;
-        case 9600: b = B9600; break;
-        case 19200: b = B19200; break;
-        case 38400: b = B38400; break;
-        case 57600: b = B57600; break;
-        case 115200: b = B115200; break;
-        default: return;
-    }
+	if (baud == 115200) b = B115200;
+	else if ((unsigned)baud == 57600) b = B57600;
+	else if ((unsigned)baud == 38400) b = B38400;
+	else if ((unsigned)baud == 19200) b = B19200;
+	else if ((unsigned)baud == 9600) b = B9600;
+	else if ((unsigned)baud == 4800) b = B4800;
+	else if ((unsigned)baud == 2400) b = B2400;
+	else if ((unsigned)baud == 1200) b = B1200;
+	else if ((unsigned)baud == 300) b = B300;
+	else if ((unsigned)baud == 110) b = 110;
+	else return;
+
     sp->tty = tty;	/* force tty association with serial port*/
     tty->termios.c_cflag = b | CS8;
     update_port(sp);

--- a/elks/include/linuxmt/init.h
+++ b/elks/include/linuxmt/init.h
@@ -27,6 +27,7 @@ extern void INITPROC mm_init(seg_t,seg_t);
 extern void INITPROC mm_stat(seg_t, seg_t);
 extern void INITPROC sched_init(void);
 extern void INITPROC serial_init(void);
+extern void INITPROC rs_setbaud(dev_t dev, unsigned long baud);
 extern void INITPROC sock_init(void);
 extern void INITPROC tty_init(void);
 

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -50,6 +50,7 @@ static char * INITPROC root_dev_name(int dev);
 static int INITPROC parse_options(void);
 static void INITPROC finalize_options(void);
 static char * INITPROC option(char *s);
+static long INITPROC atol(char *number);
 #endif
 
 static void init_task(void);
@@ -275,6 +276,16 @@ static int INITPROC parse_options(void)
 		}
 		if (!strncmp(line,"console=",8)) {
 			int dev = parse_dev(line+8);
+			char *p = strchr(line+8, ',');
+			if (p) {
+				*p++ = 0;
+#ifdef CONFIG_CHAR_DEV_RS
+				/* set serial console baud rate*/
+				rs_setbaud(dev, atol(p));
+#endif
+			}
+
+
 #if DEBUG
 			printk("console %s=0x%04x\n", line+8, dev);
 #endif
@@ -377,6 +388,15 @@ static char * INITPROC option(char *s)
 	return s;
 }
 
+static long INITPROC atol(char *number)
+{
+    long n = 0;
+
+    while (*number >= '0' && *number <= '9')
+	n = (n * 10) + *number++ - '0';
+    return n;
+}
+
 char *strchr(char *s, int c)
 {
 	for(; *s != (char)c; ++s) {
@@ -385,4 +405,5 @@ char *strchr(char *s, int c)
 	}
 	return s;
 }
+
 #endif /* CONFIG_BOOTOPTS*/

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -388,6 +388,7 @@ static char * INITPROC option(char *s)
 	return s;
 }
 
+#ifdef CONFIG_CHAR_DEV_RS
 static long INITPROC atol(char *number)
 {
     long n = 0;
@@ -396,6 +397,7 @@ static long INITPROC atol(char *number)
 	n = (n * 10) + *number++ - '0';
     return n;
 }
+#endif
 
 char *strchr(char *s, int c)
 {

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -2,7 +2,7 @@
 #console=ttyS0 debug net=eth 3 # condensed
 #init=/bin/init 3	# multiuser serial
 #init=/bin/sh		# singleuser shell
-#console=ttyS0		# serial console
+#console=ttyS0,19200 # serial console
 #root=hda1			# hd partition 1
 #ro					# read-only root
 #net=eth


### PR DESCRIPTION
Implements request in #916.

An optional initial baud rate can be specified in the /bootopts file. Do this by adding a comma and the baud rate after the specified serial console device.

@Mellvik, please test this, I haven't tested on real hardware. I've attached a kernel from the latest source for you.

[fd1440.bin.zip](https://github.com/jbruchon/elks/files/6287179/fd1440.bin.zip)
