### PR TITLE
[kernel] Prohibit filesystem writes over running programs

### DIFF
--- a/elks/fs/namei.c
+++ b/elks/fs/namei.c
@@ -37,6 +37,13 @@ int permission(register struct inode *inode, int mask)
     __u16 mode = inode->i_mode;
     int error = -EACCES;
 
+    if (mask & MAY_WRITE) {	/* disallow writing over running programs */
+	__ptask p = &task[0];
+	do {
+	    if (p->state <= TASK_STOPPED && (p->t_inode == inode))
+		return -EBUSY;
+	} while (++p < &task[MAX_TASKS]);
+    }
     if ((mask & MAY_WRITE) && IS_RDONLY(inode) &&
         !S_ISCHR(inode->i_mode) && !S_ISBLK(inode->i_mode)) /* allow writable devices*/
 	error = -EROFS;

--- a/elks/fs/open.c
+++ b/elks/fs/open.c
@@ -362,7 +362,6 @@ int sys_fchown(unsigned int fd, uid_t user, gid_t group)
 int sys_open(char *filename, int flags, int mode)
 {
     struct inode *inode;
-    register struct inode *pinode;
     int error, flag;
 
     flag = flags;
@@ -372,9 +371,8 @@ int sys_open(char *filename, int flags, int mode)
     debug_file("OPEN '%t' flags 0x%x", filename, flags);
     error = open_namei(filename, flag, mode, &inode, NULL);
     if (!error) {
-	pinode = inode;
-	if ((error = open_fd(flags, pinode)) < 0)
-	    iput(pinode);
+	if ((error = open_fd(flags, inode)) < 0)
+	    iput(inode);
     }
     debug_file(" = %d\n", error);
     return error;


### PR DESCRIPTION
Requested in #1090. Returns -EBUSY if write, create or truncate attempted on running program file.

To replace a running program, the program file can be removed first, then created.