### PR TITLE
[net] Cleanup source and debug messages for networking

### DIFF
--- a/elks/arch/i86/drivers/char/tcpdev.c
+++ b/elks/arch/i86/drivers/char/tcpdev.c
@@ -37,9 +37,7 @@ char tcpdev_inuse;
 
 char *get_tdout_buf(void)
 {
-    //printk("TCPDEV(%d) get_tdout down bufout_sem %d\n", current->pid, bufout_sem);
     down(&bufout_sem);
-    //printk("TCPDEV(%d) get_tdout GOT bufout_sem %d\n", current->pid, bufout_sem);
     return (char *)tdout_buf;
 }
 
@@ -53,7 +51,7 @@ static size_t tcpdev_read(struct inode *inode, struct file *filp, char *data,
 	    return -EAGAIN;
 	interruptible_sleep_on(&tcpdevq);
 	if (current->signal) {
-	    printk("TCPDEV(%d) read RESTARTSYS tdtail %d\n", current->pid, tdout_tail);
+	    debug_net("TCPDEV(%d) read RESTARTSYS tdtail %d\n", current->pid, tdout_tail);
 	    return -ERESTARTSYS;
 	}
     }
@@ -92,7 +90,6 @@ int tcpdev_inetwrite(void *data, unsigned int len)
 void tcpdev_clear_data_avail(void)
 {
     up(&bufin_sem);
-    //printk("TCPDEV(%d) clear data_avail bufin %d\n", current->pid, bufin_sem);
 }
 
 static size_t tcpdev_write(struct inode *inode, struct file *filp,
@@ -104,9 +101,7 @@ static size_t tcpdev_write(struct inode *inode, struct file *filp,
 	return -EINVAL;
     }
     if (len > 0) {
-	//printk("TCPDEV(%d) write: down bufin_sem %d\n", current->pid, bufin_sem);
 	down(&bufin_sem);
-	//printk("TCPDEV(%d) write: GOT bufin_sem %d\n", current->pid, bufin_sem);
 
 	tdin_tail = (unsigned) len;
 	memcpy_fromfs(tdin_buf, data, len);

--- a/elks/kernel/sleepwake.c
+++ b/elks/kernel/sleepwake.c
@@ -158,7 +158,8 @@ void up(register sem_t *s)
 {
     if (++(*s) == 0)		/* Gone non-negative */
 	wake_up((void *) s);
-if (*s != 0) printk("kernel: sem up %x FAIL %d\n", s, *s);
+
+    if (*s != 0) debug_net("kernel: sem up %x FAIL %d\n", s, *s);
 }
 
 void down(register sem_t *s)
@@ -169,5 +170,6 @@ void down(register sem_t *s)
 
     /* Take it */
     --(*s);
-if (*s != -1) printk("kernel: sem down %x FAIL %d\n", s, *s);
+
+    if (*s != -1) debug_net("kernel: sem down %x FAIL %d\n", s, *s);
 }

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -48,7 +48,7 @@ int inet_process_tcpdev(register char *buf, int len)
     case TDT_CHG_STATE:
         sock->state = (unsigned char) ((struct tdb_return_data *)buf)->ret_value;
         tcpdev_clear_data_avail();
-	debug_tune("INET(%d) chg_state sock %x %d\n", current->pid, sock, sock->state);
+	debug_net("INET(%d) chg_state sock %x %d\n", current->pid, sock, sock->state);
 	if (sock->state == SS_DISCONNECTING) {
 	    sock->flags |= SF_CLOSING;
 	    wake_up(sock->wait);
@@ -220,7 +220,7 @@ static int inet_accept(register struct socket *sock, struct socket *newsock, int
     register struct tdb_accept *cmd;
     int ret;
 
-    debug_tune("INET(%d) accept wait sock %x newsock %x\n", current->pid, sock, newsock);
+    debug_net("INET(%d) accept wait sock %x newsock %x\n", current->pid, sock, newsock);
     cmd = (struct tdb_accept *)get_tdout_buf();
     cmd->cmd = TDC_ACCEPT;
     cmd->sock = sock;
@@ -235,12 +235,12 @@ static int inet_accept(register struct socket *sock, struct socket *newsock, int
         interruptible_sleep_on(sock->wait);
         //sock->flags &= ~SF_WAITDATA;
         if (current->signal) {
-	    printk("INET(%d) accept RESTARTSYS bufin %d\n", current->pid, bufin_sem);
+	    debug_net("INET(%d) accept RESTARTSYS bufin %d\n", current->pid, bufin_sem);
             return -ERESTARTSYS;
 	}
     }
 
-    debug_tune("INET(%d) accepted sock %x newsock %x\n", current->pid, sock, newsock);
+    debug_net("INET(%d) accepted sock %x newsock %x\n", current->pid, sock, newsock);
     newsock->remaddr = ((struct tdb_accept_ret *)tdin_buf)->addr_ip;
     newsock->remport = ((struct tdb_accept_ret *)tdin_buf)->addr_port;
     ret = ((struct tdb_accept_ret *)tdin_buf)->ret_value;

--- a/elks/net/socket.c
+++ b/elks/net/socket.c
@@ -107,7 +107,6 @@ static struct socket *sock_alloc(void)
 	return NULL;
 
     sock = &inode->u.socket_i;
-    debug_tune("sock_alloc %x\n", sock);
 
     *sock = ini_sock;
 
@@ -305,7 +304,6 @@ static void sock_release(register struct socket *sock)
 
     sock->file = NULL;
     iput(SOCK_INODE(sock));
-    debug_tune("sock_free %x\n", sock);
 }
 
 static void sock_close(register struct inode *inode, struct file *filp)
@@ -394,7 +392,7 @@ int sys_listen(int fd, int backlog)
     if (sock->state != SS_UNCONNECTED)
 	return -EINVAL;
 
-    debug_tune("NET(%d) sys_listen sock %x\n", current->pid, sock);
+    debug_net("NET(%d) sys_listen sock %x\n", current->pid, sock);
     ops = sock->ops;
     if (ops && ops->listen)
 	ops->listen(sock, backlog);

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -12,8 +12,8 @@
 #define DEBUG_TCPDATA	0	/* TCP data packets*/
 #define DEBUG_RETRANS	0	/* TCP retransmissions*/
 #define DEBUG_WINDOW	0	/* TCP window size*/
-#define DEBUG_ACCEPT	1	/* TCP accept*/
-#define DEBUG_CLOSE	1	/* TCP close ops*/
+#define DEBUG_ACCEPT	0	/* TCP accept*/
+#define DEBUG_CLOSE	0	/* TCP close ops*/
 #define DEBUG_IP	0
 #define DEBUG_ARP	0
 #define DEBUG_ETH	0

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -495,7 +495,7 @@ void tcp_process(struct iphdr_s *iph)
 	if (cb->rcv_nxt != ntohl(tcph->seqnum)) {
 	    int datalen = iptcp.tcplen - TCP_DATAOFF(iptcp.tcph);
 
-	    printf("tcp: dropping packet, bad seqno: need %ld got %ld size %d\n",
+	    debug_tune("tcp: dropping packet, bad seqno: need %ld got %ld size %d\n",
 		cb->rcv_nxt - cb->irs, ntohl(tcph->seqnum) - cb->irs, datalen);
 
 	    if (cb->rcv_nxt != ntohl(tcph->seqnum) + 1)

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -83,7 +83,7 @@ static void tcpdev_bind(void)
 	struct tcpcb_list_s *n2 = tcpcb_check_port(port);
 	if (n2) {			/* port already bound */
 	    if (!db->reuse_addr) {	/* no SO_REUSEADDR on socket */
-		printf("tcp: port %u already bound, rejecting (use SO_REUSEADDR?)\n", port);
+		debug_tune("tcp: port %u already bound, rejecting (use SO_REUSEADDR?)\n", port);
 reject:
 		tcpcb_remove(n);
 		retval_to_sock(db->sock, -EADDRINUSE);
@@ -297,7 +297,7 @@ static void tcpdev_read(void)
 	    debug_tcp("tcp: disconnecting after final read %d\n", data_avail);
 	    tcpdev_sock_state(cb, SS_DISCONNECTING);
 	} else {
-	    printf("tcp: application read too small after FIN, data_avail %d\n",
+	    debug_tcp("tcp: application read too small after FIN, data_avail %d\n",
 		cb->bytes_to_push);
 	    tcpdev_checkread(cb);		/* inform kernel of remaining data*/
 	}


### PR DESCRIPTION
Cleans up excess debug messages from last 10 days work on TCP stack.

Turns off accept, close and window size messages from ^P display. Can be reenabled using DEBUG_ACCEPT/DEBUG_CLOSE/DEBUG_WINDOW in ktcp/config.h.

> tcp: application read too small after FIN, data_avail 508

This message is turned off.

> A couple more messages can go now, such as
tcp: port 49821 already bound, rejecting (use SO_REUSEADDR?)
Possibly (although this one may be useful for the back-toi-back testing)
tcp: dropping packet, bad seqno: need 182501 got 181041 size 1460

These messages are turned off, but can be seen again using ^P.

No functional changes are made in this PR. Any new problems can be discussed in a new issue, or debugged by turning on above DEBUG_xxx defines. In general, ELKS networking should be stabilized from the last couple weeks work.

Next steps will be to continue testing file transfers using the new ftpd and ftpget/ftpput recently contributed by @Mellvik. I plan on looking into QEMU compatibility and memory reduction through socket reuse using SO_REUSEADDR.