### PR TITLE
[boot] Fix boot when /bootopts removed

### DIFF
--- a/bootblocks/boot_minix.c
+++ b/bootblocks/boot_minix.c
@@ -101,8 +101,10 @@ void load_prog ()
 		if (!strcmp ((char *)(d_dir + 2 + d), "bootopts")) {
 			//puts("opts ");
 			i_now = (*(int *)(d_dir + d)) - 1;
-			loadaddr = OPTSEG << 4;
-			load_file ();
+			if (i_now != -1) {
+				loadaddr = OPTSEG << 4;
+				load_file ();
+			}
 			continue;
 		}
 	}


### PR DESCRIPTION
Fixes problem with ELKS not booting when /bootopts removed, found by @Mellvik in https://github.com/jbruchon/elks/issues/916#issuecomment-818532866.

The boot loader wasn't checking the directory entry's inode number (which was then 0) and tried to read from a non-existent sector.
