### PR TITLE
[kernel] Allow setup.S INITSEG values to be specified in config.h

### DIFF
--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -87,7 +87,7 @@ static void INITPROC add_partition(struct gendisk *hd, unsigned short int minor,
      * a device number, then we do not really need boot_partition.
      */
     if (ROOT_DEV == (0x80 | minor >> hd->minor_shift)) {
-	sector_t boot_start = setupw(0x1e2) | (sector_t) setupw(0x1e4) << 16;
+	sector_t boot_start = SETUP_PART_OFFSETLO | (sector_t) SETUP_PART_OFFSETHI << 16;
 	if (start == boot_start)
 	    boot_partition = minor;
     }

--- a/elks/arch/i86/drivers/block/init.c
+++ b/elks/arch/i86/drivers/block/init.c
@@ -49,7 +49,7 @@ void INITPROC device_init(void)
      * drive number.  If so, convert it into a proper <major, minor> block
      * device number.  -- tkchia 20200308
      */
-    if (!boot_rootdev && (setupw(0x1f6) & EF_BIOS_DEV_NUM) != 0) {
+    if (!boot_rootdev && (SETUP_ELKS_FLAGS & EF_BIOS_DEV_NUM) != 0) {
 	extern kdev_t INITPROC bioshd_conv_bios_drive(unsigned int biosdrive);
 
 	kdev_t rootdev = bioshd_conv_bios_drive((unsigned)ROOT_DEV);

--- a/elks/arch/i86/drivers/char/bioscon.c
+++ b/elks/arch/i86/drivers/char/bioscon.c
@@ -168,10 +168,10 @@ void console_init(void)
     register Console *C;
     register int i;
 
-    MaxCol = (Width = setupb(7)) - 1;
+    MaxCol = (Width = SETUP_VID_COLS) - 1;
 
     /* Trust this. Cga does not support peeking at 0x40:0x84. */
-    MaxRow = (Height = setupb(14)) - 1;
+    MaxRow = (Height = SETUP_VID_LINES) - 1;
 
     if (peekb(0x49, 0x40) == 7)  /* BIOS data segment */
 	NumConsoles = 1;

--- a/elks/arch/i86/kernel/irq-8259.c
+++ b/elks/arch/i86/kernel/irq-8259.c
@@ -12,6 +12,12 @@
 #include <arch/io.h>
 #include <arch/irq.h>
 
+/* 8259 Command/Data ports */
+#define PIC1_CMD   0x20   /* master */
+#define PIC1_DATA  0x21
+#define PIC2_CMD   0xA0   /* slave */
+#define PIC2_DATA  0xA1
+
 static unsigned char cache_21 = 0xff, cache_A1 = 0xff;
 
 /*
@@ -21,7 +27,7 @@ static unsigned char cache_21 = 0xff, cache_A1 = 0xff;
 void init_irq(void)
 {
 #ifdef CONFIG_HW_259_USE_ORIGINAL_MASK	/* for example Debugger :-) */
-    cache_21 = inb_p(0x21);
+    cache_21 = inb_p(PIC1_DATA);
 #endif
 }
 
@@ -32,10 +38,10 @@ void enable_irq(unsigned int irq)
     mask = ~(1 << (irq & 7));
     if (irq < 8) {
 	cache_21 &= mask;
-	outb(cache_21,((void *) 0x21)); //FIXME
+	outb(cache_21, PIC1_DATA);
     } else {
 	cache_A1 &= mask;
-	outb(cache_A1,((void *) 0xA1));
+	outb(cache_A1, PIC2_DATA);
     }
 }
 
@@ -58,10 +64,10 @@ void disable_irq(unsigned int irq)
     clr_irq();
     if (irq < 8) {
 	cache_21 |= mask;
-	outb(cache_21,((void *) 0x21));
+	outb(cache_21, PIC1_DATA);
     } else {
 	cache_A1 |= mask;
-	outb(cache_A1,((void *) 0xA1));
+	outb(cache_A1, PIC2_DATA);
     }
     restore_flags(flags);
 }

--- a/elks/arch/i86/kernel/irq.c
+++ b/elks/arch/i86/kernel/irq.c
@@ -78,15 +78,12 @@ int request_irq(int irq, void (*handler)(int,struct pt_regs *,void *), void *dev
     flag_t flags;
 
     irq = remap_irq(irq);
-    if (irq < 0)
+    if (irq < 0 || !handler)
 	return -EINVAL;
 
     action = irq_action + irq;
     if (action->handler != default_handler)
 	return -EBUSY;
-
-    if (!handler)
-	return -EINVAL;
 
     save_flags(flags);
     clr_irq();
@@ -94,7 +91,7 @@ int request_irq(int irq, void (*handler)(int,struct pt_regs *,void *), void *dev
     action->handler = handler;
     action->dev_id = dev_id;
 
-    enable_irq((unsigned int) irq);
+    enable_irq(irq);
 
     restore_flags(flags);
 
@@ -122,8 +119,6 @@ void free_irq(unsigned int irq)
 
     action->handler = default_handler;
     action->dev_id = NULL;
-/*    action->flags = 0;
-    action->name = NULL;*/
 
     restore_flags(flags);
 }

--- a/elks/arch/i86/kernel/system.c
+++ b/elks/arch/i86/kernel/system.c
@@ -12,34 +12,28 @@
 
 byte_t sys_caps;		/* system capabilities bits */
 
-#ifdef CONFIG_ARCH_SIBO
-extern long int basmem;
-#endif
-
 void INITPROC setup_arch(seg_t *start, seg_t *end)
 {
 #ifdef CONFIG_COMPAQ_FAST
-/*
- *	Switch COMPAQ Deskpro to high speed
- */
-    outb_p(1,0xcf);
+	outb_p(1,0xcf);	/* Switch COMPAQ Deskpro to high speed */
 #endif
 
-/*
- *	Fill in the MM numbers - really ought to be in mm not kernel ?
- */
-
-	/* Extend kernel data segment to maximum of 64K */
-	/* to make room for local heap */
+	/*
+	 * Set start to beginning of available main memory, which
+	 * is directly after end of the kernel data segment.
+	 *
+	 * Extend kernel data segment to maximum of 64K to make room
+	 * for local heap.
+	 *
+	 * Set end to end of available main memory.
+	 *
+	 * If ramdisk configured, subtract space for it from end of memory.
+	 */
 
 	/* *start = kernel_ds + (((unsigned int) (_endbss+15)) >> 4); */
 	*start = kernel_ds + 0x1000;
 
-#ifdef CONFIG_ARCH_SIBO
-	*end = basmem << 6;
-#else
-	*end = (seg_t)setupw(0x2a) << 6;
-#endif
+	*end = (seg_t)SETUP_MEM_KBYTES << 6;
 
 #if defined(CONFIG_RAMDISK_SEGMENT) && (CONFIG_RAMDISK_SEGMENT > 0)
 	if (CONFIG_RAMDISK_SEGMENT <= *end) {
@@ -56,12 +50,12 @@ void INITPROC setup_arch(seg_t *start, seg_t *end)
 	heap_add ((void *)endbss, 1 + ~endbss);
 
 	/* Misc */
-	ROOT_DEV = setupw(0x1fc);
+	ROOT_DEV = SETUP_ROOT_DEV;
 
 #ifdef SYS_CAPS
 	sys_caps = SYS_CAPS;	/* custom system capabilities */
 #else
-	byte_t arch_cpu = setupb(0x20);
+	byte_t arch_cpu = SETUP_CPU_TYPE;
 	if (arch_cpu > 5)		/* IBM PC/AT capabilities */
 		sys_caps = CAP_ALL;
 #endif

--- a/elks/arch/i86/kernel/timer-8254.c
+++ b/elks/arch/i86/kernel/timer-8254.c
@@ -38,14 +38,14 @@
 void enable_timer_tick(void)
 {
     /* set the clock frequency */
-    outb (TIMER_MODE2, (void*)TIMER_CMDS_PORT);
-    outb (TIMER_LO_BYTE, (void*)TIMER_DATA_PORT);	/* LSB */
-    outb (TIMER_HI_BYTE, (void*)TIMER_DATA_PORT);	/* MSB */
+    outb (TIMER_MODE2, TIMER_CMDS_PORT);
+    outb (TIMER_LO_BYTE, TIMER_DATA_PORT);	/* LSB */
+    outb (TIMER_HI_BYTE, TIMER_DATA_PORT);	/* MSB */
 }
 
 void disable_timer_tick(void)
 {
-    outb (TIMER_MODE0, (void*)TIMER_CMDS_PORT);
-    outb (0, (void*)TIMER_DATA_PORT);
-    outb (0, (void*)TIMER_DATA_PORT);
+    outb (TIMER_MODE0, TIMER_CMDS_PORT);
+    outb (0, TIMER_DATA_PORT);
+    outb (0, TIMER_DATA_PORT);
 }

--- a/elks/arch/i86/mm/init.c
+++ b/elks/arch/i86/mm/init.c
@@ -53,7 +53,7 @@ void INITPROC mm_stat(seg_t start, seg_t end)
 	*cp++ = setupb(i++);
 	if (i == 0x40) {
 	    printk("PC/%cT class machine, %s CPU, %uK base RAM",
-		    (sys_caps & CAP_PC_AT) ? 'A' : 'X', proc_name, setupw(0x2a));
+		    (sys_caps & CAP_PC_AT) ? 'A' : 'X', proc_name, SETUP_MEM_KBYTES);
 	    cp = proc_name;
 	    i = 0x50;
 	}

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -5,6 +5,20 @@
 #include <linuxmt/major.h>
 
 /*
+ * Setup data - normally queried by startup setup.S code, but can
+ * be overridden for embedded systems with less overhead.
+ * See setup.S for more details.
+ */
+#define SETUP_VID_COLS		setupb(7)		/* BIOS video # columns */
+#define SETUP_VID_LINES		setupb(14)		/* BIOS video # lines */
+#define SETUP_CPU_TYPE		setupb(0x20)	/* processor type */
+#define SETUP_MEM_KBYTES	setupw(0x2a)	/* base memory in 1K bytes */
+#define SETUP_ROOT_DEV		setupw(0x1fc)	/* root device, kdev_t or BIOS dev */
+#define SETUP_ELKS_FLAGS	setupw(0x1f6)	/* flags for root device type */
+#define SETUP_PART_OFFSETLO	setupw(0x1e2)	/* partition offset low word */
+#define SETUP_PART_OFFSETHI	setupw(0x1e4)	/* partition offset high word */
+
+/*
  * System capabilities - configurable for ROM or custom installations.
  * Normally, all capabilities will be set if arch_cpu > 5 (PC/AT),
  * except when SYS_CAPS is defined for custom installations or emulations.


### PR DESCRIPTION
Further work on easing porting of ELKS to embedded or non-PC systems.

This PR allows system configuration normally determined by setup.S at kernel pre-boot time to be specified at compile-time in config.h to lessen dependencies on IBM PC BIOS architecture. This also centralizes more porting dependencies in one file, config.h.

Adds defines for 8259 PIC command and data ports.
Additional cleanup work in architecture-specific setup routine `setup_arch()`.
More SIBO code removed.

At some point in the future, a lot of the initial setup.S code dealing with system startup can be moved into a seperate area, allowing easier removal for porting to other systems.