### PR TITLE
[kernel] Add option to specify size of kernel local heap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ all: .config include/autoconf.h
 	$(MAKE) -C image all
 	$(MAKE) -C elksemu PREFIX='$(TOPDIR)/cross' elksemu
 
+kclean:
+	$(MAKE) -C elks kclean
+
 clean:
 	$(MAKE) -C libc clean
 	$(MAKE) -C libc DESTDIR='$(TOPDIR)/cross' uninstall

--- a/elks/Makefile
+++ b/elks/Makefile
@@ -209,6 +209,8 @@ tar:	dist
 #########################################################################
 # Configuration stuff
 
+kclean: dokclean
+
 clean:	nodep doclean
 
 dep:	$(TOPDIR)/include/autoconf.h

--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -252,6 +252,14 @@ elks:
 #########################################################################
 # Standard commands.
 
+dokclean: $(CLEANDEP)
+	rm -fv *~ *.a *.bak *.lint *.map *.o *.tmp core $(CLEANME)
+	@for DIR in */ ; do \
+		if [ -f "$$DIR/Makefile" -a "$$DIR" != "tools" ]; then \
+			${MAKE} -C "$$DIR" dokclean ; \
+		fi ; \
+	done
+
 doclean: $(CLEANDEP)
 	rm -fv *~ *.a *.bak *.lint *.map *.o *.tmp core $(CLEANME)
 #	@for FILE in *.s ; do \

--- a/elks/arch/i86/kernel/system.c
+++ b/elks/arch/i86/kernel/system.c
@@ -31,8 +31,6 @@ void INITPROC setup_arch(seg_t *start, seg_t *end)
 	 * If ramdisk configured, subtract space for it from end of memory.
 	 */
 
-#define SETUP_HEAPSIZE	704
-
 	/* Heap allocations at even addresses, helps debugging*/
 	unsigned int endbss = (unsigned int)(_endbss + 1) & ~1;
 

--- a/elks/arch/i86/mm/init.c
+++ b/elks/arch/i86/mm/init.c
@@ -60,8 +60,7 @@ void INITPROC mm_stat(seg_t start, seg_t end)
     printk("ELKS kernel %s (%u text, %u ftext, %u data, %u bss, %u heap)\n",
 	   system_utsname.release,
 	   (unsigned)_endtext, (unsigned)_endftext, (unsigned)_enddata,
-	   (unsigned)_endbss - (unsigned)_enddata,
-	   1 + ~ (unsigned) _endbss);
+	   (unsigned)_endbss - (unsigned)_enddata, heapsize);
     printk("Kernel text at %x:0000, ", kernel_cs);
 #ifdef CONFIG_FARTEXT_KERNEL
     printk("ftext %x:0000, ", (unsigned)((long)kernel_init >> 16));

--- a/elks/include/arch/segment.h
+++ b/elks/include/arch/segment.h
@@ -8,5 +8,6 @@ extern __u16 kernel_cs, kernel_ds;
 /*@-namechecks@*/
 
 extern short *_endtext, *_endftext, *_enddata, *_endbss;
+extern unsigned int heapsize;
 
 #endif /* !__ARCH_8086_SEGMENT_H */

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -27,12 +27,14 @@
 #define SETUP_VID_COLS		80	/* BIOS video # columns */
 #define SETUP_VID_LINES		25	/* BIOS video # lines */
 #define SETUP_CPU_TYPE		5	/* processor type 80186 */
-#define SETUP_MEM_KBYTES	256	/* base memory in 1K bytes */
+#define SETUP_MEM_KBYTES	128	/* base memory in 1K bytes */
 #define SETUP_ROOT_DEV		0x0600	/* root device ROMFS */
 #define SETUP_ELKS_FLAGS	0	/* flags for root device type */
 #define SETUP_PART_OFFSETLO	0	/* partition offset low word */
 #define SETUP_PART_OFFSETHI	0	/* partition offset high word */
 #define SYS_CAPS		0	/* no XT/AT capabilities */
+
+#define SETUP_HEAPSIZE		1024	/* minimum kernel heap for now*/
 
 #define CONFIG_8018X_FCPU	20
 #define CONFIG_8018X_EB

--- a/elkscmd/sys_utils/meminfo.c
+++ b/elkscmd/sys_utils/meminfo.c
@@ -60,6 +60,7 @@ void dump_heap(int fd)
 	printf("  HEAP   TYPE  SIZE    SEG   TYPE    SIZE  CNT\n");
 
 	word_t n = getword (fd, heap_all + offsetof(list_s, next), ds);
+	// FIXME additional n!=first check for tracking kernel heap bug
 	word_t first = n;
 	goto start;
 	while (n != heap_all && n != first) {

--- a/elkscmd/sys_utils/meminfo.c
+++ b/elkscmd/sys_utils/meminfo.c
@@ -60,7 +60,10 @@ void dump_heap(int fd)
 	printf("  HEAP   TYPE  SIZE    SEG   TYPE    SIZE  CNT\n");
 
 	word_t n = getword (fd, heap_all + offsetof(list_s, next), ds);
-	while (n != heap_all) {
+	word_t first = n;
+	goto start;
+	while (n != heap_all && n != first) {
+start: ;
 		word_t h = n - offsetof(heap_s, all);
 		word_t size = getword(fd, h + offsetof(heap_s, size), ds);
 		byte_t tag = getword(fd, h + offsetof(heap_s, tag), ds) & HEAP_TAG_TYPE;


### PR DESCRIPTION
Also adds `make kclean` that allows kernel-only (no tools) clean, very useful for switching between config files and recompiling the kernel.

With some smaller memory (128K RAM) systems being ported to, this option will allow a very small (~1024 byte) kernel near heap, up to the maximum size which by default is the amount remaining when the kernel data+bss is extended to 64K. 

Given that the current 8018X port on a 128K Orckit OR566 defaults to a 26K near heap, with only 11K free for applications once /bin/sash is loaded, this option will allow many programs to run which otherwise could not.

Once committed, set `SETUP_HEAPSIZE` in config.h to configure a reduced kernel heap size. Setting too large a value will always be truncated to max heap that will fit within the remaining kernel data segment. This seems to vary between 10K and 26K based on .config file options.

NOTE: Current PR cannot yet be committed, as it seems a bug has been found in the kernel local heap manager. SETUP_HEAPSIZE is set to 704 (bytes) for testing, in elks/arch/i86/kernel/system.c. Kernel boots and meminfo shows 100 bytes free in near heap. Changing the value any lower results in `meminfo` continuously looping. This PR has temporary debug code added to meminfo to stop after first loop, and free/used memory is incorrect.

@mfld-fr : Something very strange is going on when kernel near heap gets near full. What appears to be happening when heap is specified to be small (but large enough for kernel operation) is that the last list item in the heap linked list loops back to the starting point, rather than pointing to `&_heap_all`. Thus, `meminfo` loops continuously if heap size is less than 704, say 700. 

In order to test that it wasn't meminfo's problem, HEAP_DEBUG can be turned on in heap.h, and then your unmodified kernel heap testing code will loop continuously, which shows heap list corruption. This code will run triggered by meminfo running:
```
// Dump heap
#ifdef HEAP_DEBUG
void heap_iterate (void (* cb) (heap_s *))
{
    list_s * n = _heap_all.next;

    while (n != &_heap_all) {
        heap_s * h = structof (n, heap_s, all);
        (*cb) (h);
        n = h->all.next;
    }
}
#endif /* HEAP_DEBUG */
```

I haven't gotten too far into the heap manager yet, but there seems to be data corruption in the heap manager when manipulating the end list item (which is only seen when a small heap is configured). I suspect we have never seen this error before since ELKS has always had a large enough heap such that the last link item has always been free.

This problem is easily reproducible when compiling a standard kernel, no special options, then changing SETUP_MEMSIZE to a number less than 704. It seems ELKS needs around 624 byte heap minimum.

Any thoughts on how to best debug this? Any help would be appreciated. I have thoroughly tested all the other code in this PR to be correct.