### PR TITLE
[net] Various fixes to ftpd, ktcp, and TIME_WAIT

### DIFF
--- a/elks/arch/i86/lib/unreal.S
+++ b/elks/arch/i86/lib/unreal.S
@@ -28,6 +28,7 @@
 #define USE_A20ASM
 //#define USE_HIMEM_AT
 
+	.arch	i386,nojumps
 	.code16
 	.text
 

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -151,7 +151,6 @@ disk_utils/partype				:diskutil				:1440k
 disk_utils/ramdisk				:diskutil				:1440k
 disk_utils/fdisk				:be-diskutil	:360k
 busyelks/busyelks				:busyelks
-inet/httpd/httpd				:net
 inet/httpd/sample_index.html	::var/www/index.html	:net
 ktcp/ktcp						:net
 ktcp/resolv.conf	::etc/resolv.conf	:net
@@ -160,6 +159,8 @@ inet/nettools/nslookup			:net
 inet/nettools/arp				:net
 inet/telnet/telnet				:net
 inet/telnetd/telnetd			:net
+inet/httpd/httpd				:net
+inet/ftp/ftpd					:net
 inet/tinyirc/tinyirc			:net
 inet/urlget/urlget				:net
 inet/urlget/urlget :::ftpget	:net

--- a/elkscmd/inet/Makefile
+++ b/elkscmd/inet/Makefile
@@ -19,6 +19,7 @@ SUBDIRS = \
     telnetd \
     tinyirc \
     urlget \
+	ftp \
     # EOL
 
 all:

--- a/elkscmd/inet/ftp/ftpd.c
+++ b/elkscmd/inet/ftp/ftpd.c
@@ -401,7 +401,7 @@ void usage() {
 
 int main(int argc, char **argv){
 
-	int listenfd, connfd, port = FTP_PORT;
+	int listenfd, connfd, ret, port = FTP_PORT;
 	struct sockaddr_in servaddr;
 	pid_t pid;
 
@@ -439,6 +439,20 @@ int main(int argc, char **argv){
 		perror("Error in listen");
 		exit(3);
 	}
+
+	/* become daemon, debug output on 1 and 2*/
+	if ((ret = fork()) == -1) {
+		fprintf(stderr, "ftpd: Can't fork to become daemon\n");
+		exit(1);
+	}
+	if (ret) exit(0);
+	ret = open("/dev/console", O_RDWR);
+	close(STDIN_FILENO);
+	dup2(ret, STDOUT_FILENO);
+	dup2(ret, STDERR_FILENO);
+	if (ret > STDERR_FILENO)
+		close(ret);
+	setsid();
 
 	while(1){
 		if ((connfd = accept(listenfd, NULL, NULL)) < 0) {

--- a/elkscmd/inet/urlget/net.c
+++ b/elkscmd/inet/urlget/net.c
@@ -48,11 +48,17 @@ int port;
 	in_adr.sin_family = AF_INET;
 	in_adr.sin_port = htons(port);
 	in_adr.sin_addr.s_addr = in_gethostbyname(host);
+	if (in_adr.sin_addr.s_addr == 0) {
+		fprintf(stderr, "Can't find host '%s' in /etc/hosts\n", host);
+		close (netfd);
+		return -1;
+	}
 
 	ret = connect(netfd, (struct sockaddr *)&in_adr, sizeof(struct sockaddr_in));
 	if (ret < 0){
-		perror("Connection failed");
-		exit(1);
+		perror("Connect failed");
+		close(netfd);
+		return -1;
 	}
 
 	return(netfd);

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -330,8 +330,12 @@ static void tcp_fin_wait_1(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 
     if (SEQ_LT(lastack, cb->send_una)) {
 
-	/* out FIN was acked */
-	cb->state = TS_FIN_WAIT_2;	/* cbs_in_user_timeout stays unchanged */
+	/* our FIN was acked */
+	if (cb->state == TS_CLOSING) {	/* FIN and ACK received, enter TIME_WAIT */
+	    cbs_in_user_timeout--;
+	    ENTER_TIME_WAIT(cb);
+	} else
+	    cb->state = TS_FIN_WAIT_2;	/* cbs_in_user_timeout stays unchanged */
 	cb->time_wait_exp = Now;
     }
 

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -35,22 +35,18 @@
 /* bytes to subtract from window size and when to force app write*/
 #define PUSH_THRESHOLD	512
 
-/* timeout values in seconds*/
-//#define TIMEOUT_ENTER_WAIT	30	/* length of TIME_WAIT state*/
-#define TIMEOUT_ENTER_WAIT	10	/* length of TIME_WAIT state*/
-//#define TIMEOUT_CLOSE_WAIT	240	/* length of CLOSING/LAST_ACK/FIN_WAIT states*/
-#define TIMEOUT_CLOSE_WAIT	10	/* length of CLOSING/LAST_ACK/FIN_WAIT states*/
-//#define TIMEOUT_INITIAL_RTT	4	/* initial RTT before retransmit*/
-#define TIMEOUT_INITIAL_RTT	1	/* initial RTT before retransmit*/
+/* timeout values in 1/16 seconds, or (seconds << 4). Half second = 8*/
+#define TIMEOUT_ENTER_WAIT	(8)	/* TIME_WAIT state (was 30, then 10)*/
+#define TIMEOUT_CLOSE_WAIT	(10<<4)	/* CLOSING/LAST_ACK/FIN_WAIT states (was 240)*/
+#define TIMEOUT_INITIAL_RTT	(1<<4)	/* initial RTT before retransmit (was 4)*/
+#define TCP_RETRANS_MAXWAIT	(4<<4)	/* max retransmit wait (4 secs)*/
+#define TCP_RETRANS_MINWAIT_SLIP 8	/* min retrans timeout for slip/cslip (1/2 sec)*/
+#define TCP_RETRANS_MINWAIT_ETH	4	/* min retrans timeout for ethernet (1/4 sec)*/
 
 /* retransmit settings*/
 #define TCP_RTT_ALPHA			90
 #define TCP_RETRANS_MAXMEM		4096	/* max retransmit total memory*/
 #define TCP_RETRANS_MAXTRIES		6	/* max # retransmits (~12 secs total)*/
-/* timeout values in 1/16 seconds*/
-#define TCP_RETRANS_MAXWAIT		64	/* max retransmit wait (4 secs)*/
-#define TCP_RETRANS_MINWAIT_SLIP	8	/* minimum retrans timeout for slip/cslip (1/2 sec)*/
-#define TCP_RETRANS_MINWAIT_ETH		4	/* minimum retrans timeout for ethernet (1/4 sec)*/
 
 #define SEQ_LT(a,b)	((long)((a)-(b)) < 0)
 #define SEQ_LEQ(a,b)	((long)((a)-(b)) <= 0)
@@ -69,10 +65,9 @@
 #define TF_ALL (TF_FIN | TF_SYN | TF_RST | TF_PSH | TF_ACK | TF_URG)
 
 #define	TCP_DATAOFF(x)		( (x)->data_off >> 2 )
-
 #define TCP_SETHDRSIZE(c,s)	( (c)->data_off = (s) << 2 )
 
-#define ENTER_TIME_WAIT(cb)	{ (cb)->time_wait_exp = Now + (TIMEOUT_ENTER_WAIT << 4); \
+#define ENTER_TIME_WAIT(cb)	{ (cb)->time_wait_exp = Now + TIMEOUT_ENTER_WAIT; \
 				  (cb)->state = TS_TIME_WAIT; \
 				  tcp_timeruse++; \
 				  cbs_in_time_wait++; }

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -36,7 +36,7 @@
 #define PUSH_THRESHOLD	512
 
 /* timeout values in 1/16 seconds, or (seconds << 4). Half second = 8*/
-#define TIMEOUT_ENTER_WAIT	(8)	/* TIME_WAIT state (was 30, then 10)*/
+#define TIMEOUT_ENTER_WAIT	(4<<4)	/* TIME_WAIT state (was 30, then 10)*/
 #define TIMEOUT_CLOSE_WAIT	(10<<4)	/* CLOSING/LAST_ACK/FIN_WAIT states (was 240)*/
 #define TIMEOUT_INITIAL_RTT	(1<<4)	/* initial RTT before retransmit (was 4)*/
 #define TCP_RETRANS_MAXWAIT	(4<<4)	/* max retransmit wait (4 secs)*/

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -77,7 +77,7 @@ struct tcpcb_list_s *tcpcb_new(int bufsize)
 
     memset(&n->tcpcb, 0, sizeof(struct tcpcb_s));
     n->tcpcb.buf_size = bufsize;
-    n->tcpcb.rtt = TIMEOUT_INITIAL_RTT << 4;
+    n->tcpcb.rtt = TIMEOUT_INITIAL_RTT;
 
     /* Link it to the list */
     if (tcpcbs) {
@@ -249,7 +249,7 @@ void tcpcb_expire_timeouts(void)
 	    case TS_FIN_WAIT_2:
 	    case TS_LAST_ACK:
 	    case TS_CLOSING:
-		if (TIME_GT(Now - (TIMEOUT_CLOSE_WAIT << 4), n->tcpcb.time_wait_exp)) {
+		if (TIME_GT(Now - TIMEOUT_CLOSE_WAIT, n->tcpcb.time_wait_exp)) {
 		    cbs_in_user_timeout--;
 		    tcpcb_remove(n);
 		}

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -87,7 +87,7 @@ static void tcpdev_bind(void)
 	struct tcpcb_list_s *n2 = tcpcb_check_port(port);
 	if (n2) {			/* port already bound */
 	    if (!db->reuseaddr) {	/* no SO_REUSEADDR on socket */
-		printf("tcp: port %u already bound, rejecting\n", port);
+		printf("tcp: port %u already bound, rejecting (use SO_REUSEADDR?)\n", port);
 		tcpcb_remove(n);
 		retval_to_sock(db->sock, -EADDRINUSE);
 		return;
@@ -97,9 +97,10 @@ static void tcpdev_bind(void)
 	    if (n2->tcpcb.state == TS_TIME_WAIT) {
 		LEAVE_TIME_WAIT(&n2->tcpcb);	/* entered via FIN_WAIT_2 state on FIN rcvd*/
 		tcpcb_remove(n2);
-		printf("tcp: port %u reused, removing previous time_wait socket\n", port);
+		printf("tcp: port %u reused, freeing previous socket in time_wait\n", port);
 	    } else
-		printf("tcp: port %u reused, other socket NOT in time_wait!\n", port);
+		printf("tcp: port %u reused, can't free previous socket in state %d\n",
+			port, n2->tcpcb.state);
 	}
     }
 

--- a/elkscmd/rootfs_template/bin/net
+++ b/elkscmd/rootfs_template/bin/net
@@ -60,7 +60,7 @@ start_network()
 	echo $ktcp
 	if $ktcp; then
 		echo -n "Starting daemons "
-		for daemon in telnetd httpd
+		for daemon in telnetd httpd ftpd
 		do
 			if test -f /bin/$daemon
 			then
@@ -78,7 +78,7 @@ start_network()
 stop_network()
 {
 	echo "Stopping network"
-	kill $(ps | grep "ktcp|telnet|httpd" | cut -c 1-5) > /dev/null 2>&1
+	kill $(ps | grep "ktcp|telnet|httpd|ftpd" | cut -c 1-5) > /dev/null 2>&1
 }
 
 if test "$#" -lt 1; then

--- a/libc/net/in_gethostbyname.c
+++ b/libc/net/in_gethostbyname.c
@@ -50,7 +50,7 @@ ipaddr_t in_gethostbyname(char *str)
 			*cp++ = '\0';
 		//printf("name %s addr %s\n", name, in_ntoa(addr));
 		if (!strcmp(name, str))
-			break;
+			goto out;
 		while (cp && *cp) {
 			if (*cp == ' ' || *cp == '\t') {
 				cp++;
@@ -64,6 +64,7 @@ ipaddr_t in_gethostbyname(char *str)
 				goto out;
 		}
 	}
+	addr = 0;	/* read all of /etc/hosts, fail*/
 out:
 	//if (addr) printf("found %s\n", name);
 	fclose(fp);


### PR DESCRIPTION
Various fixes discussed in #999 and elsewhere.

Summary:

- ftpd: add code to become a daemon, add to build, distribution and net start/stop.
- ktcp: fix FIN_WAIT2 bug when FIN and ACK received in FIN_WAIT_1; now goes directly to TIME_WAIT state.
- All timeouts now have 1/16 second granularity.
- TIME_WAIT default to half second.

I'm currently unable to test ELKS ftpd as I probably have the wrong settings for ftp'ing into QEMU. 