### PR TITLE
8018x: conio fixes and eoi impl

### DIFF
--- a/elks/arch/i86/drivers/char/conio-8018x.c
+++ b/elks/arch/i86/drivers/char/conio-8018x.c
@@ -24,7 +24,10 @@ void conio_init(void)
  */
 int conio_poll(void)
 {
-	// add code to poll UART here and return character if available
+    /* S0STS bit 0x40 RI (receive interrupt) */
+    if (inw(0xff00 + 0x66) & 0x40) {
+        return inw(0xff00 + 0x68); /* R0BUF */
+    }
     return 0;
 }
 

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -327,6 +327,17 @@ do_eoi:
 	jmp	a5
 a5:	jmp	a6
 a6:	out	%al,$0x20		// Ack on primary controller
+
+#elif defined(CONFIG_ARCH_8018X)
+//
+//	Determine if trap or interrupt
+//
+	cmp	$16,%ax
+	jge	was_trap	// Traps need no reset
+
+	mov $0x8000, %ax // set the NSPEC bit on the
+	mov $0xff02, %dx // EOI register so the ICU
+	out %ax, %dx // acks the highest priority interrupt
 #endif
 
 //


### PR DESCRIPTION
conio-8018x.c: add poll logic

Adds the logic on the poll function to read received characters
on the integrated serial port present on the 8018x.

irqtab.S: add EOI logic for 8018x

Sets the NSPEC bit on the ICU's EOI register which clears the
In-Service bit of the highest priority interrupt.