### PR TITLE
[net] Buggy NE2K probe?

### DIFF
--- a/elks/arch/i86/drivers/net/ne2k-asm.S
+++ b/elks/arch/i86/drivers/net/ne2k-asm.S
@@ -930,7 +930,7 @@ ne2k_probe:
 	in	%dx,%al
 	cmp	$0xff,%al	// cannot be FF
 	jz	np_err
-	cmp	0,%al		// cannot be 0
+	cmp	$0,%al		// cannot be 0
 	jz	np_err
 	
 	xor     %ax,%ax


### PR DESCRIPTION
@Mellvik,

I was trying to get DosBox-X networking working, which I finally did (internal only) but beforehand started looking at the NE2K probe code. I found this error, comparing AL after an INB instruction to the contents of location 0, rather than comparing it to the value of 0. Apparently this error has always worked.

However, I also notice a couple of lines above where you're setting page 0 and then reading it, you're sending 0x20 instead of 0x02, which is in the comments for "page 0" elsewhere in the driver.
```
ne2k_probe:

    // Poke then peek at the base address of the interface.
    // If something is there, return 0.
    // No attempt is made to get details about the i/f.

    mov net_port,%dx    // command register
    mov $0x20,%al   // set page 0 <--- should this be "mov $2,%al"? Setting page 0 uses "2" elsewhere.
    out %al,%dx
    in  %dx,%al
    cmp $0xff,%al   // cannot be FF
    jz  np_err
    cmp $0,%al      // cannot be 0  <-- fixed in this PR
```
If one looks through the driver for "page 0", there are places where 0x02 is used, and others where 0x20 is used. Sorry for my confusion, but just wanted to bring this up!

Thank you!