### PR TITLE
[net] Process all received packets and sockets before retransmits

### DIFF
--- a/elkscmd/ktcp/Makefile
+++ b/elkscmd/ktcp/Makefile
@@ -14,7 +14,7 @@ OBJS		= $(CFILES:.c=.o)
 all:	ktcp
 
 ktcp:	$(OBJS)
-	$(LD) $(LDFLAGS) -maout-heap=32768 -maout-stack=3072  -o ktcp $(OBJS) $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-heap=0xffff -maout-stack=3072  -o ktcp $(OBJS) $(LDLIBS)
 
 lint:
 	@for FILE in *.c ; do \

--- a/elkscmd/ktcp/Makefile
+++ b/elkscmd/ktcp/Makefile
@@ -14,7 +14,7 @@ OBJS		= $(CFILES:.c=.o)
 all:	ktcp
 
 ktcp:	$(OBJS)
-	$(LD) $(LDFLAGS) -maout-heap=0xffff -maout-stack=3072  -o ktcp $(OBJS) $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-heap=32768 -maout-stack=3072  -o ktcp $(OBJS) $(LDLIBS)
 
 lint:
 	@for FILE in *.c ; do \

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -70,18 +70,19 @@ void ktcp_run(void)
     fd_set fdset;
     struct timeval timeint, *tv;
     int count;
+    int loopagain = 0;
 
     while (1) {
-	if (tcp_timeruse > 0 || tcpcb_need_push > 0 ||
+	if (tcp_timeruse > 0 || tcpcb_need_push > 0 || loopagain ||
 	    cbs_in_time_wait > 0 || cbs_in_user_timeout > 0) {
 
 	    //printf("tcp: timer %d needpush %d timewait %d usertime %d\n", tcp_timeruse,
 		//tcpcb_need_push, cbs_in_time_wait, cbs_in_user_timeout);
 
 	    /* don't wait long if data needs pushing to tcpdev */
-	    if (tcpcb_need_push) {
+	    if (tcpcb_need_push || loopagain) {
 		timeint.tv_sec  = 0;
-		timeint.tv_usec = 1000;	/* 1msec */
+		timeint.tv_usec = loopagain? 0: 1000;	/* 1msec */
 	    } else {
 		timeint.tv_sec  = 1;
 		timeint.tv_usec = 0;
@@ -115,20 +116,33 @@ void ktcp_run(void)
 	//if (tcpcb_need_push > 0)
 	    tcpcb_push_data();
 
+	loopagain = 0;
+
 	/* process received packets*/
 	if (FD_ISSET(intfd, &fdset)) {
 		if (linkprotocol == LINK_ETHER)
 			eth_process();
 		else slip_process();
+		loopagain = 1;
 	}
 
 	/* process application socket actions*/
-	if (FD_ISSET(tcpdevfd, &fdset))
+	if (FD_ISSET(tcpdevfd, &fdset)) {
 		tcpdev_process();
+		loopagain = 1;
+	}
 
-	/* check for retransmit needed*/
+	/* check for expired retrans packets and free them*/
 	if (tcp_timeruse > 0)
-		tcp_retrans();
+		tcp_retrans_expire();
+
+	/* read all packets and sockets before handling retransmits*/
+	if (loopagain)
+		continue;
+
+	/* check for retransmit packets required*/
+	if (tcp_timeruse > 0)
+		tcp_retrans_retransmit();
 
 	tcpcb_printall();
     }

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -82,7 +82,7 @@ void ktcp_run(void)
 	    /* don't wait long if data needs pushing to tcpdev */
 	    if (tcpcb_need_push || loopagain) {
 		timeint.tv_sec  = 0;
-		timeint.tv_usec = loopagain? 0: 1000;	/* 1msec */
+		timeint.tv_usec = tcpcb_need_push? 1000: 0;	/* 1msec */
 	    } else {
 		timeint.tv_sec  = 1;
 		timeint.tv_usec = 0;

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -298,8 +298,8 @@ void tcp_reoutput(struct tcp_retrans_list_s *n)
     netstats.tcpretranscnt++;
 }
 
-/* called every ktcp cycle when tcp_timeruse nonzero*/
-void tcp_retrans(void)
+/* called every ktcp cycle when tcp_timeruse nonzero - check for expired retrans*/
+void tcp_retrans_expire(void)
 {
     struct tcp_retrans_list_s *n;
     int rtt;
@@ -335,6 +335,17 @@ void tcp_retrans(void)
 		ntohl(n->tcphdr[0].seqnum) - n->cb->iss + datalen,
 		n->cb->send_nxt - n->cb->send_una, n->next_retrans - Now);
 
+	n = n->next;
+    }
+}
+
+/* called every ktcp cycle when tcp_timeruse nonzero - check for retransmit* required*/
+void tcp_retrans_retransmit(void)
+{
+    struct tcp_retrans_list_s *n;
+
+    n = retrans_list;
+    while (n != NULL) {
 	/* check for retrans time up*/
 	if (TIME_GEQ(Now, n->next_retrans)) {
 	    tcp_reoutput(n);

--- a/elkscmd/ktcp/tcp_output.h
+++ b/elkscmd/ktcp/tcp_output.h
@@ -1,7 +1,8 @@
 #ifndef TCP_OUTPUT_H
 #define TCP_OUTPUT_H
 
-void tcp_retrans(void);
+void tcp_retrans_expire(void);
+void tcp_retrans_retransmit(void);
 void rmv_all_retrans(struct tcpcb_list_s *lcb);
 void rmv_all_retrans_cb(struct tcpcb_s *cb);
 

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -82,7 +82,8 @@ static void tcpdev_bind(void)
 	struct tcpcb_list_s *n2 = tcpcb_check_port(port);
 	if (n2) {			/* port already bound */
 	    if (!db->reuse_addr) {	/* no SO_REUSEADDR on socket */
-		debug_tcp("tcp: port %u already bound, rejecting (use SO_REUSEADDR?)\n", port);
+		printf("tcp: port %u already bound, rejecting (use SO_REUSEADDR?)\n", port);
+reject:
 		tcpcb_remove(n);
 		retval_to_sock(db->sock, -EADDRINUSE);
 		return;
@@ -92,10 +93,12 @@ static void tcpdev_bind(void)
 	    if (n2->tcpcb.state == TS_TIME_WAIT) {
 		LEAVE_TIME_WAIT(&n2->tcpcb);	/* entered via FIN_WAIT_2 state on FIN rcvd*/
 		tcpcb_remove(n2);
-		debug_tcp("tcp: port %u reused, freeing previous socket in time_wait\n", port);
-	    } else
-		printf("tcp: port %u reused, can't free previous socket in state %d\n",
+		printf("tcp: port %u REUSED, freeing previous socket in time_wait\n", port);
+	    } else {
+		printf("tcp: port %u NOT reused, previous socket in state %d\n",
 			port, n2->tcpcb.state);
+		goto reject;
+	    }
 	}
     }
 


### PR DESCRIPTION
Attempts to fix #1013.

@Mellvik,

This is pretty straightforward, except a complication where we have to expire the retransmit list every cycle or ktcp runs out of memory from packet processing. The main loop won't process actual retransmits required until all socket and packets waiting to be processed have completed.

I tested this and it worked well, except ktcp started running out of memory when running the fast file transfer test I use with back-to-back ftpget/ftpput's. I'm not sure why this is, but increased ktcp's heap to the maximum. We were using 32K heap, I tried setting it to 42K, and the system couldn't load ktcp, which means there was less than 10K free space available in the entire data segment. Setting to "0xffff" allows the exec loader to allocate as much as possible. So we're almost out of space in ktcp, FYI!

I hope this works and doesn't introduce other memory issues. The increased memory usage could just be from having processed packets quicker, but that doesn't make sense after the application using ktcp has exited, unless the memory usage was a checker boarding issue. Not sure. It is possible we are very close to the limit of what ktcp can handle regarding speed, packet size, and memory available. 