### PR TITLE
[boot] Move /bootopts error message to later to be seen

### DIFF
--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -116,7 +116,9 @@ void INITPROC kernel_init(void)
     fs_init();
 
 #ifdef CONFIG_BOOTOPTS
-    if (opts) finalize_options();
+    if (opts)
+	finalize_options();
+    else printk("/bootopts IGNORED: header not ## or size > 255\n");
 #endif
 
     mm_stat(base, end);
@@ -243,10 +245,8 @@ static int INITPROC parse_options(void)
 	fmemcpyb(options, kernel_ds, 0, DEF_OPTSEG, sizeof(options));
 
 	/* check file starts with ## and max len 255 bytes*/
-	if (*(unsigned short *)options != 0x2323 || options[255]) {
-		printk("Ignoring /bootopts: header not ## or size > 255\n");
+	if (*(unsigned short *)options != 0x2323 || options[255])
 		return 0;
-	}
 #if DEBUG
 	printk("/bootopts: %s", &options[3]);
 #endif


### PR DESCRIPTION
Adds request in #951 to move /bootopts options ignored error message to later in the boot, and capitalize it.

<img width="832" alt="Screen Shot 2021-06-12 at 4 43 49 PM" src="https://user-images.githubusercontent.com/11985637/121791344-c2985800-cb9d-11eb-9e26-d12b7eb9dd58.png">
