### PR TITLE
[net] Add ability to start specific daemons from bootopts

### DIFF
--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -391,9 +391,22 @@ static void INITPROC finalize_options(void)
 /* return whitespace-delimited string*/
 static char * INITPROC option(char *s)
 {
-	for(; *s != ' ' && *s != '\t' && *s != '\n'; ++s) {
+	char *t = s;
+	if (*s == '#')
+		return s;
+	for(; *s != ' ' && *s != '\t' && *s != '\n'; ++s, ++t) {
 		if (*s == '\0')
 			return NULL;
+		if (*s == '"') {
+			s++;
+			while (*s != '"') {
+				if (*s == '\0')
+					return NULL;
+				*t++ = *s++;
+			}
+			*t++ = 0;
+			break;
+		}
 	}
 	return s;
 }

--- a/elkscmd/rootfs_template/bin/net
+++ b/elkscmd/rootfs_template/bin/net
@@ -4,7 +4,7 @@
 #
 # Examples:
 #	net start eth			start ethernet networking
-#	net start slip			start slip networking at default baudrate
+#	net start slip			start slip networking
 #	net start slip 19200	start slip at 19200 baud
 #	net start cslip 4800 /dev/ttyS1
 #

--- a/elkscmd/rootfs_template/bin/net
+++ b/elkscmd/rootfs_template/bin/net
@@ -59,19 +59,21 @@ start_network()
 	echo $ktcp
 	if $ktcp; then
 		echo -n "Starting daemons "
-		for daemon in telnetd httpd
+		if test "$NETSTART" = ""; then NETSTART="telnetd ftpd httpd"; fi
+		for daemon in $NETSTART
 		do
 			if test -f /bin/$daemon
 			then
-				echo -n "$daemon "
-				$daemon || true
+				if test "$daemon" = "ftpd"
+				then
+					echo -n "ftpd $ftpd "
+					$daemon $ftpd || true
+				else
+					echo -n "$daemon "
+					$daemon || true
+				fi
 			fi
 		done
-		if test -f /bin/ftpd
-		then
-			echo -n "ftpd $ftpd"
-			ftpd $ftpd || true
-		fi
 		echo ""
 	else
 		echo "Network start failed"

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,7 +1,7 @@
 ## boot options max size 511 bytes
 #console=ttyS0 debug net=eth 3 # serial console, multiuser, networking
 #TZ=MDT7		# timezone
-#ftpd=-q net=eth 	# ftpd on qemu
+#ftpd=-q net=eth	# ftpd on qemu
 #HOSTNAME=elks1	 	# set network IP from /etc/hosts
 #GATEWAY=10.0.2.2
 #NETMASK=255.255.255.0

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,10 +1,11 @@
 ## boot options max size 511 bytes
 #console=ttyS0 debug net=eth 3 # serial console, multiuser, networking
 #TZ=MDT7		# timezone
-#ftpd=-q net=eth	# ftpd on qemu
+#ftpd=-q net=eth 	# ftpd on qemu
 #HOSTNAME=elks1	 	# set network IP from /etc/hosts
 #GATEWAY=10.0.2.2
 #NETMASK=255.255.255.0
+#NETSTART="telnetd ftpd"
 #netirq=9 netport=0x300 # NIC
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.d/rc.sys
 #init=/bin/sh		# singleuser shell


### PR DESCRIPTION
Adds NETSTART= to /bootopts to specify daemons to start at boot or with `net start`, to allow for smaller memory use when desired.

Adds ability to specify quoted strings in /bootopts.

For example, use `NETSTART="telnetd ftpd"` to start just those daemons at boot or with `net start`.