### PR TITLE
[kernel] Fix pty buffer overread bug on signals

### DIFF
--- a/elks/arch/i86/drivers/char/pty.c
+++ b/elks/arch/i86/drivers/char/pty.c
@@ -122,10 +122,9 @@ size_t pty_write (struct inode *inode, struct file *file, char *data, size_t len
 		}
 
 		ret = get_user_char ((void *)(data++));
-		if (!tty_intcheck(tty, ret)) {
+		if (!tty_intcheck(tty, ret))
 			chq_addch_nowakeup (&tty->inq, ret);
-			count++;
-		}
+		count++;
 	}
 	if (count > 0)
 		wake_up(&tty->inq.wait);


### PR DESCRIPTION
Fixes problem reported in https://github.com/jbruchon/elks/commit/aac5f84e0000105416096445a93cea152b2d844e#commitcomment-63969722.

@Mellvik, it took fooooorrrever to find this, but finally knocked it out. Turns out the PTY driver was reading an extra character from the telnetd user buffer when a character that resulted in a signal (like ^C) was processed. That character was random, as it was off the end of telnetd's internal buffer, which could have anything in it.

