### PR TITLE
[kernel] Final steps to implement variable sector size

### DIFF
--- a/bootblocks/boot_sect.S
+++ b/bootblocks/boot_sect.S
@@ -24,12 +24,14 @@
 #define BOOTSEGM	0x1FE0
 #endif
 #define MEMTOPSEG	0xA000		// 640K memory
+#define SECTOR_SIZE	1024
 
 #else
 // IBM PC
 
 #define BOOTADDR	0x7C00
 #define BIOS_DRVNUM			// use boot drive number from BIOS
+#define SECTOR_SIZE	512
 #endif
 
 #define LOADSEG       DEF_INITSEG

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -668,7 +668,11 @@ static int bioshd_ioctl(struct inode *inode,
     register struct drive_infot *drivep;
     int dev, err;
 
-    if ((!inode) || !(inode->i_rdev))
+    /* get sector size called with NULL inode and arg = superblock s_dev */
+    if (cmd == HDIO_GET_SECTOR_SIZE)
+	return drive_info[DEVICE_NR(arg)].sector_size;
+
+    if (!inode || !inode->i_rdev)
 	return -EINVAL;
 
     dev = DEVICE_NR(inode->i_rdev);

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -7,6 +7,7 @@
 #include <linuxmt/msdos_fs.h>
 #include <linuxmt/msdos_fs_i.h>
 #include <linuxmt/msdos_fs_sb.h>
+#include <linuxmt/bioshd.h>	/* for HDIO_GET_SECTOR_SIZE on bioshd*/
 #include <linuxmt/kernel.h>
 #include <linuxmt/sched.h>
 #include <linuxmt/errno.h>
@@ -83,14 +84,16 @@ static void msdos_put_super(register struct super_block *sb)
 
 /* Read the super block of an MS-DOS FS. */
 
-static struct super_block *msdos_read_super(register struct super_block *s, char *data,
+static struct super_block *msdos_read_super(struct super_block *s, char *data,
 	int silent)
 {
+	struct msdos_sb_info *sb = MSDOS_SB(s);
+	struct msdos_boot_sector *b;
 	struct buffer_head *bh;
-	register struct msdos_boot_sector *b;
+	struct file_operations *fops;
 	long total_sectors, total_displayed, data_sectors;
 	char kbytes_or_mbytes = 'k';
-	int fat32;
+	int fat32, blksize;
 
 	cache_init();
 	lock_super(s);
@@ -101,45 +104,51 @@ static struct super_block *msdos_read_super(register struct super_block *s, char
 		printk("FAT: can't read super\n");
 		return NULL;
 	}
+
+	/* have to get SECTOR_SIZE somehow... */
+	fops = get_blkfops(MAJOR(s->s_dev));
+	if (!fops || !fops->ioctl ||
+		(blksize = fops->ioctl(NULL, NULL, HDIO_GET_SECTOR_SIZE, s->s_dev)) <= 0)
+			blksize = 512;
+
 	map_buffer(bh);
 	b = (struct msdos_boot_sector *) bh->b_data;
-	MSDOS_SB(s)->cluster_size = b->cluster_size;
-	MSDOS_SB(s)->fats = b->fats;
-	MSDOS_SB(s)->fat_start = b->reserved;
+	sb->cluster_size = b->cluster_size;
+	sb->fats = b->fats;
+	sb->fat_start = b->reserved;
 	if(!b->fat_length && b->fat32_length){
 		fat32 = 1;
-		MSDOS_SB(s)->fat_length = (unsigned short)b->fat32_length;
-		MSDOS_SB(s)->root_cluster = b->root_cluster;
+		sb->fat_length = (unsigned short)b->fat32_length;
+		sb->root_cluster = b->root_cluster;
 	} else {
 		fat32 = 0;
 #ifndef FAT_BITS_32
-		MSDOS_SB(s)->fat_length = b->fat_length;
-		MSDOS_SB(s)->root_cluster = 0;
+		sb->fat_length = b->fat_length;
+		sb->root_cluster = 0;
 #endif
 	}
-	MSDOS_SB(s)->dir_start= b->reserved + b->fats*MSDOS_SB(s)->fat_length;
-	MSDOS_SB(s)->dir_entries = *((unsigned short *) b->dir_entries);
-	MSDOS_SB(s)->data_start = MSDOS_SB(s)->dir_start +
-		((MSDOS_SB(s)-> dir_entries << MSDOS_DIR_BITS) >> SECTOR_BITS);
+	sb->dir_start= b->reserved + b->fats*sb->fat_length;
+	sb->dir_entries = *((unsigned short *) b->dir_entries);
+	sb->data_start = sb->dir_start +
+		((sb-> dir_entries << MSDOS_DIR_BITS) >> SECTOR_BITS);
 	total_sectors = *((unsigned short *) b->sectors)?
 		*((unsigned short *) b->sectors) : b->total_sect;
-	data_sectors = total_sectors - MSDOS_SB(s)->data_start;
-	MSDOS_SB(s)->clusters = MSDOS_SB(s)->cluster_size?
-		data_sectors/MSDOS_SB(s)->cluster_size : 0;
-	MSDOS_SB(s)->fat_bits = fat32 ? 32 : MSDOS_SB(s)->clusters > MSDOS_FAT12 ? 16 : 12;
-	MSDOS_SB(s)->previous_cluster = 0;
+	data_sectors = total_sectors - sb->data_start;
+	sb->clusters = sb->cluster_size?  data_sectors/sb->cluster_size : 0;
+	sb->fat_bits = fat32 ? 32 : sb->clusters > MSDOS_FAT12 ? 16 : 12;
+	sb->previous_cluster = 0;
 	unmap_brelse(bh);
 
 printk("FAT: me=%x,csz=%d,#f=%d,floc=%d,fsz=%d,rloc=%d,#d=%d,dloc=%d,#s=%ld,ts=%ld\n",
-  b->media,MSDOS_SB(s)->cluster_size,MSDOS_SB(s)->fats,MSDOS_SB(s)->fat_start,
-  MSDOS_SB(s)->fat_length,MSDOS_SB(s)->dir_start,MSDOS_SB(s)->dir_entries,
-  MSDOS_SB(s)->data_start,total_sectors,b->total_sect);
+	b->media, sb->cluster_size, sb->fats, sb->fat_start,
+	sb->fat_length, sb->dir_start, sb->dir_entries,
+	sb->data_start, total_sectors, b->total_sect);
 
-	if (!MSDOS_SB(s)->fats || (MSDOS_SB(s)->dir_entries & (MSDOS_DPS-1))
+	if (!sb->fats || (sb->dir_entries & (MSDOS_DPS-1))
 	    || !b->cluster_size || 
 #ifndef FAT_BITS_32
-		MSDOS_SB(s)->clusters+2 > (unsigned long)
-			MSDOS_SB(s)->fat_length * (SECTOR_SIZE * 8 / MSDOS_SB(s)->fat_bits)
+		sb->clusters+2 > (unsigned long) sb->fat_length *
+			(SECTOR_SIZE * 8 / sb->fat_bits)
 #else
 		!fat32
 #endif
@@ -155,7 +164,7 @@ printk("FAT: me=%x,csz=%d,#f=%d,floc=%d,fsz=%d,rloc=%d,#d=%d,dloc=%d,#s=%ld,ts=%
 		kbytes_or_mbytes = 'M';
 }
 	printk("FAT: %ld%c, fat%d format\n", total_displayed, kbytes_or_mbytes,
-		MSDOS_SB(s)->fat_bits);
+		sb->fat_bits);
 
 #ifdef BLOAT_FS
 	s->s_magic = MSDOS_SUPER_MAGIC;
@@ -181,8 +190,8 @@ printk("FAT: me=%x,csz=%d,#f=%d,floc=%d,fsz=%d,rloc=%d,#d=%d,dloc=%d,#s=%ld,ts=%
 		ino = msdos_get_entry(s->s_mounted, &pos, &bh, &de); 
 		if (ino == -1) break;
 		if (de->attr == ATTR_DIR && !strncmp(de->name, "DEV        ", 11)) {
-				MSDOS_SB(s)->dev_ino = ino;
-				break;
+			sb->dev_ino = ino;
+			break;
 		}
 	}
 	if (bh)
@@ -194,18 +203,18 @@ printk("FAT: me=%x,csz=%d,#f=%d,floc=%d,fsz=%d,rloc=%d,#d=%d,dloc=%d,#s=%ld,ts=%
 
 
 #ifdef BLOAT_FS
-static void msdos_statfs(struct super_block *sb,struct statfs *buf)
+static void msdos_statfs(struct super_block *s,struct statfs *buf)
 {
 	cluster_t cluster_size,free,this;
 	struct statfs tmp;
 
-	cluster_size = MSDOS_SB(sb)->cluster_size;
-	tmp.f_type = sb->s_magic;
+	cluster_size = MSDOS_SB(s)->cluster_size;
+	tmp.f_type = s->s_magic;
 	tmp.f_bsize = SECTOR_SIZE;
-	tmp.f_blocks = MSDOS_SB(sb)->clusters * cluster_size;
+	tmp.f_blocks = MSDOS_SB(s)->clusters * cluster_size;
 	free = 0;
-	for (this = 2; this < MSDOS_SB(sb)->clusters+2; this++)
-		if (!fat_access(sb,this,-1L))
+	for (this = 2; this < MSDOS_SB(s)->clusters+2; this++)
+		if (!fat_access(s,this,-1L))
 			free++;
 	free *= cluster_size;
 	tmp.f_bfree = free;

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -12,17 +12,17 @@
 #include <linuxmt/stat.h>
 #include <linuxmt/debug.h>
 
-struct buffer_head * FATPROC msdos_sread(kdev_t dev, sector_t sector, void **start)
+struct buffer_head * FATPROC msdos_sread(struct super_block *s, sector_t sector, void **start)
 {
 	register struct buffer_head *bh;
 
-	if (!(bh = bread32(dev, sector >> (BLOCK_SIZE_BITS - SECTOR_BITS))))
+	if (!(bh = bread32(s->s_dev, sector >> (BLOCK_SIZE_BITS - SECTOR_BITS_SB(s)))))
 		return NULL;
 
 	map_buffer(bh);
 	//debug_fat("msread sector %ld block %lu\n", sector, bh->b_blocknr);
 	*start = bh->b_data +
-		(((int)sector & (BLOCK_SIZE_BITS - SECTOR_BITS)) << SECTOR_BITS);
+		(((int)sector & (BLOCK_SIZE_BITS - SECTOR_BITS_SB(s))) << SECTOR_BITS_SB(s));
 	return bh;
 }
 
@@ -53,8 +53,9 @@ int FATPROC msdos_add_cluster(register struct inode *inode)
 	sector_t sector;
 	void *data;
 	struct buffer_head *bh;
-	int fatsz = MSDOS_SB(inode->i_sb)->fat_bits;
-	cluster_t previous = MSDOS_SB(inode->i_sb)->previous_cluster;
+	struct msdos_sb_info *sb = MSDOS_SB(inode->i_sb);
+	int fatsz = sb->fat_bits;
+	cluster_t previous = sb->previous_cluster;
 
 	debug_fat("add_cluster\n");
 #ifndef FAT_BITS_32
@@ -63,7 +64,7 @@ int FATPROC msdos_add_cluster(register struct inode *inode)
 #endif
 	while (lock) sleep_on(&wait);
 	lock = 1;
-	limit = MSDOS_SB(inode->i_sb)->clusters;
+	limit = sb->clusters;
 	for (count = 0; count < limit; count++) {
 		this = ((count+previous) % limit)+2;
 		if (fat_access(inode->i_sb,this,-1L) == 0) break;
@@ -71,7 +72,7 @@ int FATPROC msdos_add_cluster(register struct inode *inode)
 	debug("free cluster: %d\r\n",this);
 
 	previous = (count+previous+1) % limit;
-	MSDOS_SB(inode->i_sb)->previous_cluster = previous;;
+	sb->previous_cluster = previous;;
 	if (count >= limit) {
 		lock = 0;
 		wake_up(&wait);
@@ -88,8 +89,8 @@ int FATPROC msdos_add_cluster(register struct inode *inode)
 
 	if (!S_ISDIR(inode->i_mode)) {
 		last = inode->i_size?
-			get_cluster(inode,(inode->i_size-1) / SECTOR_SIZE /
-			MSDOS_SB(inode->i_sb)->cluster_size) : 0;
+			get_cluster(inode,(inode->i_size-1) / SECTOR_SIZE(inode) / sb->cluster_size)
+			: 0;
 	} else {
 		last = 0;
 		if ((current = inode->u.msdos_i.i_start) != 0) {
@@ -111,12 +112,11 @@ int FATPROC msdos_add_cluster(register struct inode *inode)
 	}
 	if (last) debug("next set to %d\r\n",fat_access(inode->i_sb,last,-1L));
 
-	for (current = 0; current < MSDOS_SB(inode->i_sb)->cluster_size; current++) {
-		sector = MSDOS_SB(inode->i_sb)->data_start+(this-2) *
-			MSDOS_SB(inode->i_sb)->cluster_size+current;
+	for (current = 0; current < sb->cluster_size; current++) {
+		sector = sb->data_start + (this - 2) * sb->cluster_size+current;
 		debug("zeroing sector %lu\r\n", sector);
 
-		if (current < MSDOS_SB(inode->i_sb)->cluster_size-1 && !(sector & 1)) {
+		if (current < sb->cluster_size-1 && !(sector & 1)) {
 			if (!(bh = getblk32(inode->i_dev, sector >> 1)))
 				printk("FAT: getblk fail\n");
 			else {
@@ -126,9 +126,9 @@ int FATPROC msdos_add_cluster(register struct inode *inode)
 			}
 			current++;
 		} else {
-			if (!(bh = msdos_sread(inode->i_dev,sector,&data)))
+			if (!(bh = msdos_sread(inode->i_sb,sector,&data)))
 				printk("FAT: sread fail\n");
-			else memset(data,0,SECTOR_SIZE);
+			else memset(data,0,SECTOR_SIZE(inode));
 		}
 		if (bh) {
 			debug_fat("add_cluster block write %lu\n", bh->b_blocknr);
@@ -137,11 +137,11 @@ int FATPROC msdos_add_cluster(register struct inode *inode)
 		}
 	}
 	if (S_ISDIR(inode->i_mode)) {
-		if (inode->i_size & (SECTOR_SIZE-1)) {
+		if (inode->i_size & (SECTOR_SIZE(inode)-1)) {
 			printk("FAT: bad dir size\n");
 			return -ENOSPC;
 		}
-		inode->i_size += (cluster_t)SECTOR_SIZE*MSDOS_SB(inode->i_sb)->cluster_size;
+		inode->i_size += (cluster_t)SECTOR_SIZE(inode)*sb->cluster_size;
 		inode->i_dirt = 1;
 		debug("size is %d now (%x)\r\n",inode->i_size,inode);
 	}
@@ -236,16 +236,16 @@ ino_t FATPROC msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head *
 
 	while (1) {
 		offset = *pos;
-		if ((sector = msdos_smap(dir,(sector_t)(*pos >> SECTOR_BITS))) == -1)
+		if ((sector = msdos_smap(dir,(sector_t)(*pos >> SECTOR_BITS(dir)))) == -1)
 			return -1;
 		if (!sector)
 			return -1; /* FAT error ... */
 		*pos += sizeof(struct msdos_dir_entry);
 		if (*bh)
 			unmap_brelse(*bh);
-		if (!(*bh = msdos_sread(dir->i_dev,sector,&data)))
+		if (!(*bh = msdos_sread(dir->i_sb,sector,&data)))
 			continue;
-		*de = (struct msdos_dir_entry *) ((char *)data+(offset & (SECTOR_SIZE-1)));
+		*de = (struct msdos_dir_entry *) ((char *)data+(offset & (SECTOR_SIZE(dir)-1)));
 
 		/* return value will overfow for FAT16/32 if sector is beyond 2MB boundary */
 #ifndef CONFIG_32BIT_INODES
@@ -255,7 +255,7 @@ ino_t FATPROC msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head *
 		}
 #endif
 		//debug_fat("get entry %lu\n", sector);
-		return (sector << MSDOS_DPS_BITS)+((offset & (SECTOR_SIZE-1)) >> MSDOS_DIR_BITS);
+		return (sector << MSDOS_DPS_BITS(dir))+((offset & (SECTOR_SIZE(dir)-1)) >> MSDOS_DIR_BITS);
 	}
 }
 
@@ -312,8 +312,8 @@ static cluster_t FATPROC raw_found(struct super_block *sb, cluster_t sector,
 	int entry;
 	cluster_t start = -1;
 
-	if ((bh = msdos_sread(sb->s_dev,sector,(void **) &data))) {
-	  for (entry = 0; entry < MSDOS_DPS; entry++) {
+	if ((bh = msdos_sread(sb,sector,(void **) &data))) {
+	  for (entry = 0; entry < MSDOS_DPS_SB(sb); entry++) {
 #ifndef FAT_BITS_32
 		unsigned short starthi = (MSDOS_SB(sb)->fat_bits == 32) ? data[entry].starthi : 0;
 #else
@@ -332,7 +332,7 @@ static cluster_t FATPROC raw_found(struct super_block *sb, cluster_t sector,
 			start = number;
 	    }
 		if (ino)
-			*ino = sector*MSDOS_DPS + entry;
+			*ino = sector*MSDOS_DPS_SB(sb) + entry;
 		break;
 	  }
 	  unmap_brelse(bh);
@@ -347,7 +347,7 @@ static cluster_t FATPROC raw_scan_root(register struct super_block *sb,
 	int count;
 	cluster_t cluster = 0;
 
-	for (count = 0; count < MSDOS_SB(sb)->dir_entries/MSDOS_DPS; count++) {
+	for (count = 0; count < MSDOS_SB(sb)->dir_entries/MSDOS_DPS_SB(sb); count++) {
 		if ((cluster = raw_found(sb,(cluster_t)(MSDOS_SB(sb)->dir_start+count),name, number,
 				ino)) >= 0) break;
 	}

--- a/elks/fs/super.c
+++ b/elks/fs/super.c
@@ -21,8 +21,6 @@
 #include <arch/segment.h>
 #include <arch/bitops.h>
 
-extern struct file_operations *get_blkfops();
-
 extern int root_mountflags;
 
 struct super_block super_blocks[NR_SUPER];

--- a/elks/include/linuxmt/bioshd.h
+++ b/elks/include/linuxmt/bioshd.h
@@ -46,4 +46,6 @@
 
 #define MAX_ERRS		5
 
+#define HDIO_GET_SECTOR_SIZE    0x0330  /* ioctl get drive sector size */
+
 #endif

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -7,12 +7,8 @@
 /* tunable parameters*/
 #define PIPE_BUFSIZ	80	/* doesn't have to be power of two */
 
-#ifdef CONFIG_IMG_FD1232
-#define SECTOR_SIZE     1024	/* sector size (bytes) */
-#define SECTOR_BITS	10	/* log2(SECTOR_SIZE) */
-#else
-#define SECTOR_SIZE     512	/* sector size (bytes) */
-#define SECTOR_BITS	9	/* log2(SECTOR_SIZE) */
+#ifdef CONFIG_IMG_FD1232		/* FD1232 uses 1K byte sectors */
+#define CONFIG_VAR_SECTOR_SIZE	/* sector size may vary across disks */
 #endif
 
 /*

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -381,6 +381,7 @@ extern struct inode *__iget(struct super_block *,ino_t);
 
 /*@+namechecks@*/
 
+extern struct file_operations *get_blkfops(unsigned int);
 extern int register_blkdev(unsigned int,char *,struct file_operations *);
 extern int unregister_blkdev(void);
 extern int blkdev_open(struct inode *,struct file *);
@@ -395,12 +396,6 @@ extern int unregister_chrdev(void);
 extern struct file_operations def_chr_fops;
 extern struct inode_operations chrdev_inode_operations;
 
-extern void init_fifo(struct inode *);
-
-extern struct file_operations connecting_fifo_fops;
-extern struct file_operations read_fifo_fops;
-extern struct file_operations write_fifo_fops;
-extern struct file_operations rdwr_fifo_fops;
 extern struct file_operations read_pipe_fops;
 extern struct file_operations write_pipe_fops;
 extern struct file_operations rdwr_pipe_fops;

--- a/elks/include/linuxmt/msdos_fs.h
+++ b/elks/include/linuxmt/msdos_fs.h
@@ -15,16 +15,6 @@
 #endif
 
 #define MSDOS_ROOT_INO  1		/* == MINIX_ROOT_INO */
-#define MSDOS_DIR_BITS	5		/* log2(sizeof(struct msdos_dir_entry)) */
-#define MSDOS_DPB	(BLOCK_SIZE/sizeof(struct msdos_dir_entry)) /* dir entries/block*/
-#define MSDOS_DPB_BITS	5		/* log2(MSDOS_DPB) */
-#define MSDOS_DPS	(SECTOR_SIZE/sizeof(struct msdos_dir_entry))
-#if SECTOR_SIZE == 1024
-#define MSDOS_DPS_BITS	5		/* log2(MSDOS_DPS) */
-#endif
-#if SECTOR_SIZE == 512
-#define MSDOS_DPS_BITS	4		/* log2(MSDOS_DPS) */
-#endif
 
 #define MSDOS_SUPER_MAGIC 0x4d44 /* MD */
 
@@ -129,7 +119,7 @@ struct fat_cache {
 
 /* misc.c */
 
-struct buffer_head * FATPROC msdos_sread(kdev_t dev, sector_t sector, void **start);
+struct buffer_head * FATPROC msdos_sread(struct super_block *s, sector_t sector, void **start);
 void FATPROC lock_creation(void);
 void FATPROC unlock_creation(void);
 int  FATPROC msdos_add_cluster(struct inode *inode);

--- a/elks/include/linuxmt/msdos_fs_sb.h
+++ b/elks/include/linuxmt/msdos_fs_sb.h
@@ -41,17 +41,6 @@ struct msdos_sb_info { /* space in struct super_block is 28 bytes */
 #define SECTOR_BITS_SB(sb)		9		/* log2(SECTOR_SIZE) */
 #define MSDOS_DPS_SB(sb)		(512/sizeof(struct msdos_dir_entry)) /* dirents/sector */
 #define MSDOS_DPS_BITS(inode)	4		/* log2(MSDOS_DPS) */
-
-#endif
-
-//#define MSDOS_DPS	(SECTOR_SIZE/sizeof(struct msdos_dir_entry))
-
-#if SECTOR_SIZE == 1024
-//#define MSDOS_DPS_BITS	5		/* log2(MSDOS_DPS) */
-#endif
-
-#if SECTOR_SIZE == 512
-//#define MSDOS_DPS_BITS	4		/* log2(MSDOS_DPS) */
 #endif
 
 #ifdef CONFIG_FS_DEV

--- a/elks/include/linuxmt/msdos_fs_sb.h
+++ b/elks/include/linuxmt/msdos_fs_sb.h
@@ -10,12 +10,51 @@ struct msdos_sb_info { /* space in struct super_block is 28 bytes */
 	unsigned long clusters;      /* number of clusters */
 	unsigned long root_cluster;
 	long previous_cluster;       /* used in add_cluster */
-# ifdef CONFIG_FS_DEV
+#ifdef CONFIG_FS_DEV
 	ino_t dev_ino;               /* "/dev" ino */
-# endif
+#endif
+#ifdef CONFIG_VAR_SECTOR_SIZE
+	int sector_size;             /* physical sector size */
+	unsigned char sector_bits;   /* log2(sector_size) */
+	unsigned char msdos_dps;     /* dir entries / sector */
+	unsigned char msdos_dps_bits;/* log2(msdos_dbs) */
+#endif
 };
 
-# ifdef CONFIG_FS_DEV
+#define MSDOS_DIR_BITS	5		/* log2(sizeof(struct msdos_dir_entry)) */
+#define MSDOS_DPB	(BLOCK_SIZE/sizeof(struct msdos_dir_entry)) /* dir entries/block */
+#define MSDOS_DPB_BITS	5		/* log2(MSDOS_DPB) */
+
+#ifdef CONFIG_VAR_SECTOR_SIZE
+/* variable sector size across disks - use calculated bits in block device superblock*/
+#define SECTOR_SIZE(inode)		(MSDOS_SB(inode->i_sb)->sector_size)
+#define SECTOR_BITS(inode)		(MSDOS_SB(inode->i_sb)->sector_bits)
+#define SECTOR_SIZE_SB(sb)		(MSDOS_SB(sb)->sector_size)
+#define SECTOR_BITS_SB(sb)		(MSDOS_SB(sb)->sector_bits)
+#define MSDOS_DPS_SB(sb)		(MSDOS_SB(sb)->msdos_dps)
+#define MSDOS_DPS_BITS(inode)	(MSDOS_SB(inode->i_sb)->msdos_dps_bits)
+#else
+/* fixed sector size - uses constants for code size */
+#define SECTOR_SIZE(inode)		512		/* sector size (bytes) */
+#define SECTOR_BITS(inode)		9		/* log2(SECTOR_SIZE) */
+#define SECTOR_SIZE_SB(sb)		512		/* sector size (bytes) */
+#define SECTOR_BITS_SB(sb)		9		/* log2(SECTOR_SIZE) */
+#define MSDOS_DPS_SB(sb)		(512/sizeof(struct msdos_dir_entry)) /* dirents/sector */
+#define MSDOS_DPS_BITS(inode)	4		/* log2(MSDOS_DPS) */
+
+#endif
+
+//#define MSDOS_DPS	(SECTOR_SIZE/sizeof(struct msdos_dir_entry))
+
+#if SECTOR_SIZE == 1024
+//#define MSDOS_DPS_BITS	5		/* log2(MSDOS_DPS) */
+#endif
+
+#if SECTOR_SIZE == 512
+//#define MSDOS_DPS_BITS	4		/* log2(MSDOS_DPS) */
+#endif
+
+#ifdef CONFIG_FS_DEV
 #define DEVINO_BASE MSDOS_DPB
 #define DEVDIR_SIZE 30
 
@@ -26,7 +65,6 @@ struct msdos_devdir_entry {
 };
 
 extern struct msdos_devdir_entry devnods[DEVDIR_SIZE];
-
-# endif
+#endif
 
 #endif


### PR DESCRIPTION
Implements ioctl for HDIO_GET_SECTOR_SIZE to allow FAT filesystem to learn device sector size for PC-98 support of variable sector sizes across multiple disk drives.

Also cleanup on some FAT filesystem code.

Next step will be introducing variable sector size to FAT filesystem code and more cleanup.