### PR TITLE
Various cleanups from compressed executables PR

### DIFF
--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -378,10 +378,12 @@ int sys_execve(char *filename, char *sptr, size_t slen)
 #endif
     } else {
 	seg_get (seg_code);
-	filp->f_pos += esuph.esh_compr_tseg? esuph.esh_compr_tseg: (size_t)mh.tseg;
 #ifdef CONFIG_EXEC_MMODEL
+	filp->f_pos += esuph.esh_compr_tseg? esuph.esh_compr_tseg: (size_t)mh.tseg;
 	filp->f_pos += esuph.esh_compr_ftseg? esuph.esh_compr_ftseg: (size_t)esuph.esh_ftseg;
 	need_reloc_code = 0;
+#else
+	filp->f_pos += (size_t)mh.tseg;
 #endif
     }
 

--- a/elks/tools/elks-compress/.gitignore
+++ b/elks/tools/elks-compress/.gitignore
@@ -1,0 +1,5 @@
+exomizer/src/deps
+exomizer/src/exobasic
+exomizer/src/exomizer
+exomizer/src/sfxdecr
+exomizer/src/sfxdecr.c

--- a/elks/tools/elks-compress/Makefile
+++ b/elks/tools/elks-compress/Makefile
@@ -50,5 +50,10 @@ all:	../bin/elks-compress ../bin/exomizer
 	make -C exomizer/src
 	cp -p exomizer/src/exomizer ../bin/exomizer
 
+doclean: elks-compress-doclean
+
+elks-compress-doclean:
+	make -C exomizer/src clean
+
 #########################################################################
 ### Dependencies:


### PR DESCRIPTION
Fixes compile error when CONFIG_EXEC_MMODEL not set.

Removes exomizer binaries on source tree clean.