### PR TITLE
[kernel] Fix unreal mode and XMS buffers on real 386 hardware

### DIFF
--- a/elks/arch/i86/lib/unreal.S
+++ b/elks/arch/i86/lib/unreal.S
@@ -145,14 +145,14 @@ verify_a20:
 
 	popw	0
 
-	popf			# restore interrupt status
-	pop	%es
-	pop	%ds
 	jz	1f		# if ZF=1, the A20 gate is NOT enabled
 	mov	$1,%ax		# return 1 if enabled
+9:	popf			# restore interrupt status
+	pop	%es
+	pop	%ds
 	ret
 1:	mov	$0,%ax		# return 0 if disabled
-	ret
+	jmp	9b
 
 #
 # enable/disable A20 gate using keyboard port/controller, entry AH=0 disable

--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -27,7 +27,7 @@ static long_t xms_alloc_ptr = 0x00100000L;	/* 1M */
 /* try to enable unreal mode and A20 gate. Return 1 if successful */
 int xms_init(void)
 {
-	if (enable_unreal_mode()) {
+	if (enable_unreal_mode() > 0) {
 		if (/*verify_a20() ||*/ enable_a20_gate()) {
 			xms_enabled = 1;	/* enables xms_fmemcpyw()*/
 

--- a/elkscmd/sys_utils/unreal16.S
+++ b/elkscmd/sys_utils/unreal16.S
@@ -40,6 +40,7 @@ sys_write = 4
 syscall = 0x80
 videoline = 0xb8000+80*2*22
 
+    .arch	i386,nojumps
     .code16
     .text
 	.extern	enable_unreal_mode


### PR DESCRIPTION
Finally got a chance to test booting an XMS-enabled kernel on a 386 desktop machine. It died in the partition code just like @Mellvik's testing found.

Found two possible problems, the A20 verification code improperly returned the wrong value (indicating always enabled), which likely skipped the following actual A20 enable method. Kernel now boots and operates on 386 desktop, saving 64K in main memory kernel buffers, and uses 128K in XMS memory. Runs great!

@Mellvik, hopefully this will work better on your Compaq. If not, it should at least fail properly and not enable XMS if A20 not functional.