### PR TITLE
[kernel] Add VideoSeg kernel global for portability

### DIFF
--- a/elks/arch/i86/drivers/char/console-direct.c
+++ b/elks/arch/i86/drivers/char/console-direct.c
@@ -67,6 +67,7 @@ static unsigned short int NumConsoles = MAX_CONSOLES;
 
 int Current_VCminor = 0;
 int kraw = 0;
+unsigned VideoSeg = 0xB800;
 
 #ifdef CONFIG_EMUL_ANSI
 #define TERM_TYPE " emulating ANSI "

--- a/elks/arch/i86/kernel/timer.c
+++ b/elks/arch/i86/kernel/timer.c
@@ -1,6 +1,7 @@
 #include <linuxmt/config.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/timer.h>
+#include <linuxmt/ntty.h>
 
 #include <arch/io.h>
 #include <arch/irq.h>
@@ -33,7 +34,7 @@ void timer_tick(int irq, struct pt_regs *regs)
 	static unsigned char wheel[4] = {'-', '\\', '|', '/'};
 	static int c = 0;
 
-	pokeb((79 + 0*80) * 2, 0xB800, wheel[c++ & 0x03]);
+	pokeb((79 + 0*80) * 2, VideoSeg, wheel[c++ & 0x03]);
     }
 #endif
 }
@@ -42,6 +43,6 @@ void spin_timer(int onflag)
 {
 #ifdef CONFIG_CONSOLE_DIRECT
     if ((spin_on = onflag) == 0)
-	pokeb((79 + 0*80) * 2, 0xB800, ' ');
+	pokeb((79 + 0*80) * 2, VideoSeg, ' ');
 #endif
 }

--- a/elks/include/linuxmt/ntty.h
+++ b/elks/include/linuxmt/ntty.h
@@ -109,6 +109,10 @@ extern void tty_freeq(struct tty *tty);
 
 extern void set_console(dev_t dev);
 
+#ifdef CONFIG_CONSOLE_DIRECT
+extern unsigned VideoSeg;
+#endif
+
 /* tty.flags */
 #define TTY_STOPPED 	1
 #define TTY_OPEN	2


### PR DESCRIPTION
This should help porting direct console to architectures where the video ram is not at segment 0xb800. The address can be initialized in the console_init routine. This address is used for the "spin timer" rotating icon in the upper right corner of the screen, which indicates disk I/O is occurring.