### PR TITLE
[cmds] Fine tune compressed executables

### DIFF
--- a/elks/arch/i86/defconfig
+++ b/elks/arch/i86/defconfig
@@ -243,6 +243,7 @@ CONFIG_IMG_FD1440=y
 # CONFIG_IMG_HD is not set
 CONFIG_IMG_DEV=y
 CONFIG_IMG_BOOT=y
+# CONFIG_APPS_COMPRESS is not set
 
 #
 # Binary Images

--- a/elkscmd/sys_utils/chmem.c
+++ b/elkscmd/sys_utils/chmem.c
@@ -31,6 +31,7 @@
 #include <stdarg.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <string.h>
 #include <linuxmt/minix.h>
 
 #define SEPBIT   0x00200000	/* this bit is set for separate I/D */
@@ -108,10 +109,16 @@ int do_chmem(char *filename, int changeheap, int changestack,
 		total = (unsigned long)(size_t)header.tseg+(size_t)suplhdr.esh_ftseg
 			+(size_t)header.dseg+(size_t)header.bseg+oldheap+oldstack;
 	}
-	printf("%5u  %5u  %5u  %5u  %5u  %5u   %6lu %6lu %s%s\n",
+	printf("%5u  %5u  %5u  %5u  %5u  %5u   %6lu %6lu %s",
 		(size_t)header.tseg, (size_t)suplhdr.esh_ftseg, (size_t)header.dseg, (size_t)header.bseg,
-		displayheap, header.minstack, totdata, total,
-		filename, header.version == 0? " (v0 header)": "");
+		displayheap, header.minstack, totdata, total, filename);
+
+	if (header.version == 0)
+		printf(" (v0 header)");
+	if (suplhdr.esh_compr_tseg || suplhdr.esh_compr_dseg || suplhdr.esh_compr_ftseg)
+		printf(" (%u %u %u)",
+			suplhdr.esh_compr_tseg, suplhdr.esh_compr_ftseg, suplhdr.esh_compr_dseg);
+	printf("\n");
 
 	if (!changeheap && !changestack) {
 		close(fd);

--- a/image/Make.image
+++ b/image/Make.image
@@ -47,6 +47,9 @@ template:
 	cp -a $(TEMPLATE_DIR) $(DESTDIR)
 	find $(DESTDIR) -name .keep -delete
 	$(MAKE) -C $(ELKSCMD_DIR) -f Make.install install "CONFIG=$(CONFIG)"
+ifdef CONFIG_EXEC_COMPRESS
+	cd $(TOPDIR)/target/bin; elks-compress *
+endif
 	$(MAKE) -C $(BOOTBLOCKS_DIR)
 	bash -c "./ver.pl $(ELKS_DIR)/Makefile-rules > $(DESTDIR)/etc/issue"
 	git log --abbrev-commit | head -1 | sed 's/commit/ELKS built from commit/' > $(DESTDIR)/etc/motd

--- a/image/Make.image
+++ b/image/Make.image
@@ -47,7 +47,7 @@ template:
 	cp -a $(TEMPLATE_DIR) $(DESTDIR)
 	find $(DESTDIR) -name .keep -delete
 	$(MAKE) -C $(ELKSCMD_DIR) -f Make.install install "CONFIG=$(CONFIG)"
-ifdef CONFIG_EXEC_COMPRESS
+ifdef CONFIG_APPS_COMPRESS
 	cd $(TOPDIR)/target/bin; elks-compress *
 endif
 	$(MAKE) -C $(BOOTBLOCKS_DIR)

--- a/image/config.in
+++ b/image/config.in
@@ -39,6 +39,7 @@ mainmenu_option next_comment
 		if [ "$CONFIG_IMG_MINIX" == "y" -o "$CONFIG_IMG_FAT" == "y" ]; then
 			bool 'Bootable' CONFIG_IMG_BOOT y
 		fi
+		bool 'Compressed exectuables' CONFIG_APPS_COMPRESS n
 
 		comment 'Binary Images'
 


### PR DESCRIPTION
In thinking about the usability of ELKS on floppy, (and in preparation for a v0.5.0), I noticed while testing ftpget transfers that there is only 69K free on a 1.44Mb floppy, not even enough to transfer a kernel for temp storage. We are also almost completely out of space on our 360K boot floppy. More space is needed if one is actually trying to use ELKS for something real.

Quite a bit of work was put in to ELKS compressed executables in v0.4.0, but a distribution floppy of compressed executables was never produced. In addition, there were some comments made about the usability and speed of some compressed programs on older systems, based on the tradeoff of program disk size vs decompression speed. Looking through the large variety of (mostly unused) programs on the 1.44Mb floppy distribution, it was found that if all executables were compressed, there would be a whopping 327K made available! This would greatly improve the actual usability of running ELKS on non-hard drive systems.

This PR produces the standard disk image with all executables compressed, if CONFIG_EXEC_COMPRESS is set in config, which is default ON. Changes were made to `elks-compress` so that a wildcard could be used to compress all applications at once, for simplicity. It will work properly with symlinks as well as some edge cases that were previously rejected.

The issue now may be, which executables should not be compressed? 

@Mellvik, would you be willing to test a bit to see how this feels? Given the ultimate increased usability, it seems we're better off, even on slower systems, sacrificing some speed for utility in much increased free floppy space. Certainly, most programs should be compressed, and possibly all programs that are used only once, like /bin/init. /bin/sh is a bit trickier, in that we could compress just the text section, which might allow for the data section to be left uncompressed for slightly faster shell scripts on floppies (this would be tested using `elks-compress -d target/bin/sh`). Another option is to rewrite the kernel decompression routine in ASM, which would probably help the speed.

Of course, a user option to support compressed executables (CONFIG_EXEC_COMPRESS), but not write any (not ON by default, but selectable) could be a good option. That's not yet added in this PR. Another option would be a per-application selection of which NOT to compress. This PR just changes one line in images/Make.images to do the compression of all executables for the time being.