### PR TITLE
[net] Reduce ktcp memory usage on listening sockets

### DIFF
--- a/elkscmd/inet/nettools/arp.c
+++ b/elkscmd/inet/nettools/arp.c
@@ -19,7 +19,6 @@
 #include <ktcp/arp.h>
 #include <arpa/inet.h>
 
-struct sockaddr_in localadr,remaddr;
 struct arp_cache arp_cache[ARP_CACHE_MAX];
 
 char *mac_ntoa(eth_addr_t eth_addr)
@@ -35,6 +34,7 @@ int main(void)
 {
     int i, s, ret;
     struct stat_request_s sr;
+    struct sockaddr_in localadr, remaddr;
 
     if ( (s = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
 	perror("socket error");
@@ -42,7 +42,7 @@ int main(void)
     }
 
     localadr.sin_family = AF_INET;
-    localadr.sin_port = 0;
+    localadr.sin_port = PORT_ANY;
     localadr.sin_addr.s_addr = INADDR_ANY;  
     ret = bind(s, (struct sockaddr *)&localadr, sizeof(struct sockaddr_in));
     if ( ret == -1) {

--- a/elkscmd/inet/nettools/netstat.c
+++ b/elkscmd/inet/nettools/netstat.c
@@ -75,7 +75,7 @@ int main(void)
     }
 
     localadr.sin_family = AF_INET;
-    localadr.sin_port = 0;
+    localadr.sin_port = PORT_ANY;
     localadr.sin_addr.s_addr = INADDR_ANY;  
     ret = bind(s, (struct sockaddr *)&localadr, sizeof(struct sockaddr_in));
     if ( ret == -1) {

--- a/elkscmd/inet/nettools/nslookup.c
+++ b/elkscmd/inet/nettools/nslookup.c
@@ -105,7 +105,7 @@ int main(int argc, char *argv[]) {
   memset(&addr, 0, sizeof(addr));
 
   addr.sin_family = AF_INET;
-  addr.sin_port = 0; /* any port */
+  addr.sin_port = PORT_ANY;
   addr.sin_addr.s_addr = INADDR_ANY;
 
   if (bind(fd, (struct sockaddr *)&addr, sizeof(struct sockaddr_in))==-1) {

--- a/elkscmd/inet/tinyirc/tinyirc.c
+++ b/elkscmd/inet/tinyirc/tinyirc.c
@@ -902,9 +902,9 @@ char *hostname;
 	sa.sin_port = htons((unsigned short) IRCPORT);
 	s = socket(hp->h_addrtype, SOCK_STREAM, 0);
 #else
-	sa.sin_addr.s_addr = in_gethostbyname(hostname);
 	sa.sin_family = AF_INET;
-	sa.sin_port = htons((unsigned short) IRCPORT);
+	sa.sin_port = PORT_ANY;
+	sa.sin_addr.s_addr = INADDR_ANY;
 	s = socket(AF_INET, SOCK_STREAM, 0);
 #endif
 	if (s > 0) {
@@ -913,6 +913,8 @@ char *hostname;
 		exit(1);
 	    }
 	}
+	sa.sin_port = htons((unsigned short) IRCPORT);
+	sa.sin_addr.s_addr = in_gethostbyname(hostname);
 	if (connect(s, (struct sockaddr *) &sa, sizeof(sa)) < 0) {
 	close(s);
 	s = -1;

--- a/elkscmd/ktcp/netconf.c
+++ b/elkscmd/ktcp/netconf.c
@@ -66,5 +66,5 @@ void netconf_send(struct tcpcb_s *cb)
 	tcpcb_buf_write(cb, (unsigned char *)&arp_cache, ARP_CACHE_MAX*sizeof(struct arp_cache));
 	break;
     }
-    cb->bytes_to_push = CB_BUF_USED(cb);
+    cb->bytes_to_push = cb->buf_used;
 }

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -184,7 +184,8 @@ static void tcp_listen(struct iptcp_s *iptcp, struct tcpcb_s *lcb)
     if (h->flags & TF_ACK)
 	debug_tcp("tcp: ACK in listen not implemented\n");
 
-    n = tcpcb_clone(lcb);    /* copy lcb into linked list*/
+    /* duplicate control block but with normal sized input buffer */
+    n = tcpcb_clone(lcb, CB_NORMAL_SIZE);    /* copy lcb into linked list*/
     if (!n)
 	return;		     /* no memory for new connection*/
     cb = &n->tcpcb;
@@ -439,7 +440,7 @@ void tcp_process(struct iphdr_s *iph)
 		return;
 
 	/* Dummy up a new control block and send RST to shutdown sender */
-	cbnode = tcpcb_new();
+	cbnode = tcpcb_new(1);
 	if (cbnode) {
 	    __u32 seqno = ntohl(tcph->seqnum);
 	    cbnode->tcpcb.state = TS_CLOSED;

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -252,7 +252,7 @@ static void tcp_established(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 	    //if (cb->bytes_to_push <= 0)
 	    if (cb->bytes_to_push >= 0)
 		tcpcb_need_push++;
-	    cb->bytes_to_push = CB_BUF_USED(cb);
+	    cb->bytes_to_push = cb->buf_used;
 	}
 	tcpdev_checkread(cb);
     }

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -11,10 +11,10 @@
 
 /*
  * /etc/tcpdev max read/write size
- * Must be at least as big as CB_IN_BUF_SIZE
+ * Must be at least as big as CB_NORMAL_SIZE
  * And at least as big as TCPDEV_INBUFFERSIZE in <linuxmt/tcpdev.h> (currently 1024)
  */
-#define TCPDEV_BUFSIZ	(CB_IN_BUF_SIZE + sizeof(struct tdb_return_data))
+#define TCPDEV_BUFSIZ	(CB_NORMAL_SIZE + sizeof(struct tdb_return_data))
 
 /* max tcp buffer size (no ip header)*/
 #define TCP_BUFSIZ	(TCPDEV_BUFSIZ + sizeof(tcphdr_t) + TCP_OPT_MSS_LEN)
@@ -22,14 +22,15 @@
 /* max ip buffer size (with link layer frame)*/
 #define IP_BUFSIZ	(TCP_BUFSIZ + sizeof(iphdr_t) + sizeof(struct ip_ll))
 
-/* control block input buffer size - max window size*/
-#define CB_IN_BUF_SIZE	4096	/* doesn't need to be power of two*/
+/* control block input buffer size - max window size, doesn't have to be power of two*/
+#define CB_NORMAL_SIZE	4096	/* normal input buffer size*/
+#define CB_LISTEN_SIZE  128	/* small buffer size for listening sockets*/
 
 /* max outstanding send window size*/
 #define TCP_SEND_WINDOW_MAX	1024	/* should be less than TCP_RETRANS_MAXMEM*/
 
 /* max advertised receive window size*/
-#define THROTTLE_MAX_WINDOW	512	/* FIXME CB_IN_BUF_SIZE when PTY fixed*/
+#define THROTTLE_MAX_WINDOW	512	/* FIXME CB_NORMAL_SIZE when PTY fixed*/
 
 /* bytes to subtract from window size and when to force app write*/
 #define PUSH_THRESHOLD	512
@@ -112,8 +113,8 @@ struct iptcp_s {
 #define	TS_LAST_ACK	9
 #define	TS_TIME_WAIT	10
 
-#define CB_BUF_USED(x)	((x)->buf_len)
-#define CB_BUF_SPACE(x)	(CB_IN_BUF_SIZE - CB_BUF_USED((x)))
+#define CB_BUF_USED(x)	((x)->buf_used)
+#define CB_BUF_SPACE(x)	((x)->buf_size - CB_BUF_USED((x)))
 
 struct tcpcb_s {
 	void *	newsock;
@@ -131,10 +132,6 @@ struct tcpcb_s {
 
 	__u32	time_wait_exp;
 	__u16	wait_data;
-	__u8	buf_base[CB_IN_BUF_SIZE];
-	__u16	buf_head;
-	__u16	buf_tail;
-	__u16	buf_len;
 
 	short	bytes_to_push;
 
@@ -153,6 +150,12 @@ struct tcpcb_s {
 	__u16	flags;
 	__u8	*data;
 	__u16	datalen;
+
+	__u16	buf_head;
+	__u16	buf_tail;
+	__u16	buf_used;		/* # valid bytes in buffer */
+	__u16	buf_size;		/* total buffer size */
+	__u8	buf_base[];
 };
 
 /* TCP options*/
@@ -163,9 +166,9 @@ struct tcpcb_s {
 #define TCP_OPT_MSS_LEN		4	/* total MSS option length*/
 
 struct	tcpcb_list_s {
-	struct tcpcb_s		tcpcb;
 	struct tcpcb_list_s	*prev;
 	struct tcpcb_list_s	*next;
+	struct tcpcb_s		tcpcb;	/* must be last */
 };
 
 struct	tcp_retrans_list_s {
@@ -188,7 +191,7 @@ int tcpcb_need_push;
 int tcp_timeruse;		/* # retransmits alloced*/
 int tcp_retrans_memory;		/* total retransmit memory*/
 
-struct tcpcb_list_s *tcpcb_new(void);
+struct tcpcb_list_s *tcpcb_new(int bufsize);
 struct tcpcb_list_s *tcpcb_find(__u32 addr, __u16 lport, __u16 rport);
 struct tcpcb_list_s *tcpcb_find_by_sock(void *sock);
 

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -113,8 +113,7 @@ struct iptcp_s {
 #define	TS_LAST_ACK	9
 #define	TS_TIME_WAIT	10
 
-#define CB_BUF_USED(x)	((x)->buf_used)
-#define CB_BUF_SPACE(x)	((x)->buf_size - CB_BUF_USED((x)))
+#define CB_BUF_SPACE(x)	((x)->buf_size - (x)->buf_used)
 
 struct tcpcb_s {
 	void *	newsock;

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -268,16 +268,16 @@ void tcpcb_push_data(void)
 	    tcpdev_checkread(&n->tcpcb);
 }
 
-/* There must be free space greater-equal than len */
+/* There must be free space greater-equal than len or will wrap*/
 void tcpcb_buf_write(struct tcpcb_s *cb, unsigned char *data, int len)
 {
     int tail = cb->buf_tail;
 
-    cb->buf_used += len;
     while (--len >= 0) {
-	cb->buf_base[tail] = *data++;
-	if (++tail >= cb->buf_size)
+	cb->buf_base[tail++] = *data++;
+	if (tail >= cb->buf_size)
 	    tail = 0;
+	cb->buf_used++;
     }
     cb->buf_tail = tail;
 }
@@ -287,11 +287,11 @@ void tcpcb_buf_read(struct tcpcb_s *cb, unsigned char *data, int len)
 {
     int head = cb->buf_head;
 
-    cb->buf_used -= len;
     while (--len >= 0) {
-	*data++= cb->buf_base[head];
-	if (++head >= cb->buf_size)
+	*data++= cb->buf_base[head++];
+	if (head >= cb->buf_size)
 	    head = 0;
+	cb->buf_used--;
     }
     cb->buf_head = head;
 }

--- a/elkscmd/ktcp/tcp_cb.h
+++ b/elkscmd/ktcp/tcp_cb.h
@@ -4,7 +4,7 @@
 extern int tcpcb_num;
 
 void tcpcb_init(void);
-struct tcpcb_list_s *tcpcb_clone(struct tcpcb_s *cb);
+struct tcpcb_list_s *tcpcb_clone(struct tcpcb_s *cb, int bufsize);
 void tcpcb_remove(struct tcpcb_list_s *n);
 void tcpcb_remove_cb(struct tcpcb_s *cb);
 void tcpcb_buf_read(struct tcpcb_s *cb, unsigned char *data, int len);

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -364,7 +364,9 @@ void tcp_output(struct tcpcb_s *cb)
 
     cb->send_nxt += cb->datalen;
 
-    len = CB_BUF_SPACE(cb) - PUSH_THRESHOLD;
+    len = CB_BUF_SPACE(cb);
+    if (cb->buf_size > CB_LISTEN_SIZE)	/* advertise real usable for "listen" buffers */
+	len -= PUSH_THRESHOLD;
     if (len <= 0)
 	len = 1;			/* Never advertise zero window size */
     if (len > THROTTLE_MAX_WINDOW)	/* throttle down to allow ELKS apps to keep up */

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -65,7 +65,12 @@ static void tcpdev_bind(void)
 	return;
     }
 
-    n = tcpcb_new();
+    /*
+     * If binding to PORT_ANY, assume calling connect later,
+     * allocate normal (larger) sized input buffer.
+     * Otherwise, assume later listen, so allocate small buffer.
+     */
+    n = tcpcb_new(db->addr.sin_port == PORT_ANY? CB_NORMAL_SIZE: CB_LISTEN_SIZE);
     if (n == NULL) {
 	retval_to_sock(db->sock,-ENOMEM);
 	return;

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -290,7 +290,7 @@ void tcpdev_checkread(struct tcpcb_s *cb)
 
 #if 0 /* removed - wait_data mechanism no longer used in inet_read*/
     struct tdb_return_data *ret_data = (struct tdb_return_data *)sbuf;
-    //unsigned int data_avail = CB_BUF_USED(cb);
+    //unsigned int data_avail = cb->buf_used;
     data_avail = cb->wait_data < cb->bytes_to_push ? cb->wait_data : cb->bytes_to_push;
     cb->bytes_to_push -= data_avail;
     if (cb->bytes_to_push <= 0)


### PR DESCRIPTION
Drastically reduces the size of TCP control blocks from over 4K bytes to just 206 for listening sockets (waiting for passive remote open). This is done by allowing control block input buffers to be variably sized.

Since ktcp normally runs with telnetd and httpd servers idle, this removes 8K in heap space requirements, allowing more active connections. Active opened sockets, and accept sockets use the same 4K input buffer size.

The control block's TCP input buffer size is determined at `bind` time by inspecting the local port number: if 0 (any port), ktcp assumes that a `connect` call will be forthcoming and allocates a 4K buffer. If the local port is non-zero, it assumes the next socket call won't be connect, but rather `listen`, and allocates a 128 byte buffer (to receive a SYN, indicating a remote connection request to accept). The new accept socket created by listen after SYN received is then allocated with a normal 4K buffer.

This is fairly well tested, but the old "must press a space to continue" bug has appeared a couple times during testing with small buffers. It was earlier thought this was a PTY bug, but I am seeing it during ftpput transfers, but only sometimes after a telnet to localhost telnetd has run. So quite strange. It is possible this issue has something to do with the advertised window size, which is much smaller for listen sockets.

Nonetheless, normal operation appears to stop ktcp from running out of memory for quite a bit longer. 

I'd like to see some real hardware testing before commit, and I'll continue trying to track down the single strange behavior sometimes seen.