### PR TITLE
[init] Enhancements for running on smaller memory systems

### DIFF
--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,6 +1,6 @@
 ##
 #console=ttyS0 debug net=eth 3 # condensed
-#init=/bin/init 3	# multiuser serial
+#init=/bin/init 3 n	# multiuser serial no sysinit
 #init=/bin/sh		# singleuser shell
 #console=ttyS0,19200 # serial console
 #root=hda1			# hd partition 1

--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -44,7 +44,7 @@ getty: getty.o
 	$(LD) $(LDFLAGS) -maout-heap=1024 -maout-stack=1024 -o getty getty.o $(LDLIBS)
 
 login: getpass.o login.o
-	$(LD) $(LDFLAGS) -o login getpass.o login.o $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-stack=2048 -o login getpass.o login.o $(LDLIBS)
 
 kill: kill.o
 	$(LD) $(LDFLAGS) -o kill kill.o $(LDLIBS)
@@ -68,7 +68,7 @@ ps: ps.o
 	$(LD) $(LDFLAGS) -o ps ps.o $(LDLIBS)
 
 meminfo: meminfo.o
-	$(LD) $(LDFLAGS) -o meminfo meminfo.o $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-heap=1 -maout-stack=512 -o meminfo meminfo.o $(LDLIBS)
 
 who: who.o
 	$(LD) $(LDFLAGS) -o who who.o $(LDLIBS)

--- a/elkscmd/sys_utils/login.c
+++ b/elkscmd/sys_utils/login.c
@@ -88,7 +88,9 @@ void login(register struct passwd * pwd, struct utmp * ut_ent)
 
 	execl(pwd->pw_shell,sh_name,(char*)0);
 
-	write(STDOUT_FILENO, "No shell!\n", 10);
+	write(STDOUT_FILENO, "No shell (errno ", 16);
+	write(STDOUT_FILENO, itoa(errno), 2);
+	write(STDOUT_FILENO, ")\n", 2);
 	exit(1);
 }
 


### PR DESCRIPTION
Pursuant to discussions in #920 with @riktw, increases available RAM for applications programs.

Decreases size of `/bin/init` by almost 3K bytes, allowing for more usable program memory on small/all systems.
This was done by removing 1K buffers for stdin, stdout and stderr dragged in by any use of printf/stdio functions.

Decreases heap and stack usage of `meminfo` and `login` to allow running on systems with very little RAM.
Adds errno output on login "No shell" message to show possible memory shortage.

Adds 'n' option to `init` to not run SYSINIT script (typically /etc/rc.d/rc.sys). This option is usable in /bootopts as non-reserved keywords are passed to init as arguments. Thus, lines like the following will start ELKS without running SYSINIT:
```
init=/bin/init 1 n  # start at runlevel 1 (single user) and no sysinit
(or)
n
```
This enables ELKS boot on smaller systems without having to recompile the image or kernel.