### PR TITLE
[setup] Allow IBM PC specific code to be removed from setup.S for new ports

### DIFF
--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -230,6 +230,16 @@ start_os:
 	stosw
 #endif
 
+#ifdef CONFIG_ARCH_IBMPC
+//
+// Set keyboard repeat rate using INT 16h
+// Determine display type using INT 10h AH=12 and INT 10h AH=1A
+// Get display page and mode using INT 10h AH=0F
+// Determine CPU type using somewhat outdated methods
+// Clear BIOS data area for fd/hd (24 bytes)
+// Determine size of main memory using INT 12h
+// FIXME move to separate setup-bios.S file or individual drivers
+
 #ifdef CONFIG_HW_KEYBOARD_BIOS
 	mov	$0x0305,%ax	// set the keyboard repeat rate to the max
 	xor	%bx,%bx
@@ -262,7 +272,7 @@ start_os:
 #else
         mov   $25,%al		// height of display in rows
 #endif
-#endif
+#endif /* CONFIG_HW_VGA*/
 
 novga:	mov	%al,14		// CGA 25 rows
 
@@ -290,6 +300,7 @@ novga:	mov	%al,14		// CGA 25 rows
 	mov	%ax,%ds
 	int	$0x12		// determine the size of the basememory
 	mov	%ax,0x2a
+#endif /* CONFIG_ARCH_IBMPC*/
 
 // End of shared setup code
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -735,8 +746,9 @@ add_ptr:
 
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+#ifdef CONFIG_ARCH_IBMPC
 /*
-! TODO: move probing to boot tools
+! TODO move to setup-cpuid.S or remove entirely (inaccurate/outdated)
 ! Probe for the CPU
 ! These information is taken from "PC intern 3.0", Data Becker Verlag, 1992
 ! and from the Linux-Kernel, arch/i386/kernel/head.S
@@ -907,7 +919,41 @@ queue_end:
 
 	or	%dx,%dx
 	ret
+//
+// The processor name must not be longer than 15 characters!
+//
+#if !defined(CONFIG_ROMCODE) || defined(CONFIG_CPU_8086)
+p8088:	.ascii "Intel 8088"
+	.byte 0
+p8086:	.ascii "Intel 8086"
+	.byte 0
+pv20:	.ascii "NEC V20"
+	.byte 0
+pv30:	.ascii "NEC V30"
+	.byte 0
+p80188:	.ascii "Intel 80188"
+	.byte 0
+p80186:	.ascii "Intel 80186"
+	.byte 0
 #endif
+#if !defined(CONFIG_ROMCODE) || defined(CONFIG_CPU_80286)
+p80286:	.ascii "Intel 80286"
+	.byte 0
+#endif
+#if !defined(CONFIG_ROMCODE)
+px86:   .ascii "Unknown x86"
+	.byte 0
+#endif
+//
+// Here is the CPU id stored
+//
+v_id:	.byte 0,0,0,0
+v_id2:	.byte 0,0,0,0
+v_id3:	.byte 0,0,0,0
+	.byte 0
+
+#endif /* !defined(CONFIG_ROMCODE) || defined(CONFIG_CPU_8086)*/
+#endif /* CONFIG_ARCH_IBMPC*/
 
 // Utility/debugging routines
 
@@ -970,39 +1016,6 @@ hex4sp: call hex4
 	call putc
 	pop %ax
 	ret
-
-//
-// The processor name must not be longer than 15 characters!
-//
-#if !defined(CONFIG_ROMCODE) || defined(CONFIG_CPU_8086)
-p8088:	.ascii "Intel 8088"
-	.byte 0
-p8086:	.ascii "Intel 8086"
-	.byte 0
-pv20:	.ascii "NEC V20"
-	.byte 0
-pv30:	.ascii "NEC V30"
-	.byte 0
-p80188:	.ascii "Intel 80188"
-	.byte 0
-p80186:	.ascii "Intel 80186"
-	.byte 0
-#endif
-#if !defined(CONFIG_ROMCODE) || defined(CONFIG_CPU_80286)
-p80286:	.ascii "Intel 80286"
-	.byte 0
-#endif
-#if !defined(CONFIG_ROMCODE)
-px86:   .ascii "Unknown x86"
-	.byte 0
-#endif
-//
-// Here is the CPU id stored
-//
-v_id:	.byte 0,0,0,0
-v_id2:	.byte 0,0,0,0
-v_id3:	.byte 0,0,0,0
-	.byte 0
 
 no_sig_mess:	.ascii	"No ELKS setup signature found ..."
 		.byte	0x00

--- a/elks/arch/i86/mm/init.c
+++ b/elks/arch/i86/mm/init.c
@@ -28,42 +28,36 @@
  *	INITSEG:0x01ff	- AA if psmouse present
  */
 
-char proc_name[16];
 __u16 kernel_cs, kernel_ds;
 
 void INITPROC mm_stat(seg_t start, seg_t end)
 {
+#ifdef CONFIG_ARCH_IBMPC
     register int i;
     register char *cp;
+    static char proc_name[16];
 
-#ifdef CONFIG_ARCH_SIBO
-    i = 0x30;
-    cp = proc_name;
-    do {
-	*cp++ = setupb(i++);
-
-    } while (i < 0x40);
-    printk("Psion Series 3a machine, %s CPU\n%uK base"
-	    ", CPUID `NEC V30'", proc_name, basemem);
-
-#else
     i = 0x30;
     cp = proc_name;
     do {
 	*cp++ = setupb(i++);
 	if (i == 0x40) {
-	    printk("PC/%cT class machine, %s CPU, %uK base RAM",
-		    (sys_caps & CAP_PC_AT) ? 'A' : 'X', proc_name, SETUP_MEM_KBYTES);
+	    printk("PC/%cT class machine, %s CPU, ",
+		    (sys_caps & CAP_PC_AT) ? 'A' : 'X', proc_name);
 	    cp = proc_name;
 	    i = 0x50;
 	}
     } while (i < 0x5D);
     if (*proc_name)
 	printk(", CPUID `%s'", proc_name);
-
 #endif
 
-    printk(".\nELKS kernel %s (%u text, %u ftext, %u data, %u bss, %u heap)\n",
+#ifdef CONFIG_ARCH_8018X
+    printk("8018X machine, ");
+#endif
+
+    printk("%uK base RAM.\n", SETUP_MEM_KBYTES);
+    printk("ELKS kernel %s (%u text, %u ftext, %u data, %u bss, %u heap)\n",
 	   system_utsname.release,
 	   (unsigned)_endtext, (unsigned)_endftext, (unsigned)_enddata,
 	   (unsigned)_endbss - (unsigned)_enddata,


### PR DESCRIPTION
When CONFIG_ARCH_IBMPC not set, removes all BIOS INT calls in setup.S for probing system configuration.
These values are currently set for non-IBM PC ports in config.h.

Setup data segment still exists for the time being.

@cocus, you should be good to go for your CONFIG_ROMCODE and CONFIG_ARCH_8018X port, as far as setup.S is concerned, as well as no BIOS dependencies in startup code. The entry point for you after system init will be `start_os` in setup.S.