### PR TITLE
[net] Cleanup ftpget, set reuse port 21 in ftp daemon

### DIFF
--- a/elkscmd/inet/ftp/ftpd.c
+++ b/elkscmd/inet/ftp/ftpd.c
@@ -425,6 +425,11 @@ int main(int argc, char **argv){
 		exit(1);
 	}
 
+	/* set local port resuse, allows server to be restarted in less than 10 secs */
+	ret = 1;
+	if (setsockopt(listenfd, SOL_SOCKET, SO_REUSEADDR, &ret, sizeof(ret)) < 0)
+		perror("setsockopt SO_REUSEADDR");
+
 	bzero(&servaddr, sizeof(servaddr));
 	servaddr.sin_family      = AF_INET;
 	servaddr.sin_addr.s_addr = htonl(INADDR_ANY);

--- a/elkscmd/inet/urlget/net.c
+++ b/elkscmd/inet/urlget/net.c
@@ -18,9 +18,9 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-int net_connect(host, port)
-char *host;
-int port;
+void errmsg(const char *, ...);
+
+int net_connect(char *host, int port)
 {
 	int netfd;
 	struct sockaddr_in in_adr;
@@ -28,15 +28,20 @@ int port;
 	int ret;
 	
 	netfd = socket(AF_INET, SOCK_STREAM, 0);
+	if (netfd < 0) {
+		errmsg("Can't open socket (check if ktcp is running)");
+		return -1;
+	}
 	
 	in_adr.sin_family = AF_INET;
 	in_adr.sin_port = PORT_ANY;
 	in_adr.sin_addr.s_addr = INADDR_ANY;
 
     ret = bind(netfd, (struct sockaddr *)&in_adr, sizeof(struct sockaddr_in));
-	if (ret < 0){
+	if (ret < 0) {
 		perror("Bind failed");
-		exit(1);
+		close(netfd);
+		return -1;
 	}
 	
 	l.l_onoff = 1;	/* turn on linger option: will send RST on close*/
@@ -49,14 +54,13 @@ int port;
 	in_adr.sin_port = htons(port);
 	in_adr.sin_addr.s_addr = in_gethostbyname(host);
 	if (in_adr.sin_addr.s_addr == 0) {
-		fprintf(stderr, "Can't find host '%s' in /etc/hosts\n", host);
-		close (netfd);
+		errmsg("Can't find host '%s' in /etc/hosts", host);
+		close(netfd);
 		return -1;
 	}
 
 	ret = connect(netfd, (struct sockaddr *)&in_adr, sizeof(struct sockaddr_in));
 	if (ret < 0){
-		perror("Connect failed");
 		close(netfd);
 		return -1;
 	}
@@ -65,9 +69,7 @@ int port;
 }
 
 /* if errflag set, send TCP RST on close, else send FIN */
-void net_close(fd, errflag)
-int fd;
-int errflag;
+void net_close(int fd, int errflag)
 {
 	int ret;
 	struct linger l;


### PR DESCRIPTION
Cleans up urlget/ftpget source, standardizes error messages. "Usage" lines still need work.

Use setsockopt to reuse port 21 in ftp daemon.

Sets buffer to power of two in urlget/ftpget (8000 -> 4096). Not sure proper size due to track caching; all programs will wait in kernel doing 512 byte writes to network, and BIOS I/O only works in 1K chunks, so disk reads are only optimized through track caching.

No other functional changes.