### PR TITLE
[cmds] Support localtime in RTC clock

### DIFF
--- a/elkscmd/rootfs_template/etc/rc.d/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sys
@@ -1,14 +1,15 @@
-# This file performs system initialization
+# System initialization script
 
 echo Running $0 script
-# uncomment to display script execution
 #set -x
 
 umask 022
 export PATH=/bin
 
-# init date from hardware
-clock -s
+# get TZ timezone variable from /etc/profile
+# remove -u option if RTC is localtime
+source /etc/profile
+clock -s -u
 
 check_filesystem()
 {
@@ -32,7 +33,6 @@ fi
 #
 #mount -t msdos /dev/fd1 /mnt || true
 #mount -t msdos /dev/hda1 /mnt
-#mount -t msdos /dev/hda /mnt
 #mount /dev/hda /mnt
 
 #
@@ -51,11 +51,9 @@ cslip)
 	;;
 *)
 	# normal network start
-	#net start
 	#net start eth
 	#net start cslip 19200
 	#net start slip 115200 /dev/ttyS0
-	#net stop
 	;;
 esac
 

--- a/elkscmd/sys_utils/clock.c
+++ b/elkscmd/sys_utils/clock.c
@@ -371,7 +371,7 @@ int main(int argc, char **argv)
 #if ELKS
       /* system time is offset by TZ variable for now, localtime handled in C library*/
       tz.tz_minuteswest = 0;
-      tz.tz_dsttime = 0;
+      tz.tz_dsttime = DST_NONE;
 #else
       tz.tz_minuteswest = timezone / 60;
       tz.tz_dsttime = daylight;
@@ -395,7 +395,7 @@ int main(int argc, char **argv)
       else
 	tmp = localtime (&systime);
 
-      asm("cli \n");
+      clr_irq();
       save_control = cmos_read (11);   /* tell the clock it's being set */
       cmos_write (11, (save_control | 0x80));
       save_freq_select = cmos_read (10);       /* stop and reset prescaler */
@@ -411,7 +411,7 @@ int main(int argc, char **argv)
 
       cmos_write (10, save_freq_select);
       cmos_write (11, save_control);
-      asm("sti \n");
+      set_irq();
     }
   return 0;
 }

--- a/elkscmd/sys_utils/clock.c
+++ b/elkscmd/sys_utils/clock.c
@@ -6,11 +6,10 @@
 #include <time.h>
 #include <sys/time.h>
 #include <string.h>
-#ifdef __ia16__
 #include <arch/irq.h>
 #include <arch/io.h>
-#endif
 
+#define ELKS 1
 
 /* V1.0
  * CMOS clock manipulation - Charles Hedrick, hedrick@cs.rutgers.edu, Apr 1992
@@ -137,9 +136,11 @@
  * I had to remove the code that waits for the falling edge
  * of the update flag -- it never seems to actually happen!
  * And since the long code is so slow, the program just locks.
+ *
+ * v1.6 Work with RTC localtime as well as UTC
  */
 
-#define VERSION "1.5.ELKS"
+#define VERSION "1.6"
 
 /* Globals */
 int readit = 0;
@@ -158,49 +159,6 @@ int usage(void)
     exit(1);
 }
 
-#ifdef __BCC__
-#asm
-_inb:
-    push bp
-    mov bp, sp
-    push dx
-    xor ax, ax
-    mov dx, 4[bp]
-    in al, dx
-    pop dx
-    pop bp
-    ret
-#endasm
-
-#asm
-_outb:
-    push bp
-    mov bp, sp
-    push ax
-    push dx
-    xor ax, ax
-    mov al, 4[bp]
-    mov dx, 6[bp]
-    out dx, al
-    pop dx
-    pop ax
-    pop bp
-    ret
-#endasm
-
-#asm
-_clr_irq:
-    cli
-    ret
-#endasm
-
-#asm
-_set_irq:
-    sti
-    ret
-#endasm
-#endif
-
 unsigned char cmos_read(unsigned char reg)
 {
   register unsigned char ret;
@@ -211,9 +169,7 @@ unsigned char cmos_read(unsigned char reg)
   return ret;
 }
 
-void cmos_write(reg, val)
-unsigned char reg;
-unsigned char val;
+void cmos_write(unsigned char reg, unsigned char val)
 {
   clr_irq ();
   outb_p (reg | 0x80, 0x70);
@@ -221,9 +177,7 @@ unsigned char val;
   set_irq ();
 }
 
-
-int cmos_read_bcd (addr)
-int addr;
+int cmos_read_bcd (int addr)
 {
   int b;
   b = cmos_read (addr);
@@ -239,8 +193,7 @@ void cmos_write_bcd(int addr, int value)
 /*    doesn't check boundary conditions */
 /*    doesn't set wday or yday */
 /*    doesn't return the local time */
-time_t utc_mktime(t)
-struct tm *t;
+time_t utc_mktime(struct tm *t)
 {
     static int mday[12] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
     int year_ofs;
@@ -284,10 +237,7 @@ int main(int argc, char **argv)
 {
   struct tm tm;
   time_t systime;
-  time_t last_time;
   int arg;
-  double factor;
-  double not_adjusted;
   unsigned char save_control, save_freq_select;
 
   while ((arg = getopt (argc, argv, "rwsuv")) != -1)
@@ -322,22 +272,6 @@ int main(int argc, char **argv)
 
   if (readit || setit)
     {
-#if 0
-      long i;
-
-/* read RTC exactly on falling edge of update flag */
-/* Wait for rise.... (may take upto 1 second) */
-
-      for (i = 0; i < 10000000L; i++)
-	if (cmos_read (10) & 0x80)
-	  break;
-
-/* Wait for fall.... (must try at least 2.228 ms) */
-
-      for (i = 0; i < 1000000L; i++)
-	if (!(cmos_read (10) & 0x80))
-	  break;
-#endif /* 0 */
 
 /* The purpose of the "do" loop is called "low-risk programming" */
 /* In theory it should never run more than once */
@@ -363,15 +297,18 @@ int main(int argc, char **argv)
     {
 /*
  * utc_mktime() assumes we're in Greenwich, England.  If the CMOS
- * clock isn't in GMT, we need to adjust.  We'll just use the
- * time zone information returned in gettimeofday().
+ * clock isn't in GMT, we need to adjust.
  */
       systime = utc_mktime(&tm);
       if (!universal) {
+#if ELKS
+          tzset();			/* read TZ= env string and set timezone var */
+          systime += timezone;
+#else
           struct timezone tz;
-
           gettimeofday(NULL, &tz);
           systime += tz.tz_minuteswest * 60L;
+#endif
       }
 #if 0
 /*
@@ -429,24 +366,24 @@ int main(int argc, char **argv)
 	  exit (2);
 	}
 
-#ifndef KEEP_OFF
       tv.tv_sec = systime;
       tv.tv_usec = 0;
-#if 0
+#if ELKS
+      /* system time is offset by TZ variable for now, localtime handled in C library*/
+      tz.tz_minuteswest = 0;
+      tz.tz_dsttime = 0;
+#else
       tz.tz_minuteswest = timezone / 60;
       tz.tz_dsttime = daylight;
+#endif
 
       if (settimeofday (&tv, &tz) != 0)
-#else
-      if (settimeofday (&tv, NULL) != 0)
-#endif
         {
 	  fprintf (stderr,
 		   "Unable to set time -- probably you are not root\n");
 	  exit (1);
 	}
 
-#endif
     }
 
   if (writeit)
@@ -458,15 +395,7 @@ int main(int argc, char **argv)
       else
 	tmp = localtime (&systime);
 
-#ifndef KEEP_OFF
-#ifdef __BCC__
-#asm
-      cli
-#endasm
-#endif
-#ifdef __ia16__
-  asm("cli \n");
-#endif
+      asm("cli \n");
       save_control = cmos_read (11);   /* tell the clock it's being set */
       cmos_write (11, (save_control | 0x80));
       save_freq_select = cmos_read (10);       /* stop and reset prescaler */
@@ -482,15 +411,7 @@ int main(int argc, char **argv)
 
       cmos_write (10, save_freq_select);
       cmos_write (11, save_control);
-#ifdef __BCC__
-#asm
-      sti
-#endasm
-#endif
-#ifdef __ia16__
-   asm("sti \n");
-#endif
-#endif
+      asm("sti \n");
     }
-  exit (0);
+  return 0;
 }

--- a/libc/include/sys/time.h
+++ b/libc/include/sys/time.h
@@ -1,3 +1,4 @@
 #include <time.h>
 
 int gettimeofday (struct timeval * restrict tp, void * restrict tzp);
+int settimeofday (const struct timeval *tp, const struct timezone *tzp);


### PR DESCRIPTION
Adds support for PC realtime clock in localtime, contributed by @tyama501 in #1040.

Trim down rc.sys file to 1024 bytes for faster boot.
Clean up clock.c source.

The kernel timezone structure is still set to 0 as before, and C library handles the timezone conversions. This may want to change at some point.