### PR TITLE
[boot][net] Allow HOSTNAME=,GATEWAY= and TZ= in /bootopts and /etc/profile

### DIFF
--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -187,6 +187,7 @@ int main(int argc,char **argv)
     int ch;
     int bflag = 0;
     int mtu = 0;
+    char *p;
     static char *linknames[3] = { "ethernet", "slip", "cslip" };
 
     while ((ch = getopt(argc, argv, "bdm:p:s:l:")) != -1) {
@@ -219,10 +220,17 @@ int main(int argc,char **argv)
 	}
     }
 
-    /* using in_gethostbyname rather than in_aton allows /etc/hosts aliases to be used as parms*/
-    local_ip = in_gethostbyname(optind < argc? argv[optind++]: DEFAULT_IP);
-    gateway_ip = in_gethostbyname(optind < argc? argv[optind++]: DEFAULT_GATEWAY);
-    netmask_ip = in_gethostbyname(optind < argc? argv[optind++]: DEFAULT_NETMASK);
+    /*
+     * Default IP, gateway and netmask set by env variables in
+     * /bootopts or /etc/profile. They can be IP addresses or
+     * names in /etc/hosts.
+     */
+    char *default_ip = (p=getenv("HOSTNAME"))? p: DEFAULT_IP;
+    char *default_gateway = (p=getenv("GATEWAY"))? p: DEFAULT_GATEWAY;
+    char *default_netmask = (p=getenv("NETMASK"))? p: DEFAULT_NETMASK;
+    local_ip = in_gethostbyname(optind < argc? argv[optind++]: default_ip);
+    gateway_ip = in_gethostbyname(optind < argc? argv[optind++]: default_gateway);
+    netmask_ip = in_gethostbyname(optind < argc? argv[optind++]: default_netmask);
     MTU = mtu ? mtu : (linkprotocol == LINK_ETHER ? ETH_MTU : SLIP_MTU);
 
     /* must exit() in next two stages on error to reset kernel tcpdev_inuse to 0*/

--- a/elkscmd/rootfs_template/bin/net
+++ b/elkscmd/rootfs_template/bin/net
@@ -12,12 +12,11 @@
 # See qemu.sh NET= line for host forwarding into ELKS using QEMU
 #
 
-# default IP address, gateway and network mask
-localip=10.0.2.15
-gateway=10.0.2.2
-#localip=10.0.0.15
-#gateway=10.0.0.127
-netmask=255.255.255.0
+# Default IP address, gateway and network mask set by env variables in
+# /bootopts or /etc/profile. They can be IP addresses or names in /etc/hosts.
+localip=$HOSTNAME
+gateway=$GATEWAY
+netmask=$NETMASK
 
 # default link layer [eth|slip|cslip]
 link=eth

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,8 +1,10 @@
 ##
 #console=ttyS0 debug net=eth 3
 #ftpd=-q net=eth
-#init=/bin/init 3 n	# multiuser serial no sysinit
-#init=/bin/sh		# singleuser shell
-#console=ttyS0,19200	# serial console
+#HOSTNAME=elks
+#TZ=MDT7
+#init=/bin/init 3 n	# muser serial no sysinit
+#init=/bin/sh		# suser shell
+#console=ttyS0,19200	# ser console
 #root=hda1 ro		# hd part 1, read-only root
 #netirq=9 netport=0x300

--- a/elkscmd/rootfs_template/etc/hosts
+++ b/elkscmd/rootfs_template/etc/hosts
@@ -1,3 +1,5 @@
 #127.0.0.1	localhost
-10.0.2.15	elks elks2
+10.0.2.15	elks1 elks
+10.0.2.16	elks2
+10.0.2.17	elks3
 10.0.2.2	gateway

--- a/elkscmd/rootfs_template/etc/profile
+++ b/elkscmd/rootfs_template/etc/profile
@@ -1,3 +1,6 @@
 export PATH=/bin
-# change for localtime
-export TZ=GMT0
+# timezone, hostname etc can be set in either /bootopts or here
+#export TZ=GMT0
+#export HOSTNAME=10.0.2.15
+#export GATEWAY=10.0.2.2
+#export NETMASK=255.255.255.0

--- a/elkscmd/rootfs_template/etc/rc.d/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sys
@@ -6,7 +6,7 @@ echo Running $0 script
 umask 022
 export PATH=/bin
 
-# get TZ timezone variable from /etc/profile
+# get TZ timezone variable from /bootopts or /etc/profile
 # remove -u option if RTC is localtime
 source /etc/profile
 clock -s -u

--- a/elkscmd/sys_utils/login.c
+++ b/elkscmd/sys_utils/login.c
@@ -37,14 +37,13 @@ extern char *getpass(char *prompt);
 
 void login(register struct passwd * pwd, struct utmp * ut_ent)
 {
+	int envno = 0;
+	char **newenv;
 	char user_env[STR_SIZE];
 	char shell_env[STR_SIZE];
 	char home_env[STR_SIZE];
 	char sh_name[STR_SIZE];
-	int envno = 0;
-	char * renv[5];
-	environ = renv;
-
+	char *renv[16];
 
 	if (fchown(0,pwd->pw_uid,pwd->pw_gid)<0) perror("login (chown)");
 #ifdef USE_UTMP
@@ -66,19 +65,27 @@ void login(register struct passwd * pwd, struct utmp * ut_ent)
 		exit(1);
 	}
 
+	/* copy capitalized /bootopts env vars to login environment */
+	newenv = renv;
+	while (*environ) {
+		if (*environ[0] >= 'A' && *environ[0] <= 'Z')
+			newenv[envno++] = *environ;
+		environ++;
+	}
+
 	strcpy(user_env,"USER=");
 	strncpy(user_env+5,pwd->pw_name, STR_SIZE - 6);
-	environ[envno++] = user_env;
+	newenv[envno++] = user_env;
 
 	strcpy(home_env,"HOME=");
 	strncpy(home_env+5,pwd->pw_dir, STR_SIZE - 6);
-	environ[envno++] = home_env;
+	newenv[envno++] = home_env;
 
 	strcpy(shell_env,"SHELL=");
 	strncpy(shell_env+6,pwd->pw_shell, STR_SIZE - 7);
-	environ[envno++] = shell_env;
-	environ[envno++] = "TERM=ansi";
-	environ[envno] = NULL;
+	newenv[envno++] = shell_env;
+	newenv[envno++] = "TERM=ansi";
+	newenv[envno] = NULL;
 
 	*sh_name = '-';
 	strncpy(sh_name+1,pwd->pw_shell, STR_SIZE - 1);
@@ -86,6 +93,7 @@ void login(register struct passwd * pwd, struct utmp * ut_ent)
 	if (chdir(pwd->pw_dir)<0)
 		write(STDOUT_FILENO, "No home directory. Starting in /\n", 33);
 
+	environ = renv;
 	execl(pwd->pw_shell,sh_name,(char*)0);
 
 	write(STDOUT_FILENO, "No shell (errno ", 16);


### PR DESCRIPTION
Enhancement for issue requested in #1042. Allows timezone, network hostname (IP or name), gateway, and netmask to be specified in /bootopts or /etc/profile to ease managing kernel images for multiple machines.

Use described in https://github.com/jbruchon/elks/issues/1042#issuecomment-988162826.

Examples provided in /bootopts and /etc/profile.

(@Mellvik: yes, /bootopts is getting pretty full. I'm looking into a way to increase its size to 512 bytes separately).