### PR TITLE
[net] Debugging code for CLOSE_WAIT bug

### DIFF
--- a/elkscmd/inet/nettools/netstat.c
+++ b/elkscmd/inet/nettools/netstat.c
@@ -28,7 +28,7 @@
 #include <ktcp/tcp.h>
 #include <ktcp/netconf.h>
 
-char tcp_states[11][13] = {
+char *tcp_states[11] = {
 	"CLOSED",
 	"LISTEN",
 	"SYN_SENT",

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -55,7 +55,8 @@ void dprintf(const char *, ...);
 #endif
 
 #if DEBUG_CLOSE
-#define debug_close	DPRINTF
+//#define debug_close	DPRINTF
+#define debug_close	printf
 #else
 #define debug_close(...)
 #endif

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -201,4 +201,5 @@ void tcp_send_fin(struct tcpcb_s *cb);
 void tcp_send_reset(struct tcpcb_s *cb);
 void tcp_reset_connection(struct tcpcb_s *cb);
 
+extern char *tcp_states[];	/* used in DEBUG_CLOSE only*/
 #endif

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -226,7 +226,7 @@ void tcpcb_expire_timeouts(void)
 
     while (n) {
 	next = n->next;
-#if DEBUG_CLOSE
+#if 0 //DEBUG_CLOSE
 	if (n->tcpcb.state > TS_ESTABLISHED) {
 	    int secs = (unsigned)(n->tcpcb.time_wait_exp - Now);
 	    unsigned int tenthsecs = ((secs + 8) & 15) >> 1;
@@ -239,8 +239,9 @@ void tcpcb_expire_timeouts(void)
 	    case TS_TIME_WAIT:
 		if (TIME_GT(Now, n->tcpcb.time_wait_exp)) {
 		    LEAVE_TIME_WAIT(&n->tcpcb);
-			debug_close("tcp: exit TIME_WAIT state on port %u remote %s:%u\n",
-				n->tcpcb.localport, in_ntoa(n->tcpcb.remaddr), n->tcpcb.remport);
+		    debug_close("tcp[%p] exit TIME_WAIT state on port %u remote %s:%u\n",
+				n->tcpcb.sock, n->tcpcb.localport,
+				in_ntoa(n->tcpcb.remaddr), n->tcpcb.remport);
 		    tcpcb_remove(n);
 		}
 		break;


### PR DESCRIPTION
Adds debugging printf code to see what's happening in https://github.com/jbruchon/elks/issues/1016#issuecomment-975753093.

@Mellvik, this should automatically display exactly what is happening with the undesired CLOSE_WAIT state after closing a socket with data remaining. The closing state transitions taken are all displayed. 

Please capture the results and post. No ^P required.