### PR TITLE
[kernel] Move buffer init after console init, add bufs= to /bootopts

### DIFF
--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -49,7 +49,7 @@ int xms_init(void)
 	enabled = verify_a20();
 	printk(" now %s, ", enabled? "on" : "off");
 #ifdef CONFIG_FS_XMS_INT15
-	printk("using int 15,");
+	printk("using int 15, ");
 #else
 	if (!enabled) {
 		printk("xms disabled, A20 error,");
@@ -59,7 +59,7 @@ int xms_init(void)
 		printk("xms disabled, requires 386,");
 		return 0;
 	}
-	printk("using unreal mode,");
+	printk("using unreal mode, ");
 #endif
 	xms_enabled = 1;	/* enables xms_fmemcpyw()*/
 	return xms_enabled;

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -26,6 +26,8 @@
 #define NR_MAPBUFS  8
 #endif
 
+int boot_bufs;		/* /bootopts # buffers override */
+
 /* Buffer heads: local heap allocated */
 static struct buffer_head *buffer_heads;
 
@@ -124,17 +126,20 @@ int INITPROC buffer_init(void)
     /* XMS buffers override EXT buffers override internal buffers*/
 #if defined(CONFIG_FS_EXTERNAL_BUFFER) || defined(CONFIG_FS_XMS_BUFFER)
     int bufs_to_alloc = CONFIG_FS_NR_EXT_BUFFERS;
+    int xms_enabled = 0;
 
 #ifdef CONFIG_FS_XMS_BUFFER
-    int xms_enabled = xms_init();	/* try to enable unreal mode and A20 gate*/
+    xms_enabled = xms_init();	/* try to enable unreal mode and A20 gate*/
     if (xms_enabled)
 	bufs_to_alloc = CONFIG_FS_NR_XMS_BUFFERS;
-    printk(" %d %s buffers\n", bufs_to_alloc, xms_enabled? "xms": "ext");
 #endif
-
+    if (boot_bufs)
+	bufs_to_alloc = boot_bufs;
+    printk("%d %s buffers\n", bufs_to_alloc, xms_enabled? "xms": "ext");
 #else
     int bufs_to_alloc = NR_MAPBUFS;
 #endif
+
     buffer_heads = heap_alloc(bufs_to_alloc * sizeof(struct buffer_head),
 	HEAP_TAG_BUFHEAD|HEAP_TAG_CLEAR);
     if (!buffer_heads) return 1;

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -46,6 +46,7 @@ static char *envp_init[MAX_INIT_ENVS+1];
 static unsigned char options[OPTSEGSZ];
 
 extern int boot_rootdev;
+extern int boot_bufs;
 extern int dprintk_on;
 static char * INITPROC root_dev_name(int dev);
 static int INITPROC parse_options(void);
@@ -86,9 +87,6 @@ void INITPROC kernel_init(void)
     sched_init();
     setup_arch(&base, &end);
     mm_init(base, end);
-    if (buffer_init())	/* also enables xms and unreal mode if configured and possible*/
-	panic("No buf mem");
-    inode_init();
     irq_init();
     tty_init();
 
@@ -106,6 +104,10 @@ void INITPROC kernel_init(void)
 #ifdef CONFIG_CHAR_DEV_RS
     serial_init();
 #endif
+
+    inode_init();
+    if (buffer_init())	/* also enables xms and unreal mode if configured and possible*/
+	panic("No buf mem");
 
     device_init();
 
@@ -316,6 +318,10 @@ static int INITPROC parse_options(void)
 		}
 		if (!strncmp(line,"netport=",8)) {
 			net_port = (int)simple_strtol(line+8, 16);
+			continue;
+		}
+		if (!strncmp(line,"bufs=",5)) {
+			boot_bufs = (int)simple_strtol(line+5, 10);
 			continue;
 		}
 		

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -4,9 +4,10 @@
 #QEMU=1	net=eth		# ftpd on QEMU
 #HOSTNAME=elks1	 	# set network IP from /etc/hosts
 #GATEWAY=10.0.2.2
-#NETMASK=255.255.255.0
+#NETMASK=
 #NETSTART="telnetd ftpd"
 #netirq=9 netport=0x300 # NIC
+#bufs=128
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.d/rc.sys
 #init=/bin/sh		# singleuser shell
 #console=ttyS0,19200	# serial console


### PR DESCRIPTION
Requested by https://github.com/jbruchon/elks/pull/1018#issuecomment-1013040317.

Allows xms: startup to display on serial console.

Use new 'bufs=xxx' /bootopts option to specify either xms (if compiled in and available) or ext (external main memory) buffer count.
