### PR TITLE
[kernel] APM and hard reset code for IBM PC architecture only

### DIFF
--- a/elks/arch/i86/kernel/system.c
+++ b/elks/arch/i86/kernel/system.c
@@ -74,11 +74,13 @@ void INITPROC setup_arch(seg_t *start, seg_t *end)
 #endif
 }
 
-/* Stubs for functions needed elsewhere */
+/*
+ * The following routines may need porting on non-IBM PC architectures
+ */
 
 void hard_reset_now(void)
 {
-#ifdef __ia16__
+#ifdef CONFIG_ARCH_IBMPC
     asm("mov $0x40,%ax\n\t"
 	"mov %ax,%ds\n\t"
 	"movw $0x1234,0x72\n\t"
@@ -87,7 +89,6 @@ void hard_reset_now(void)
 #endif
 }
 
-#ifdef CONFIG_APM
 /*
  *	Use Advanced Power Management to power off system
  *	For details on how this code works, see
@@ -95,7 +96,7 @@ void hard_reset_now(void)
  */
 void apm_shutdown_now(void)
 {
-#ifdef __ia16__
+#if defined(CONFIG_APM) && defined(CONFIG_ARCH_IBMPC)
     asm("movw $0x5301,%ax\n\t"
 	"xorw %bx,%bx\n\t"
 	"int $0x15\n\t"
@@ -112,7 +113,4 @@ void apm_shutdown_now(void)
 	"apm_error:\n\t"
 	);
 #endif
-    printk("Cannot power off: APM not supported\n");
-    return;
 }
-#endif

--- a/elks/include/arch/system.h
+++ b/elks/include/arch/system.h
@@ -6,7 +6,8 @@
 
 extern byte_t sys_caps;		/* system capabilities bits*/
 
-extern void arch_setuptasks(void);
 extern void INITPROC setup_arch(seg_t *,seg_t *);
+extern void hard_reset_now(void);
+extern void apm_shutdown_now(void);
 
 #endif

--- a/elks/kernel/sys.c
+++ b/elks/kernel/sys.c
@@ -23,8 +23,6 @@
 
 static int C_A_D = 1;
 
-extern void hard_reset_now(void);
-extern void apm_shutdown_now(void);
 extern int sys_kill(sig_t,pid_t);
 
 /*
@@ -52,16 +50,17 @@ int sys_reboot(unsigned int magic, unsigned int magic_too, int flag)
 		return 0;
 	    case 0x0123:		/* reboot*/
 		hard_reset_now();
+		printk("Reboot failed\n");
+		/* fall through*/
 	    case 0x6789:		/* shutdown*/
 		sys_kill(1, SIGKILL);
 		sys_kill(-1, SIGKILL);
 		printk("System halted\n");
 		do_exit(0);
-#ifdef CONFIG_APM
+		/* no return*/
 	    case 0xDEAD:		/* poweroff*/
 		apm_shutdown_now();
 		printk("APM shutdown failed\n");
-#endif
 	}
     }
 


### PR DESCRIPTION
Compiles in advanced power management and hard reset code for IBM PC architecture only (CONFIG_ARCH_IBMPC).
These functions are called by the `poweroff` and `reboot` commands respectively.

Will fix problem reported in https://github.com/jbruchon/elks/issues/1047#issuecomment-991704101.

@tyama501, if the PC-98 supports APM or hard reset, those functions can be changed in elks/arch/i86/kernel/system.c and submitted. (elks/config.in will also have to be changed to allow CONFIG_APM to be set).
