### PR TITLE
[boot] Fix kernel image overwrite bug at boot on large kernel images

### DIFF
--- a/bootblocks/boot_sect.S
+++ b/bootblocks/boot_sect.S
@@ -18,7 +18,7 @@
 
 // Must match ELKS
 #define ELKS_INITSEG (0x0100)
-#define ELKS_SYSSEG  (0x1000)
+#define ELKS_SYSSEG  (0x1300)
 
 // Whether to try to do whole-track reads, or read one sector at a time
 //

--- a/elks/arch/i86/tools/build.c
+++ b/elks/arch/i86/tools/build.c
@@ -253,9 +253,20 @@ int main(int argc, char **argv)
     fprintf(stderr, "System is %d kB\n", sz / 1024);
 #endif
     sys_size = (sz + 15) / 16;
-    fprintf(stderr, "System is %d\n", sz);
+    fprintf(stderr, "System is %d (%xh paras)\n", sz, sys_size);
     if (sys_size > SYS_SIZE)
 	die("System is too big");
+#ifndef CONFIG_ROMCODE
+    /* compute boot load address to avoid overwriting image at boot relocation time*/
+    fsz = (ex->a_hdrlen + (intel_long(ex->a_text) + intel_long(ex->a_data)) + 15) / 16
+	+ REL_SYSSEG;
+    fprintf(stderr, "Text/Data load ending segment is %x, limit %x\n", fsz, DEF_SYSSEG);
+    if (fsz > DEF_SYSSEG + REL_SYSSEG) {	/* start of reloc entry table at boot */
+	fprintf(stderr, "System too large for DEF_SYSSEG at %x, increase DEF_SYSSEG\n",
+	    DEF_SYSSEG);
+	exit(1);
+    }
+#endif
     while (sz > 0) {
 	int32_t l, n;
 

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -62,7 +62,7 @@
 
 /* Don't touch these, unless you really know what you are doing. */
 #define DEF_INITSEG	0x0100	/* setup data, for netboot use 0x5000 */
-#define DEF_SYSSEG	0x1000
+#define DEF_SYSSEG	0x1300	/* initial system image load address by boot code */
 #define DEF_SETUPSEG	DEF_INITSEG + 0x20
 #define DEF_SYSSIZE	0x2F00
 


### PR DESCRIPTION
Changes the boot-time load address for the kernel image from 0x1000 to 0x1300 to accommodate larger kernel images.

The setup code run directly after the boot sector was overwriting the kernel image and trashing the relocation entries, causing boot failure.

This PR also adds a calculation in the tools/build system image builder to calculate the remaining space that will be available at boot and give an error with a suggested new load address so this won't happen again.

A seperate PR will get the system load address DEF_SYSSEG from config.h rather than the duplicate entry in boot.h so two files don't have to be maintained for this important address.