### PR TITLE
[boot] Runtime selection of network card IRQ

### DIFF
--- a/elks/arch/i86/drivers/net/ne2k.c
+++ b/elks/arch/i86/drivers/net/ne2k.c
@@ -20,6 +20,8 @@
 
 #include "ne2k.h"
 
+int net_irq = NE2K_IRQ;		/* default IRQ, changed by netirq= in /bootopts */
+
 // Static data
 struct wait_queue rxwait;
 struct wait_queue txwait;
@@ -347,9 +349,9 @@ void ne2k_drv_init(void)
 			printk ("eth: NE2K not detected\n");
 			break;
 		}
-		err = request_irq (NE2K_IRQ, ne2k_int, INT_GENERIC);
+		err = request_irq (net_irq, ne2k_int, INT_GENERIC);
 		if (err) {
-			printk ("eth: NE2K IRQ %d request error: %i\n", NE2K_IRQ, err);
+			printk ("eth: NE2K IRQ %d request error: %i\n", net_irq, err);
 			break;
 		}
 
@@ -376,7 +378,7 @@ void ne2k_drv_init(void)
        }
 
        if (!err) {
-           printk ("eth: NE2K at 0x%x, irq %d, MAC %02x", NE2K_PORT, NE2K_IRQ, addr[0]);
+           printk ("eth: NE2K at 0x%x, irq %d, MAC %02x", NE2K_PORT, net_irq, addr[0]);
            i = 1;
            while (i < 6) printk(":%02x", addr[i++]);
            printk("\n");

--- a/elks/arch/i86/drivers/net/wd.c
+++ b/elks/arch/i86/drivers/net/wd.c
@@ -126,6 +126,8 @@ typedef struct {
 	unsigned short count;	/* header + packet length in bytes */
 } __attribute__((packed)) e8390_pkt_hdr;
 
+int net_irq = WD_IRQ;		/* default IRQ, changed by netirq= in /bootopts */
+
 static struct wait_queue rxwait;
 static struct wait_queue txwait;
 
@@ -581,10 +583,10 @@ void wd_drv_init(void)
 	word_t hw_addr[6U];
 
 	do {
-		err = request_irq(WD_IRQ, wd_int, INT_GENERIC);
+		err = request_irq(net_irq, wd_int, INT_GENERIC);
 		if (err) {
 			printk("eth: WD IRQ %d request error: %i\n",
-				WD_IRQ, err);
+				net_irq, err);
 			break;
 		}
 		err = register_chrdev(ETH_MAJOR, "eth", &wd_fops);
@@ -596,7 +598,7 @@ void wd_drv_init(void)
 		for (u = 0U; u < 6U; u++)
 			mac_addr[u] = (hw_addr[u] & 0xffU);
 		printk ("eth: SMC/WD8003 at 0x%x, irq %d, MAC %02X",
-			WD_PORT, WD_IRQ, mac_addr[0]);
+			WD_PORT, net_irq, mac_addr[0]);
 		for (u = 1U; u < 6U; u++)
 			printk(":%02X", mac_addr[u]);
 		printk("\n");

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -45,6 +45,7 @@ static char *envp_init[MAX_INIT_ENVS+1];
 static unsigned char options[256];
 
 extern int boot_rootdev;
+extern int net_irq;
 extern int dprintk_on;
 static char * INITPROC root_dev_name(int dev);
 static int INITPROC parse_options(void);
@@ -307,6 +308,10 @@ static int INITPROC parse_options(void)
 		if (!strncmp(line,"init=",5)) {
 			line += 5;
 			init_command = argv_init[1] = line;
+			continue;
+		}
+		if (!strncmp(line,"netirq=",7)) {
+			net_irq = atoi(line+7);
 			continue;
 		}
 		/*

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -27,6 +27,7 @@ int root_mountflags = MS_RDONLY;
 #else
 int root_mountflags = 0;
 #endif
+int net_irq;
 static int boot_console;
 static char bininit[] = "/bin/init";
 static char *init_command = bininit;
@@ -45,7 +46,6 @@ static char *envp_init[MAX_INIT_ENVS+1];
 static unsigned char options[256];
 
 extern int boot_rootdev;
-extern int net_irq;
 extern int dprintk_on;
 static char * INITPROC root_dev_name(int dev);
 static int INITPROC parse_options(void);

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -5,4 +5,4 @@
 #console=ttyS0,19200 # serial console
 #root=hda1			# hd partition 1
 #ro					# read-only root
-#net=eth
+#netirq=9			# set NIC IRQ


### PR DESCRIPTION
Adds the ability to specify the IRQ for NE2K and WD network interface cards at boot, in /bootopts, rather than having to recompile the kernel.

Use `netirq=9` etc to specify in /bootopts when making distribution, or can also be done from ELKS by editing /bootopts, saving, sync, reboot.