### PR TITLE
[net] Non-SWS enhancement to receive window advertisement

### DIFF
--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -288,6 +288,7 @@ static void tcp_established(struct iptcp_s *iptcp, struct tcpcb_s *cb)
     if (datasize == 0 && ((h->flags & TF_ALL) == TF_ACK))
 	return; /* ACK with no data received - so don't answer*/
 
+    debug_tune("ACK %d\n", datasize);
     cb->rcv_nxt += datasize;
     tcp_send_ack(cb);
 }

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -26,8 +26,13 @@
  * control block input buffer size - max window size, doesn't have to be power of two
  * default will be (ETH_MTU - IP_HDRSIZ) * 3 = (1500-40) * 3 = 4380
  */
+#define USE_SWS		0		/* =1 to use silly window algorithm */
+
+#if USE_SWS
+#define CB_NORMAL_BUFSIZ	4380	/* normal input buffer size*/
+#else
 #define CB_NORMAL_BUFSIZ	4892	/* bufsize for older receive window algorithm*/
-//#define CB_NORMAL_BUFSIZ	4380	/* normal input buffer size*/
+#endif
 
 /* max outstanding send window size*/
 #define TCP_SEND_WINDOW_MAX	1024	/* should be less than TCP_RETRANS_MAXMEM*/

--- a/elkscmd/ktcp/tcp_output.c
+++ b/elkscmd/ktcp/tcp_output.c
@@ -362,6 +362,35 @@ void tcp_retrans_retransmit(void)
     }
 }
 
+static int tcp_calc_rcv_window(struct tcpcb_s *cb)
+{
+    int len;
+
+#if USE_SWS
+    /* must have half the buffer or MTU bytes available for nonzero window */
+    int minwindow = cb->buf_size >> 1;
+    if (minwindow > MTU-40)
+	minwindow = MTU-40;
+    len = CB_BUF_SPACE(cb);
+    if (len < minwindow)
+	len = 0;			/* advertise zero window, stops sender */
+    debug_tune("tcp output: datalen %d min sws %u space %u window %u\n",
+	cb->datalen, minwindow, CB_BUF_SPACE(cb), len);
+#else
+    len = CB_BUF_SPACE(cb);
+    if (cb->buf_size > PUSH_THRESHOLD)	/* FIXME temp hack for small listen buffers */
+	len -= PUSH_THRESHOLD;
+    if (len < 0)
+	len = 0;			/* zero window will stop sender */
+    //if (len <= 0)
+	//len = 1;			/* Never advertise zero window size */
+    debug_tune("tcp output: datalen %d space %u window %u\n",
+	cb->datalen, CB_BUF_SPACE(cb), len);
+#endif
+
+    return len;
+}
+
 void tcp_output(struct tcpcb_s *cb)
 {
     struct tcphdr_s *th = (struct tcphdr_s *)tcpbuf;
@@ -375,25 +404,7 @@ void tcp_output(struct tcpcb_s *cb)
 
     cb->send_nxt += cb->datalen;
 
-#if 0
-    /* must have half the buffer or MTU bytes available for nonzero window */
-    int minwindow = cb->buf_size >> 1;
-    if (minwindow > MTU)
-	minwindow = MTU;
-    len = CB_BUF_SPACE(cb);
-    if (len < minwindow)
-	len = 0;			/* advertise zero window, stops sender */
-    debug_tune("tcp output: min sws %u space %u window %u\n",
-	minwindow, CB_BUF_SPACE(cb), len);
-#else
-    len = CB_BUF_SPACE(cb);
-    if (cb->buf_size > PUSH_THRESHOLD)	/* FIXME temp hack for small listen buffers */
-	len -= PUSH_THRESHOLD;
-    if (len <= 0)
-	len = 1;			/* Never advertise zero window size */
-    debug_tune("tcp output: space %u window %u\n", CB_BUF_SPACE(cb), len);
-#endif
-
+    len = tcp_calc_rcv_window(cb);
     th->window = htons(len);
     th->urgpnt = 0;
     th->flags = cb->flags;

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -258,6 +258,10 @@ static void tcpdev_read(void)
 	return;
     }
 
+    if (data_avail > cb->buf_used)	// FIXME testing only
+	printf("tcpdev_read: data_avail > used, avail %d used %d\n",
+	    data_avail, cb->buf_used);
+
     data_avail = db->size < data_avail ? db->size : data_avail;
     cb->bytes_to_push -= data_avail;
     if (cb->bytes_to_push <= 0)
@@ -287,8 +291,10 @@ static void tcpdev_read(void)
 
     /* send ACK to restart server should window have been full (unless it's netstat)*/
     if (cb->remport != NETCONF_PORT || cb->remaddr != 0)
-	if (cb->remport != local_ip)	/* no ack to localhost either*/
-		tcp_send_ack(cb);
+	if (cb->remport != local_ip) {	/* no ack to localhost either*/
+	    debug_tune("addtl ACK, app read %d bytes\n", data_avail);
+	    tcp_send_ack(cb);
+	}
 }
 
 /* inform kernel of socket data bytes available*/


### PR DESCRIPTION
Possible solution to initial receive window hang discussed in #1022. Does NOT use silly window solution.

Includes silly window solution, but turned off for now. Implementing a full-scale receive window calculation is turning out to be very touchy. After reading the Linux 2.0 sources, they strongly recommend against Clark's algorithm, saying BSD systems  get quite confused by it. They implement a slightly more complex solution that will require quite a bit more testing. At this time, what is important to ELKS is that we get reliable networking, not super-efficient networking. We have not achieved the former yet.

@Mellvik, I have come to the conclusion that now is definitely not the time to be changing this algorithm, as even though it seems simple, it becomes very complicated when taking into account the remote end's interpretation of our changing window size and extra ACK sent after ever application read. The current code, including this PR, has worked quite well, except for the single hanging problem discovered in #1022. In addition, a prior PR fixed an additional problem by sending an "extra knock" ACK which ktcp currently still requires. When adding SWS support, this "extra" ACK is causing more complications than I have time to debug and analyze at this time, especially with all the outstanding other problems. While the contained SWS solution works, it is not causing the remote end to send larger, more efficient packets, and also causes a strange jerkiness again in telnet on occasion.

This PR keeps the original, very basic algorithm with one change: originally when the window was previously calculated as negative or 0, it was set to 1. This PR sets it to 0. That is, exactly the same except that we won't advertise a byte of space if we have none. I am interested to see whether this changes the behavior and stops the hang in #1022, or otherwise affects all our previously working programs.

That said, there is lots more to be learned on packet traces, especially on fine tuning for speed, after we get all the other networking bugs fixed, ftpd fully working, and have tested ELKS TCP to our liking. Only after that should we embark on this road, and we may not ever need to anyways.

Thus, this PR will be committed and can be tested with file transfers and telnet with no changes. The previous SWS code is left in but should not be turned on or tested at this time. If this PR fails to work better, then we will be reverting to never advertising a zero window, and advertising 1 byte as it used to, and #1022 will stay open until our other problems are solved. 

There is still quite a bit of extra close_wait and other code that needs to be turned off, as soon as the ftpd server starts working reliably in passive (and active) mode. I look forward to hearing how/if this last change works.

Thank you!