### PR TITLE
[images] Fix build for 360k and 720k disk images

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -45,7 +45,7 @@ sys_utils/getty			:boot	:sysutil
 sys_utils/login			:boot	:sysutil
 ash/ash		::bin/sh	:boot	:ash	# install as /bin/sh
 #sash/sash	::bin/sh	:boot	:~ash	# install as /bin/sh if no ASH
-sash/sash				:boot	:sash
+sash/sash				:1440k	:sash
 sys_utils/mount			:boot	:sysutil
 sys_utils/umount		:boot	:sysutil
 sys_utils/clock			:boot	:sysutil


### PR DESCRIPTION
Fixes #1033.

Removes /bin/sash to make space for all the applications for 360k and 720k disks. Because of the enhancements made to networking, the 720k distribution has run out of space. 

For now, removing /bin/sash (~36k bytes) is far easier than juggling/removing other applications to make space, since /bin/sh can do almost everything /bin/sash can. I think it's probably time for "selectable" compressed applications, which would allow most applications to be compressed on the 360k and 720k distributions, instead of removing functionality like we're having to at the moment.

If all applications were compressed on 360k and 720k disks, those distributions could contain far more functionality. The standard 1.44M floppy also needs a set of lesser-used applications to be selected for compression as well.

Suggestions welcome. 