### PR TITLE
Prepare for extended (placed at > 1MB address) memory buffers in 386 systems

### DIFF
--- a/elks/arch/i86/drivers/block/ll_rw_blk.c
+++ b/elks/arch/i86/drivers/block/ll_rw_blk.c
@@ -172,7 +172,8 @@ static void make_request(unsigned short major, int rw, struct buffer_head *bh)
     sector_t sector, count;
     int max_req;
 
-    debug_blk("BLK(%x) %lu %s\n", bh->b_dev, bh->b_blocknr, rw==READ? "read": "write");
+    debug_blk("BLK(%x) %lu %s addr %x:%x\n", bh->b_dev, bh->b_blocknr,
+		rw==READ? "read": "write", bh->b_seg, buffer_data(bh));
     count = (sector_t) (BLOCK_SIZE >> 9);
     sector = bh->b_blocknr * count;
 

--- a/elks/fs/block_dev.c
+++ b/elks/fs/block_dev.c
@@ -212,7 +212,7 @@ static int blk_rw(struct inode *inode, register struct file *filp,
 	     */
 	    ll_rw_blk(WRITE, bh);
 	    wait_on_buffer(bh);
-	    if (!bh->b_uptodate) { /* Write error. */
+	    if (!buffer_uptodate(bh)) { /* Write error. */
 		brelse(bh);
 		if (!written) written = -EIO;
 		break;

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -41,7 +41,7 @@
 #define SETUP_PART_OFFSETHI	0	/* partition offset high word */
 #define SYS_CAPS		0	/* no XT/AT capabilities */
 
-#define SETUP_HEAPSIZE		1024	/* minimum kernel heap for now*/
+#define SETUP_HEAPSIZE		1232	/* minimum kernel heap for now*/
 
 #define CONFIG_8018X_FCPU	16
 #define CONFIG_8018X_EB

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -119,17 +119,16 @@
 
 struct buffer_head {
     char			*b_data;	/* Address if in L1 buffer area, else 0 */
+    seg_t			b_seg;		/* Current (L1 or L2) buffer segment */
     block32_t			b_blocknr;	/* 32-bit block numbers required for FAT */
     kdev_t			b_dev;
     struct buffer_head		*b_next_lru;
     struct buffer_head		*b_prev_lru;
     struct wait_queue		b_wait;
-    block_t			b_count;
-    seg_t			b_seg;		/* Current (L1 or L2) buffer segment */
+    unsigned char		b_count;
     char			b_lock;
     char			b_dirty;
     char			b_uptodate;
-    char			b_reserved;
 #ifdef CONFIG_FS_EXTERNAL_BUFFER
     seg_t			b_ds;		/* L2 buffer data segment */
     char			*b_L2data;	/* Offset into L2 allocation block */

--- a/elks/include/linuxmt/heap.h
+++ b/elks/include/linuxmt/heap.h
@@ -14,11 +14,13 @@
 
 #define HEAP_TAG_FREE    0x00
 #define HEAP_TAG_USED    0x80
+#define HEAP_TAG_CLEAR   0x40	/* return cleared memory*/
 #define HEAP_TAG_TYPE    0x0F
 #define HEAP_TAG_SEG     0x01
 #define HEAP_TAG_STRING  0x02
 #define HEAP_TAG_TTY     0x03
 #define HEAP_TAG_INTHAND 0x04
+#define HEAP_TAG_BUFHEAD 0x05
 
 
 // TODO: move free list node from header to body

--- a/elks/include/linuxmt/init.h
+++ b/elks/include/linuxmt/init.h
@@ -17,7 +17,7 @@ struct drive_infot;
 
 /* kernel init routines*/
 extern void INITPROC kernel_init(void);
-extern void INITPROC buffer_init(void);
+extern int  INITPROC buffer_init(void);
 extern void console_init(void);
 extern void INITPROC fs_init(void);
 extern void INITPROC inode_init(void);

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -86,7 +86,8 @@ void INITPROC kernel_init(void)
     sched_init();
     setup_arch(&base, &end);
     mm_init(base, end);
-    buffer_init();
+    if (buffer_init())
+		panic("No buf mem");
     inode_init();
     irq_init();
     tty_init();

--- a/elks/lib/heap.c
+++ b/elks/lib/heap.c
@@ -3,6 +3,7 @@
 
 #include <linuxmt/kernel.h>
 #include <linuxmt/heap.h>
+#include <linuxmt/string.h>
 //#include <linuxmt/lock.h>
 
 // Minimal block size to hold heap header
@@ -91,7 +92,11 @@ void * heap_alloc (word_t size, byte_t tag)
 {
 	WAIT_LOCK (&_heap_lock);
 	heap_s * h = free_get (size, tag);
-	if (h) h++;  // skip header
+	if (h) {
+		h++;						// skip header
+		if (tag & HEAP_TAG_CLEAR)
+			memset(h, 0, size);
+	}
 	if (!h) printk("HEAP: no memory (%u bytes)\n", size);
 	EVENT_UNLOCK (&_heap_lock);
 	return h;

--- a/elkscmd/cgatext/makefile
+++ b/elkscmd/cgatext/makefile
@@ -12,7 +12,7 @@ NAME	= cgatext
 OUT	= $(NAME)
 CFLAGS	+= -I$(ELKS)/elks/include/arch
 OBJS	+= main.o
-LIBS	= $(ELKS_LIB86)/libmem.a
+LIBS	= $(ELKS_LIB86)/lib86.a
 
 all: $(OUT)
 

--- a/elkscmd/sys_utils/meminfo.c
+++ b/elkscmd/sys_utils/meminfo.c
@@ -54,7 +54,7 @@ void dump_heap(int fd)
 	word_t total_size = 0;
 	word_t total_free = 0;
 	long total_segsize = 0;
-	static char *heaptype[] = { "free", "SEG ", "STR ", "TTY ", "INT " };
+	static char *heaptype[] = { "free", "SEG ", "STR ", "TTY ", "INT ", "BUFH" };
 	static char *segtype[] = { "free", "CSEG", "DSEG", "BUF ", "RDSK" };
 
 	printf("  HEAP   TYPE  SIZE    SEG   TYPE    SIZE  CNT\n");


### PR DESCRIPTION
Adds the ability to dynamically allocate the number of "external" L2 buffers to the kernel. This will allow for a later runtime selection of "extended" (memory buffers in memory above 1M address) or "external" (L2 buffers in main memory below 640K) buffers, depending on whether the machine has extended memory or not and can be placed in unreal mode.

Buffer heads now dynamically allocated from the local kernel heap. This increases the SETUP_HEAPSIZE in config.h for the minimum heap size for very small systems, but doesn't actually use any more data segment memory.

Clean up buffer management source.
One-line fix for #991.

Found that when CONFIG_FS_EXTERNAL_BUFFERS is not set, BIOS I/O will be performed directly into L1 buffers, which are not 1K aligned. This could cause a problem on very early systems with a 64K address wrap problem on BIOS I/O. Shouldn't be a problem since the default is to use 64 external buffers, rather than the 12 otherwise when option not set.

Next step will be introducing a new "physical ram descriptor" data type which will allow a single routine to move memory to/from either "extended" memory above 1MB, or "main/far" memory and L1 kernel buffers. That will allow the kernel L2 buffers to be placed either in extended or main memory. ELKS currently calls main memory buffers "external" buffers, as they are external to the kernel data segment. We will call the buffers allocated above 1MB "xms" buffers, even though the DOS XMS specification won't be used internally. The new approach will allow buffers to be placed in extended/XMS memory which is not addressable by the CPU except when in protected or unreal mode.