### PR TITLE
[net] First pass fixing ftpd on QEMU

### DIFF
--- a/elkscmd/inet/ftp/ftpd.c
+++ b/elkscmd/inet/ftp/ftpd.c
@@ -29,6 +29,7 @@
 #define		FALSE		0
 #define		FTP_PORT	21
 #define		PASV_PORT	49821U	/* 'random' port for passive connections */
+#define		QEMU_PORT	8041U	/* outside port for QEMU */
 #define		BLOAT
 
 #ifndef MAXPATHLEN
@@ -397,7 +398,6 @@ int do_pasv(int controlfd, int *datafd) {
 	if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &i, sizeof(int)) < 0)
                 perror("SO_RCVBUF");
 
-	//bzero(&pasv, sizeof(pasv));
 	pasv.sin_family = AF_INET;
 	pasv.sin_addr.s_addr = htonl(INADDR_ANY);
 	pasv.sin_port = htons(port);
@@ -414,9 +414,7 @@ int do_pasv(int controlfd, int *datafd) {
 		} 
 		port++;
 		if (qemu) {
-			//sleep(1);
-			//usleep(800);	/* Experimental */
-			if (port >= (PASV_PORT + 8)) port = PASV_PORT;
+			if (port >= (PASV_PORT + 9)) port = PASV_PORT;
 		}
     		pasv.sin_port = htons(port);
 	}
@@ -438,8 +436,11 @@ int do_pasv(int controlfd, int *datafd) {
 	sprintf(str, "227 Entering Passive Mode (%d,%d,%d,%d,%d,%d)\r\n", UC(a[0]),
 		UC(a[1]), UC(a[2]), UC(a[3]), UC(p[0]), UC(p[1]));
 
-	if (qemu)
-		sprintf(str, "227 Entering Passive Mode (127,0,0,1,31,%u)\r\n", 105 + (port-PASV_PORT));
+	if (qemu) {
+		unsigned int qport = QEMU_PORT + port - PASV_PORT;
+		sprintf(str, "227 Entering Passive Mode (127,0,0,1,%u,%u)\r\n",
+			htons(qport)&0xff, htons(qport)>>8);
+	}
     	write(controlfd, str, strlen(str));
 	if (debug) printf("%s", str);
 	i = sizeof(pasv);

--- a/elkscmd/inet/ftp/ftpd.c
+++ b/elkscmd/inet/ftp/ftpd.c
@@ -391,8 +391,8 @@ int do_pasv(int controlfd, int *datafd) {
 		return -1;
 	}
 
-	//if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &i, sizeof(i)) < 0) 
-		//perror("SO_REUSEADDR");
+	if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &i, sizeof(i)) < 0)
+		perror("SO_REUSEADDR");
 	i = SO_LISTEN_BUFSIZ;
 	if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &i, sizeof(int)) < 0)
                 perror("SO_RCVBUF");
@@ -414,9 +414,9 @@ int do_pasv(int controlfd, int *datafd) {
 		} 
 		port++;
 		if (qemu) {
-			sleep(1);
+			//sleep(1);
 			//usleep(800);	/* Experimental */
-			if (port >= (PASV_PORT + 4)) port = PASV_PORT;
+			if (port >= (PASV_PORT + 8)) port = PASV_PORT;
 		}
     		pasv.sin_port = htons(port);
 	}
@@ -598,7 +598,7 @@ int main(int argc, char **argv){
 		perror("Error in listen");
 		exit(3);
 	}
-	if (!debug) {
+	if (debug < 2) {
 		/* become daemon, debug output on 1 and 2*/
 		if ((ret = fork()) == -1) {
 			fprintf(stderr, "ftpd: Can't fork to become daemon\n");

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -460,7 +460,7 @@ void tcp_process(struct iphdr_s *iph)
     }
 
     if (!cbnode) {
-	printf("tcp: refusing packet %s:%u->%d\n", in_ntoa(iph->saddr),
+	printf("tcp: refusing packet from %s:%u to :%u\n", in_ntoa(iph->saddr),
 		ntohs(tcph->sport), ntohs(tcph->dport));
 
 	if (tcph->flags & TF_RST)

--- a/elkscmd/rootfs_template/bin/net
+++ b/elkscmd/rootfs_template/bin/net
@@ -60,7 +60,7 @@ start_network()
 	echo $ktcp
 	if $ktcp; then
 		echo -n "Starting daemons "
-		for daemon in telnetd httpd ftpd
+		for daemon in telnetd httpd
 		do
 			if test -f /bin/$daemon
 			then
@@ -68,6 +68,11 @@ start_network()
 				$daemon || true
 			fi
 		done
+		if test -f /bin/ftpd
+		then
+			echo -n "ftpd $ftpd"
+			ftpd $ftpd || true
+		fi
 		echo ""
 	else
 		echo "Network start failed"

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,8 +1,8 @@
 ##
 #console=ttyS0 debug net=eth 3
-#ftpd=-q
+#ftpd=-q net=eth
 #init=/bin/init 3 n	# multiuser serial no sysinit
 #init=/bin/sh		# singleuser shell
 #console=ttyS0,19200	# serial console
-#root=hda1 ro	# hd partition 1, read-only root
-#netirq=9 netport=0x300	# NIC parms
+#root=hda1 ro		# hd part 1, read-only root
+#netirq=9 netport=0x300

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,7 +1,8 @@
 ##
-#console=ttyS0 debug net=eth 3 # condensed
+#console=ttyS0 debug net=eth 3
+#ftpd=-q
 #init=/bin/init 3 n	# multiuser serial no sysinit
 #init=/bin/sh		# singleuser shell
 #console=ttyS0,19200	# serial console
 #root=hda1 ro	# hd partition 1, read-only root
-#netirq=9 netport=0x300	# set NIC parms
+#netirq=9 netport=0x300	# NIC parms

--- a/qemu.sh
+++ b/qemu.sh
@@ -55,7 +55,7 @@ KEYBOARD=
 #SERIAL="-chardev msmouse,id=chardev1 -device isa-serial,chardev=chardev1,id=serial1"
 
 # Uncomment this to route ELKS /dev/ttyS0 to host terminal
-#CONSOLE="-serial stdio"
+CONSOLE="-serial stdio"
 # Hides qemu window also
 #CONSOLE="-serial stdio -nographic"
 
@@ -67,8 +67,22 @@ KEYBOARD=
 # Incoming http forwarding: example: connect to ELKS httpd with 'http://localhost:8080'
 # HOSTFWD="-net user,hostfwd=tcp:127.0.0.1:8080-10.0.2.15:80"
 
-# Simultaneous telnet and http forwarding
-FWD="hostfwd=tcp:127.0.0.1:8080-10.0.2.15:80,hostfwd=tcp:127.0.0.1:2323-10.0.2.15:23"
+# Simultaneous telnet, http and ftp forwarding
+FWD="\
+hostfwd=tcp:127.0.0.1:8080-10.0.2.15:80,\
+hostfwd=tcp:127.0.0.1:2323-10.0.2.15:23,\
+hostfwd=tcp::8020-:20,\
+hostfwd=tcp::8021-:21,\
+hostfwd=tcp::8041-:49821,\
+hostfwd=tcp::8042-:49822,\
+hostfwd=tcp::8043-:49823,\
+hostfwd=tcp::8044-:49824,\
+hostfwd=tcp::8045-:49825,\
+hostfwd=tcp::8046-:49826,\
+hostfwd=tcp::8047-:49827,\
+hostfwd=tcp::8048-:49828,\
+hostfwd=tcp::8049-:49829"
+
 # new style
 #NET="-net nic,model=ne2k_isa -net user,$FWD"
 # old style, with configurable interrupt line


### PR DESCRIPTION
Enhancements to allow easier operation of ftpd on QEMU, for testing.

@Mellvik, tell me what you think about this. I'm already finding a number of potential issues between ftpd and QEMU.
The following changes are made in this PR:
- SO_REUSEADDR turned on for passive mode file transfers (both QEMU and real hardware). This should be safe, but still should be tested on real hardware at some point. SO_REUSEADDR should not yet be enabled elsewhere (pending more work on it).
- Eliminate 1 second sleep in ftpd for socket timeout, uses SO_REUSEADDR and displays appropriate messages.
- Added ability to set ftpd -q or ftpd -q in /bootopts: use "ftpd=-q" when running QEMU for testing. Use "ftpd=-d" for debug output at boot without having to kill and restart.
- ftpd -q and -d options don't disable becoming a daemon; run ftpd -d -d for old behavior.
- Added ftp port forwarding lines in qemu.sh. It would be nice to figure out how to do this without having to kluge ftpd to prepare a special passive mode string!
- Forward 9 ports rather than 5 for more realistic emulation. (May be off-by-one error in ftpd on wrap).

In quick testing, I found the following issues (could be my mistakes):
- managed to send files to ELKS, using "mput foo*", but can't get "mget foo*" to work to send from ELKS afterwards.
- QEMU seems to stop working after a bit... the INT 0 timer stops, and ftpd stops working, only when using serial console. Very strange, but have seen this behavior before. I think its a QEMU problem. This can be duplicated by uncommenting the first two entries in /bootopts and running a few file transfers.
- Sometimes ftpd just stops responding. Not sure if that's the above problem or not.
- Any ideas on how active mode might be tested using QEMU?

Overall, this first pass makes things a lot easier for testing. @Mellvik, let me know if you're OK with commit.