### PR TITLE
Add SCSI hard drive support for PC-98

### DIFF
--- a/elks/arch/i86/lib/bios1B.S
+++ b/elks/arch/i86/lib/bios1B.S
@@ -47,7 +47,9 @@ call_bios:
 
 //	Do a disk interrupt.
 
-	push %ax
+	cmp $0x84,%ah
+	jz sense
+
 	push %bx
 	push %cx
 	push %dx
@@ -57,6 +59,33 @@ call_bios:
 	xchg %ch,%dl     // sector number for PC_98
 	xchg %bx,%bp
 
+
+	push %ax
+	mov %ch,%al
+	and $0x80,%al
+	cmp $0x80,%al
+	jnz fd
+
+hd:
+	pop %ax
+	mov $0x200,%bx   // 512Bytes
+	cmp $2,%al
+	jnz ch_hd
+	shl %bx          // 1024Bytes
+ch_hd:
+	mov %ch,%al
+	and $0x0F,%al
+	or  $0xA0,%al    // Physical Device Address
+	push %dx
+	and $0xC0,%dl
+	mov %dl,%ch      // MSBits of cylinder number
+	pop %dx
+	and $0x3F,%dl
+	dec %dl
+	jmp call_1B
+
+fd:
+	pop %ax
 #ifdef CONFIG_IMG_FD1232
 	mov $0x400,%bx   // 1024Bytes
 	mov %ch,%al
@@ -74,13 +103,24 @@ ch_1440:
 	or  $0x30,%al    // Physical Device Address
 	mov $0x02,%ch    // 512Bytes per sector
 #endif
+
+call_1B:
 	int $0x1B
 
 	pop %bp
 	pop %dx
 	pop %cx
 	pop %bx
-	pop %ax
+	jmp result
+
+sense:
+	mov %dl,%al
+	and $0x0F,%al
+	or  $0xA0,%al    // Physical Device Address
+	int $0x1B
+
+result:
+	mov $0,%al
 
 //	Now recover the results
 //	Make some breathing room

--- a/elks/include/linuxmt/bioshd.h
+++ b/elks/include/linuxmt/bioshd.h
@@ -33,6 +33,7 @@
 #define BIOSHD_RESET		0x0300
 #define BIOSHD_WRITE		0xD500
 #define BIOSHD_READ		0xD600
+#define BIOSHD_DRIVE_PARMS	0x8400
 #else
 #define BIOSHD_INT		0x13
 #define BIOSHD_RESET		0x0000


### PR DESCRIPTION
- Add SCSI ID mapping and CHS parameters function for PC-98 in bioshd.c
- Modified int1B functions for SCSI hard drives

IBM style mbr (not PC-98 style) is needed for mounting partitions for now.
IDE hard drives are not supported.

Thank you!
