### PR TITLE
[kernel] Fix reported disk size at boot

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -182,7 +182,7 @@ bc/bc							:other					:1440k
 #nano/nano-2.0.6/src/nano		:other					:1440k
 #nano-X/bin/nxclock				:nanox					:1440k
 nano-X/bin/nxdemo				:nanox					:1440k
-nano-X/bin/nxlandmine			:nanox				:720k
+nano-X/bin/nxlandmine			:nanox					:1440k
 nano-X/bin/nxterm				:nanox
 nano-X/bin/nxworld				:nanox					:1440k
 nano-X/bin/nxworld.map	::lib/nxworld.map	:nanox		:1440k


### PR DESCRIPTION
Fixes #1088.

May add this display into standard boot messages later, not just when CONFIG_SMALL_KERNEL not defined.

Also fixes 720k floppy image build, ran out of space (again) due to network program size increases.