### PR TITLE
Move 8259 PIC and 8254 PIT handlers to seperate source files

### DIFF
--- a/Documentation/text/porting-guide.txt
+++ b/Documentation/text/porting-guide.txt
@@ -1,6 +1,6 @@
 ELKS Porting Guide
 ==================
-8 May 2021 - Rev 1 ghaerr
+11 May 2021 - Rev 2 ghaerr
 
 Platforms (target)
 -------------------------------------------
@@ -89,15 +89,10 @@ INT 10h AH=05h Select active page				CONFIG_CONSOLE_BIOS
 INT 10h AH=06h Scroll up						CONFIG_CONSOLE_BIOS
 INT 10h AH=07h Scroll up						CONFIG_CONSOLE_BIOS
 INT 10h AH=09h Write character at cursor		CONFIG_CONSOLE_BIOS
-INT 10h AH=0Ah Write character at cursor (EMU86 only)
 INT 10h AH=0Eh Write teletype current page		CONFIG_CONSOLE_HEADLESS,boot_sect.S,setup.S
 INT 10h AH=0Fh Get video mode					setup.S
 INT 10h AH=12h Get EGA video configuration		CONFIG_HW_VGA
 INT 10h AH=1Ah Get VGA video configuration		CONFIG_HW_VGA
-INT 10h AH=13h Write string (EMU86 only)
-INT 10h AH=1Dh Write byte as hexidecimal (EMU86 only)
-
-INT 11h        BIOS device list (EMU86 only)
 
 INT 12h        Get memory in kilobytes			boot_sect.S, setup.S
 
@@ -106,14 +101,6 @@ INT 13h AH=02h Read disk sector					CONFIG_BLK_DEV_BIOS, boot_sect.S
 INT 13h AH=03h Write disk sector				CONFIG_BLK_DEV_BIOS
 INT 13h AH=08h Get drive parms					CONFIG_BLK_DEV_BIOS
 
-INT 15h        BIOS misc services (EMU86 only)
-
 INT 16h AH=00h Wait and read keyboard char		CONFIG_CONSOLE_HEADLESS, boot_sect.S
 INT 16h AH=01h Peek keyboard char				CONFIG_CONSOLE_HEADLESS
 INT 16h AH=03h Set typematic rate				CONFIG_HW_KEYBOARD_BIOS
-INT 16h AH=11h Wait and read keyboard char (EMU86 only)
-INT 16h AH=10h Extended wait and read char (EMU86 only)
-
-INT 17h        BIOS Printer services (EMU86 only)
-
-INT 1Ah        BIOS Time services (EMU86 only)

--- a/elks/arch/i86/kernel/Makefile
+++ b/elks/arch/i86/kernel/Makefile
@@ -35,12 +35,11 @@ include $(BASEDIR)/Makefile-rules
 #########################################################################
 # Objects to be compiled.
 
-ifeq ($(CONFIG_ARCH_SIBO), y)
-OBJS  = strace.o system.o irq.o ../sibo/irqtab.o process.o \
-		entry.o signal.o timer.o
-else
 OBJS  = strace.o system.o irq.o irqtab.o process.o \
 		entry.o signal.o timer.o
+
+ifeq ($(CONFIG_ARCH_IBMPC), y)
+OBJS += irq-8259.o timer-8254.o
 endif
 
 #########################################################################

--- a/elks/arch/i86/kernel/irq-8259.c
+++ b/elks/arch/i86/kernel/irq-8259.c
@@ -1,0 +1,68 @@
+/*
+ * 8259 Programmable Interrupt Controller
+ *
+ * This file contains code used for the 8259 PIC only.
+ */
+
+#include <linuxmt/config.h>
+#include <linuxmt/errno.h>
+#include <linuxmt/sched.h>
+#include <linuxmt/types.h>
+
+#include <arch/io.h>
+#include <arch/irq.h>
+
+static unsigned char cache_21 = 0xff, cache_A1 = 0xff;
+
+/*
+ *	Low level interrupt handling for the X86 PC/XT and PC/AT platform
+ */
+
+void init_irq(void)
+{
+#ifdef CONFIG_HW_259_USE_ORIGINAL_MASK	/* for example Debugger :-) */
+    cache_21 = inb_p(0x21);
+#endif
+}
+
+void enable_irq(unsigned int irq)
+{
+    unsigned char mask;
+
+    mask = ~(1 << (irq & 7));
+    if (irq < 8) {
+	cache_21 &= mask;
+	outb(cache_21,((void *) 0x21)); //FIXME
+    } else {
+	cache_A1 &= mask;
+	outb(cache_A1,((void *) 0xA1));
+    }
+}
+
+int remap_irq(int irq)
+{
+    if ((unsigned int)irq > 15 || (irq > 7 && !(sys_caps & CAP_IRQ8TO15)))
+	return -EINVAL;
+    if (irq == 2 && (sys_caps & CAP_IRQ2MAP9))
+	irq = 9;			/* Map IRQ 9/2 over */
+    return irq;
+}
+
+#if 0
+void disable_irq(unsigned int irq)
+{
+    flag_t flags;
+    unsigned char mask = 1 << (irq & 7);
+
+    save_flags(flags);
+    clr_irq();
+    if (irq < 8) {
+	cache_21 |= mask;
+	outb(cache_21,((void *) 0x21));
+    } else {
+	cache_A1 |= mask;
+	outb(cache_A1,((void *) 0xA1));
+    }
+    restore_flags(flags);
+}
+#endif

--- a/elks/arch/i86/kernel/timer-8254.c
+++ b/elks/arch/i86/kernel/timer-8254.c
@@ -1,0 +1,51 @@
+/*
+ * 8253/8254 Programmable Interval Timer
+ *
+ * This file contains code used for the 8253/8254 PIT only.
+ */
+
+#include <linuxmt/config.h>
+#include <linuxmt/config.h>
+#include <linuxmt/mm.h>
+#include <linuxmt/timer.h>
+
+#include <arch/io.h>
+#include <arch/irq.h>
+#include <arch/param.h>
+#include <arch/ports.h>
+
+/*
+ * 4/2001 Use macros to directly generate timer constants based on the
+ *        value of HZ macro. This works the same for both the 8253 and
+ *        8254 timers. - Thomas McWilliams  <tmwo@users.sourceforge.net>
+ *
+ *  These 8253/8254 macros generate proper timer constants based on the
+ *  timer tick macro HZ which is defined in param.h (usually 100 Hz).
+ *
+ *  The PC timer chip can be programmed to divide its reference frequency
+ *  by a 16 bit unsigned number. The reference frequency of 1193181.8 Hz
+ *  happens to be 1/3 of the NTSC color burst frequency. In fact, the
+ *  hypothetical exact reference frequency for the timer is 39375000/33 Hz.
+ *  The macros use scaled fixed point arithmetic for greater accuracy.
+ */
+
+#define TIMER_MODE0 0x30   /* timer 0, binary count, mode 0, lsb/msb */
+#define TIMER_MODE2 0x34   /* timer 0, binary count, mode 2, lsb/msb */
+
+#define TIMER_LO_BYTE (__u8)(((5+(11931818L/(HZ)))/10)%256)
+#define TIMER_HI_BYTE (__u8)(((5+(11931818L/(HZ)))/10)/256)
+
+void enable_timer_tick(void)
+{
+    /* set the clock frequency */
+    outb (TIMER_MODE2, (void*)TIMER_CMDS_PORT);
+    outb (TIMER_LO_BYTE, (void*)TIMER_DATA_PORT);	/* LSB */
+    outb (TIMER_HI_BYTE, (void*)TIMER_DATA_PORT);	/* MSB */
+}
+
+void disable_timer_tick(void)
+{
+    outb (TIMER_MODE0, (void*)TIMER_CMDS_PORT);
+    outb (0, (void*)TIMER_DATA_PORT);
+    outb (0, (void*)TIMER_DATA_PORT);
+}

--- a/elks/arch/i86/kernel/timer.c
+++ b/elks/arch/i86/kernel/timer.c
@@ -12,32 +12,12 @@
  *
  * 9/1999 The 100 Hz system timer 0 can configure for variable input
  *        frequency. Christian Mardm"oller (chm@kdt.de)
- *
- * 4/2001 Use macros to directly generate timer constants based on the
- *        value of HZ macro. This works the same for both the 8253 and
- *        8254 timers. - Thomas McWilliams  <tmwo@users.sourceforge.net>
  */
 
 volatile jiff_t jiffies = 0;
 static int spin_on;
 
 extern void rs_pump(void);
-
-/*  These 8253/8254 macros generate proper timer constants based on the
- *  timer tick macro HZ which is defined in param.h (usually 100 Hz).
- *
- *  The PC timer chip can be programmed to divide its reference frequency
- *  by a 16 bit unsigned number. The reference frequency of 1193181.8 Hz
- *  happens to be 1/3 of the NTSC color burst frequency. In fact, the
- *  hypothetical exact reference frequency for the timer is 39375000/33 Hz.
- *  The macros use scaled fixed point arithmetic for greater accuracy.
- */
-
-#define TIMER_MODE0 0x30   /* timer 0, binary count, mode 0, lsb/msb */
-#define TIMER_MODE2 0x34   /* timer 0, binary count, mode 2, lsb/msb */
-
-#define TIMER_LO_BYTE (__u8)(((5+(11931818L/(HZ)))/10)%256)
-#define TIMER_HI_BYTE (__u8)(((5+(11931818L/(HZ)))/10)/256)
 
 void timer_tick(int irq, struct pt_regs *regs, void *data)
 {
@@ -47,17 +27,6 @@ void timer_tick(int irq, struct pt_regs *regs, void *data)
     rs_pump();		/* check if received serial chars and call wake_up*/
 #endif
 
-#ifdef CONFIG_ARCH_SIBO
-    /* As we are now responsible for clearing interrupt */
-	extern void keyboard_irq(int, struct pt_regs *, void *);
-    clr_irq();
-    outb(0x0, 0x0A);
-    outb(0x0, 0x0C);
-    outb(0x0, 0x10);
-    set_irq();
-    keyboard_irq(1, regs, NULL);
-#else
-
 #ifdef CONFIG_CONSOLE_DIRECT
     /* spin timer wheel in upper right of screen*/
     if (spin_on && !(jiffies & 7)) {
@@ -66,29 +35,6 @@ void timer_tick(int irq, struct pt_regs *regs, void *data)
 
 	pokeb((79 + 0*80) * 2, 0xB800, wheel[c++ & 0x03]);
     }
-#endif
-#endif
-}
-
-void enable_timer_tick(void)
-{
-#ifdef CONFIG_ARCH_SIBO
-    outb (0x00, 0x15);
-    outb (0x02, 0x08);
-#else
-    /* set the clock frequency */
-    outb (TIMER_MODE2, (void*)TIMER_CMDS_PORT);
-    outb (TIMER_LO_BYTE, (void*)TIMER_DATA_PORT);	/* LSB */
-    outb (TIMER_HI_BYTE, (void*)TIMER_DATA_PORT);	/* MSB */
-#endif
-}
-
-void stop_timer(void)
-{
-#ifndef CONFIG_ARCH_SIBO
-    outb (TIMER_MODE0, (void*)TIMER_CMDS_PORT);
-    outb (0, (void*)TIMER_DATA_PORT);
-    outb (0, (void*)TIMER_DATA_PORT);
 #endif
 }
 

--- a/elks/include/arch/irq.h
+++ b/elks/include/arch/irq.h
@@ -3,11 +3,15 @@
 
 #include <linuxmt/types.h>
 
-extern void disable_irq(unsigned int);
-extern void enable_irq(unsigned int);
-extern void do_IRQ(int,void *);
-extern int request_irq(int,void (*)(int,struct pt_regs *,void *),void *);
-extern void free_irq(unsigned int);
+/* irq.c*/
+void do_IRQ(int,void *);
+int request_irq(int,void (*)(int,struct pt_regs *,void *),void *);
+
+/* irq-8259.c*/
+void init_irq(void);
+void enable_irq(unsigned int);
+int remap_irq(int);
+
 void idle_halt(void);
 
 #ifdef __KERNEL__

--- a/elks/include/linuxmt/timer.h
+++ b/elks/include/linuxmt/timer.h
@@ -82,13 +82,19 @@ struct timer_list {
 };
 
 struct pt_regs;
+
+/* sched.c*/
 extern void init_timer(struct timer_list *);
 extern void add_timer(struct timer_list *);
 extern int del_timer(struct timer_list *);
-extern void timer_tick(int, struct pt_regs *, void *);
-extern void enable_timer_tick(void);
-extern void stop_timer(void);
 extern void do_timer(struct pt_regs *);
-extern void spin_timer(int);
+
+/* timer.c*/
+void timer_tick(int, struct pt_regs *, void *);
+void spin_timer(int);
+
+/* timer-8254.c*/
+void enable_timer_tick(void);
+void disable_timer_tick(void);
 
 #endif


### PR DESCRIPTION
First of a few cleanup PRs to seperate chip-specific kernel files into their own source file for ease of porting.
Adds `irq-8259.c` and `timer-8254.c` source files for IBM PC architecture. Chip-specific PIC code in `irqtab.S` still remains.

This will be useful should @cocus or @mfld-fr submit PRs for 8086 SBCs with non-IBM PC programmable interrupt controllers (PICs) or programmable interval timers (PITs).

Updated porting-guide.txt to only functions required in ROM BIOS for ELKS.
The SIBO port is slowly being removed with the cleanup PRs.
