### PR TITLE
80386 Unreal mode research

### DIFF
--- a/elkscmd/sys_utils/unreal16.S
+++ b/elkscmd/sys_utils/unreal16.S
@@ -29,7 +29,9 @@
 # 12 Sep 2020:
 # Use `_start' rather than `entry' as program entry point. TK Chia
 #
-# 4 Nov 2021: bug fixes and cleanup ghaerr
+# 4 Nov 2021: ghaerr
+# bug fixes and cleanup
+# add A20 enable and verify (uses A20.ASM code by Chris Giese)
 ##############################################################################
 
 sys_exit = 1
@@ -44,8 +46,7 @@ videoline = 0xb8000+80*2*22
 _start:
 
 # check for 32-bit CPU
-        mov     $needs_386_msg,%dx
-        mov     $needs_386_len,%cx
+        mov     $needs_386_msg,%si
 
         pushf
                 pushf
@@ -63,8 +64,7 @@ _start:
         je msg_and_exit
 
 # check if (32-bit) CPU is in V86 mode
-        mov     $v86_msg_len,%dx
-        mov     $v86_msg,%cx
+        mov     $v86_msg,%si
 
         smsww %bx               # 'SMSW' is a '286+ instruction
         andb $1,%bl
@@ -117,8 +117,8 @@ _start:
 # Action of "rep movsb" in (un)real mode:
 # With a32 prefix byte (0x67):  byte [ES:EDI++] <- [DS:ESI++], ECX times
 # Without prefix byte:          byte [ES:DI++] <- [DS:SI++], CX times
-		cld
-        .byte 0x67 #a32
+        cld
+        .byte 0x67		# addr32
         rep movsb
 
 # or poke byte
@@ -126,17 +126,128 @@ _start:
         addr32 movb $0x2C,%es:videoline+23
         pop     %es
 
-        mov     $success_msg_len,%dx
-        mov     $success_msg,%cx
+# output unreal enabled message
+        mov     $unreal_enabled_msg,%si
+	call	puts
 
-msg_and_exit: 
-        mov     $1,%bx
-        mov     $sys_write,%ax
-        int     $syscall
+# test for A20 enabled, enable if not
+#	mov	$1,%ah		# test disable A20
+#	call	set_a20
 
-        mov     $0,%bx
+	mov	$a20_enabled_msg,%si
+	call	verify_a20
+	jnz	1f		# NZ=enabled
+	mov	$a20_disabled_msg,%si
+	call	puts
+
+	mov	$0,%ah		# enable A20
+	call	set_a20
+
+	mov	$a20_enabled_msg,%si
+	call	verify_a20
+	jnz	1f		# NZ=enabled
+	mov	$a20_disabled_msg,%si
+
+1:	call	puts
+
+# exit - unreal mode and A20 gate should both be enabled
+	call	exit
+
+# verify if A20 gate is enabled, return Z=disabled, NZ=enabled
+verify_a20:
+	push	%ax
+	push	%ds
+	push	%es
+
+	xor	%ax,%ax
+	mov	%ax,%ds
+	dec	%ax
+	mov	%ax,%es
+
+	mov	%es:0x10,%ax	# read word at FFFF:0010 (1 meg)
+	not	%ax		# 1's complement
+	pushw	0		# save word at 0000:0000 (0)
+
+	mov	%ax,0		# word at 0 = ~(word at 1 meg)
+	mov	0,%ax		# read it back
+	cmp	%es:0x10,%ax	# fail if word at 0 == word at 1 meg
+
+	popw	0
+
+	pop	%es
+	pop	%ds
+	pop	%ax
+	ret			# if ZF=1, the A20 gate is NOT enabled
+
+# enable/disable A20 gate using keyboard port/controller, entry AH=0 disable
+set_a20:
+	cli
+	call	empty_8042
+	mov	$0xD0,%al	# 8042 command byte to read output port
+	out	%al,$0x64
+1:	in	$0x64,%al
+	test	$1,%al		# output buffer (data _from_ keyboard) full?
+	jz	1b		# no, loop
+
+	in	$0x60,%al	# read output port
+	or	%ah,%ah
+	jne	2f
+	and	$0xFD,%al	# AND ~2 to disable
+	jmp	3f
+2:	or	$2,%al		# OR 2 to enable
+3:	mov	%al,%ah
+
+	call	empty_8042
+	mov	$0xD1,%al	# 8042 command byte to write output port
+	out	%al,$0x64
+
+	call	empty_8042
+	mov	%ah,%al		# the value to write
+	out	%al,$0x60
+
+	call	empty_8042
+	sti
+	ret
+
+0:
+	jmp	1f		# a delay (probably not effective nor necessary)
+1:	in	$0x60,%al	# read and discard data/status from 8042
+empty_8042:
+	jmp	2f		# delay
+2:	in	$0x64,%al
+	test	$1,%al		# output buffer (data _from_ keyboard) full?
+	jnz	0b		# yes, read and discard
+	test	$2,%al		# input buffer (data _to_ keyboard) empty?
+	jnz	empty_8042	# no, loop
+	ret
+
+# write string at SI and exit
+msg_and_exit:
+	call	puts
+exit:   mov     $0,%bx
         mov     $sys_exit,%ax
         int     $syscall
+
+# write string at SI
+puts:	call	strlen
+	mov	$1,%bx
+	mov	%si,%cx
+	mov	%ax,%dx
+	mov     $sys_write,%ax
+	int     $syscall
+	ret
+
+# return length of string at SI
+strlen:	push	%si
+	xor	%bx,%bx
+	dec	%bx
+1:	inc	%bx
+	lodsb
+	test	%al,%al
+	jnz	1b
+	mov	%bx,%ax
+	pop	%si
+        ret
 
         .data
         
@@ -227,15 +338,23 @@ gdt_ptr:.word gdt_len - 1
 
 needs_386_msg:
         .ascii "Sorry, 80386+ CPU required\n"
-        needs_386_len = . - needs_386_msg
+        .byte  0
 v86_msg:
         .ascii "Sorry, CPU in Virtual-8086 mode\n"
-        v86_msg_len = . - v86_msg
+        .byte  0
 
-success_msg:
+unreal_enabled_msg:
         .ascii "Unreal mode enabled if line above written with black on green text.\n"
-        success_msg_len = . - success_msg
+        .byte  0
         
+a20_enabled_msg:
+	.ascii	"A20 gate enabled\n"
+	.byte	0
+
+a20_disabled_msg:
+	.ascii	"A20 gate disabled\n"
+	.byte	0
+
 # This string is written directly to text-mode video memory.
 # The alternating spaces are treated as character attribute bytes.
 # 0x20 = black text (color 0) on green background (color 2)

--- a/elkscmd/sys_utils/unreal16.S
+++ b/elkscmd/sys_utils/unreal16.S
@@ -28,22 +28,24 @@
 #
 # 12 Sep 2020:
 # Use `_start' rather than `entry' as program entry point. TK Chia
+#
+# 4 Nov 2021: bug fixes and cleanup ghaerr
 ##############################################################################
 
+sys_exit = 1
+sys_write = 4
+syscall = 0x80
+videoline = 0xb8000+80*2*22
+
     .code16
+    .text
 
-	.text
-
-	.global	_start
+    .global _start
 _start:
 
-# set text video mode 80x25 and clear screen
-        movw $0x0003,%ax
-        int $0x10
-
 # check for 32-bit CPU
-        movw	$_cpu16_msg_len,%dx
-        movw	$_cpu16_msg,%cx
+        mov     $needs_386_msg,%dx
+        mov     $needs_386_len,%cx
 
         pushf
                 pushf
@@ -61,20 +63,20 @@ _start:
         je msg_and_exit
 
 # check if (32-bit) CPU is in V86 mode
-        movw	$_v86_msg_len,%dx
-        movw	$_v86_msg,%cx
+        mov     $v86_msg_len,%dx
+        mov     $v86_msg,%cx
 
         smsww %bx               # 'SMSW' is a '286+ instruction
         andb $1,%bl
         jne msg_and_exit
 
-# point _gdt_ptr to _gdt
+# point gdt_ptr to gdt
         xorl %eax,%eax
         movw %ds,%ax
         shll $4,%eax
 
-        addl $_gdt, %eax
-        movl %eax, (_gdt_ptr+2)
+        addl $gdt, %eax
+        movl %eax, gdt_ptr+2
 
         cli                     # interrupts off
 
@@ -82,12 +84,12 @@ _start:
         pushl %es
         pushl %fs
         pushl %gs
-                lgdt (_gdt_ptr)
+                lgdt gdt_ptr
                 movl %cr0, %eax # CR0.PE=1: enable protected mode
                 orb $1,%al
                 movl %eax, %cr0
 
-                movw $DATA_SEL, %bx # selector to segment with 4GB-1 limit
+                movw $LINEAR_SEL, %bx # selector to segment with 4GB-1 limit
                 movw %bx,%ds    # set segment limits in descriptor caches
                 movw %bx,%es
                 movw %bx,%fs
@@ -102,86 +104,141 @@ _start:
         popl %fs
         popl %es
         popl %ds
+        sti
 
-# demo use of 32-bit address by copying stuff to bottom line of 80x25 screen
-        pushl %es
-        xorw %di,%di
-        movw %di,%es
-        movl $(0xB8000+80*2*4),%edi
-        movl $_unreal_msg, %esi
-        movl $_unreal_msg_len, %ecx
+# demo use of 32-bit address by copying stuff directly to memory-mapped screen
+        push    %es
+        xor     %di,%di
+        mov     %di,%es
+        movl    $videoline,%edi
+        movl    $unreal_msg,%esi
+        movl    $unreal_msg_len,%ecx
+
 # Action of "rep movsb" in (un)real mode:
 # With a32 prefix byte (0x67):  byte [ES:EDI++] <- [DS:ESI++], ECX times
 # Without prefix byte:          byte [ES:DI++] <- [DS:SI++], CX times
+		cld
         .byte 0x67 #a32
         rep movsb
-# or poke byte
-        addr32 movb $'!',  %es:0xb8296
-        addr32 movb $0x2C, %es:0xb8297
-        popl %es
 
-        movw	$_success_msg_len,%dx
-        movw	$_success_msg,%cx
+# or poke byte
+        addr32 movb $'!',%es:videoline+22
+        addr32 movb $0x2C,%es:videoline+23
+        pop     %es
+
+        mov     $success_msg_len,%dx
+        mov     $success_msg,%cx
 
 msg_and_exit: 
+        mov     $1,%bx
+        mov     $sys_write,%ax
+        int     $syscall
 
-        movw	$1,%bx
-        movw	$4,%ax
-        int	$0x80
-
-        movw	$0,%bx
-        movw	$1,%ax
-        int	$0x80
+        mov     $0,%bx
+        mov     $sys_exit,%ax
+        int     $syscall
 
         .data
         
+# The GDT contains 8-byte DESCRIPTORS for each protected-mode segment.
+# Each descriptor contains a 32-bit segment base address, a 20-bit segment
+# limit, and 12 bits describing the segment type. The descriptors look
+# like this:
+#
+#           MSB    bit 6   bit 5   bit 4   bit 3   bit 2   bit 1   LSB
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#byte 0  | bit 7<---------------- segment limit------------------->bit 0 |
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#byte 1  |bit 15<---------------- segment limit------------------->bit 8 |
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#byte 2  | bit 7<---------------- segment base-------------------->bit 0 |
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#byte 3  |bit 15<---------------- segment base-------------------->bit 8 |
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#byte 4  |bit 23<---------------- segment base-------------------->bit 16|
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#byte 5  |   P   |      DPL      | <----------- segment type ----------> |
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#
+# P is the Segment Present bit. It should always be 1.
+#
+# DPL is the DESCRIPTOR PRIVILEGE LEVEL. For simple code like this, these
+# two bits should always be zeroes.
+#
+# Segment Type (again, for simple code like this) is hex 12 for data
+# segments, hex 1A for code segments.
+#
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#byte 6  |   G   |   B   |   0   | avail | bit 19<-- seg limit--->bit 16 |
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#
+# G is the Limit Granularity. If zero, the segment limit is in bytes
+# (0 to 1M, in 1-byte increments). If one, the segment limit is in 4K PAGES
+# (0 to 4G, in 4K increments). For simple code, set this bit to 1, and
+# set the segment limit to its highest value (FFFFF hex). You now have
+# segments that are 4G in size! The Intel CPUs can address no more than
+# 4G of memory, so this is like having no segments at all. No wonder
+# protected mode is popular.
+#
+# B is the Big bit; also called the D (Default) bit. For code segments,
+# all instructions will use 32-bit operands and addresses by default
+# (BITS 32, in NASM syntax, USE32 in Microsoft syntax) if this bit is set.
+# 16-bit protected mode is not very interesting, so set this bit to 1.
+#
+# None of these notes apply to the NULL descriptor. All of its bytes
+# should be set to zero.
+#
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#byte 7  |bit 31<---------------- segment base------------------->bit 24 |
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+
 # Global Descriptor Table
 # NULL descriptor (required):
-_gdt:   .word 0         # limit 15:0
+gdt:    .word 0         # limit 15:0
         .word 0         # base 15:0
         .byte 0         # base 23:16
         .byte 0         # access byte (descriptor type)
         .byte 0         # b7-4=flags, b3-0=limit 19:16
         .byte 0         # base 31:24
         
-# code segment descriptor:
-CODE_SEL = . - _gdt
-        .word 0xFFFF
-        .word 0
-        .byte 0
-        .byte 0x92      # present, ring 0, data, expand-up, writable
-        .byte 0x8F      
-        .byte 0
-
-# data segment descriptor:
-DATA_SEL = . - _gdt
-        .word 0xFFFF
-        .word 0
+# linear data segment descriptor:
+LINEAR_SEL = . - gdt
+        .word 0xFFFF    # limit 0xFFFFF
+        .word 0         # base 0
         .byte 0
         .byte 0x92      # present, ring 0, data, expand-up, writable
 # can put zero byte here (instead of 0xCF) to DISABLE unreal mode:
-        .byte 0xCF      # 32-bit segment, page-granular 20-bit limit=4GB-1
+        .byte 0xCF      # page-granular, 32-bit, limit=4GB-1
         .byte 0
-_gdt_end: 
+gdt_len = . - gdt
 
-_gdt_ptr: 
-            .word _gdt_end - _gdt - 1
-            .long _gdt
+gdt_ptr:.word gdt_len - 1
+        .long gdt
 
-_cpu16_msg: 
-        .ascii "Sorry, 32-bit CPU required\n"
-        _cpu16_msg_len = . - _cpu16_msg
-_v86_msg: 
-        .ascii "Sorry, CPU in Virtual-8086 mode (Windows DOS box or EMM386 loaded)\n"
-        _v86_msg_len = . - _v86_msg
-_success_msg: 
-        .ascii "Unreal mode enabled!\nThe black-on-green text on the screen is written with 32bit offsets.\n"
-        _success_msg_len = . - _success_msg
+needs_386_msg:
+        .ascii "Sorry, 80386+ CPU required\n"
+        needs_386_len = . - needs_386_msg
+v86_msg:
+        .ascii "Sorry, CPU in Virtual-8086 mode\n"
+        v86_msg_len = . - v86_msg
+
+success_msg:
+        .ascii "Unreal mode enabled if line above written with black on green text.\n"
+        success_msg_len = . - success_msg
         
 # This string is written directly to text-mode video memory.
 # The alternating spaces are treated as character attribute bytes.
 # 0x20 = black text (color 0) on green background (color 2)
-_unreal_msg: 
+unreal_msg:
         .ascii "U n r e a l   m o d e "
-        _unreal_msg_len = . - _unreal_msg
-
+        unreal_msg_len = . - unreal_msg


### PR DESCRIPTION
This PR aims to use the `unreal16` program to allow testing the ability to run the ELKS kernel and various applications after having turned on the 80386 processor "unreal" mode, which is an operating mode in 80386 processors and later that allow segment register limits to be expanded from 64K to access all of machine memory in a 32-bit linear fashion, while retaining 16-bit real mode compatibility.

The previously contributed `unreal16` application is cleaned up to be a proper ELKS application (no BIOS calls), and GDT documentation added. 

For testing, run `unreal16`. This should display some black-on-green text indicating that unreal mode is operating properly. Further testing is required by continuing to run ELKS on real hardware using other applications to ensure that the kernel actually functions properly with unreal mode permanently on, as it is left on on unreal16 application exit.

Next, various methods to turn on the A20 memory line will be added (and possibly left on), which should then immediately allow very fast access to any machine memory above 1Mb (high memory). Unreal16 will then be used for reading and writing high memory for testing on different real PCs. After that, a kernel modification to allow external L2 cache buffers above 1Mb to be used, which should be pretty straightforward. This would greatly speed up ELKS operation on 80386 or later processors with extra memory.

From my current research, there are different mechanisms used to turn on/off A20 across PC systems, and the BIOS is the only portable method. Ultimately, the testing learned from running unreal16 as an application will allow moving its code into the ELKS kernel, and turning on unreal mode if the system is configured for high memory buffers and the processor is 80386 or later. It is not clear whether the A20 line can be left on, which would stop auto-wrap of 8086 segments,  which could possibly cause misbehaved programs to operate differently.

The 80286 processor could be supported using the undocumented LOADALL instruction, but that may be more trouble than its worth, instead of the straightforward approach usable with the 80386. That support could come afterwards if desired.