### PR TITLE
[net] Use GCC builtin for ntohs/ntohl macros

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -163,6 +163,7 @@ inet/telnetd/telnetd			:net
 inet/tinyirc/tinyirc			:net
 inet/urlget/urlget				:net
 inet/urlget/urlget :::ftpget	:net
+inet/urlget/urlget :::ftpput	:net
 inet/urlget/urlget :::httpget	:net
 #mtools/mcopy					:mtools					:1400k
 #mtools/mdel					:mtools					:1440k

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -158,11 +158,9 @@ printf("SYN sent, wrong ACK (listen port not expired)\n");
 	cb->send_nxt++;
 	cb->send_una++;
 	cb->state = TS_ESTABLISHED;
-	cb->flags = TF_ACK;
 	debug_tcp("TS_ESTABLISHED\n");
 
-	cb->datalen = 0;
-	tcp_output(cb);
+	tcp_send_ack(cb);
 	retval_to_sock(cb->sock, 0);
 
 	return;
@@ -289,9 +287,7 @@ static void tcp_established(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 	return; /* ACK with no data received - so don't answer*/
 
     cb->rcv_nxt += datasize;
-    cb->flags = TF_ACK;
-    cb->datalen = 0;
-    tcp_output(cb);
+    tcp_send_ack(cb);
 }
 
 static void tcp_synrecv(struct iptcp_s *iptcp, struct tcpcb_s *cb)
@@ -338,11 +334,8 @@ static void tcp_fin_wait_1(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 	cb->time_wait_exp = Now;
     }
 
-    if (needack) {
-	cb->flags = TF_ACK;		/* TODO : Unify this somewhere */
-	cb->datalen = 0;
-	tcp_output(cb);
-    }
+    if (needack)
+	tcp_send_ack(cb);
 }
 
 static void tcp_fin_wait_2(struct iptcp_s *iptcp, struct tcpcb_s *cb)
@@ -363,11 +356,8 @@ static void tcp_fin_wait_2(struct iptcp_s *iptcp, struct tcpcb_s *cb)
     /* Process like there was no FIN */
     tcp_established(iptcp, cb);
 
-    if (needack) {
-	cb->flags = TF_ACK;		/* TODO: Unify this somewhere */
-	cb->datalen = 0;
-	tcp_output(cb);
-    }
+    if (needack)
+	tcp_send_ack(cb);
 }
 
 static void tcp_closing(struct iptcp_s *iptcp, struct tcpcb_s *cb)

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -203,7 +203,7 @@ static void tcpdev_read(void)
     struct tdb_return_data *ret_data;
     struct tcpcb_list_s *n;
     struct tcpcb_s *cb;
-    int data_avail;
+    unsigned int data_avail;
     void * sock = db->sock;
 
     n = tcpcb_find_by_sock(sock);
@@ -272,7 +272,7 @@ void tcpdev_checkread(struct tcpcb_s *cb)
 
 #if 0 /* removed - wait_data mechanism no longer used in inet_read*/
     struct tdb_return_data *ret_data = (struct tdb_return_data *)sbuf;
-    //int data_avail = CB_BUF_USED(cb);
+    //unsigned int data_avail = CB_BUF_USED(cb);
     data_avail = cb->wait_data < cb->bytes_to_push ? cb->wait_data : cb->bytes_to_push;
     cb->bytes_to_push -= data_avail;
     if (cb->bytes_to_push <= 0)

--- a/elkscmd/ktcp/vjhc.c
+++ b/elkscmd/ktcp/vjhc.c
@@ -71,6 +71,7 @@ static int rcv_toss;
 static rcv_state_ut *rcv_state;
 static rcv_state_ut *rcv_last;
 
+#ifndef __ia16__
 /* Encode/decode ops - used to be macros, changed to functions
  * for reduced code size
  */
@@ -92,6 +93,7 @@ static unsigned long ntohl(unsigned long x)
 			  ((((unsigned long)x) & 0xff00) << 8)	|
 			  ((((unsigned long)x) & 0xff) << 24) );
 }
+#endif
 
 void vjhc_encode(__u8 *cp, const __u32 n)
 {

--- a/libc/include/netinet/in.h
+++ b/libc/include/netinet/in.h
@@ -9,13 +9,20 @@
 
 typedef __u32 ipaddr_t;		/* ip address in network byte order*/
 
-#define ntohs(x)	( (((x) >> 8) & 0xff) | ((unsigned char)(x) << 8) )
-#define htons(x)	ntohs(x)
+#ifdef __ia16__
+#define ntohs(x)	__builtin_bswap16(x)
+#define ntohl(x)	__builtin_bswap32(x)
 
+#else
+
+#define ntohs(x)	( (((x) >> 8) & 0xff) | ((unsigned char)(x) << 8) )
 #define ntohl(x)	( ((((unsigned long)x) >> 24) & 0xff)	| \
 			  ((((unsigned long)x) >> 8 ) & 0xff00)		| \
 			  ((((unsigned long)x) & 0xff00) << 8)		| \
 			  ((((unsigned long)x) & 0xff) << 24) )
+#endif
+
+#define htons(x)	ntohs(x)
 #define	htonl(x)	ntohl(x)
 
 #endif /* _ARPA_INET_H_ */


### PR DESCRIPTION
Use gcc builtins for better code size/speed in network applications.
Also minor cleanups in `ktcp`.

No need for additional testing.