### PR TITLE
[net] Fix network hang bug after netstat executed

### DIFF
--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -10,7 +10,7 @@
 #define DEBUG_TCP	0	/* TCP ops*/
 #define DEBUG_TUNE	1	/* tuning options*/
 #define DEBUG_TCPDATA	0	/* TCP data packets*/
-#define DEBUG_RETRANS	1	/* TCP retransmissions*/
+#define DEBUG_RETRANS	0	/* TCP retransmissions*/
 #define DEBUG_CLOSE	1	/* TCP close ops*/
 #define DEBUG_IP	0
 #define DEBUG_ARP	0

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -82,15 +82,12 @@ void ktcp_run(void)
 	    if (tcpcb_need_push) {
 		timeint.tv_sec  = 0;
 		timeint.tv_usec = 1000;	/* 1msec */
-		//printf("SMALL WAIT\n");
 	    } else {
 		timeint.tv_sec  = 1;
 		timeint.tv_usec = 0;
-		//intf("1SEC WAIT\n");
 	    }
 	    tv = &timeint;
 	} else {
-	    //printf("select WAIT\n");
 	    tv = NULL;		/* no timeout if no timers active or push needed */
 	}
 

--- a/elkscmd/ktcp/netconf.c
+++ b/elkscmd/ktcp/netconf.c
@@ -67,4 +67,5 @@ void netconf_send(struct tcpcb_s *cb)
 	break;
     }
     cb->bytes_to_push = cb->buf_used;
+    tcpcb_need_push++;
 }

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -139,7 +139,7 @@ static void tcp_syn_sent(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 
     if (h->flags & (TF_SYN|TF_ACK)) {
 	if (cb->seg_ack != cb->send_una + 1) {
-printf("SYN sent, wrong ACK (listen port not expired)\n");
+	    printf("tcp: SYN sent, wrong ACK (listen port not expired)\n");
 	    /* Send RST */
 	    cb->send_nxt = h->acknum;
 	    //tcp_send_reset(cb);
@@ -232,7 +232,7 @@ static void tcp_established(struct iptcp_s *iptcp, struct tcpcb_s *cb)
     datasize = iptcp->tcplen - TCP_DATAOFF(h);
 
     if (datasize != 0) {
-	printf("tcp: recv data len %u avail%u\n", datasize, CB_BUF_SPACE(cb));
+	debug_tune("tcp: recv data len %u avail %u\n", datasize, CB_BUF_SPACE(cb));
 	/* Process the data */
 	data = (__u8 *)h + TCP_DATAOFF(h);
 
@@ -278,7 +278,7 @@ static void tcp_established(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 	cb->rcv_nxt++;
 	cb->state = TS_CLOSE_WAIT;
 	cb->time_wait_exp = Now;	/* used for debug output only*/
-printf("tcp: got FIN with data %d buffer %d\n", datasize, cb->buf_used);
+	debug_tune("tcp: got FIN with data %d buffer %d\n", datasize, cb->buf_used);
 	if (cb->bytes_to_push <= 0)
 	    tcpdev_sock_state(cb, SS_DISCONNECTING);
     }

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -266,7 +266,7 @@ static void tcpdev_read(void)
     /* if remote closed and more data, update data avail then indicate disconnecting*/
     if (cb->state == TS_CLOSE_WAIT) {
 	if (cb->bytes_to_push <= 0) {
-	    printf("tcp: disconnecting after final read %d\n", data_avail);
+	    debug_tune("tcp: disconnecting after final read %d\n", data_avail);
 	    tcpdev_sock_state(cb, SS_DISCONNECTING);
 	} else {
 	    printf("tcp: application read too small after FIN, data_avail %d\n",


### PR DESCRIPTION
Finally found the last known network problem, which was that networking activity sometimes hung after running netstat.

Cleans up some printfs, moves them into "debug_tune", which is turned on by default with ^P if needed for further details.

At this point, ELKS networking should be fast, use full-sized 1500 MTU packets, require no receive throttling, and not hang.
Tested on QEMU using ftpget and ftpput internally, and telnet to remote host. Haven't tested with ftpd nor telnetting into ELKS.
