### PR TITLE
[ktcp] Fine tune TCP send and receive window sizes

### DIFF
--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -196,13 +196,8 @@ static int inet_listen(register struct socket *sock, int backlog)
     tcpdev_inetwrite(cmd, sizeof(struct tdb_listen));
 
     /* Sleep until tcpdev has news */
-    while (bufin_sem == 0) {
+    while (bufin_sem == 0)
         interruptible_sleep_on(sock->wait);
-        if (current->signal) {
-printk("inet_listen: RESTARTSYS\n");
-            return -ERESTARTSYS;
-        }
-    }
 
     ret = ((struct tdb_return_data *)tdin_buf)->ret_value;
     tcpdev_clear_data_avail();
@@ -231,7 +226,7 @@ static int inet_accept(register struct socket *sock,
         interruptible_sleep_on(sock->wait);
         //sock->flags &= ~SO_WAITDATA;
         if (current->signal) {
-printk("INET(%d) accept RESTARTSYS\n", current->pid);
+	    debug_net("INET(%d) accept RESTARTSYS\n", current->pid);
             return -ERESTARTSYS;
 	}
     }

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -351,7 +351,7 @@ static int inet_write(register struct socket *sock, char *ubuf, int size,
 
 	if (ret < 0) {
             if (ret == -ERESTARTSYS) {
-		/* delay process 10ms*/
+		/* delay process 100ms*/
 		current->state = TASK_INTERRUPTIBLE;
 		current->timeout = jiffies + 10;
                 schedule();

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -8,6 +8,7 @@
 #define USE_DEBUG_EVENT 1	/* use CTRLP to toggle debug output*/
 #define DEBUG_STARTDEF	0	/* default startup debug display*/
 #define DEBUG_TCP	1
+#define DEBUG_RETRANS	1
 #define DEBUG_CLOSE	1
 #define DEBUG_IP	0
 #define DEBUG_ARP	0
@@ -31,6 +32,12 @@ void dprintf(const char *, ...);
 #define debug_tcp	DPRINTF
 #else
 #define debug_tcp(...)
+#endif
+
+#if DEBUG_RETRANS
+#define debug_retrans	DPRINTF
+#else
+#define debug_retrans(...)
 #endif
 
 #if DEBUG_CLOSE

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -2,7 +2,7 @@
 #define CONFIG_H
 
 /* compile time options*/
-#define CSLIP			1	/* compile in CSLIP support*/
+#define CSLIP		0	/* compile in CSLIP support*/
 
 /* turn these on for ELKS debugging*/
 #define USE_DEBUG_EVENT 1	/* use CTRLP to toggle debug output*/

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -7,9 +7,10 @@
 /* turn these on for ELKS debugging*/
 #define USE_DEBUG_EVENT 1	/* use CTRLP to toggle debug output*/
 #define DEBUG_STARTDEF	0	/* default startup debug display*/
-#define DEBUG_TCP	1
-#define DEBUG_RETRANS	1
-#define DEBUG_CLOSE	1
+#define DEBUG_TCP	1	/* TCP ops*/
+#define DEBUG_TCPDATA	0	/* TCP data packets*/
+#define DEBUG_RETRANS	1	/* TCP retransmissions*/
+#define DEBUG_CLOSE	1	/* TCP close ops*/
 #define DEBUG_IP	0
 #define DEBUG_ARP	0
 #define DEBUG_ETH	0
@@ -32,6 +33,12 @@ void dprintf(const char *, ...);
 #define debug_tcp	DPRINTF
 #else
 #define debug_tcp(...)
+#endif
+
+#if DEBUG_TCPDATA
+#define debug_tcpdata	DPRINTF
+#else
+#define debug_tcpdata(...)
 #endif
 
 #if DEBUG_RETRANS

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -45,7 +45,7 @@
 /* retransmit settings*/
 #define TCP_RTT_ALPHA			90
 #define TCP_RETRANS_MAXMEM		4096	/* max retransmit total memory*/
-#define TCP_RETRANS_MAXTRIES		3	/* max # retransmits*/
+#define TCP_RETRANS_MAXTRIES		6	/* max # retransmits (~12 secs total)*/
 /* timeout values in 1/16 seconds*/
 #define TCP_RETRANS_MAXWAIT		64	/* max retransmit wait (4 secs)*/
 #define TCP_RETRANS_MINWAIT_SLIP	8	/* minimum retrans timeout for slip/cslip (1/2 sec)*/

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -28,6 +28,9 @@
 /* max outstanding send window size*/
 #define TCP_SEND_WINDOW_MAX	1024	/* should be less than TCP_RETRANS_MAXMEM*/
 
+/* max advertised receive window size*/
+#define THROTTLE_MAX_WINDOW	512	/* FIXME CB_IN_BUF_SIZE when PTY fixed*/
+
 /* bytes to subtract from window size and when to force app write*/
 #define PUSH_THRESHOLD	512
 

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -70,7 +70,7 @@ struct tcpcb_list_s *tcpcb_new(void)
 
     n = (struct tcpcb_list_s *) malloc(sizeof(struct tcpcb_list_s));
     if (n == NULL) {
-	debug_tcp("ktcp: Out of memory 2\n");
+	debug_tcp("ktcp: Out of memory for CB\n");
 	return NULL;
     }
     debug_mem("Alloc CB %d bytes\n", sizeof(struct tcpcb_list_s));
@@ -117,21 +117,19 @@ void tcpcb_remove(struct tcpcb_list_s *n)
     struct tcpcb_list_s *next = n->next;
 
     debug_tcp("tcp: REMOVING control block %x\n", n);
+    debug_mem("Free CB\n");
     tcpcb_num--;	/* for netstat*/
 
     if (n->prev)
 	n->prev->next = next;
     else {
-
 	/* Head update */
 	n = next;
 	n->prev = NULL;
 
 	rmv_all_retrans(tcpcbs);
-	debug_mem("Free CB\n");
 	free(tcpcbs);
 	tcpcbs = n;
-
 	return;
     }
 
@@ -140,7 +138,6 @@ void tcpcb_remove(struct tcpcb_list_s *n)
 
     rmv_all_retrans(n);
     free(n);
-    debug_mem("Free CB\n");
 }
 
 struct tcpcb_list_s *tcpcb_check_port(__u16 lport)

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -229,7 +229,7 @@ void tcpcb_expire_timeouts(void)
 	    int secs = (unsigned)(n->tcpcb.time_wait_exp - Now);
 	    unsigned int tenthsecs = ((secs + 8) & 15) >> 1;
 	    secs >>= 4;
-	    debug_close("ktcp: check expire %s (%d.%d)\n",
+	    debug_close("tcp: expire check %s (%d.%d)\n",
 		tcp_states[n->tcpcb.state], secs, tenthsecs);
 	}
 #endif

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -352,8 +352,9 @@ void tcp_output(struct tcpcb_s *cb)
 
     len = CB_BUF_SPACE(cb) - PUSH_THRESHOLD;
     if (len <= 0)
-	len = 1;		/* Never advertise zero window size */
-    else len = 255;	//FIXME testing only
+	len = 1;			/* Never advertise zero window size */
+    if (len > THROTTLE_MAX_WINDOW)	/* throttle down to allow ELKS apps to keep up */
+	len = THROTTLE_MAX_WINDOW;
     th->window = htons(len);
     th->urgpnt = 0;
     th->flags = cb->flags;

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -337,7 +337,7 @@ static void tcpdev_write(void)
 	return;
     }
 
-    /* delay sending if outstanding send window too large*/
+    /* Delay sending if outstanding send window too large. FIXME could hang if no ACKs rcvd*/
     maxwindow = cb->rcv_wnd;
     if (maxwindow > TCP_SEND_WINDOW_MAX)	/* limit retrans memory usage*/
 	maxwindow = TCP_SEND_WINDOW_MAX;
@@ -348,7 +348,7 @@ static void tcpdev_write(void)
 	return;
     }
 
-    printf("tcp write: seq %lu size %d rcvwnd %u unack %lu retrans cnt %d\n",
+    debug_tcp("tcp write: seq %lu size %d rcvwnd %u unack %lu retrans cnt %d\n",
 	cb->send_nxt, size, cb->rcv_wnd, cb->send_nxt - cb->send_una, tcp_timeruse);
 
     cb->flags = TF_PSH|TF_ACK;

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -343,13 +343,14 @@ static void tcpdev_write(void)
 	maxwindow = TCP_SEND_WINDOW_MAX;
     if (cb->send_nxt - cb->send_una + size > maxwindow) {
 	printf("tcp limit: seq %lu size %d maxwnd %u unack %lu rcvwnd %u\n",
-	    cb->send_nxt, size, maxwindow, cb->send_nxt - cb->send_una, cb->rcv_wnd);
+	    cb->send_nxt - cb->iss, size, maxwindow, cb->send_nxt - cb->send_una, cb->rcv_wnd);
 	retval_to_sock(sock, -ERESTARTSYS);	/* kernel will retry 100ms later*/
 	return;
     }
 
-    debug_tcp("tcp write: seq %lu size %d rcvwnd %u unack %lu retrans cnt %d\n",
-	cb->send_nxt, size, cb->rcv_wnd, cb->send_nxt - cb->send_una, tcp_timeruse);
+    debug_tcp("tcp write: seq %lu size %d rcvwnd %u unack %lu (cnt %d, mem %u)\n",
+	cb->send_nxt - cb->iss, size, cb->rcv_wnd, cb->send_nxt - cb->send_una,
+	tcp_timeruse, tcp_retrans_memory);
 
     cb->flags = TF_PSH|TF_ACK;
     cb->datalen = size;

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -308,14 +308,14 @@ static void tcpdev_write(void)
 
     /* This is a bit ugly but I'm to lazy right now */
     if (tcp_retrans_memory > TCP_RETRANS_MAXMEM) {
-	printf("ktcp: RETRANS limit exceeded\n");
+	printf("ktcp: RETRANS memory limit exceeded\n");
 	retval_to_sock(sock, -ENOMEM);
 	return;
     }
 
     n = tcpcb_find_by_sock(sock);
     if (!n || n->tcpcb.state == TS_CLOSED) {
-	printf("ktcp: write to unknown socket\n");
+	debug_tcp("tcp: write to unknown socket\n");
 	retval_to_sock(sock, -EPIPE);
 	return;
     }
@@ -342,7 +342,7 @@ static void tcpdev_write(void)
     if (maxwindow > TCP_SEND_WINDOW_MAX)	/* limit retrans memory usage*/
 	maxwindow = TCP_SEND_WINDOW_MAX;
     if (cb->send_nxt - cb->send_una + size > maxwindow) {
-	printf("tcp limit: seq %lu size %d maxwnd %u unack %lu rcvwnd %u\n",
+	debug_tcp("tcp limit: seq %lu size %d maxwnd %u unack %lu rcvwnd %u\n",
 	    cb->send_nxt - cb->iss, size, maxwindow, cb->send_nxt - cb->send_una, cb->rcv_wnd);
 	retval_to_sock(sock, -ERESTARTSYS);	/* kernel will retry 100ms later*/
 	return;

--- a/elkscmd/rootfs_template/bin/net
+++ b/elkscmd/rootfs_template/bin/net
@@ -78,6 +78,7 @@ start_network()
 stop_network()
 {
 	echo "Stopping network"
+	kill $(ps | grep "ktcp|telnet|httpd" | cut -c 1-5) > /dev/null 2>&1
 }
 
 if test "$#" -lt 1; then


### PR DESCRIPTION
Allows for larger (current max 512) receive window to increase file transfer speed, tested as fixed in https://github.com/jbruchon/elks/issues/976#issuecomment-953244002.

Should fix server receive window ignored when sending packets (#986).

@Mellvik, as you can see, the send packet limiting code now compares against the receive window size, or 1024 (TCP_SEND_WINDOW_MAX), whichever is smaller. A message "tcp write: limiting write at max window ..." will temporarily be displayed when/if ktcp stops sending for 10ms to give time for the server to process the previous packets. If you uchange line 341 in ktcp/tcpdev.c to `printf` it will display the outstanding window and unacked send size should more information be needed to trigger the limiting.

If this message appears too frequently, the ktcp write packet rescheduling timer can be increased from 10ms by adjusting the following code in elks/net/ipv4/af_inet.c in inet_write():
```
        
        if (ret < 0) {
            if (ret == -ERESTARTSYS) {
                /* delay process 10ms*/
                current->state = TASK_INTERRUPTIBLE;
                current->timeout = jiffies + 10;  // <-- change from 10 to a higher number to wait longer
                schedule();
            } else
```
I can only test on QEMU at the moment, and this fix doesn't change any telnet/localhost behavior.