### PR TITLE
[kernel] Add SO_REUSEADDR setsockopt option for servers

### DIFF
--- a/elks/include/linuxmt/net.h
+++ b/elks/include/linuxmt/net.h
@@ -67,11 +67,13 @@ struct proto_ops {
     int (*fcntl) ();
 };
 
-#define SO_CLOSING	(1 << 0)
-#define SO_ACCEPTCON	(1 << 1)
-#define SO_WAITDATA	(1 << 2)
-#define SO_NOSPACE	(1 << 3)
-#define SO_RST_ON_CLOSE	(1 << 4)
+/* careful: option names are close to public SO_ options in socket.h */
+#define SF_CLOSING	(1 << 0)
+#define SF_ACCEPTCON	(1 << 1)
+#define SF_WAITDATA	(1 << 2)
+#define SF_NOSPACE	(1 << 3)
+#define SF_RST_ON_CLOSE	(1 << 4)
+#define SF_REUSE_ADDR	(1 << 5)
 
 struct net_proto {
     char *name;			/* Protocol name */

--- a/elks/include/linuxmt/socket.h
+++ b/elks/include/linuxmt/socket.h
@@ -15,7 +15,8 @@ struct sockaddr {
 /* for setsockopt(2) */
 #define SOL_SOCKET	1
 
-/* careful: option name scheme interferes with internal SO_ options in net.h*/
+/* careful: option names are close to internal SF_ options in net.h*/
+#define SO_REUSEADDR	2
 #define SO_LINGER	13		/* only implemented for l_linger = 0*/
 
 struct linger {

--- a/elks/include/linuxmt/tcpdev.h
+++ b/elks/include/linuxmt/tcpdev.h
@@ -29,7 +29,7 @@
 struct tdb_release {
     unsigned char cmd;
     struct socket *sock;
-	int reset;
+    int reset;
 };
 
 struct tdb_accept {
@@ -48,6 +48,7 @@ struct tdb_listen {
 struct tdb_bind {
     unsigned char cmd;
     struct socket *sock;
+    int reuseaddr;
     struct sockaddr_in addr;
 };
 

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -117,11 +117,12 @@ static int inet_bind(register struct socket *sock, struct sockaddr *addr,
 
     /* TODO : Check if the user has permision to bind the port */
 
-	down(&rwlock);
+    down(&rwlock);
     cmd = (struct tdb_bind *)get_tdout_buf();
     cmd->cmd = TDC_BIND;
     cmd->sock = sock;
-	cmd->reuseaddr = sock->flags & SF_REUSE_ADDR;
+
+    cmd->reuseaddr = sock->flags & SF_REUSE_ADDR;
     memcpy_fromfs(&cmd->addr, addr, sockaddr_len);
 
     tcpdev_inetwrite(cmd, sizeof(struct tdb_bind));
@@ -132,7 +133,7 @@ static int inet_bind(register struct socket *sock, struct sockaddr *addr,
 
     ret = ((struct tdb_return_data *)tdin_buf)->ret_value;
     tcpdev_clear_data_avail();
-	up(&rwlock);
+    up(&rwlock);
 
     return (ret >= 0 ? 0 : ret);
 }

--- a/elks/net/nano/af_nano.c
+++ b/elks/net/nano/af_nano.c
@@ -247,9 +247,9 @@ static int nano_accept(register struct socket *sock,
 	if (flags & O_NONBLOCK)
 	    return -EAGAIN;
 
-	sock->flags |= SO_WAITDATA;
+	sock->flags |= SF_WAITDATA;
 	interruptible_sleep_on(sock->wait);
-	sock->flags &= ~SO_WAITDATA;
+	sock->flags &= ~SF_WAITDATA;
 
 	if (current->signal /* & ~current->blocked */ )
 	    return -ERESTARTSYS;
@@ -316,9 +316,9 @@ static int nano_read(register struct socket *sock,
 	if (nonblock)
 	    return -EAGAIN;
 
-	sock->flags |= SO_WAITDATA;
+	sock->flags |= SF_WAITDATA;
 	interruptible_sleep_on(sock->wait);
-	sock->flags &= ~SO_WAITDATA;
+	sock->flags &= ~SF_WAITDATA;
 
 	if (current->signal /* & ~current->blocked */ )
 	    return -ERESTARTSYS;
@@ -386,11 +386,11 @@ static int nano_write(register struct socket *sock,
     pupd = NA_DATA(sock)->npd_peerupd;	/* safer than sock->conn */
 
     while (!(space = NA_BUF_SPACE(pupd))) {
-	sock->flags |= SO_NOSPACE;
+	sock->flags |= SF_NOSPACE;
 	if (nonblock)
 	    return -EAGAIN;
 
-	sock->flags &= ~SO_NOSPACE;
+	sock->flags &= ~SF_NOSPACE;
 	interruptible_sleep_on(sock->wait);
 
 	if (current->signal /* & ~current->blocked */ )
@@ -465,7 +465,7 @@ static int nano_select(register struct socket *sock,
      *      Handle server sockets specially.
      */
 
-    if (sock->flags & SO_ACCEPTCON) {
+    if (sock->flags & SF_ACCEPTCON) {
 	if (sel_type == SEL_IN) {
 	    if (sock->iconn)
 		return 1;

--- a/elks/net/socket.c
+++ b/elks/net/socket.c
@@ -604,8 +604,8 @@ int sys_setsockopt(int fd, int level, int option_name, void *option_value,
     }
 
     if (setoption)
-	sock->flags |= setoption;
-    else sock->flags &= ~setoption;
+	sock->flags |= flags;
+    else sock->flags &= ~flags;
 
     return 0;
 }

--- a/elks/net/unix/af_unix.c
+++ b/elks/net/unix/af_unix.c
@@ -264,9 +264,9 @@ static int unix_accept(struct socket *sock, struct socket *newsock, int flags)
 	if (flags & O_NONBLOCK)
 	    return -EAGAIN;
 
-	sock->flags |= SO_WAITDATA;
+	sock->flags |= SF_WAITDATA;
 	interruptible_sleep_on(sock->wait);
-	sock->flags &= ~SO_WAITDATA;
+	sock->flags &= ~SF_WAITDATA;
 
 	if (current->signal /* & ~current->blocked */ )
 	    return -ERESTARTSYS;
@@ -330,9 +330,9 @@ static int unix_read(struct socket *sock, char *ubuf, int size, int nonblock)
 	if (nonblock)
 	    return -EAGAIN;
 
-	sock->flags |= SO_WAITDATA;
+	sock->flags |= SF_WAITDATA;
 	interruptible_sleep_on(sock->wait);
-	sock->flags &= ~SO_WAITDATA;
+	sock->flags &= ~SF_WAITDATA;
 
 	if (current->signal /* & ~current->blocked */ )
 	    return -ERESTARTSYS;
@@ -397,12 +397,12 @@ static int unix_write(struct socket *sock, char *ubuf, int size, int nonblock)
     pupd = UN_DATA(sock)->peerupd;	/* safer than sock->conn */
 
     while (!(space = UN_BUF_SPACE(pupd))) {
-	sock->flags |= SO_NOSPACE;
+	sock->flags |= SF_NOSPACE;
 
 	if (nonblock)
 	    return -EAGAIN;
 
-	sock->flags &= ~SO_NOSPACE;
+	sock->flags &= ~SF_NOSPACE;
 	interruptible_sleep_on(sock->wait);
 
 	if (current->signal /* & ~current->blocked */ )
@@ -474,7 +474,7 @@ static int unix_select(struct socket *sock, int sel_type)
      *      Handle server sockets specially.
      */
 
-    if (sock->flags & SO_ACCEPTCON) {
+    if (sock->flags & SF_ACCEPTCON) {
 	if (sel_type == SEL_IN) {
 
 	    if (sock->iconn)

--- a/elkscmd/inet/httpd/httpd.c
+++ b/elkscmd/inet/httpd/httpd.c
@@ -152,6 +152,11 @@ int main(int argc, char **argv)
 		exit(-1);
 	}
 
+	/* set local port reuse, allows server to be restarted in less than 10 secs */
+	ret = 1;
+	if (setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, &ret, sizeof(int)) < 0)
+		perror("setsockopt SO_REUSEADDR");
+
 	localadr.sin_family = AF_INET;
 	localadr.sin_port = htons(DEF_PORT);
 	localadr.sin_addr.s_addr = INADDR_ANY;

--- a/elkscmd/inet/telnetd/telnetd.c
+++ b/elkscmd/inet/telnetd/telnetd.c
@@ -192,6 +192,12 @@ int main(int argc, char **argv)
 		fprintf(stderr, "telnetd: Can't open socket (check if ktcp is running)\n");
 		exit(-1);
 	}
+
+	/* set local port reuse, allows server to be restarted in less than 10 secs */
+	ret = 1;
+	if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &ret, sizeof(int)) < 0)
+		perror("setsockopt SO_REUSEADDR");
+
 	memset(&addr_in, 0, sizeof(addr_in));
 	addr_in.sin_family = AF_INET;
 	addr_in.sin_addr.s_addr = htons(INADDR_ANY);

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -349,7 +349,7 @@ static void tcp_fin_wait_2(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 	/* Remove the flag */
 	iptcp->tcph->flags &= ~TF_FIN;
 	cbs_in_user_timeout--;
-	ENTER_TIME_WAIT(cb);
+	ENTER_TIME_WAIT(cb);		/* this sets the 10 sec wait after active close! */
 	needack = 1;
     }
 

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -237,6 +237,8 @@ void tcpcb_expire_timeouts(void)
 	    case TS_TIME_WAIT:
 		if (TIME_GT(Now, n->tcpcb.time_wait_exp)) {
 		    LEAVE_TIME_WAIT(&n->tcpcb);
+			debug_close("tcp: exit TIME_WAIT state on port %u remote %s:%u\n",
+				n->tcpcb.localport, in_ntoa(n->tcpcb.remaddr), n->tcpcb.remport);
 		    tcpcb_remove(n);
 		}
 		break;

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -78,7 +78,9 @@ static void tcpdev_bind(void)
 	    next_port++;
 	port = next_port;
     } else {
-	if (tcpcb_check_port(port) != NULL) {	/* Port already bound */
+	/* check if port already bound */
+	struct tcpcb_list *n2 = tcpcb_check_port(port);
+	if (n2 && !db->reuseaddr) {
 	    tcpcb_remove(n);
 	    retval_to_sock(db->sock, -EADDRINUSE);
 	    return;


### PR DESCRIPTION
Adds the ability to reuse local port numbers in `bind`. No other checking is performed when requested, so this option should be used carefully, and only with servers.

Cleaned up some messy naming confusing between public SO_xxx symbols and internal flags. The internal flags were renamed SF_xxx.

@Mellvik, this should fix the problem being discussed in #996 and #997.
The following code should be added to ftpd before calling bind:
```
int enable = 1;
setsockopt(fd, SO_REUSEADDR, &enable, sizeof(int));
```