### PR TITLE
[net] Add SO_RCVBUF socket option to enable smaller TCP buffers for listening

### DIFF
--- a/elks/include/linuxmt/net.h
+++ b/elks/include/linuxmt/net.h
@@ -22,6 +22,7 @@ struct socket {
     short type;
     unsigned char state;
     unsigned char flags;
+    unsigned int rcv_bufsiz;
     struct proto_ops *ops;
     void *data;
 
@@ -38,7 +39,6 @@ struct socket {
 
     struct wait_queue *wait;
     struct inode *inode;
-    struct fasync_struct *fasync_list;
     struct file *file;
 };
 

--- a/elks/include/linuxmt/socket.h
+++ b/elks/include/linuxmt/socket.h
@@ -17,7 +17,11 @@ struct sockaddr {
 
 /* careful: option names are close to internal SF_ options in net.h*/
 #define SO_REUSEADDR	2
+#define SO_RCVBUF	8		/* set TCP CB receive buffer size*/
 #define SO_LINGER	13		/* only implemented for l_linger = 0*/
+
+/* non-standard options */
+#define SO_LISTEN_BUFSIZ	128	/* suggested buffer size for listen to save mem*/
 
 struct linger {
         int             l_onoff;        /* Linger active                */

--- a/elks/include/linuxmt/tcpdev.h
+++ b/elks/include/linuxmt/tcpdev.h
@@ -48,7 +48,8 @@ struct tdb_listen {
 struct tdb_bind {
     unsigned char cmd;
     struct socket *sock;
-    int reuseaddr;
+    int reuse_addr;
+    int rcv_bufsiz;
     struct sockaddr_in addr;
 };
 

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -122,7 +122,8 @@ static int inet_bind(register struct socket *sock, struct sockaddr *addr,
     cmd->cmd = TDC_BIND;
     cmd->sock = sock;
 
-    cmd->reuseaddr = sock->flags & SF_REUSE_ADDR;
+    cmd->reuse_addr = sock->flags & SF_REUSE_ADDR;
+    cmd->rcv_bufsiz = sock->rcv_bufsiz;
     memcpy_fromfs(&cmd->addr, addr, sockaddr_len);
 
     tcpdev_inetwrite(cmd, sizeof(struct tdb_bind));

--- a/elks/net/socket.c
+++ b/elks/net/socket.c
@@ -81,6 +81,7 @@ static struct socket *sock_alloc(void)
 	0,		/* type */
 	SS_UNCONNECTED, /* state */
 	0,		/* flags */
+	0,		/* rcv_bufsiz */
 	NULL,		/* ops */
 	NULL,		/* data */
 #if defined(CONFIG_INET)
@@ -94,7 +95,6 @@ static struct socket *sock_alloc(void)
 #endif
 	NULL,		/* wait */
 	NULL,		/* inode */
-	NULL,		/* fasync_list */
 	NULL,		/* file */
     };
     register struct inode *inode;
@@ -593,9 +593,14 @@ int sys_setsockopt(int fd, int level, int option_name, void *option_value,
 	break;
 
     case SO_REUSEADDR:
+    case SO_RCVBUF:
 	if (option_len != sizeof(int))
 	    return -EINVAL;
 	memcpy_fromfs(&setoption, option_value, sizeof(int));
+	if (option_name == SO_RCVBUF) {
+	    sock->rcv_bufsiz = setoption;
+	    return 0;
+	}
 	flags = SF_REUSE_ADDR;
 	break;
 

--- a/elkscmd/inet/ftp/ftpd.c
+++ b/elkscmd/inet/ftp/ftpd.c
@@ -428,7 +428,12 @@ int main(int argc, char **argv){
 	/* set local port resuse, allows server to be restarted in less than 10 secs */
 	ret = 1;
 	if (setsockopt(listenfd, SOL_SOCKET, SO_REUSEADDR, &ret, sizeof(ret)) < 0)
-		perror("setsockopt SO_REUSEADDR");
+		perror("SO_REUSEADDR");
+
+	/* set small listen buffer to save ktcp memory */
+	ret = SO_LISTEN_BUFSIZ;
+	if (setsockopt(listenfd, SOL_SOCKET, SO_RCVBUF, &ret, sizeof(int)) < 0)
+		perror("SO_RCVBUF");
 
 	bzero(&servaddr, sizeof(servaddr));
 	servaddr.sin_family      = AF_INET;

--- a/elkscmd/inet/httpd/httpd.c
+++ b/elkscmd/inet/httpd/httpd.c
@@ -155,7 +155,12 @@ int main(int argc, char **argv)
 	/* set local port reuse, allows server to be restarted in less than 10 secs */
 	ret = 1;
 	if (setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, &ret, sizeof(int)) < 0)
-		perror("setsockopt SO_REUSEADDR");
+		perror("SO_REUSEADDR");
+
+	/* set small listen buffer to save ktcp memory */
+	ret = SO_LISTEN_BUFSIZ;
+	if (setsockopt(listen_sock, SOL_SOCKET, SO_RCVBUF, &ret, sizeof(int)) < 0)
+		perror("SO_RCVBUF");
 
 	localadr.sin_family = AF_INET;
 	localadr.sin_port = htons(DEF_PORT);

--- a/elkscmd/inet/telnetd/telnetd.c
+++ b/elkscmd/inet/telnetd/telnetd.c
@@ -196,7 +196,12 @@ int main(int argc, char **argv)
 	/* set local port reuse, allows server to be restarted in less than 10 secs */
 	ret = 1;
 	if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &ret, sizeof(int)) < 0)
-		perror("setsockopt SO_REUSEADDR");
+		perror("SO_REUSEADDR");
+
+	/* set small listen buffer to save ktcp memory */
+	ret = SO_LISTEN_BUFSIZ;
+	if (setsockopt(sockfd, SOL_SOCKET, SO_RCVBUF, &ret, sizeof(int)) < 0)
+		perror("SO_RCVBUF");
 
 	memset(&addr_in, 0, sizeof(addr_in));
 	addr_in.sin_family = AF_INET;

--- a/elkscmd/inet/urlget/net.c
+++ b/elkscmd/inet/urlget/net.c
@@ -48,7 +48,7 @@ int net_connect(char *host, int port)
 	l.l_linger = 0;	/* must be 0 to turn on option*/
 	ret = setsockopt(netfd, SOL_SOCKET, SO_LINGER, &l, sizeof(l));
 	if (ret < 0)
-		perror("setsockopt RST");
+		perror("SO_LINGER RST");
 
 	in_adr.sin_family = AF_INET;
 	in_adr.sin_port = htons(port);
@@ -80,7 +80,7 @@ void net_close(int fd, int errflag)
 		l.l_linger = 0;
 		ret = setsockopt(fd, SOL_SOCKET, SO_LINGER, &l, sizeof(l));
 		if (ret < 0)
-			perror("setsockopt FIN");
+			perror("SO_LINGER FIN");
 	}
 	close(fd);
 }

--- a/elkscmd/ktcp/deveth.h
+++ b/elkscmd/ktcp/deveth.h
@@ -8,6 +8,7 @@
 #define ETH_TYPE_IPV4 0x0008
 #define ETH_TYPE_ARP  0x0608
 
+#define ETH_MTU		1500
 
 /* Ethernet header (no VLAN tag) */
 

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -44,12 +44,12 @@ ipaddr_t netmask_ip;
 
 /* defaults*/
 int linkprotocol = 	LINK_ETHER;
-unsigned int MTU =	SLIP_MTU;
 char ethdev[] = 	"/dev/eth";
 char *serdev = 		"/dev/ttyS0";
 speed_t baudrate = 	57600;
 
 int dflag;
+unsigned int MTU;
 static int intfd;	/* interface fd*/
 
 void ktcp_run(void)
@@ -143,6 +143,7 @@ int main(int argc,char **argv)
 {
     int ch;
     int bflag = 0;
+    int mtu = 0;
     static char *linknames[3] = { "ethernet", "slip", "cslip" };
 
     while ((ch = getopt(argc, argv, "bdm:p:s:l:")) != -1) {
@@ -154,7 +155,7 @@ int main(int argc,char **argv)
 	    dflag++;
 	    break;
 	case 'm':		/* MTU*/
-		MTU = atoi(optarg);
+		mtu = atoi(optarg);
 		break;
 	case 'p':		/* link protocol*/
 	    linkprotocol = !strcmp(optarg, "eth")? LINK_ETHER :
@@ -179,6 +180,7 @@ int main(int argc,char **argv)
     local_ip = in_gethostbyname(optind < argc? argv[optind++]: DEFAULT_IP);
     gateway_ip = in_gethostbyname(optind < argc? argv[optind++]: DEFAULT_GATEWAY);
     netmask_ip = in_gethostbyname(optind < argc? argv[optind++]: DEFAULT_NETMASK);
+    MTU = mtu ? mtu : (linkprotocol == LINK_ETHER ? ETH_MTU : SLIP_MTU);
 
     /* must exit() in next two stages on error to reset kernel tcpdev_inuse to 0*/
     if ((tcpdevfd = tcpdev_init("/dev/tcpdev")) < 0)

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -184,8 +184,8 @@ static void tcp_listen(struct iptcp_s *iptcp, struct tcpcb_s *lcb)
     if (h->flags & TF_ACK)
 	debug_tcp("tcp: ACK in listen not implemented\n");
 
-    /* duplicate control block but with normal sized input buffer */
-    n = tcpcb_clone(lcb, CB_NORMAL_SIZE);    /* copy lcb into linked list*/
+    /* duplicate control block but with normal sized input buffer, SO_RCVBUF ignored for now */
+    n = tcpcb_clone(lcb, CB_NORMAL_BUFSIZ);    /* copy lcb into linked list*/
     if (!n)
 	return;		     /* no memory for new connection*/
     cb = &n->tcpcb;

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -11,10 +11,10 @@
 
 /*
  * /etc/tcpdev max read/write size
- * Must be at least as big as CB_NORMAL_SIZE
+ * Must be at least as big as CB_NORMAL_BUFSIZ
  * And at least as big as TCPDEV_INBUFFERSIZE in <linuxmt/tcpdev.h> (currently 1024)
  */
-#define TCPDEV_BUFSIZ	(CB_NORMAL_SIZE + sizeof(struct tdb_return_data))
+#define TCPDEV_BUFSIZ	(CB_NORMAL_BUFSIZ + sizeof(struct tdb_return_data))
 
 /* max tcp buffer size (no ip header)*/
 #define TCP_BUFSIZ	(TCPDEV_BUFSIZ + sizeof(tcphdr_t) + TCP_OPT_MSS_LEN)
@@ -22,15 +22,17 @@
 /* max ip buffer size (with link layer frame)*/
 #define IP_BUFSIZ	(TCP_BUFSIZ + sizeof(iphdr_t) + sizeof(struct ip_ll))
 
-/* control block input buffer size - max window size, doesn't have to be power of two*/
-#define CB_NORMAL_SIZE	4096	/* normal input buffer size*/
-#define CB_LISTEN_SIZE  128	/* small buffer size for listening sockets*/
+/*
+ * control block input buffer size - max window size, doesn't have to be power of two
+ * default will be (ETH_MTU - IP_HDRSIZ) * 3 + PUSH_THRESHOLD = (1500-40) * 3 + 512 = 4892
+ */
+#define CB_NORMAL_BUFSIZ	4096	/* normal input buffer size*/
 
 /* max outstanding send window size*/
 #define TCP_SEND_WINDOW_MAX	1024	/* should be less than TCP_RETRANS_MAXMEM*/
 
 /* max advertised receive window size*/
-#define THROTTLE_MAX_WINDOW	512	/* FIXME CB_NORMAL_SIZE when PTY fixed*/
+#define THROTTLE_MAX_WINDOW	512	/* FIXME CB_NORMAL_BUFSIZ when PTY fixed*/
 
 /* bytes to subtract from window size and when to force app write*/
 #define PUSH_THRESHOLD	512

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -365,7 +365,7 @@ void tcp_output(struct tcpcb_s *cb)
     cb->send_nxt += cb->datalen;
 
     len = CB_BUF_SPACE(cb);
-    if (cb->buf_size > CB_LISTEN_SIZE)	/* advertise real usable for "listen" buffers */
+    if (cb->buf_size > PUSH_THRESHOLD)	/* FIXME temp hack for small listen buffers */
 	len -= PUSH_THRESHOLD;
     if (len <= 0)
 	len = 1;			/* Never advertise zero window size */
@@ -382,7 +382,6 @@ void tcp_output(struct tcpcb_s *cb)
 	options[0] = TCP_OPT_MSS;
 	options[1] = TCP_OPT_MSS_LEN;		/* total options length (4)*/
 	*(__u16 *)(options + 2) = htons(MTU - 40);
-	//*(__u16 *)(options + 2) = htons(512 - 40);
 	header_len += TCP_OPT_MSS_LEN;
     }
 


### PR DESCRIPTION
@Mellvik,

This should fix the 128-byte buffer problem you saw on the packet trace discussed in #1002, please test.

`telnetd`, `ftpd` and `httpd` use the new SO_RCVBUF setsockopt option, which for now, only sets the buffer size for listen buffers. This reduces the ktcp heap requirement of all three servers running by around 12K. Ftpd transfers should work well in both directions.

This PR sets the MTU for ethernet properly at 1500, but that should have no effect, since the receive window calculations have not changed yet. That, the PUSH_THRESHOLD, allowing a larger receive window, and tuning the buffer sizes will all come in the next PR.

A couple of the ktcp "port reused" message have been set to debug only messages.

On a separate note, testing `ftpget` for directory listings results in a 502 error message. I presume that's because ftpd doesn't support passive transfers yet?
