### PR TITLE
[kernel] Dynamically allocate pipes when needed

### DIFF
--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -5,7 +5,6 @@
 #include <linuxmt/major.h>
 
 /* tunable parameters*/
-#define MAX_PIPES	4	/* pipe buffers are statically allocated in kernel */
 #define PIPE_BUFSIZ	80	/* doesn't have to be power of two */
 
 

--- a/elks/include/linuxmt/heap.h
+++ b/elks/include/linuxmt/heap.h
@@ -21,6 +21,7 @@
 #define HEAP_TAG_TTY     0x03
 #define HEAP_TAG_INTHAND 0x04
 #define HEAP_TAG_BUFHEAD 0x05
+#define HEAP_TAG_PIPE    0x06
 
 
 // TODO: move free list node from header to body

--- a/elkscmd/sys_utils/meminfo.c
+++ b/elkscmd/sys_utils/meminfo.c
@@ -54,7 +54,7 @@ void dump_heap(int fd)
 	word_t total_size = 0;
 	word_t total_free = 0;
 	long total_segsize = 0;
-	static char *heaptype[] = { "free", "SEG ", "STR ", "TTY ", "INT ", "BUFH" };
+	static char *heaptype[] = { "free", "SEG ", "STR ", "TTY ", "INT ", "BUFH", "PIPE" };
 	static char *segtype[] = { "free", "CSEG", "DSEG", "BUF ", "RDSK" };
 
 	printf("  HEAP   TYPE  SIZE    SEG   TYPE    SIZE  CNT\n");


### PR DESCRIPTION
Removes limit on number of pipes in use; they're now dynamically allocated as needed.
Frees up more kernel data space.