### PR TITLE
[kernel] Fix compilation errors in nano sockets and meta drivers

### DIFF
--- a/elks/arch/i86/drivers/char/meta.c
+++ b/elks/arch/i86/drivers/char/meta.c
@@ -40,7 +40,6 @@ static struct ud_driver *get_driver(int major)
 
 struct ud_request *new_request(void)
 {
-    int i;
     register struct ud_request *r = requests;
 
     do {
@@ -68,9 +67,10 @@ int post_request(struct ud_driver *driver, struct ud_request *request)
 }
 
 
-static void do_meta_request(kdev_t device)
+static void do_meta_request(void)
 {
-    int major = MAJOR(device);
+    //int major = MAJOR(device);
+    int major = MAJOR(CURRENT->rq_dev); /* FIXME: change MAX_BLKDEV and create /dev/meta*/
     struct ud_driver *driver = get_driver(major);
     struct ud_request *udr;
     struct request *req;
@@ -78,7 +78,7 @@ static void do_meta_request(kdev_t device)
 
     printk("do_meta_request %d %x\n", major, blk_dev[major].current_request);
     if (NULL == driver) {
-	end_request(0, req->rq_dev);
+	end_request(0);
 	return;
     }
     printk("1");
@@ -117,7 +117,7 @@ static void do_meta_request(kdev_t device)
 	/* REQUEST HAS BEEN RETURNED BY USER PROGRAM */
 	/* request must be dealt with and ended */
 	if (udr->udr_status == 1) {
-	    end_request(0, req->rq_dev);
+	    end_request(0);
 	    udr->udr_status = 0;
 	    continue;
 	}
@@ -132,7 +132,7 @@ static void do_meta_request(kdev_t device)
 	    		driver->udd_data, driver->udd_task->mm.dseg, 1024/2);
 #endif
 	}
-	end_request(1, req->rq_dev);
+	end_request(1);
 	wake_up(&udr->udr_wait);
     }
 }

--- a/elks/include/linuxmt/major.h
+++ b/elks/include/linuxmt/major.h
@@ -24,7 +24,7 @@
  *  4 - /dev/tty*,ttyp*,ttyS*                         char tty, pty slave, serial
  *  5 -
  *  6 - /dev/lp                /dev/rom               block romflash
- *  7 -
+ *  7 -                        /dev/udd               block meta user device driver
  *  8 - /dev/tcpdev                                   kernel <-> ktcp comm
  *  9 - /dev/eth                                      NIC driver
  * 10 - /dev/cgatext
@@ -40,7 +40,7 @@
 #define TTY_MAJOR         4
 #define TTYAUX_MAJOR      5
 #define LP_MAJOR          6
-#define MISC_MAJOR        7
+#define UDD_MAJOR         7
 #define TCPDEV_MAJOR      8
 #define ETH_MAJOR         9  /* should be rather a network-class driver */
 #define CGATEXT_MAJOR     10

--- a/elks/include/linuxmt/udd.h
+++ b/elks/include/linuxmt/udd.h
@@ -14,8 +14,8 @@
 
 #include <linuxmt/fs.h>
 
-#define MAX_UDD	8
-#define MAX_UDR	32
+#define MAX_UDD	1 /* FIXME only 1 UDD until device passed to request_fn*/
+#define MAX_UDR	8
 
 struct ud_driver {
     int udd_type;

--- a/elks/include/linuxmt/udd.h
+++ b/elks/include/linuxmt/udd.h
@@ -20,7 +20,7 @@
 struct ud_driver {
     int udd_type;
     int udd_major;
-    struct task *udd_task;
+    struct task_struct *udd_task;
     char *udd_data;
     struct ud_request *udd_req;
     struct wait_queue udd_wait;
@@ -37,7 +37,7 @@ struct ud_driver {
 struct ud_driver_trunc {
     int udd_type;
     int udd_major;
-    struct task *udd_task;
+    struct task_struct *udd_task;
     char *udd_data;
 };
 

--- a/elks/net/nano/af_nano.c
+++ b/elks/net/nano/af_nano.c
@@ -18,6 +18,8 @@
 
 #ifdef CONFIG_NANO
 
+int sock_awaitconn(register struct socket *mysock, struct socket *servsock, int flags);
+
 struct nano_proto_data nano_datas[NSOCKETS_NANO];
 
 static struct nano_proto_data *nano_data_alloc(void)
@@ -146,10 +148,8 @@ static int nano_release(register struct socket *sock, struct socket *peer)
 static int nano_bind(struct socket *sock,
 		     struct sockaddr *umyaddr, int sockaddr_len)
 {
-    int ano, i;
     register struct nano_proto_data *upd = sock->data;
     register struct nano_proto_data *pupd;
-    unsigned short old_ds;
 
     printk("nano_bind %x\n", sock);
 
@@ -194,7 +194,7 @@ static int nano_connect(register struct socket *sock,
 /*    if (sock->state == SS_CONNECTED)
 	return -EISCONN;*/	/*Already checked in socket.c*/
 
-    if (get_user(&(((sockaddr_na *)uservaddr)->sun_family)) != AF_NANO) {
+    if (get_user(&(((struct sockaddr_na *)uservaddr)->sun_family)) != AF_NANO) {
 	printk("ADR - {%d}\n", sockna.sun_family);
 	return -EINVAL;
     }
@@ -289,8 +289,8 @@ static int nano_getname(register struct socket *sock,
     } else
 	upd = NA_DATA(sock);
 
-    return move_addr_to_user(&upd->npd_sockaddr_na, upd->npd_sockaddr_len,
-				    usockaddr, usockaddr_len)
+    return move_addr_to_user((char *)&upd->npd_sockaddr_na, upd->npd_sockaddr_len,
+				    (char *)usockaddr, usockaddr_len);
 }
 
 static int nano_read(register struct socket *sock,
@@ -456,8 +456,7 @@ static int nano_write(register struct socket *sock,
     return (size - todo);
 }
 
-static int nano_select(register struct socket *sock,
-		       int sel_type, select_table * wait)
+static int nano_select(register struct socket *sock, int sel_type)
 {
     struct nano_proto_data *upd, *peerupd;
 
@@ -469,10 +468,10 @@ static int nano_select(register struct socket *sock,
 	if (sel_type == SEL_IN) {
 	    if (sock->iconn)
 		return 1;
-	    select_wait(sock->wait, wait);
+	    select_wait(sock->wait);
 	    return (sock->iconn ? 1 : 0);
 	}
-	select_wait(sock->wait, wait);
+	select_wait(sock->wait);
 
 	return 0;
     }
@@ -485,7 +484,7 @@ static int nano_select(register struct socket *sock,
 	else if (sock->state != SS_CONNECTED)
 	    return 1;
 
-	select_wait(sock->wait, wait);
+	select_wait(sock->wait);
 
 	return 0;
     }
@@ -499,7 +498,7 @@ static int nano_select(register struct socket *sock,
 	if (NA_BUF_SPACE(peerupd) > 0)
 	    return 1;
 
-	select_wait(sock->wait, wait);
+	select_wait(sock->wait);
 
 	return 0;
     }

--- a/image/Make.devices
+++ b/image/Make.devices
@@ -170,6 +170,11 @@ endif
 #	$MKSET  0 15 $(MKDEV) /dev/loop c 7
 
 ##############################################################################
+# UDD user device driver, experimental
+
+#	$(MKDEV) /dev/udd c 7 0
+
+##############################################################################
 # TCPDEV, used by ktcp
 
 	$(MKDEV) /dev/tcpdev c 8 0


### PR DESCRIPTION
Fixes #1087.

Fixes compilation errors in CONFIG_NANO (nano sockets) and CONFIG_DEV_META (user device drivers) options. It looks like these two options had not been compiled since the move from the `bcc` compiler.

Untested, as no known programs use nano sockets. Possible use for older MIcrowindows/Nano-X programs compiled client/server (which is not the case today for ELKS).

CONFIG_DEV_META compiles but needs work, as /dev/meta is not created, MAX_BLKDEV is too low, and there are no user device drivers. This option should probably be removed, or moved to experimental.