### PR TITLE
[boot] Increase /bootopts max size to 511 bytes

### DIFF
--- a/bootblocks/boot_minix.c
+++ b/bootblocks/boot_minix.c
@@ -5,12 +5,13 @@
 // Sector 2 : boot loader
 //------------------------------------------------------------------------------
 
+#include "linuxmt/config.h"
 #include "minix.h"
 
 // Global constants
 
-#define LOADSEG 0x0100
-#define OPTSEG	0x0050		// bootopts copied here
+#define LOADSEG DEF_INITSEG
+#define OPTSEG	DEF_OPTSEG             // bootopts copied here
 
 // Global variables
 

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -95,16 +95,17 @@
 #define SETUP_DATA	REL_INITSEG
 
 /* Define segment locations of low memory, must not overlap */
-#define DEF_OPTSEG	0x50  /* 0x100 bytes boot options*/
-#define REL_INITSEG	0x60  /* 0x200 bytes setup data */
-#define DMASEG		0x80  /* 0x400 bytes floppy sector buffer */
+#define DEF_OPTSEG	0x50  /* 0x200 bytes boot options*/
+#define OPTSEGSZ 0x200    /* max size of /bootopts file (1K max) */
+#define REL_INITSEG	0x70  /* 0x200 bytes setup data */
+#define DMASEG		0x90  /* 0x400 bytes floppy sector buffer */
 
 #ifdef CONFIG_TRACK_CACHE     /* floppy track buffer in low mem */
 #define DMASEGSZ 0x2400	      /* SECTOR_SIZE * 18 (9216) */
-#define REL_SYSSEG	0x2C0 /* kernel code segment */
+#define REL_SYSSEG	0x2D0 /* kernel code segment */
 #else
 #define DMASEGSZ 0x0400	      /* BLOCK_SIZE (1024) */
-#define REL_SYSSEG	0x0C0 /* kernel code segment */
+#define REL_SYSSEG	0x0D0 /* kernel code segment */
 #endif
 
 #endif /* !CONFIG_ROMCODE */

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -43,7 +43,7 @@ static char *argv_init[80] = { NULL, bininit, NULL };
 #if ENV
 static char *envp_init[MAX_INIT_ENVS+1];
 #endif
-static unsigned char options[256];
+static unsigned char options[OPTSEGSZ];
 
 extern int boot_rootdev;
 extern int dprintk_on;
@@ -118,7 +118,7 @@ void INITPROC kernel_init(void)
 #ifdef CONFIG_BOOTOPTS
     if (opts)
 	finalize_options();
-    else printk("/bootopts IGNORED: header not ## or size > 255\n");
+    else printk("/bootopts IGNORED: header not ## or size > %d\n", OPTSEGSZ-1);
 #endif
 
     mm_stat(base, end);
@@ -244,8 +244,8 @@ static int INITPROC parse_options(void)
 	/* copy /bootops loaded by boot loader at 0050:0000*/
 	fmemcpyb(options, kernel_ds, 0, DEF_OPTSEG, sizeof(options));
 
-	/* check file starts with ## and max len 255 bytes*/
-	if (*(unsigned short *)options != 0x2323 || options[255])
+	/* check file starts with ## and max len 511 bytes*/
+	if (*(unsigned short *)options != 0x2323 || options[OPTSEGSZ-1])
 		return 0;
 #if DEBUG
 	printk("/bootopts: %s", &options[3]);

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,10 +1,12 @@
-##
-#console=ttyS0 debug net=eth 3
-#ftpd=-q net=eth
-#HOSTNAME=elks
-#TZ=MDT7
-#init=/bin/init 3 n	# muser serial no sysinit
-#init=/bin/sh		# suser shell
-#console=ttyS0,19200	# ser console
-#root=hda1 ro		# hd part 1, read-only root
-#netirq=9 netport=0x300
+## boot options max size 511 bytes
+#console=ttyS0 debug net=eth 3 # serial console, multiuser, networking
+#TZ=MDT7		# timezone
+#ftpd=-q net=eth	# ftpd on qemu
+#HOSTNAME=elks1	 	# set network IP from /etc/hosts
+#GATEWAY=10.0.2.2
+#NETMASK=255.255.255.0
+#netirq=9 netport=0x300 # NIC
+#init=/bin/init 3 n	# multiuser serial no /etc/rc.d/rc.sys
+#init=/bin/sh		# singleuser shell
+#console=ttyS0,19200	# serial console
+#root=hda1 ro		# root hd partition 1, read-only


### PR DESCRIPTION
Doubles usable size of /bootopts file for specifying boot, network, console and other options.

More examples were added to the /bootopts file to enhance usability.