### PR TITLE
[kernel] Various cleanups of block/char device drivers, irqs

### DIFF
--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -69,14 +69,14 @@ extern void resetup_one_dev(struct gendisk *dev, int drive);
 #ifdef MAJOR_NR
 
 /*
- * Add entries as needed. Currently the only block devices
- * supported are hard-disks and floppies.
+ * Add entries as needed. Current block devices are
+ * hard-disks, floppies, SSD and ramdisk.
  */
 
 #ifdef RAMDISK
 
 /* ram disk */
-#define DEVICE_NAME "ramdisk"
+#define DEVICE_NAME "rd"
 #define DEVICE_REQUEST do_rd_request
 #define DEVICE_NR(device) ((device) & 7)
 #define DEVICE_ON(device)
@@ -86,8 +86,8 @@ extern void resetup_one_dev(struct gendisk *dev, int drive);
 
 #ifdef SSDDISK
 
-/* SiBO solid-state disk */
-#define DEVICE_NAME "ssddisk"
+/* solid-state disk */
+#define DEVICE_NAME "ssd"
 #define DEVICE_REQUEST do_ssd_request
 #define DEVICE_NR(device) ((device) & 3)
 #define DEVICE_ON(device)
@@ -100,7 +100,7 @@ extern void resetup_one_dev(struct gendisk *dev, int drive);
 static void floppy_on();	/*(unsigned int nr); */
 static void floppy_off();	/*(unsigned int nr); */
 
-#define DEVICE_NAME "floppy"
+#define DEVICE_NAME "fd"
 #define DEVICE_INTR do_floppy
 #define DEVICE_REQUEST do_fd_request
 #define DEVICE_NR(device) ((device) & 3)
@@ -111,7 +111,7 @@ static void floppy_off();	/*(unsigned int nr); */
 
 #ifdef ATDISK
 
-#define DEVICE_NAME "harddisk"
+#define DEVICE_NAME "hd"
 #define DEVICE_REQUEST do_directhd_request
 #define DEVICE_NR(device) (MINOR(device)>>6)
 #define DEVICE_ON(device)
@@ -121,7 +121,7 @@ static void floppy_off();	/*(unsigned int nr); */
 
 #ifdef BIOSDISK
 
-#define DEVICE_NAME "BIOSHD"
+#define DEVICE_NAME "bioshd"
 #define DEVICE_REQUEST do_bioshd_request
 #define DEVICE_NR(device) (MINOR(device)>>MINOR_SHIFT)
 #define DEVICE_ON(device)
@@ -131,7 +131,7 @@ static void floppy_off();	/*(unsigned int nr); */
 
 #ifdef METADISK
 
-#define DEVICE_NAME "meta"
+#define DEVICE_NAME "udd"
 #define DEVICE_REQUEST do_meta_request
 #define DEVICE_NR(device) (MINOR(device))
 #define DEVICE_ON(device)
@@ -152,7 +152,7 @@ static void end_request(int uptodate)
     req = CURRENT;
 
     if (!uptodate) {
-	printk("%s:I/O error\n", DEVICE_NAME);
+	printk("%s: I/O error: ", DEVICE_NAME);
 	printk("dev %x, sector %lu\n", req->rq_dev, req->rq_sector);
 
 #ifdef MULTI_BH

--- a/elks/arch/i86/drivers/block/directhd.c
+++ b/elks/arch/i86/drivers/block/directhd.c
@@ -6,7 +6,6 @@
  * 14.04.1998 Bugfixes by Alastair Bridgewater nyef@sudval.org
  */
 
-#include <linuxmt/hdreg.h>
 #include <linuxmt/major.h>
 #include <linuxmt/genhd.h>
 #include <linuxmt/fs.h>
@@ -15,6 +14,7 @@
 #include <linuxmt/directhd.h>
 #include <linuxmt/debug.h>
 
+#include <arch/hdreg.h>
 #include <arch/io.h>
 #include <arch/segment.h>
 

--- a/elks/arch/i86/drivers/char/console-direct.c
+++ b/elks/arch/i86/drivers/char/console-direct.c
@@ -126,7 +126,7 @@ static void ScrollUp(register Console * C, int y)
 
     vp = (__u16 *)((__u16)(y * Width) << 1);
     if ((unsigned int)y < MaxRow)
-	fmemcpyb(vp, C->vseg, vp + Width, C->vseg, (MaxRow - y) * (Width << 1));
+	fmemcpyw(vp, C->vseg, vp + Width, C->vseg, (MaxRow - y) * Width);
     ClearRange(C, 0, MaxRow, MaxCol, MaxRow);
 }
 
@@ -138,7 +138,7 @@ static void ScrollDown(register Console * C, int y)
 
     vp = (__u16 *)((__u16)(yy * Width) << 1);
     while (--yy >= y) {
-	fmemcpyb(vp, C->vseg, vp - Width, C->vseg, Width << 1);
+	fmemcpyw(vp, C->vseg, vp - Width, C->vseg, Width);
 	vp -= Width;
     }
     ClearRange(C, 0, y, MaxCol, y);

--- a/elks/arch/i86/drivers/char/kbd-poll-pc98.c
+++ b/elks/arch/i86/drivers/char/kbd-poll-pc98.c
@@ -77,8 +77,5 @@ static void restart_timer(void)
 void kbd_init(void)
 {
     conio_init();
-#if 0
-    enable_irq(1);		/* enable BIOS Keyboard interrupts */
-#endif
     restart_timer();
 }

--- a/elks/arch/i86/drivers/char/kbd-poll.c
+++ b/elks/arch/i86/drivers/char/kbd-poll.c
@@ -83,8 +83,5 @@ static void restart_timer(void)
 void kbd_init(void)
 {
     conio_init();
-#if 0
-    enable_irq(1);		/* enable BIOS Keyboard interrupts */
-#endif
     restart_timer();
 }

--- a/elks/arch/i86/kernel/irq-8259.c
+++ b/elks/arch/i86/kernel/irq-8259.c
@@ -22,7 +22,7 @@
 
 void init_irq(void)
 {
-#if 0
+#if NOTNEEDED
     if (sys_caps & CAP_IRQ2MAP9) {	/* PC/AT or greater */
 	save_flags(flags);
 	clr_irq();

--- a/elks/include/arch/hdreg.h
+++ b/elks/include/arch/hdreg.h
@@ -4,8 +4,6 @@
 /* This file contains some defines for the AT-hd-controller. Various sources.
  */
 
-#define HD_IRQ 14		/* the standard disk interrupt */
-
 /* ide.c has it's own port definitions in "ide.h" */
 
 /* Hd controller regs. Ref: IBM AT Bios-listing */

--- a/elks/include/arch/ports.h
+++ b/elks/include/arch/ports.h
@@ -89,14 +89,16 @@
 #define COM4_PORT	0x2e8
 #define COM4_IRQ	2		/* unregistered unless COM4_PORT found*/
 
-/* ne2k, ne2k.c, may be overridden in /bootopts
- * using netirq= and netport= 		*/
-#define NE2K_IRQ	12
+/* ne2k, ne2k.c, may be overridden in /bootopts using netirq= and netport= */
 #define NE2K_PORT	0x300
+#define NE2K_IRQ	12
 
 /* wd, wd.c*/
-#define WD_IRQ		2
 #define WD_PORT		0x240
+#define WD_IRQ		2
+
+/* bioshd.c*/
+#define FDC_DOR		0x3F2		/* floppy digital output register*/
 
 /* obsolete - experimental IDE hard drive, directhd.c (broken)*/
 #define HD1_PORT	0x1f0

--- a/elkscmd/busyelks/cmd/fdisk.c
+++ b/elkscmd/busyelks/cmd/fdisk.c
@@ -13,7 +13,7 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
-#include <linuxmt/hdreg.h>
+#include <arch/hdreg.h>
 
 #include "../fdisk.h"
 #include "cmd.h"

--- a/elkscmd/disk_utils/fdisk.c
+++ b/elkscmd/disk_utils/fdisk.c
@@ -15,7 +15,7 @@
 #include <sys/ioctl.h>
 
 #ifdef __ia16__
-#include <linuxmt/hdreg.h>
+#include <arch/hdreg.h>
 #endif
 
 struct partition

--- a/elkscmd/sys_utils/makeboot.c
+++ b/elkscmd/sys_utils/makeboot.c
@@ -24,7 +24,7 @@
 #include <sys/stat.h>
 #include <sys/ioctl.h>
 #include <sys/mount.h>
-#include <linuxmt/hdreg.h>
+#include <arch/hdreg.h>
 #include <linuxmt/minix_fs.h>
 #include <linuxmt/kdev_t.h>
 #include "../../bootblocks/mbr_autogen.c"


### PR DESCRIPTION
Cleans up source code for block and character devices, moves port and irq numbers to architecture specific locations.

Also displays multi-line floppy and hard disk cylinder, head, sector and total size information by default instead of previous single-line summary. (Old display available by commenting out PRINT_DRIVE_INFO in bioshd.c).