### PR TITLE
[cmds] Fix sash and ash ^C handling

### DIFF
--- a/elkscmd/ash/linenoise_elks.c
+++ b/elkscmd/ash/linenoise_elks.c
@@ -269,13 +269,18 @@ static int isUnsupportedTerm(void) {
 /* Raw mode: 1960 magic shit. */
 static int enableRawMode(int fd) {
     struct termios raw;
+    static char once = 0;
 
     if (!isatty(STDIN_FILENO)) goto fatal;
     if (!atexit_registered) {
         atexit(linenoiseAtExit);
         atexit_registered = 1;
     }
-    if (tcgetattr(fd,&orig_termios) == -1) goto fatal;
+
+    if (!once) {
+        if (tcgetattr(fd,&orig_termios) == -1) goto fatal;
+        once = 1;
+    }
 
     raw = orig_termios;  /* modify the original mode */
     /* input modes: no break, no CR to NL, no parity check, no strip char,

--- a/elkscmd/sash/sash.c
+++ b/elkscmd/sash/sash.c
@@ -365,6 +365,7 @@ readfile(name)
 		if (fgets(buf, CMDLEN - 1, fp) == NULL) {
 			if (ferror(fp) && (errno == EINTR)) {
 				clearerr(fp);
+				intflag = FALSE;
 				continue;
 			}
 			break;
@@ -906,6 +907,60 @@ catchquit()
 
 	if (intcrlf)
 		write(STDOUT, "\n", 1);
+}
+
+/* replacement fread to fix fgets not returning ferror/errno properly on SIGINT*/
+size_t fread(void *buf, size_t size, size_t nelm, FILE *fp)
+{
+   int len, v;
+   size_t bytes, got = 0;
+   __io_init_vars();        /* replaces Inline_init*/
+
+   v = fp->mode;
+
+   /* Want to do this to bring the file pointer up to date */
+   if (v & __MODE_WRITING)
+      fflush(fp);
+
+   /* Can't read or there's been an EOF or error then return zero */
+   if ((v & (__MODE_READ | __MODE_EOF | __MODE_ERR)) != __MODE_READ)
+      return 0;
+
+   /* This could be long, doesn't seem much point tho */
+   bytes = size * nelm;
+
+   len = fp->bufread - fp->bufpos;
+   if (len >= bytes)            /* Enough buffered */
+   {
+      memcpy(buf, fp->bufpos, bytes);
+      fp->bufpos += bytes;
+      return nelm;
+   }
+   else if (len > 0)            /* Some buffered */
+   {
+      memcpy(buf, fp->bufpos, len);
+      fp->bufpos += len;
+      got = len;
+   }
+
+   /* Need more; do it with a direct read */
+   len = read(fp->fd, (char *)buf + got, bytes - got);
+   /* Possibly for now _or_ later */
+#if 1	/* Fixes stdio when SIGINT received*/
+   if (intflag) {
+      len = -1;
+      errno = EINTR;
+   }
+#endif
+   if (len < 0)
+   {
+      fp->mode |= __MODE_ERR;
+      len = 0;
+   }
+   else if (len == 0)
+      fp->mode |= __MODE_EOF;
+
+   return (got + len) / size;
 }
 
 /* END CODE */


### PR DESCRIPTION
Fixes both `sash` and `ash` problems discussed in #1061.

More specifically:
Fixes ash problem where terminal mode was incorrectly reset to raw mode after ^C.

Fixes sash improper shell command line handling when ^C typed. Now, old input buffer contents are cleared and new prompt is immediately displayed. The reason for this problem was explained in https://github.com/jbruchon/elks/pull/1061#issuecomment-999658102 and required a fix to the `fread` stdio library routine, which is included in sash for the time being.
