### PR TITLE
[kernel] Fix heap and segment allocator merge bug

### DIFF
--- a/elks/arch/i86/drivers/char/Makefile
+++ b/elks/arch/i86/drivers/char/Makefile
@@ -43,7 +43,7 @@ ifeq ($(CONFIG_ARCH_8018X), y)
 endif
 
 ifeq ($(CONFIG_ARCH_IBMPC), y)
-	CONIO = BIOS
+	CONIO = bios
 	SERIAL = 8250
 	OBJS += lp.o
 endif

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -156,7 +156,7 @@ void seg_free (segment_s * seg)
 	// Try to merge with next segment if free
 
 	list_s * n = seg->all.next;
-	if (n->next != &_seg_all) {
+	if (n != &_seg_all) {
 		segment_s * next = structof (n, segment_s, all);
 		if (next->flags == SEG_FLAG_FREE) {
 			list_remove (&(next->free));

--- a/elks/lib/heap.c
+++ b/elks/lib/heap.c
@@ -131,7 +131,7 @@ void heap_free (void * data)
 	// Try to merge with next block if free
 
 	list_s * n = h->all.next;
-	if (n->next != &_heap_all) {
+	if (n != &_heap_all) {
 		heap_s * next = structof (n, heap_s, all);
 		if (next->tag == HEAP_TAG_FREE) {
 			list_remove (&(next->free));

--- a/elkscmd/sys_utils/meminfo.c
+++ b/elkscmd/sys_utils/meminfo.c
@@ -60,11 +60,7 @@ void dump_heap(int fd)
 	printf("  HEAP   TYPE  SIZE    SEG   TYPE    SIZE  CNT\n");
 
 	word_t n = getword (fd, heap_all + offsetof(list_s, next), ds);
-	// FIXME additional n!=first check for tracking kernel heap bug
-	word_t first = n;
-	goto start;
-	while (n != heap_all && n != first) {
-start: ;
+	while (n != heap_all) {
 		word_t h = n - offsetof(heap_s, all);
 		word_t size = getword(fd, h + offsetof(heap_s, size), ds);
 		byte_t tag = getword(fd, h + offsetof(heap_s, tag), ds) & HEAP_TAG_TYPE;


### PR DESCRIPTION
Fixes #957.

Tested on heap allocator. Untested on segment allocator, but believed correct.

Also fixes compilation bug introduced by previous PR when building BIOS Console.