### PR TITLE
[kernel] Cleanup and document INITSEG/setup variable locations

### DIFF
--- a/Documentation/text/boot.txt
+++ b/Documentation/text/boot.txt
@@ -58,3 +58,25 @@ The boot sector contains some parameters at the end:
 
 *patched by arch/i86/tools/build when the kernel is being built.
 Only 497, 500,501 and 508,509 are used at present.
+
+New ELKS "INITSEG" (setup data segment) offsets:
++------+-----+------+-------------------+--------------------------+------------
+| 0007 |   7 | byte | screen_cols       | screen width             | setup.S
+| 000E |  14 | byte | screen_lines      | screen height            | setup.S
+| 0020 |  32 | byte | cpu_type          | deprecated               | setup.S
+| 002A |  42 | word | mem_kbytes        | base memory size in K    | setup.S
+| 0030 |  48 |16byte| proc_name         | processor name           | setup.S
+| 0050 |  80 |13byte| cpu_id            | cpu id                   | setup.S
+| 01E2 | 482 | long | part_offset       | partition offset in sects| boot_sect.S
+| 01E2 | 482 | long | part_offset       | partition offset in sects| boot_sect.S
+| 01E6 | 486 | long | elks_magic        | "ELKS"                   | bootsect.S
+| 01EF | 495 | word | SETUPSEG          | UNUSED                   |
+| 01F1 | 497 | byte | setup_sects       | size in 512-byte sects   | build tool
+| 01F2 | 498 | word | root_flags        | UNUSED                   |
+| 01F4 | 500 | word | syssize           | kernel size in paras     | build tool
+| 01F6 | 502 | word | elks_flags        | BLOB, BIOS_DRV           | boot_sect.S
+| 01F8 | 504 | word | RAMDISK           | UNUSED                   |
+| 01FA | 506 | word | SVGAMODE          | UNUSED                   |
+| 01FC | 508 | word | root_dev          | BIOS drive or kdev_t     | boot_sect.S
+| 01FE | 510 | word | boot_flag         | AA55h                    | boot_sect.S
++------+-----+------+-------------------+--------------------------+------------

--- a/Documentation/text/boot.txt
+++ b/Documentation/text/boot.txt
@@ -59,7 +59,40 @@ The boot sector contains some parameters at the end:
 *patched by arch/i86/tools/build when the kernel is being built.
 Only 497, 500,501 and 508,509 are used at present.
 
-New ELKS "INITSEG" (setup data segment) offsets:
+Setup and INITSEG Variables
+---------------------------
+INITSEG variables are mostly used to pass information from the boot loader
+to setup, and also the kernel. This is unfortunately still a kind of
+black-magic area of ELKS.
+
+Setup is ASM code that executes immediately after the boot loader, and
+prior to the kernel. It is located in the 2nd 512 bytes of the kernel image
+on disk (/linux).
+
+The first 512 bytes of the kernel disk image is a dummy boot sector that
+contains preset values for certain setup variable locations. Following that
+is the a.out kernel executable header and then the kernel text, fartext,
+data and relocation table sections.
+
+When building the kernel image Image, a special tool called build is used to
+concatenate the dummy boot loader, the setup code and the kernel executable
+together. build also writes the sizes of setup and the kernel into INITSEG,
+which at the time is the dummy boot sector.
+
+Setup's data segment is at a fixed location and is called INITSEG, and is
+initially the contents of the dummy boot sector. Setup is required to
+perform the relocations from the a.out relocation table on the kernel
+executable, and also to determine certain hardware configurations easier done
+in assembly, which are saved in it's data segment (INITSEG), which is also
+known to the kernel, since it's at a fixed segment address.
+
+After relocation, setup passes control to the kernel _start in crt0.S, which
+then calls start_kernel. The kernel can still read various INITSEG values
+using the setupb/setupw functions.
+
+ELKS "INITSEG" (setup data segment) offsets:
++------+-----+------+-------------------+--------------------------+------------
+| Hex  | Dec | Size | Name              | Description              | Where set
 +------+-----+------+-------------------+--------------------------+------------
 | 0007 |   7 | byte | screen_cols       | screen width             | setup.S
 | 000E |  14 | byte | screen_lines      | screen height            | setup.S

--- a/elks/arch/i86/boot/bootsect.S
+++ b/elks/arch/i86/boot/bootsect.S
@@ -61,6 +61,7 @@ ROOT_DEV = 0
 #define RAMDISK 	0
 #endif 
 
+#define DUMMYBOOT
 #include <linuxmt/boot.h>
 
 .global     _start

--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -62,18 +62,18 @@
 !	...
 !	0x50:	zero terminated string containing the cpuid, 13 bytes
 !	...
-!	0x1e2:	part_offset, 4 bytes. Sector offset of booted MBR partition
-!	0x1e6:	elks_magic, 2 bytes
-!	0x1ef:	SETUPSEG
-!	0x1f1:	SETUPSECS, 1 byte
-!	0x1f2:	ROOTFLAGS, 2 bytes
-!	0x1f4:	SYSSIZE, 2 bytes
-!	0x1f6:	ELKSFLAGS, 2 bytes
-!	0x1f8:	RAMDISK
-!	0x1fa:	SVGA_MODE
-!	0x1fc:	ROOT_DEV, 2 bytes. Either BIOS boot device or actual kdev_t ROOT_DEV
-!	0x1fe:	0x55 = boot_flag, Low part
-!	0x1ff:	0xAA = boot_flag, High part
+!	0x1e2:	part_offset	long Sector offset of booted MBR partition
+!	0x1e6:	elks_magic	long "ELKS"
+!	0x1ea-0x1ee:		5 bytes UNUSED
+!	0x1ef:	SETUPSEG	word UNUSED
+!	0x1f1:	setup_sects	byte in 512-byte sectors, written by build tool
+!	0x1f2:	ROOTFLAGS	word UNUSED
+!	0x1f4:	syssize		word in paragraphs, written by build tool
+!	0x1f6:	elks_flags	word EF_xxx
+!	0x1f8:	RAMDISK		word UNUSED
+!	0x1fa:	SVGA_MODE	word UNUSED
+!	0x1fc:	root_dev	word Either BIOS boot device or actual kdev_t ROOT_DEV
+!	0x1fe:	boot_flag	word = 0xAA55
 !
 ! NOTE! These had better be the same as in bootsect.s!
 */

--- a/elks/arch/i86/tools/build.c
+++ b/elks/arch/i86/tools/build.c
@@ -35,8 +35,9 @@
 #include <fcntl.h>
 #include <stdint.h>
 
-#include <linuxmt/errno.h>
 #include <linuxmt/config.h>
+#include <linuxmt/errno.h>
+#include <linuxmt/boot.h>
 
 #include "a.out.h"
 
@@ -285,11 +286,11 @@ int main(int argc, char **argv)
 	sz -= l;
     }
     close(id);
-    if (lseek(1, 497, 0) == 497) {
+    if (lseek(1, setup_sects, 0) == setup_sects) {
 	if (write(1, &setup_sectors, 1) != 1)
 	    die("Write of setup sectors failed");
     }
-    if (lseek(1, 500, 0) == 500) {
+    if (lseek(1, syssize, 0) == syssize) {
 	buf[0] = (sys_size & 0xff);
 	buf[1] = ((sys_size >> 8) & 0xff);
 	if (write(1, buf, 2) != 2)

--- a/elks/include/linuxmt/boot.h
+++ b/elks/include/linuxmt/boot.h
@@ -42,15 +42,20 @@
    Boot Protocol (https://www.kernel.org/doc/html/latest/x86/boot.html).
    Fields which are specific to ELKS are indicated below.  */
 
-#if defined __ASSEMBLER__ && !defined BOOTSEG
-part_offset	=	0x1e2		/* sector offset of booted partition*/
-elks_magic	=	0x1e6		/* should read "ELKS" (45 4c 4b 53) */
-setup_sects	=	0x1f1
-root_flags	=	0x1f2
-syssize		=	0x1f4
-elks_flags	=	0x1f6		/* 16-bit ELKS flags (EF_...) */
-root_dev	=	0x1fc
-boot_flag	=	0x1fe
+#ifndef DUMMYBOOT
+#define screen_cols	7		/* byte screen width*/
+#define screen_lines	14		/* byte screen height*/
+#define cpu_type	0x20		/* byte cpu type*/
+#define mem_kbytes	0x2a		/* word base memory size in Kbytes*/
+#define proc_name	0x30		/* 16 bytes processor name string*/
+#define cpu_id		0x50		/* 13 bytes cpu id string*/
+#define part_offset	0x1e2		/* long sector offset of booted partition*/
+#define elks_magic	0x1e6		/* long "ELKS" (45 4c 4b 53) checked by bootsect.S*/
+#define setup_sects	0x1f1		/* byte 512-byte sectors used by setup.S*/
+#define syssize		0x1f4		/* word paragraph kernel size used by setup.S*/
+#define elks_flags	0x1f6		/* word 16-bit ELKS flags, BLOB and BIOS_DRV*/
+#define root_dev	0x1fc		/* word BIOS drive or kdev_t ROOT_DEV*/
+#define boot_flag	0x1fe		/* word constant AA55h*/
 #endif
 
 #endif


### PR DESCRIPTION
Better documentation for INITSEG variables. These are mostly used to pass information from the boot loader to setup, and also the kernel. This is unfortunately still a kind of black-magic area of ELKS.

This PR aims to document these variables and the process a bit more.

Setup is ASM code that executes immediately after the boot loader, and prior to the kernel. It is located in the 2nd 512 bytes of the kernel image on disk (/linux). The first 512 bytes of the kernel disk image is a dummy boot sector that contains preset values for certain setup variable locations. Following that is the a.out kernel executable header and then the kernel text, fartext, data and relocation table sections.

When building the kernel image `Image`, a special tool called `build` is used to concatenate the dummy boot loader, the setup code and the kernel executable together. `build` also writes the sizes of setup and the kernel into INITSEG, which at the time is the dummy boot sector.

Setup's data segment is at a fixed location and is called INITSEG, and is initially the contents of the dummy boot sector. Setup is required to perform the relocations from the a.out relocation table on the kernel executable, and also to determine certain hardware configurations easier done in assembly, which are saved in it's data segment (INITSEG), which is also known to the kernel, since it's at a fixed segment address.

After relocation, setup passes control to the kernel _start in crt0.S, which then calls start_kernel. The kernel can still read various INITSEG values using the `setupb/setupw` functions.
