### PR TITLE
[net] Add tcp hex packet display

### DIFF
--- a/elkscmd/ktcp/Makefile
+++ b/elkscmd/ktcp/Makefile
@@ -5,7 +5,7 @@ include $(BASEDIR)/Make.defs
 SHELL		= /bin/sh
 
 CFILES		= ktcp.c slip.c ip.c icmp.c tcp.c tcp_cb.c tcp_output.c \
-		  timer.c tcpdev.c netconf.c vjhc.c deveth.c arp.c
+		  timer.c tcpdev.c netconf.c vjhc.c deveth.c arp.c hexdump.c
 
 OBJS		= $(CFILES:.c=.o)
 

--- a/elkscmd/ktcp/config.h
+++ b/elkscmd/ktcp/config.h
@@ -8,8 +8,9 @@
 #define USE_DEBUG_EVENT 1	/* use CTRLP to toggle debug output*/
 #define DEBUG_STARTDEF	0	/* default startup debug display*/
 #define DEBUG_TCP	0	/* TCP ops*/
+#define DEBUG_TCPPKT	0	/* TCP packets info*/
+#define DEBUG_TCPDATA	1	/* TCP packet data display*/
 #define DEBUG_TUNE	1	/* tuning options*/
-#define DEBUG_TCPDATA	0	/* TCP data packets*/
 #define DEBUG_RETRANS	0	/* TCP retransmissions*/
 #define DEBUG_WINDOW	0	/* TCP window size*/
 #define DEBUG_ACCEPT	0	/* TCP accept*/
@@ -42,6 +43,12 @@ void dprintf(const char *, ...);
 #define debug_tune	DPRINTF
 #else
 #define debug_tune(...)
+#endif
+
+#if DEBUG_TCPPKT
+#define debug_tcppkt	DPRINTF
+#else
+#define debug_tcppkt(...)
 #endif
 
 #if DEBUG_TCPDATA

--- a/elkscmd/ktcp/hexdump.c
+++ b/elkscmd/ktcp/hexdump.c
@@ -1,0 +1,93 @@
+/*
+ * Hex display function
+ *
+ * void hexdump(unsigned char *addr, int count, int summary, char *prefix)
+ */
+#include <stdio.h>
+#include <string.h>
+#include "config.h"
+
+#if DEBUG_TCPDATA
+
+#define printf DPRINTF
+#define isprint(c) ((c) > ' ' && (c) <= '~')
+
+static int lastnum[16] = {-1};
+static int lastaddr = -1;
+
+static void
+printline(int address, int *num, char *chr, int count, int summary, char *prefix)
+{
+	int   j;
+
+	if (lastaddr >= 0)
+	{
+		for (j = 0; j < count; j++)
+			if (num[j] != lastnum[j])
+				break;
+		if (j == 16 && summary)
+		{
+			if (lastaddr + 16 == address)
+			{
+				printf("*\n");
+			}
+			return;
+		}
+	}
+
+	lastaddr = address;
+	printf("%s%04x:", prefix, address);
+	for (j = 0; j < count; j++)
+	{
+		if (j == 8)
+			putchar(' ');
+		if (num[j] >= 0)
+			printf(" %02x", num[j]);
+		else
+			printf("   ");
+		lastnum[j] = num[j];
+		num[j] = -1;
+	}
+
+	for (j=count; j < 16; j++)
+	{
+		if (j == 8)
+			putchar(' ');
+		printf("   ");
+	}
+
+	printf("  ");
+	for (j = 0; j < count; j++)
+		printf("%c", chr[j]);
+	printf("\n");
+}
+
+
+void hexdump(unsigned char *addr, int count, int summary, char *prefix)
+{
+	int offset;
+	char buf[20];
+	int num[16];
+
+	if (!prefix) prefix = "";
+	for (offset = 0; count > 0; count -= 16, offset += 16)
+	{
+		int j, ch;
+
+		memset(buf, 0, 16);
+		for (j = 0; j < 16; j++)
+			num[j] = -1;
+		for (j = 0; j < 16; j++)
+		{
+			ch = *addr++;
+
+			num[j] = ch;
+			if (isprint(ch) && ch < 0x80)
+				buf[j] = ch;
+			else
+				buf[j] = '.';
+		}
+		printline(offset, num, buf, count > 16? 16: count, summary, prefix);
+	}
+}
+#endif /* DEBUG_TCPDATA*/

--- a/elkscmd/ktcp/ip.c
+++ b/elkscmd/ktcp/ip.c
@@ -179,7 +179,7 @@ void ip_sendpacket(unsigned char *packet, int len, struct addr_pair *apair, stru
     memcpy((char *)iph + iphdrlen, packet, len); //FIXME don't copy, fixup in upper layer
 
     ip_print(iph, 0);
-#if DEBUG_TCP
+#if DEBUG_TCPPKT | DEBUG_TCPDATA
     if (iph->protocol == PROTO_TCP && cb) {	/* really - one of them is enough */
 	struct iptcp_s iptcp;
 	iptcp.iph = iph;

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -26,7 +26,7 @@
 
 timeq_t Now;
 
-#if DEBUG_TCPDATA
+#if DEBUG_TCPPKT
 static char *tcp_flags(int flags)
 {
     static char buf[7];
@@ -45,25 +45,31 @@ static char *tcp_flags(int flags)
 
 void tcp_print(struct iptcp_s *head, int recv, struct tcpcb_s *cb)
 {
-#if DEBUG_TCPDATA
-    debug_tcpdata("tcp: %s ", recv? "recv": "send");
-    debug_tcpdata("%u->%u ", ntohs(head->tcph->sport), ntohs(head->tcph->dport));
-    debug_tcpdata("[%s] ", tcp_flags(head->tcph->flags));
+#if DEBUG_TCPPKT
+    debug_tcppkt("tcp: %s ", recv? "recv": "send");
+    debug_tcppkt("%u->%u ", ntohs(head->tcph->sport), ntohs(head->tcph->dport));
+    debug_tcppkt("[%s] ", tcp_flags(head->tcph->flags));
     if (cb) {
       if (recv) {
 	if (head->tcplen > 20)
-	    debug_tcpdata("seq %lu-%lu ", ntohl(head->tcph->seqnum) - cb->irs,
+	    debug_tcppkt("seq %lu-%lu ", ntohl(head->tcph->seqnum) - cb->irs,
 		ntohl(head->tcph->seqnum) - cb->irs+head->tcplen-20);
-	debug_tcpdata("ack %lu ", ntohl(head->tcph->acknum) - cb->iss);
+	debug_tcppkt("ack %lu ", ntohl(head->tcph->acknum) - cb->iss);
       } else {
-	if (head->tcplen > 20) debug_tcpdata("seq %lu-%lu ",
+	if (head->tcplen > 20) debug_tcppkt("seq %lu-%lu ",
 	ntohl(head->tcph->seqnum) - cb->iss,
 	ntohl(head->tcph->seqnum) - cb->iss+head->tcplen-20);
-	debug_tcpdata("ack %lu ", ntohl(head->tcph->acknum) - cb->irs);
+	debug_tcppkt("ack %lu ", ntohl(head->tcph->acknum) - cb->irs);
       }
     }
-    debug_tcpdata("win %u urg %d ", ntohs(head->tcph->window), head->tcph->urgpnt);
-    debug_tcpdata("chk %x len %u\n", tcp_chksum(head), head->tcplen);
+    debug_tcppkt("win %u urg %d ", ntohs(head->tcph->window), head->tcph->urgpnt);
+    debug_tcppkt("chk %x len %u\n", tcp_chksum(head), head->tcplen);
+#endif
+#if DEBUG_TCPDATA
+    int datalen = head->tcplen - TCP_DATAOFF(head->tcph);
+    unsigned char *data = (__u8 *)head->tcph + TCP_DATAOFF(head->tcph);
+    if (datalen)
+	hexdump(data, datalen, 0, recv? "<- ": "-> ");
 #endif
 }
 

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -202,5 +202,7 @@ void tcp_send_fin(struct tcpcb_s *cb);
 void tcp_send_reset(struct tcpcb_s *cb);
 void tcp_reset_connection(struct tcpcb_s *cb);
 
+void hexdump(unsigned char *addr, int count, int summary, char *prefix);
+
 extern char *tcp_states[];	/* used in DEBUG_CLOSE only*/
 #endif


### PR DESCRIPTION
Adds ability to see incoming and outgoing TCP packet data for better debugging. Set using DEBUG_TCPDATA in ktcp config.h.

Each packet is displayed individually along with the direction (incoming or outgoing).

Hopefully this will help debug some of our off-by-one packet problems seen recently, by allowing a closer look of the actual data being sent and received by ktcp.

Example output logging into remote macOS telnet server from ELKS:
<img width="752" alt="Screen Shot 2021-12-23 at 7 25 49 PM" src="https://user-images.githubusercontent.com/11985637/147308620-c2dc0547-2af3-4ed1-aeb4-d29aae228c5b.png">
