### PR TITLE
[kernel] Fix dropping data in PTY

### DIFF
--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -288,6 +288,12 @@ size_t tty_write(struct inode *inode, struct file *file, char *data, size_t len)
     while (i < len) {
 	s = chq_wait_wr(&tty->outq, file->f_flags & O_NONBLOCK);
 	if (s < 0) {
+	    /* FIXME EAGAIN not returned, cycle required on telnet nonblocking terminal */
+	    if (s == -EINTR || s == -EAGAIN) {
+		wake_up(&tty->outq.wait);
+		schedule();
+		continue;
+	    }
 	    if (i == 0)
 		i = s;
 	    break;

--- a/elks/arch/i86/drivers/char/pty.c
+++ b/elks/arch/i86/drivers/char/pty.c
@@ -111,6 +111,7 @@ size_t pty_write (struct inode *inode, struct file *file, char *data, size_t len
 	while (count < len) {
 		ret = chq_wait_wr (&tty->inq, (file->f_flags & O_NONBLOCK) | count);
 		if (ret < 0) {
+			//if (ret == -EINTR) continue;
 			if (count == 0) count = ret;
 			break;
 		}

--- a/elkscmd/inet/telnetd/telnetd.c
+++ b/elkscmd/inet/telnetd/telnetd.c
@@ -139,14 +139,14 @@ static void client_loop (int fdsock, int fdterm)
 		if (!count_in && FD_ISSET (fdsock, &fds_read)) {
 			count_in = read (fdsock, buf_in, sizeof(buf_in));
 			if (count_in <= 0) {
-				if (count < 0)
+				if (count_in < 0)
 					perror ("telnetd read sock");
 				break;
 			}
 		}
 		if (count_in && FD_ISSET (fdterm, &fds_write)) {
 #ifdef RAWTELNET
-			count = write (fdterm, buf_in, count_in);
+			write (fdterm, buf_in, count_in);
 #else
 			tel_in(fdterm, fdsock, buf_in, count_in);
 #endif
@@ -164,7 +164,7 @@ static void client_loop (int fdsock, int fdterm)
 		}
 		if (count_out && FD_ISSET (fdsock, &fds_write)) {
 #ifdef RAWTELNET
-			count = write (fdsock, buf_out, count_out);
+			write (fdsock, buf_out, count_out);
 #else
 			tel_out(fdsock, buf_out, count_out);
 #endif


### PR DESCRIPTION
Fixes problem associated with overrunning output buffer on TTY writes, notably associated with PTY driver.

Fixes #1012, problem duplicated on QEMU.