### PR TITLE
[build] Generate system-nm.map file on kernel build

### DIFF
--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -203,6 +203,7 @@ CFLAGS  = $(CROSS_CFLAGS) $(CPU_CC) $(ARCH_CC) $(CFLBASE) -Wall -Os -Wno-strict-
 LD      = ia16-elf-ld.gold
 LDFLAGS = $(CPU_LD) -s
 POSTLINK = elf2elks
+NM      = ia16-elf-nm
 AR      = ia16-elf-ar
 
 INCLUDES += -I$(TOPDIR)/libc/include

--- a/elks/arch/i86/Makefile
+++ b/elks/arch/i86/Makefile
@@ -132,10 +132,11 @@ else
 # Begin PC image build
 
 boot/system:	$(XINCLUDE) $(AARCHIVES) $(ADRIVERS) boot/crt0.o
-	(cd $(BASEDIR) ; $(LD) $(LDFLAGS) -M $(ARCH_LD) -T $(TOPDIR)/elks/elks-small.ld \
+	(cd $(BASEDIR) ; $(LD) $(CPU_LD) -M $(ARCH_LD) -T $(TOPDIR)/elks/elks-small.ld \
 		$(ARCH_DIR)/boot/crt0.o \
 		init/main.o '-(' $(ARCHIVES) $(DRIVERS) '-)' $(LIBGCC) \
 		-o $(ARCH_DIR)/boot/system > $(ARCH_DIR)/boot/system.map ; \
+		$(NM) $(ARCH_DIR)/boot/system > $(ARCH_DIR)/boot/system-nm.map; \
 		$(POSTLINK) $(ROMPOSTLINKFLAGS) $(ARCH_DIR)/boot/system)
 #		sort -k3,4 $(ARCH_DIR)/boot/system.tmp > $(ARCH_DIR)/boot/system.map ; \
 #		rm -f $(ARCH_DIR)/boot/system.tmp )


### PR DESCRIPTION
Adds map file containing pubic and private symbols to kernel build.

Required for EMU86 enhancement PR https://github.com/mfld-fr/emu86/pull/71.