### PR TITLE
[cmds] Fix heap on ps command

### DIFF
--- a/elks/arch/i86/drivers/block/ssd_test.c
+++ b/elks/arch/i86/drivers/block/ssd_test.c
@@ -3,9 +3,9 @@
  *
  * June 2020 Greg Haerr
  *
- * Use ramdisk utility for testing:
- *	ramdisk /dev/ssd make 192
- *	mkfs /dev/ssd 192
+ * Use ramdisk utility for testing: (block argument = half of NUM_SECTS below)
+ *	ramdisk /dev/ssd make 96
+ *	mkfs /dev/ssd 96
  *	sync
  *	fsck -lvf /dev/ssd
  *	mount /dev/ssd /mnt

--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -65,7 +65,7 @@ shutdown: shutdown.o
 	$(LD) $(LDFLAGS) -o shutdown shutdown.o $(LDLIBS)
 
 ps: ps.o
-	$(LD) $(LDFLAGS) -maout-heap=1 -maout-stack=2048 -o ps ps.o $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-heap=1024 -maout-stack=2048 -o ps ps.o $(LDLIBS)
 
 meminfo: meminfo.o
 	$(LD) $(LDFLAGS) -maout-heap=1 -maout-stack=512 -o meminfo meminfo.o $(LDLIBS)


### PR DESCRIPTION
Fixes insufficient heap introduced accidentally in 885bf55a313a469f3412c26dfb545fcb58b3df31.

Updates SSD test documentation in ssd_test.c.