### PR TITLE
[cmds] Add changes for ELKS to run on 256K memory systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ endif
 
 include $(TOPDIR)/Make.defs
 
-.PHONY: all clean kconfig defconfig config menuconfig
+.PHONY: all clean libc kconfig defconfig config menuconfig
 
 all: .config include/autoconf.h
 	$(MAKE) -C libc all
@@ -30,6 +30,11 @@ clean:
 	    echo ' * `make config` or `make menuconfig` to configure it.' ;\
 	    echo ;\
 	fi
+
+libc:
+	$(MAKE) -C libc DESTDIR='$(TOPDIR)/cross' uninstall
+	$(MAKE) -C libc all
+	$(MAKE) -C libc DESTDIR='$(TOPDIR)/cross' install
 
 elks/arch/i86/drivers/char/KeyMaps/config.in:
 	$(MAKE) -C elks/arch/i86/drivers/char/KeyMaps config.in

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -78,7 +78,7 @@ sys_utils/ps					:sysutil		:360k
 sys_utils/reboot				:sysutil		:360k
 sys_utils/makeboot				:sysutil		:360k
 sys_utils/man					:sysutil				:1440k
-sys_utils/meminfo				:sysutil				:1440k
+sys_utils/meminfo				:sysutil		:360k
 sys_utils/mouse					:sysutil				:1440k
 sys_utils/passwd				:sysutil				:1440k
 sys_utils/poweroff				:sysutil			:720k
@@ -108,7 +108,7 @@ misc_utils/miniterm				:miscutil			:720k
 misc_utils/fdtest				:miscutil				:1440k
 misc_utils/tar					:miscutil				:1440k
 misc_utils/od					:miscutil				:1440k
-misc_utils/hd					:miscutil		:360k
+misc_utils/hd					:miscutil				:1440k
 misc_utils/time					:miscutil			:720k
 misc_utils/kilo					:miscutil				:1440k
 misc_utils/mined				:miscutil				:1440k

--- a/elkscmd/rootfs_template/etc/passwd
+++ b/elkscmd/rootfs_template/etc/passwd
@@ -1,5 +1,6 @@
 root::0:0:System Administrator:/root:/bin/sh
 toor::0:0:System Administrator:/root:/bin/sash
+mem::0:0:System Administrator:/root:/bin/meminfo
 bin:*:1:1:bin:/bin:
 daemon:*:2:2:System Daemon:/sbin:
 adm:*:3:4:adm:/var/adm:

--- a/elkscmd/sash/config.h
+++ b/elkscmd/sash/config.h
@@ -3,7 +3,9 @@
  */
 
 #define WILDCARDS
+#define BUILTINS      /* unset to build a very small shell for 256K systems */
 
+#ifdef BUILTINS
 #define CMD_ALIAS     /* 1048 bytes. Includes unalias */
 #define CMD_CHGRP     /* 2164 bytes */
 #define CMD_CHMOD     /*  260 bytes */
@@ -35,6 +37,7 @@
 #define CMD_TOUCH     /*  236 bytes */
 #define CMD_UMASK     /*  272  bytes */
 #define CMD_HISTORY
+#endif
 
 #ifdef CMD_CP
 #define FUNC_COPYFILE

--- a/elkscmd/sash/sash.c
+++ b/elkscmd/sash/sash.c
@@ -349,7 +349,10 @@ readfile(name)
 
 	while (TRUE) {
 		fflush(stdout);
-		if (ttyflag) showprompt();
+#ifdef CMD_SOURCE
+		if (ttyflag)
+#endif
+			showprompt();
 
 #ifdef CMD_SOURCE
 		if (intflag && !ttyflag && (fp != stdin)) {

--- a/elkscmd/sys_utils/init.c
+++ b/elkscmd/sys_utils/init.c
@@ -270,7 +270,7 @@ pid_t respawn(const char **a)
 	    execv(argv[0], argv);
 	}
 
-	fatalmsg("exec failed: %s\r\n", argv[0]);
+	fatalmsg("exec failed: %s (%d)\r\n", argv[0], errno);
     }
 
 /* here I must do something about utmp */

--- a/libc/system/execvp.c
+++ b/libc/system/execvp.c
@@ -155,6 +155,7 @@ execvp(char *fname, char **argv)
 
 	    tryrun(pname, argv);
 	    if( errno == EACCES ) besterr = EACCES;
+	    if( errno == ENOMEM ) goto out;
 
 	    brk(pname);
 	    pname = fname;


### PR DESCRIPTION
Adds features requested or required in #920 to enable ELKS to run on systems with as little as 256K RAM.

Adds ability to easily create a very slimmed-down version of the standalone shell `sash` with no builtin commands. This is turned on via editing elkscmd/sash/config.h and commenting out the line:
```
#define BUILTINS      /* unset to build a very small shell for 256K systems */
```
Adds "mem" login to run `meminfo` at login prompt.
Adds `meminfo` to 360k floppy images.
Adds errno to /bin/init "Can't exec" message for future debugging.
Fixes libc `execvp` function to properly return correct errno when no memory to run programs (for sash).
Adds "make libc" build entry point for faster rebuilding of libc when making changes in it.
