### PR TITLE
8018x port of PIT, PIC + headless console

### DIFF
--- a/elks/arch/i86/drivers/char/Makefile
+++ b/elks/arch/i86/drivers/char/Makefile
@@ -39,6 +39,11 @@ ifeq ($(CONFIG_ARCH_SIBO), y)
 OBJS  = init.o sibo/sibo_con.o sibo/sibo_conasm.o sibo/sibo_font.o \
 	sibo/sibo_key.o sibo/sibo_keyasm.o mem.o \
 	meta.o ntty.o sibo/sibo_serasm.o pty.o
+else ifeq ($(CONFIG_ARCH_8018X), y)
+	OBJS  = init.o mem.o \
+		ntty.o meta.o tcpdev.o pty.o bell.o
+
+	OBJS += headless-8018x.o
 else
 OBJS  = serial.o serfast.o lp.o init.o mem.o \
 	ntty.o meta.o tcpdev.o pty.o bell.o

--- a/elks/arch/i86/drivers/char/headless-8018x.c
+++ b/elks/arch/i86/drivers/char/headless-8018x.c
@@ -1,0 +1,95 @@
+/*
+ * Headless Console using 80C18X's Serial1
+ *
+ * Based off Greg Haerr's "headless-bios.c"
+ * 
+ * This file contains code used for the embedded 8018X family only.
+ * 
+ * 16 May 21 Santiago Hormazabal
+ */
+
+#include <linuxmt/types.h>
+#include <linuxmt/config.h>
+#include <linuxmt/errno.h>
+#include <linuxmt/fcntl.h>
+#include <linuxmt/fs.h>
+#include <linuxmt/kernel.h>
+#include <linuxmt/major.h>
+#include <linuxmt/mm.h>
+#include <linuxmt/timer.h>
+#include <linuxmt/sched.h>
+#include <linuxmt/chqueue.h>
+#include <linuxmt/ntty.h>
+#include <arch/io.h>
+#include <arch/segment.h>
+#include "console.h"
+
+
+void console_init(void)
+{
+    printk("8018X serial headless console\n");
+}
+
+void cout(char c)
+{
+    while((inw(0xff00 + 0x66) & 8) == 0); /* S0STS */
+    outb(c, 0xff00 + 0x6A); /* T0BUF */
+}
+
+void Console_conin(unsigned char Key)
+{
+    register struct tty *ttyp = &ttys[0];	/* /dev/tty1*/
+
+    if (!tty_intcheck(ttyp, Key))
+	chq_addch(&ttyp->inq, Key);
+}
+
+void Console_conout(dev_t dev, char Ch)
+{
+    if (Ch == '\n')
+        cout('\r');
+    
+    cout(Ch);
+}
+
+static int Console_ioctl(struct tty *tty, int cmd, char *arg)
+{
+    switch (cmd) {
+    case TCSETS:
+    case TCSETSW:
+    case TCSETSF:
+	return 0;
+    }
+
+    return -EINVAL;
+}
+
+static int Console_write(register struct tty *tty)
+{
+    int cnt = 0;
+
+    while (tty->outq.len > 0) {
+        cout((byte_t)tty_outproc(tty));
+        cnt++;
+    }
+    return cnt;
+}
+
+static void Console_release(struct tty *tty)
+{
+    ttystd_release(tty);
+}
+
+static int Console_open(register struct tty *tty)
+{
+    return ttystd_open(tty);
+}
+
+struct tty_ops headlesscon_ops = {
+    Console_open,
+    Console_release,
+    Console_write,
+    NULL,
+    Console_ioctl,
+    Console_conout
+};

--- a/elks/arch/i86/kernel/Makefile
+++ b/elks/arch/i86/kernel/Makefile
@@ -42,6 +42,10 @@ ifeq ($(CONFIG_ARCH_IBMPC), y)
 OBJS += irq-8259.o timer-8254.o
 endif
 
+ifeq ($(CONFIG_ARCH_8018X), y)
+OBJS += irq-8018x.o timer-8254.o
+endif
+
 #########################################################################
 # Commands.
 

--- a/elks/arch/i86/kernel/Makefile
+++ b/elks/arch/i86/kernel/Makefile
@@ -43,7 +43,7 @@ OBJS += irq-8259.o timer-8254.o
 endif
 
 ifeq ($(CONFIG_ARCH_8018X), y)
-OBJS += irq-8018x.o timer-8254.o
+OBJS += irq-8018x.o timer-8018x.o
 endif
 
 #########################################################################

--- a/elks/arch/i86/kernel/irq-8018x.c
+++ b/elks/arch/i86/kernel/irq-8018x.c
@@ -1,0 +1,45 @@
+/*
+ * 8018X's Integrated Interrupt Controller Unit
+ *
+ * This file contains code used for the embedded 8018X family only.
+ * 
+ * 16 May 21 Santiago Hormazabal
+ */
+
+#include <linuxmt/config.h>
+#include <linuxmt/errno.h>
+#include <linuxmt/sched.h>
+#include <linuxmt/types.h>
+
+#include <arch/io.h>
+#include <arch/irq.h>
+
+/* TMR and SER interrupts are enabled by default */
+unsigned int cache_08 = 0xfa;
+
+/*
+ *	Low level interrupt handling for the X86 8018X
+ *	platforms
+ */
+
+void init_irq(void)
+{
+}
+
+void enable_irq(unsigned int irq)
+{
+    unsigned int mask;
+
+    mask = ~(1 << irq);
+
+    cache_08 &= mask;
+
+    /* TODO: Create a list of PCB registers instead of using hardcoded offsets */
+    outw(cache_08, 0xff00 + 0x08); /* IMASK */
+}
+
+int remap_irq(int irq)
+{
+    return irq;
+}
+

--- a/elks/arch/i86/kernel/timer-8018x.c
+++ b/elks/arch/i86/kernel/timer-8018x.c
@@ -1,0 +1,63 @@
+/*
+ * 8018X's Integrated Timer/Counter Unit
+ *
+ * This file contains code used for the embedded 8018X family only.
+ * 
+ * 16 May 21 Santiago Hormazabal
+ */
+
+#include <linuxmt/config.h>
+#include <linuxmt/config.h>
+#include <linuxmt/mm.h>
+#include <linuxmt/timer.h>
+
+#include <arch/io.h>
+#include <arch/irq.h>
+#include <arch/param.h>
+#include <arch/ports.h>
+
+/*
+ * Main goal is to have Timer2 generating a 1ms period signal, so
+ * calculate the appropriate value of the prescaler counter.
+ * Note that 1kHz corresponds to 1ms period. Timer2 is clocked
+ * by 1/4 of FCPU.
+ *
+ * Timer2Interval = (FCPU / 4) / 1kHz
+ */
+#define TIMER2_INTERVAL (CONFIG_8018X_FCPU * 1000000L / (4 * 1000))
+
+/*
+ * With a reference of 1ms (1kHz) coming into Timer0, calculate how
+ * many counts are needed to achieve the "HZ" rate (usually 100Hz).
+ *
+ * Timer0Interval = 1kHz / HZ
+ */
+#define TIMER0_INTERVAL (1000 / HZ)
+
+void enable_timer_tick(void)
+{
+    /* Set Timer2 Maxcount register */
+    outw(TIMER2_INTERVAL, 0xff00 + 0x42); /* T2CMPA */
+    /* Clear the Timer count register before starting it */
+    outw(0x0000, 0xff00 + 0x40); /* T2CNT */
+
+    /* Set Timer0 Maxcount register */
+    outw(TIMER0_INTERVAL, 0xff00 + 0x32); /* T0CMPA */
+    /* Clear the Timer count register before starting it */
+    outw(0x0000, 0xff00 + 0x30); /* T0CNT */
+
+    /* Enable Timer2, release inhibit to change EN bit, continuous mode */
+    outw(0xc001, 0xff00 + 0x46); /* T2CON */
+
+    /* Enable Timer0, release inhibit to change EN bit, INT enabled, use Timer2 as source, continuous mode */
+    outw(0xe009, 0xff00 + 0x36); /* T0CON */
+}
+
+void disable_timer_tick(void)
+{
+    /* Disable Timer2, release inhibit to change EN bit */
+    outw(0x4000, 0xff00 + 0x46); /* T2CON */
+
+    /* Disable Timer0, release inhibit to change EN bit */
+    outw(0x4000, 0xff00 + 0x36); /* T0CON */
+}

--- a/elks/config.in
+++ b/elks/config.in
@@ -9,7 +9,8 @@ mainmenu_option next_comment
 
 	choice 'Select system' \
 		"IBM-PC CONFIG_ARCH_IBMPC \
-		 SIBO   CONFIG_ARCH_SIBO" IBM-PC
+		 SIBO   CONFIG_ARCH_SIBO  \
+		 8018X	CONFIG_ARCH_8018X" IBM-PC
 
 	if [ "$CONFIG_ARCH_IBMPC" = "y" ]; then
 
@@ -65,6 +66,12 @@ mainmenu_option next_comment
 		bool 'Use bootup IRQ-Mask of 8259 as default'    CONFIG_HW_259_USE_ORIGINAL_MASK n
 		bool 'Advanced Power Management support'         CONFIG_APM y
 
+	elif [ "$CONFIG_ARCH_8018X" = "y" ]; then
+
+		comment 'Platform'
+
+		comment 'Devices'
+
 	fi
 
 endmenu
@@ -78,7 +85,7 @@ mainmenu_option next_comment
 	bool 'System Trace'                       CONFIG_STRACE       n
 	bool 'Halt on Idle'                       CONFIG_IDLE_HALT    n
 
-	if [ "$CONFIG_ARCH_IBMPC" = "y" ]; then
+	if [ "$CONFIG_ARCH_IBMPC" = "y" ] || [ "$CONFIG_ARCH_8018X" = "y" ]; then
 		bool 'Build kernel as ROM-bootable'   CONFIG_ROMCODE      n
     fi
 


### PR DESCRIPTION
This PR adds support for the 8018x embedded platforms, supporting on this stage the integrated peripherals that equate to the PIC (interrupt controller), PIT (timer/counters) and a headless console (via the serial port).