### PR TITLE
[net] Cleanup non-SWS receive window implementation

### DIFF
--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -55,8 +55,7 @@ void dprintf(const char *, ...);
 #endif
 
 #if DEBUG_CLOSE
-//#define debug_close	DPRINTF
-#define debug_close	printf
+#define debug_close	DPRINTF
 #else
 #define debug_close(...)
 #endif

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -26,19 +26,14 @@
  * control block input buffer size - max window size, doesn't have to be power of two
  * default will be (ETH_MTU - IP_HDRSIZ) * 3 = (1500-40) * 3 = 4380
  */
-#define USE_SWS		0		/* =1 to use silly window algorithm */
-
-#if USE_SWS
 #define CB_NORMAL_BUFSIZ	4380	/* normal input buffer size*/
-#else
-#define CB_NORMAL_BUFSIZ	4892	/* bufsize for older receive window algorithm*/
-#endif
+#define USE_SWS			0	/* =1 to use silly window algorithm */
 
 /* max outstanding send window size*/
 #define TCP_SEND_WINDOW_MAX	1024	/* should be less than TCP_RETRANS_MAXMEM*/
 
 /* threshold to wait before pushing data to application (turned off for now) */
-#define PUSH_THRESHOLD	512
+//#define PUSH_THRESHOLD	512
 
 /* timeout values in 1/16 seconds, or (seconds << 4). Half second = 8*/
 #define TIMEOUT_ENTER_WAIT	(4<<4)	/* TIME_WAIT state (was 30, then 10)*/

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -258,10 +258,6 @@ static void tcpdev_read(void)
 	return;
     }
 
-    if (data_avail > cb->buf_used)	// FIXME testing only
-	printf("tcpdev_read: data_avail > used, avail %d used %d\n",
-	    data_avail, cb->buf_used);
-
     data_avail = db->size < data_avail ? db->size : data_avail;
     cb->bytes_to_push -= data_avail;
     if (cb->bytes_to_push <= 0)
@@ -292,7 +288,8 @@ static void tcpdev_read(void)
     /* send ACK to restart server should window have been full (unless it's netstat)*/
     if (cb->remport != NETCONF_PORT || cb->remaddr != 0)
 	if (cb->remport != local_ip) {	/* no ack to localhost either*/
-	    debug_tune("addtl ACK, app read %d bytes\n", data_avail);
+	    debug_tune("tcp: extra ACK seq %ld, app read %d bytes\n",
+		cb->rcv_nxt - cb->irs, data_avail);
 	    tcp_send_ack(cb);
 	}
 }


### PR DESCRIPTION
Cleaned up version of working receive window implementation, discussed in #1028.

Removes 512-byte PUSH_THRESHOLD subtraction from buffer space available but otherwise same algorithm as was last tested by @Mellvik.

Debug close code not displayed unless ^P.
Added additional dropped packet printf, also displays ACK and "extra" ACK sequence numbers in ^P mode for debugging.
SWS window management code still in, but commented out. Left in to show bad behavior in debug traces for now.

Should work well. If so, #1022 can be closed.