### PR TITLE
[ktcp] Fix DEBUG_TCPDATA blank output

### DIFF
--- a/elkscmd/ktcp/hexdump.c
+++ b/elkscmd/ktcp/hexdump.c
@@ -40,7 +40,7 @@ printline(int address, int *num, char *chr, int count, int summary, char *prefix
 	for (j = 0; j < count; j++)
 	{
 		if (j == 8)
-			putchar(' ');
+			printf(" ");
 		if (num[j] >= 0)
 			printf(" %02x", num[j]);
 		else
@@ -52,7 +52,7 @@ printline(int address, int *num, char *chr, int count, int summary, char *prefix
 	for (j=count; j < 16; j++)
 	{
 		if (j == 8)
-			putchar(' ');
+			printf(" ");
 		printf("   ");
 	}
 


### PR DESCRIPTION
Fixes problem of spaces appearing in ktcp output reported in https://github.com/jbruchon/elks/issues/1090#issuecomment-1013879564.

