### PR TITLE
[net, ftp] ftpd updated to support globbing, improved QEMU support

### DIFF
--- a/elkscmd/inet/ftp/ftpd.c
+++ b/elkscmd/inet/ftp/ftpd.c
@@ -21,7 +21,7 @@
 #include	<time.h>
 #include	<sys/stat.h>
 #include	<sys/types.h>
-#include 	<sys/wait.h>
+#include	<sys/wait.h>
 #include 	<dirent.h>
 
 #define		BLOAT
@@ -644,8 +644,7 @@ int main(int argc, char **argv) {
 			break;
 		}
 		waitpid(-1, NULL, WNOHANG);		/* reap previous accepts*/
-		strncpy(real_ip, in_ntoa(client.sin_addr.s_addr), 20); // Save for QEMU hack
-		if (debug) printf("New connection from %s (0x%lx)\n", real_ip, client.sin_addr.s_addr);
+		if (debug) printf("Connnect from new Client.\n");
 		/* child process */
 		if((pid = fork()) == 0) {
 			close(listenfd);
@@ -657,6 +656,7 @@ int main(int argc, char **argv) {
 			char *str;
 			char *complete = "226 Transfer Complete.\r\n";
 
+			strncpy(real_ip, in_ntoa(client.sin_addr.s_addr), 20); // Save for QEMU hack
 			if (debug) printf("Child running - cmd chan is %d.\n", connfd);
 			send_reply(connfd, 220, "Welcome - ELKS minimal FTP server speaking");
 

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,7 +1,7 @@
 ## boot options max size 511 bytes
 #console=ttyS0 debug net=eth 3 # serial console, multiuser, networking
 #TZ=MDT7		# timezone
-#ftpd=-q net=eth	# ftpd on qemu
+#QEMU=1	net=eth		# ftpd on QEMU
 #HOSTNAME=elks1	 	# set network IP from /etc/hosts
 #GATEWAY=10.0.2.2
 #NETMASK=255.255.255.0

--- a/elkscmd/rootfs_template/etc/profile
+++ b/elkscmd/rootfs_template/etc/profile
@@ -4,3 +4,4 @@ export PATH=/bin
 #export HOSTNAME=10.0.2.15
 #export GATEWAY=10.0.2.2
 #export NETMASK=255.255.255.0
+#export QEMU=1


### PR DESCRIPTION
Update to the ELKS `ftpd` FTP server:
- Pick up QEMU mode from the environment (`QEMU=1`) to simplify boot procedures (see #1071 (discussion))
- Added wildcard support (#1067)
- Added another (minimal) QEMU hack which enable full and transparent support for active mode file transfers when the QEMU option is enabled.
- Some cleanups and optimizations

For a change, this update has been primarily tested on QEMU. 
More cleanups and support for a few additional commands (EPRT, EPSV) planned.

