### PR TITLE
Add kbd-poll-pc98

### DIFF
--- a/elks/arch/i86/drivers/char/Makefile
+++ b/elks/arch/i86/drivers/char/Makefile
@@ -70,7 +70,7 @@ ifdef CONFIG_ARCH_PC98
 ifdef CONFIG_CONSOLE_HEADLESS
 OBJS += console-headless.o
 endif
-OBJS += conio-pc98.o conio-pc98-asm.o kbd-poll.o
+OBJS += conio-pc98.o conio-pc98-asm.o kbd-poll-pc98.o
 OBJS += lp.o
 endif
 

--- a/elks/arch/i86/drivers/char/conio-pc98-asm.S
+++ b/elks/arch/i86/drivers/char/conio-pc98-asm.S
@@ -6,9 +6,10 @@
 	.text
 
 	.global early_putchar
-	.global early_getchar
-	.global conio_poll
-	.global early_getinit
+	.global bios_getchar
+	.global bios_getarrow
+	.global bios_getroll
+	.global bios_getinit
 	.global read_tvram_x
 	.global write_tvram_x
 	.global clear_tvram
@@ -142,8 +143,7 @@ clear_tvram:
 	pop %bx
 	ret
 
-early_getchar:
-conio_poll:
+bios_getchar:
 	push %bx
 	mov $5,%ah
 	int $0x18
@@ -154,7 +154,17 @@ get_end:
 	pop %bx
 	ret
 
-early_getinit:
+bios_getarrow:
+	mov $0x0407,%ax
+	int $0x18
+	ret
+
+bios_getroll:
+	mov $0x0406,%ax
+	int $0x18
+	ret
+
+bios_getinit:
 	mov $3,%ah
 	int $0x18
 	ret

--- a/elks/arch/i86/drivers/char/conio-pc98.c
+++ b/elks/arch/i86/drivers/char/conio-pc98.c
@@ -8,12 +8,24 @@
 
 void conio_init()
 {
-    early_getinit();
+    bios_getinit();
     cursor_on();
 }
 
 void bell(void)
 {
+}
+
+int conio_poll(void)
+{
+    int cdata;
+    int adata;
+    int rdata;
+
+    cdata = bios_getchar();
+    adata = bios_getarrow();
+    rdata = bios_getroll();
+    return (rdata & 0xC000) | (adata & 0x3F00) | (cdata & 0x00FF);
 }
 
 void conio_putc(byte_t c)

--- a/elks/arch/i86/drivers/char/kbd-poll-pc98.c
+++ b/elks/arch/i86/drivers/char/kbd-poll-pc98.c
@@ -1,0 +1,84 @@
+/*
+ * Polling keyboard driver
+ *
+ * Calls conio_poll to get kbd input
+ */
+#include <linuxmt/types.h>
+#include <linuxmt/config.h>
+#include <linuxmt/timer.h>
+#include <linuxmt/sched.h>
+#include "console.h"
+#include "conio.h"
+
+char kbd_name[] = "polling";
+
+static void restart_timer(void);
+
+/*
+ * Poll for keyboard character
+ * Decodes non-zero high byte into arrow/fn keys
+ */
+static void kbd_timer(int data)
+{
+    int dav, extra = 0;
+
+    if ((dav = conio_poll())) {
+	if (dav & 0xFF)
+	    Console_conin(dav & 0x7F);
+	else {
+	    dav = (dav >> 8) & 0xFF;
+
+	    if (dav & 0x4)
+	        dav = 'A';	/* up*/
+	    else if (dav & 0x20)
+	        dav = 'B';	/* down*/
+	    else if (dav & 0x10)
+	        dav = 'C';	/* right*/
+	    else if (dav & 0x8)
+	        dav = 'D';	/* left*/
+	    else if (dav & 0x80) {		/* Roll Down for PC-98 */
+	        dav = '5';	/* pgup*/
+	        extra = '~';
+	    }
+	    else if (dav & 0x40) {		/* Roll Up for PC-98 */
+	        dav = '6';	/* pgdn*/
+	        extra = '~';
+	    }
+	    else
+	        dav = 0;
+
+	    if (dav) {
+		Console_conin(033);
+#ifdef CONFIG_EMUL_ANSI
+		Console_conin('[');
+#endif
+		Console_conin(dav);
+#ifdef CONFIG_EMUL_ANSI
+		if (extra)
+		    Console_conin(extra);
+#endif
+	    }
+	}
+    }
+    restart_timer();
+}
+
+static void restart_timer(void)
+{
+    static struct timer_list timer;
+
+    init_timer(&timer);
+    timer.tl_expires = jiffies + (8 * HZ/100);	/* every 8/100 second*/
+    timer.tl_function = kbd_timer;
+    add_timer(&timer);
+}
+
+
+void kbd_init(void)
+{
+    conio_init();
+#if 0
+    enable_irq(1);		/* enable BIOS Keyboard interrupts */
+#endif
+    restart_timer();
+}


### PR DESCRIPTION
Add kbd-poll-pc98 and modified conio-pc98 for Arrow keys and Page Up, Page Down.

Roll Down key of PC-98 is assigned to Page Up.
Roll Up key of PC-98 is assigned to Page Down.

There is no keys for Home and End for PC-98, so it is not assigned for now.
We can assign combinational key like Roll Down + Up arrow for Home,
and Roll Up + Down arrow for End if necessary.

It seems the insert and delete keys are not handled in the original kbd-poll.
Please tell me if this is my misunderstanding.

Thank you.  


