### PR TITLE
Move unreal and a20 gate enable code into kernel library

### DIFF
--- a/elks/arch/i86/lib/Makefile
+++ b/elks/arch/i86/lib/Makefile
@@ -36,6 +36,7 @@ SRCS1 = \
 	peekpoke.S \
 	string.S \
 	bios16.S \
+	unreal.S \
 	printreg.S \
 	atomic.S \
 	# end of list

--- a/elks/arch/i86/lib/unreal.S
+++ b/elks/arch/i86/lib/unreal.S
@@ -1,0 +1,253 @@
+####################################################################################
+# Unreal mode and A20 line management routines
+# derived from UNREAL.ASM and A20.ASM code by Chris Giese
+# 8 Nov 2021 Greg Haerr
+#
+# int enable_unreal_mode(void)	- Attempt to turn on 80386 unreal mode,
+#				  returns 0 on success else error code
+# int enable_a20_gate(void)	- Enable A20 gate, return 0 on success
+# verify_a20		- ASM routine: verify A20 gate status, return NZ if enabled
+# set_a20		- ASM routine: enable (AH=1) or disable (AH=0) A20 gate
+#
+	.code16
+	.text
+
+	.global	enable_unreal_mode
+	.global	enable_a20_gate
+	.global	verify_a20
+	.global	set_a20
+
+# Try to set unreal mode. Currently requires 386 CPU or better.
+# Returns 0 if OK, otherwise error code (1=not 386, 2=in V86 mode).
+enable_unreal_mode:
+# check for 32-bit CPU
+	pushf
+		pushf
+		popw %bx        # old FLAGS -> BX
+		movw %bx,%ax
+		xorb $0x70,%ah  # try changing b14 (NT) or b13:b12 (IOPL)
+		pushw %ax
+		popf
+		pushf
+		popw %ax        # new FLAGS -> AX
+	popf
+	xorb %ah,%bh
+	xorw %ax,%ax
+	andb $0x70,%bh          # 32-bit CPU if we changed NT or IOPL
+	je	not_32bit
+
+# check if (32-bit) CPU is in V86 mode
+	smsww %bx               # 'SMSW' is a '286+ instruction
+	andb $1,%bl
+	jne	in_vm86mode
+
+# point gdt_ptr to gdt
+	xorl %eax,%eax
+	movw %ds,%ax
+	shll $4,%eax
+
+	addl $gdt, %eax
+	movl %eax, gdt_ptr+2
+
+	cli                     # interrupts off
+	pushl %ds
+	pushl %es
+	pushl %fs
+	pushl %gs
+		lgdt gdt_ptr
+		movl %cr0, %eax # CR0.PE=1: enable protected mode
+		orb $1,%al
+		movl %eax, %cr0
+
+		movw $LINEAR_SEL, %bx # selector to segment with 4GB-1 limit
+		movw %bx,%ds    # set segment limits in descriptor caches
+		movw %bx,%es
+		movw %bx,%fs
+		movw %bx,%gs
+
+		decb %al        # CR0.PE=0: back to (un)real mode
+		movl %eax, %cr0
+
+# loading segment registers in (un)real mode changes their base address
+# but not the segment limit; which remains 4GB-1
+	popl %gs
+	popl %fs
+	popl %es
+	popl %ds
+	sti
+
+	xor	%ax,%ax		# system is in unreal mode - return 0
+	ret
+
+not_32bit:
+	mov	$1,%ax		# requires 32 bit CPU
+	ret
+in_vm86mode:
+	mov	$2,%ax		# CPU in V86 mode
+	ret
+
+# Attempt to enable A20 address gate
+# Return 0 if enabled.
+enable_a20_gate:
+	mov	$0,%ah		# enable A20
+	call	set_a20
+	call	verify_a20
+	jnz	1f		# NZ=enabled
+	mov	$1,%ax		# return 1 on fail
+	ret
+1:	xor	%ax,%ax		# return 0 if enabled
+	ret
+
+# verify if A20 gate is enabled, return Z=disabled, NZ=enabled
+verify_a20:
+	push	%ax
+	push	%ds
+	push	%es
+
+	xor	%ax,%ax
+	mov	%ax,%ds
+	dec	%ax
+	mov	%ax,%es
+
+	mov	%es:0x10,%ax	# read word at FFFF:0010 (1 meg)
+	not	%ax		# 1's complement
+	pushw	0		# save word at 0000:0000 (0)
+
+	mov	%ax,0		# word at 0 = ~(word at 1 meg)
+	mov	0,%ax		# read it back
+	cmp	%es:0x10,%ax	# fail if word at 0 == word at 1 meg
+
+	popw	0
+
+	pop	%es
+	pop	%ds
+	pop	%ax
+	ret			# if ZF=1, the A20 gate is NOT enabled
+
+# enable/disable A20 gate using keyboard port/controller, entry AH=0 disable
+set_a20:
+	cli
+	call	empty_8042
+	mov	$0xD0,%al	# 8042 command byte to read output port
+	out	%al,$0x64
+1:	in	$0x64,%al
+	test	$1,%al		# output buffer (data _from_ keyboard) full?
+	jz	1b		# no, loop
+
+	in	$0x60,%al	# read output port
+	or	%ah,%ah
+	jne	2f
+	and	$0xFD,%al	# AND ~2 to disable
+	jmp	3f
+2:	or	$2,%al		# OR 2 to enable
+3:	mov	%al,%ah
+
+	call	empty_8042
+	mov	$0xD1,%al	# 8042 command byte to write output port
+	out	%al,$0x64
+
+	call	empty_8042
+	mov	%ah,%al		# the value to write
+	out	%al,$0x60
+
+	call	empty_8042
+	sti
+	ret
+
+0:
+	jmp	1f		# a delay (probably not effective nor necessary)
+1:	in	$0x60,%al	# read and discard data/status from 8042
+empty_8042:
+	jmp	2f		# delay
+2:	in	$0x64,%al
+	test	$1,%al		# output buffer (data _from_ keyboard) full?
+	jnz	0b		# yes, read and discard
+	test	$2,%al		# input buffer (data _to_ keyboard) empty?
+	jnz	empty_8042	# no, loop
+	ret
+
+# The GDT contains 8-byte DESCRIPTORS for each protected-mode segment.
+# Each descriptor contains a 32-bit segment base address, a 20-bit segment
+# limit, and 12 bits describing the segment type. The descriptors look
+# like this:
+#
+#           MSB    bit 6   bit 5   bit 4   bit 3   bit 2   bit 1   LSB
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#byte 0  | bit 7<---------------- segment limit------------------->bit 0 |
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#byte 1  |bit 15<---------------- segment limit------------------->bit 8 |
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#byte 2  | bit 7<---------------- segment base-------------------->bit 0 |
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#byte 3  |bit 15<---------------- segment base-------------------->bit 8 |
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#byte 4  |bit 23<---------------- segment base-------------------->bit 16|
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#byte 5  |   P   |      DPL      | <----------- segment type ----------> |
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#
+# P is the Segment Present bit. It should always be 1.
+#
+# DPL is the DESCRIPTOR PRIVILEGE LEVEL. For simple code like this, these
+# two bits should always be zeroes.
+#
+# Segment Type (again, for simple code like this) is hex 12 for data
+# segments, hex 1A for code segments.
+#
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#byte 6  |   G   |   B   |   0   | avail | bit 19<-- seg limit--->bit 16 |
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#
+# G is the Limit Granularity. If zero, the segment limit is in bytes
+# (0 to 1M, in 1-byte increments). If one, the segment limit is in 4K PAGES
+# (0 to 4G, in 4K increments). For simple code, set this bit to 1, and
+# set the segment limit to its highest value (FFFFF hex). You now have
+# segments that are 4G in size! The Intel CPUs can address no more than
+# 4G of memory, so this is like having no segments at all. No wonder
+# protected mode is popular.
+#
+# B is the Big bit; also called the D (Default) bit. For code segments,
+# all instructions will use 32-bit operands and addresses by default
+# (BITS 32, in NASM syntax, USE32 in Microsoft syntax) if this bit is set.
+# 16-bit protected mode is not very interesting, so set this bit to 1.
+#
+# None of these notes apply to the NULL descriptor. All of its bytes
+# should be set to zero.
+#
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+#byte 7  |bit 31<---------------- segment base------------------->bit 24 |
+#        +-------+-------+-------+-------+-------+-------+-------+-------+
+
+	.data
+# Global Descriptor Table
+# NULL descriptor (required):
+gdt:    .word 0         # limit 15:0
+        .word 0         # base 15:0
+        .byte 0         # base 23:16
+        .byte 0         # access byte (descriptor type)
+        .byte 0         # b7-4=flags, b3-0=limit 19:16
+        .byte 0         # base 31:24
+        
+# linear data segment descriptor:
+LINEAR_SEL = . - gdt
+        .word 0xFFFF    # limit 0xFFFFF
+        .word 0         # base 0
+        .byte 0
+        .byte 0x92      # present, ring 0, data, expand-up, writable
+# can put zero byte here (instead of 0xCF) to DISABLE unreal mode:
+        .byte 0xCF      # page-granular, 32-bit, limit=4GB-1
+        .byte 0
+gdt_len = . - gdt
+
+gdt_ptr:.word gdt_len - 1
+        .long gdt

--- a/elks/include/linuxmt/memory.h
+++ b/elks/include/linuxmt/memory.h
@@ -31,4 +31,7 @@ word_t fmemcmpw (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg, s
 #define _FP_OFF(fp)	((unsigned)(unsigned long)(void __far *)(fp))
 #define _MK_FP(seg,off)	((void __far *)((((unsigned long)(seg)) << 16) | (off)))
 
+int enable_unreal_mode(void);
+int enable_a20_gate(void);
+
 #endif

--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -103,9 +103,10 @@ console: console.o
 makeboot: makeboot.o
 	$(LD) $(LDFLAGS) -o makeboot makeboot.o $(LDLIBS)
 
-unreal16: unreal16.o
+unreal16: unreal16.o unreal.o
 	$(LD) -melks-libc -mcmodel=small -c unreal16.S -o unreal16.o
-	$(LD) -melks-libc -mcmodel=small -nostdlib -o unreal16 unreal16.o
+	$(LD) -melks-libc -mcmodel=small -c $(ELKS_DIR)/arch/i86/lib/unreal.S -o unreal.o
+	$(LD) -melks-libc -mcmodel=small -nostdlib -o unreal16 unreal16.o unreal.o
 
 all: $(PRGS)
 

--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -10,6 +10,8 @@ include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
+ELKS_LIB=$(ELKS_DIR)/arch/i86/lib
+
 # clock enabled and has direct I/O port access
 # knl, insmod removed as useless
 # exitemu disabled because it calls INT directly to DOSEMU
@@ -103,9 +105,11 @@ console: console.o
 makeboot: makeboot.o
 	$(LD) $(LDFLAGS) -o makeboot makeboot.o $(LDLIBS)
 
+unreal.o: $(ELKS_LIB)/unreal.S
+	$(LD) -melks-libc -mcmodel=small -c $(ELKS_LIB)/unreal.S -o unreal.o
+
 unreal16: unreal16.o unreal.o
 	$(LD) -melks-libc -mcmodel=small -c unreal16.S -o unreal16.o
-	$(LD) -melks-libc -mcmodel=small -c $(ELKS_DIR)/arch/i86/lib/unreal.S -o unreal.o
 	$(LD) -melks-libc -mcmodel=small -nostdlib -o unreal16 unreal16.o unreal.o
 
 all: $(PRGS)

--- a/elkscmd/sys_utils/unreal16.S
+++ b/elkscmd/sys_utils/unreal16.S
@@ -32,6 +32,7 @@
 # 4 Nov 2021: ghaerr
 # bug fixes and cleanup
 # add A20 enable and verify (uses A20.ASM code by Chris Giese)
+# split enable_unreal_mode and enable_a20_gate into seperate kernel file
 ##############################################################################
 
 sys_exit = 1
@@ -41,73 +42,26 @@ videoline = 0xb8000+80*2*22
 
     .code16
     .text
+	.extern	enable_unreal_mode
+	.extern	enable_a20_gate
+	.extern	verify_a20
+	.extern	set_a20
 
     .global _start
 _start:
 
-# check for 32-bit CPU
-        mov     $needs_386_msg,%si
-
-        pushf
-                pushf
-                popw %bx        # old FLAGS -> BX
-                movw %bx,%ax
-                xorb $0x70,%ah  # try changing b14 (NT) or b13:b12 (IOPL)
-                pushw %ax
-                popf
-                pushf
-                popw %ax        # new FLAGS -> AX
-        popf
-        xorb %ah,%bh
-        xorw %ax,%ax
-        andb $0x70,%bh          # 32-bit CPU if we changed NT or IOPL
-        je msg_and_exit
-
-# check if (32-bit) CPU is in V86 mode
-        mov     $v86_msg,%si
-
-        smsww %bx               # 'SMSW' is a '286+ instruction
-        andb $1,%bl
-        jne msg_and_exit
-
-# point gdt_ptr to gdt
-        xorl %eax,%eax
-        movw %ds,%ax
-        shll $4,%eax
-
-        addl $gdt, %eax
-        movl %eax, gdt_ptr+2
-
-        cli                     # interrupts off
-
-        pushl %ds
-        pushl %es
-        pushl %fs
-        pushl %gs
-                lgdt gdt_ptr
-                movl %cr0, %eax # CR0.PE=1: enable protected mode
-                orb $1,%al
-                movl %eax, %cr0
-
-                movw $LINEAR_SEL, %bx # selector to segment with 4GB-1 limit
-                movw %bx,%ds    # set segment limits in descriptor caches
-                movw %bx,%es
-                movw %bx,%fs
-                movw %bx,%gs
-
-                decb %al        # CR0.PE=0: back to (un)real mode
-                movl %eax, %cr0
-
-# loading segment registers in (un)real mode changes their base address
-# but not the segment limit; which remains 4GB-1
-        popl %gs
-        popl %fs
-        popl %es
-        popl %ds
-        sti
+	call	enable_unreal_mode
+	cmp	$1,%ax
+	jnz	1f
+	mov     $needs_386_msg,%si
+	jmp	msg_and_exit
+1:	cmp	$2,%ax
+	jnz	2f
+	mov     $v86_msg,%si
+	jmp	msg_and_exit
 
 # demo use of 32-bit address by copying stuff directly to memory-mapped screen
-        push    %es
+2:      push    %es
         xor     %di,%di
         mov     %di,%es
         movl    $videoline,%edi
@@ -135,91 +89,20 @@ _start:
 #	call	set_a20
 
 	mov	$a20_enabled_msg,%si
-	call	verify_a20
+	call	verify_a20	# check initial A20 gate status
 	jnz	1f		# NZ=enabled
 	mov	$a20_disabled_msg,%si
 	call	puts
 
-	mov	$0,%ah		# enable A20
-	call	set_a20
-
+	call	enable_a20_gate	# enable A20 and return gate status
 	mov	$a20_enabled_msg,%si
-	call	verify_a20
-	jnz	1f		# NZ=enabled
+	cmp	$0,%ax
+	jz	1f		# 0=enabled
 	mov	$a20_disabled_msg,%si
-
 1:	call	puts
 
 # exit - unreal mode and A20 gate should both be enabled
 	call	exit
-
-# verify if A20 gate is enabled, return Z=disabled, NZ=enabled
-verify_a20:
-	push	%ax
-	push	%ds
-	push	%es
-
-	xor	%ax,%ax
-	mov	%ax,%ds
-	dec	%ax
-	mov	%ax,%es
-
-	mov	%es:0x10,%ax	# read word at FFFF:0010 (1 meg)
-	not	%ax		# 1's complement
-	pushw	0		# save word at 0000:0000 (0)
-
-	mov	%ax,0		# word at 0 = ~(word at 1 meg)
-	mov	0,%ax		# read it back
-	cmp	%es:0x10,%ax	# fail if word at 0 == word at 1 meg
-
-	popw	0
-
-	pop	%es
-	pop	%ds
-	pop	%ax
-	ret			# if ZF=1, the A20 gate is NOT enabled
-
-# enable/disable A20 gate using keyboard port/controller, entry AH=0 disable
-set_a20:
-	cli
-	call	empty_8042
-	mov	$0xD0,%al	# 8042 command byte to read output port
-	out	%al,$0x64
-1:	in	$0x64,%al
-	test	$1,%al		# output buffer (data _from_ keyboard) full?
-	jz	1b		# no, loop
-
-	in	$0x60,%al	# read output port
-	or	%ah,%ah
-	jne	2f
-	and	$0xFD,%al	# AND ~2 to disable
-	jmp	3f
-2:	or	$2,%al		# OR 2 to enable
-3:	mov	%al,%ah
-
-	call	empty_8042
-	mov	$0xD1,%al	# 8042 command byte to write output port
-	out	%al,$0x64
-
-	call	empty_8042
-	mov	%ah,%al		# the value to write
-	out	%al,$0x60
-
-	call	empty_8042
-	sti
-	ret
-
-0:
-	jmp	1f		# a delay (probably not effective nor necessary)
-1:	in	$0x60,%al	# read and discard data/status from 8042
-empty_8042:
-	jmp	2f		# delay
-2:	in	$0x64,%al
-	test	$1,%al		# output buffer (data _from_ keyboard) full?
-	jnz	0b		# yes, read and discard
-	test	$2,%al		# input buffer (data _to_ keyboard) empty?
-	jnz	empty_8042	# no, loop
-	ret
 
 # write string at SI and exit
 msg_and_exit:
@@ -250,91 +133,6 @@ strlen:	push	%si
         ret
 
         .data
-        
-# The GDT contains 8-byte DESCRIPTORS for each protected-mode segment.
-# Each descriptor contains a 32-bit segment base address, a 20-bit segment
-# limit, and 12 bits describing the segment type. The descriptors look
-# like this:
-#
-#           MSB    bit 6   bit 5   bit 4   bit 3   bit 2   bit 1   LSB
-#        +-------+-------+-------+-------+-------+-------+-------+-------+
-#byte 0  | bit 7<---------------- segment limit------------------->bit 0 |
-#        +-------+-------+-------+-------+-------+-------+-------+-------+
-#
-#        +-------+-------+-------+-------+-------+-------+-------+-------+
-#byte 1  |bit 15<---------------- segment limit------------------->bit 8 |
-#        +-------+-------+-------+-------+-------+-------+-------+-------+
-#
-#        +-------+-------+-------+-------+-------+-------+-------+-------+
-#byte 2  | bit 7<---------------- segment base-------------------->bit 0 |
-#        +-------+-------+-------+-------+-------+-------+-------+-------+
-#
-#        +-------+-------+-------+-------+-------+-------+-------+-------+
-#byte 3  |bit 15<---------------- segment base-------------------->bit 8 |
-#        +-------+-------+-------+-------+-------+-------+-------+-------+
-#
-#        +-------+-------+-------+-------+-------+-------+-------+-------+
-#byte 4  |bit 23<---------------- segment base-------------------->bit 16|
-#        +-------+-------+-------+-------+-------+-------+-------+-------+
-#
-#        +-------+-------+-------+-------+-------+-------+-------+-------+
-#byte 5  |   P   |      DPL      | <----------- segment type ----------> |
-#        +-------+-------+-------+-------+-------+-------+-------+-------+
-#
-# P is the Segment Present bit. It should always be 1.
-#
-# DPL is the DESCRIPTOR PRIVILEGE LEVEL. For simple code like this, these
-# two bits should always be zeroes.
-#
-# Segment Type (again, for simple code like this) is hex 12 for data
-# segments, hex 1A for code segments.
-#
-#        +-------+-------+-------+-------+-------+-------+-------+-------+
-#byte 6  |   G   |   B   |   0   | avail | bit 19<-- seg limit--->bit 16 |
-#        +-------+-------+-------+-------+-------+-------+-------+-------+
-#
-# G is the Limit Granularity. If zero, the segment limit is in bytes
-# (0 to 1M, in 1-byte increments). If one, the segment limit is in 4K PAGES
-# (0 to 4G, in 4K increments). For simple code, set this bit to 1, and
-# set the segment limit to its highest value (FFFFF hex). You now have
-# segments that are 4G in size! The Intel CPUs can address no more than
-# 4G of memory, so this is like having no segments at all. No wonder
-# protected mode is popular.
-#
-# B is the Big bit; also called the D (Default) bit. For code segments,
-# all instructions will use 32-bit operands and addresses by default
-# (BITS 32, in NASM syntax, USE32 in Microsoft syntax) if this bit is set.
-# 16-bit protected mode is not very interesting, so set this bit to 1.
-#
-# None of these notes apply to the NULL descriptor. All of its bytes
-# should be set to zero.
-#
-#        +-------+-------+-------+-------+-------+-------+-------+-------+
-#byte 7  |bit 31<---------------- segment base------------------->bit 24 |
-#        +-------+-------+-------+-------+-------+-------+-------+-------+
-
-# Global Descriptor Table
-# NULL descriptor (required):
-gdt:    .word 0         # limit 15:0
-        .word 0         # base 15:0
-        .byte 0         # base 23:16
-        .byte 0         # access byte (descriptor type)
-        .byte 0         # b7-4=flags, b3-0=limit 19:16
-        .byte 0         # base 31:24
-        
-# linear data segment descriptor:
-LINEAR_SEL = . - gdt
-        .word 0xFFFF    # limit 0xFFFFF
-        .word 0         # base 0
-        .byte 0
-        .byte 0x92      # present, ring 0, data, expand-up, writable
-# can put zero byte here (instead of 0xCF) to DISABLE unreal mode:
-        .byte 0xCF      # page-granular, 32-bit, limit=4GB-1
-        .byte 0
-gdt_len = . - gdt
-
-gdt_ptr:.word gdt_len - 1
-        .long gdt
 
 needs_386_msg:
         .ascii "Sorry, 80386+ CPU required\n"
@@ -346,7 +144,7 @@ v86_msg:
 unreal_enabled_msg:
         .ascii "Unreal mode enabled if line above written with black on green text.\n"
         .byte  0
-        
+
 a20_enabled_msg:
 	.ascii	"A20 gate enabled\n"
 	.byte	0


### PR DESCRIPTION
Splits unreal mode and a20 gate enable code out of `unreal16` source, into shared kernel library routine.

`unreal16` will now use same code the kernel uses for enabling unreal mode and a20 gate line in next step. This will help facilitate updates for 286 CPUs or other incompatible PC systems in the future.