### PR TITLE
[net] Implement SWS handling on advertised receive window

### DIFF
--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -246,7 +246,7 @@ static void tcp_established(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 	tcpcb_buf_write(cb, data, datasize);
 
 	/* always push data for now*/
-	if (1 || (h->flags & TF_PSH) || CB_BUF_SPACE(cb) <= PUSH_THRESHOLD) {
+	if (1 /*|| (h->flags & TF_PSH) || CB_BUF_SPACE(cb) <= PUSH_THRESHOLD*/) {
 	    if (cb->bytes_to_push <= 0)
 		tcpcb_need_push++;
 	    cb->bytes_to_push = cb->buf_used;

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -238,7 +238,8 @@ static void tcp_established(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 
 	/* check if buffer space for received packet*/
 	if (datasize > CB_BUF_SPACE(cb)) {
-	    printf("tcp: dropping packet, no buffer space: %u > %d\n", datasize, CB_BUF_SPACE(cb));
+	    printf("tcp: dropping packet, no buffer space: %u > %d\n",
+		datasize, CB_BUF_SPACE(cb));
 	    netstats.tcpdropcnt++;
 	    return;
 	}
@@ -279,7 +280,7 @@ static void tcp_established(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 	debug_close("tcp[%p] packet in established, fin: 1, data: %d, setting state to CLOSE_WAIT\n", cb->sock, datasize);
 	cb->state = TS_CLOSE_WAIT;
 	cb->time_wait_exp = Now;	/* used for debug output only*/
-	debug_tune("tcp: got FIN with data %d buffer %d\n", datasize, cb->buf_used);
+	debug_tcp("tcp: got FIN with data %d buffer %d\n", datasize, cb->buf_used);
 	if (cb->bytes_to_push <= 0)
 	    tcpdev_sock_state(cb, SS_DISCONNECTING);
     }

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -26,13 +26,14 @@
  * control block input buffer size - max window size, doesn't have to be power of two
  * default will be (ETH_MTU - IP_HDRSIZ) * 3 = (1500-40) * 3 = 4380
  */
+//#define CB_NORMAL_BUFSIZ	4892	/* bufsize for older receive window algorithm*/
 #define CB_NORMAL_BUFSIZ	4380	/* normal input buffer size*/
 
 /* max outstanding send window size*/
 #define TCP_SEND_WINDOW_MAX	1024	/* should be less than TCP_RETRANS_MAXMEM*/
 
 /* threshold to wait before pushing data to application (turned off for now) */
-//#define PUSH_THRESHOLD	512
+#define PUSH_THRESHOLD	512
 
 /* timeout values in 1/16 seconds, or (seconds << 4). Half second = 8*/
 #define TIMEOUT_ENTER_WAIT	(4<<4)	/* TIME_WAIT state (was 30, then 10)*/

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -24,15 +24,15 @@
 
 /*
  * control block input buffer size - max window size, doesn't have to be power of two
- * default will be (ETH_MTU - IP_HDRSIZ) * 3 + PUSH_THRESHOLD = (1500-40) * 3 + 512 = 4892
+ * default will be (ETH_MTU - IP_HDRSIZ) * 3 = (1500-40) * 3 = 4380
  */
-#define CB_NORMAL_BUFSIZ	4892	/* normal input buffer size*/
+#define CB_NORMAL_BUFSIZ	4380	/* normal input buffer size*/
 
 /* max outstanding send window size*/
 #define TCP_SEND_WINDOW_MAX	1024	/* should be less than TCP_RETRANS_MAXMEM*/
 
-/* bytes to subtract from window size (was remaining buf space to force push)*/
-#define PUSH_THRESHOLD	512
+/* threshold to wait before pushing data to application (turned off for now) */
+//#define PUSH_THRESHOLD	512
 
 /* timeout values in 1/16 seconds, or (seconds << 4). Half second = 8*/
 #define TIMEOUT_ENTER_WAIT	(4<<4)	/* TIME_WAIT state (was 30, then 10)*/

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -26,8 +26,8 @@
  * control block input buffer size - max window size, doesn't have to be power of two
  * default will be (ETH_MTU - IP_HDRSIZ) * 3 = (1500-40) * 3 = 4380
  */
-//#define CB_NORMAL_BUFSIZ	4892	/* bufsize for older receive window algorithm*/
-#define CB_NORMAL_BUFSIZ	4380	/* normal input buffer size*/
+#define CB_NORMAL_BUFSIZ	4892	/* bufsize for older receive window algorithm*/
+//#define CB_NORMAL_BUFSIZ	4380	/* normal input buffer size*/
 
 /* max outstanding send window size*/
 #define TCP_SEND_WINDOW_MAX	1024	/* should be less than TCP_RETRANS_MAXMEM*/

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -390,8 +390,8 @@ void tcp_output(struct tcpcb_s *cb)
 	len = 1;			/* Never advertise zero window size */
 #endif
 
-    debug_tune("tcp output: space %u min sws %u window %u\n",
-	CB_BUF_SPACE(cb), minwindow, len);
+    debug_tune("tcp output: min sws %u space %u window %u\n",
+	minwindow, CB_BUF_SPACE(cb), len);
     th->window = htons(len);
     th->urgpnt = 0;
     th->flags = cb->flags;

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -366,7 +366,7 @@ void tcp_output(struct tcpcb_s *cb)
 {
     struct tcphdr_s *th = (struct tcphdr_s *)tcpbuf;
     struct addr_pair apair;
-    int header_len, len;
+    int header_len, len, minwindow;
 
     th->sport = htons(cb->localport);
     th->dport = htons(cb->remport);
@@ -375,12 +375,23 @@ void tcp_output(struct tcpcb_s *cb)
 
     cb->send_nxt += cb->datalen;
 
+#if 1
+    /* must have half the buffer or MTU bytes available for nonzero window */
+    minwindow = cb->buf_size >> 1;
+    if (minwindow > MTU)
+	minwindow = MTU;
     len = CB_BUF_SPACE(cb);
+    if (len < minwindow)
+	len = 0;			/* advertise zero window, stops sender */
+#else
     if (cb->buf_size > PUSH_THRESHOLD)	/* FIXME temp hack for small listen buffers */
 	len -= PUSH_THRESHOLD;
     if (len <= 0)
 	len = 1;			/* Never advertise zero window size */
-    debug_tune("tcp output: space %u, window %u\n", CB_BUF_SPACE(cb), len);
+#endif
+
+    debug_tune("tcp output: space %u min sws %u window %u\n",
+	CB_BUF_SPACE(cb), minwindow, len);
     th->window = htons(len);
     th->urgpnt = 0;
     th->flags = cb->flags;

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -237,7 +237,7 @@ static void tcpdev_read(void)
 
     cb = &n->tcpcb;
     if (cb->state == TS_CLOSING || cb->state == TS_LAST_ACK || cb->state == TS_TIME_WAIT) {
-	debug_tcp("tcpdev_read: returning -EPIPE to socket read\n");
+	printf("tcpdev_read: returning -EPIPE to socket read state %d\n", cb->state);
 	retval_to_sock(sock, -EPIPE);
 	return;
     }
@@ -247,7 +247,7 @@ static void tcpdev_read(void)
 
     if (data_avail == 0) {
 	if (cb->state == TS_CLOSE_WAIT) {
-	    printf("tcp: read on CLOSE_WAIT socket\n");
+	    printf("tcpdev_read: read on CLOSE_WAIT socket, return -EPIPE\n");
 	    retval_to_sock(sock, -EPIPE);
 	} else if (db->nonblock)
 	    retval_to_sock(sock, -EAGAIN);
@@ -359,7 +359,7 @@ static void tcpdev_write(void)
 
     n = tcpcb_find_by_sock(sock);
     if (!n || n->tcpcb.state == TS_CLOSED) {
-	debug_tcp("tcp: write to unknown socket\n");
+	printf("tcpdev_write: write to unknown socket\n");
 	retval_to_sock(sock, -EPIPE);
 	return;
     }
@@ -367,6 +367,7 @@ static void tcpdev_write(void)
     cb = &n->tcpcb;
 
     if (cb->state != TS_ESTABLISHED && cb->state != TS_CLOSE_WAIT) {
+	printf("tcpdev_write: write to socket in improper state %d\n", cb->state);
 	retval_to_sock(sock, -EPIPE);
 	return;
     }

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -243,7 +243,7 @@ static void tcpdev_read(void)
     }
 
     data_avail = cb->bytes_to_push;
-    debug_tune("tcpdev_read %u bytes avail %u\n", db->size, data_avail);
+    //debug_tune("tcpdev_read %u bytes avail %u\n", db->size, data_avail);
 
     if (data_avail == 0) {
 	if (cb->state == TS_CLOSE_WAIT) {
@@ -275,7 +275,7 @@ static void tcpdev_read(void)
     /* if remote closed and more data, update data avail then indicate disconnecting*/
     if (cb->state == TS_CLOSE_WAIT) {
 	if (cb->bytes_to_push <= 0) {
-	    debug_tune("tcp: disconnecting after final read %d\n", data_avail);
+	    debug_tcp("tcp: disconnecting after final read %d\n", data_avail);
 	    tcpdev_sock_state(cb, SS_DISCONNECTING);
 	} else {
 	    printf("tcp: application read too small after FIN, data_avail %d\n",
@@ -412,9 +412,11 @@ static void tcpdev_release(void)
     void * sock = db->sock;
 
     n = tcpcb_find_by_sock(sock);
-    debug_close("tcpdev release: close socket %p, state is %s\n", sock, tcp_states[n->tcpcb.state]);
     if (n) {
 	cb = &n->tcpcb;
+	debug_close("tcpdev release: close socket %p, state is %s\n",
+	    sock, tcp_states[cb->state]);
+
 	switch(cb->state){
 	    case TS_CLOSED:
 		tcpcb_remove(n);


### PR DESCRIPTION
Implements receive-side silly window syndrome handling in ktcp.

@Mellvik, I plan on committing this and you can then test #1022. Basically, ktcp must either have half the buffer size available, or MTU bytes available, whichever is smaller, or the receive window is set to 0. This stops the sending of small packets and is the implementation of Dave Clark's algorithm.

The good news about this change is we no longer have to have an additional unused 512 bytes allocated in the TCP receive buffer, helping conserve more memory in ktcp. The receive buffer is now 3\*1460 = 4380 bytes per socket.

You can use ^P to show the advertised window size, as well as the calculated sms minimum window size and buffer remaining.

Tested on QEMU internally and to remote telnet server with high-speed input. The receive window gets set to 0 which stops the sender for a bit and things seem to operate smoothly.