### PR TITLE
[kernel] Enable interrupts during block I/O

### DIFF
--- a/elks/arch/i86/drivers/block/ll_rw_blk.c
+++ b/elks/arch/i86/drivers/block/ll_rw_blk.c
@@ -152,6 +152,7 @@ static void add_request(struct blk_dev_struct *dev, struct request *req)
     mark_buffer_clean(req->rq_bh);
     if (!(tmp = dev->current_request)) {
 	dev->current_request = req;
+	set_irq();
 	(dev->request_fn) ();
     }
     else {
@@ -162,8 +163,8 @@ static void add_request(struct blk_dev_struct *dev, struct request *req)
 	}
 	req->rq_next = tmp->rq_next;
 	tmp->rq_next = req;
+	set_irq();
     }
-    set_irq();
 }
 
 static void make_request(unsigned short major, int rw, struct buffer_head *bh)


### PR DESCRIPTION
While reading through the ELKS low-level block I/O code, it was found that interrupts were left disabled needlessly for almost all of the time prior to calling the actual block request handlers (such as bioshd, ssd, ramdisk, etc)!!

ELKS uses BIOS for all disk I/O, but most BIOSes re-enable interrupts immediately upon entry to INT 13h. It is not clear how interrupts were reenabled after other block I/O (such as SSD or ramdisk), other than perhaps through the timer interrupt. The longer period of having interrupts disabled beforehand could have had an effect on serial or network activity, which this should help.

This is tested only on QEMU.

