### PR TITLE
[net] Add net.cfg network configuration file

### DIFF
--- a/elkscmd/rootfs_template/bin/net
+++ b/elkscmd/rootfs_template/bin/net
@@ -12,18 +12,8 @@
 # See qemu.sh NET= line for host forwarding into ELKS using QEMU
 #
 
-# Default IP address, gateway and network mask set by env variables in
-# /bootopts or /etc/profile. They can be IP addresses or names in /etc/hosts.
-localip=$HOSTNAME
-gateway=$GATEWAY
-netmask=$NETMASK
-
-# default link layer [eth|slip|cslip]
-link=eth
-
-# default serial port and baud rate if slip/cslip
-device=/dev/ttyS0
-baud=38400
+# read net configuration file
+source /etc/net.cfg
 
 usage()
 {
@@ -39,6 +29,7 @@ getty_off()
 
 start_network()
 {
+	custom_prestart_network
 	echo "Starting networking" on $link
 	case "$link" in
 	slip)
@@ -59,26 +50,25 @@ start_network()
 	echo $ktcp
 	if $ktcp; then
 		echo -n "Starting daemons "
-		if test "$NETSTART" = ""; then NETSTART="telnetd ftpd httpd"; fi
-		for daemon in $NETSTART
+		for daemon in $netstart
 		do
-			if test -f /bin/$daemon
-			then
-				echo -n "$daemon "
-				$daemon || true
-			fi
+			eval cmdline=\$$daemon
+			echo -n "'$cmdline' "
+			$cmdline || true
 		done
 		echo ""
 	else
 		echo "Network start failed"
 		exit 1
 	fi
+	custom_poststart_network
 }
 
 stop_network()
 {
 	echo "Stopping network"
 	kill $(ps | grep "ktcp|telnet|httpd|ftpd" | cut -c 1-5) > /dev/null 2>&1
+	custom_stop_network
 }
 
 if test "$#" -lt 1; then

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,6 +1,6 @@
 ## boot options max size 511 bytes
 #console=ttyS0 debug net=eth 3 # serial console, multiuser, networking
-#QEMU=1			# network testing
+#QEMU=1			# to use ftp/ftpd in qemu
 #TZ=MDT7		# timezone
 #netirq=9 netport=0x300 # NIC
 #bufs=128

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,11 +1,7 @@
 ## boot options max size 511 bytes
 #console=ttyS0 debug net=eth 3 # serial console, multiuser, networking
+#QEMU=1			# network testing
 #TZ=MDT7		# timezone
-#QEMU=1	net=eth		# ftpd on QEMU
-#HOSTNAME=elks1	 	# set network IP from /etc/hosts
-#GATEWAY=10.0.2.2
-#NETMASK=
-#NETSTART="telnetd ftpd"
 #netirq=9 netport=0x300 # NIC
 #bufs=128
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.d/rc.sys

--- a/elkscmd/rootfs_template/etc/net.cfg
+++ b/elkscmd/rootfs_template/etc/net.cfg
@@ -17,7 +17,7 @@ link=eth
 device=/dev/ttyS0
 baud=38400
 
-# ftp active/passive port numbers change with QEMU
+# to use ftp/ftpd in qemu
 #export QEMU=1
 
 # daemons to start are actually environment variable command lines specified below

--- a/elkscmd/rootfs_template/etc/net.cfg
+++ b/elkscmd/rootfs_template/etc/net.cfg
@@ -1,0 +1,46 @@
+#
+# /etc/net.cfg - ELKS Networking Configuration File / Shell Script
+#
+# sourced by /bin/net for ktcp and daemons
+
+# Default IP address, gate and network mask.
+# These can be IP addresses or names in /etc/hosts.
+localip=10.0.2.15
+#localip=elks1			# set network IP from /etc/hosts
+gateway=10.0.2.2
+netmask=255.255.255.0
+
+# default link layer [eth|slip|cslip]
+link=eth
+
+# default serial port and baud rate if slip/cslip
+device=/dev/ttyS0
+baud=38400
+
+# ftp active/passive port numbers change with QEMU
+#export QEMU=1
+
+# daemons to start are actually environment variable command lines specified below
+netstart="telnetd ftpd httpd"
+#netstart="ftpd"
+
+# specific daemon command lines, named in netstart=
+telnetd="telnetd"
+ftpd="ftpd -d"
+httpd="httpd"
+
+# custom code executed before network startup
+custom_prestart_network()
+{
+}
+
+# custom code executed after network startup
+custom_poststart_network()
+{
+	#echo "Network started"
+}
+
+# custom code executed after network shutdown
+custom_stop_network()
+{
+}

--- a/elkscmd/rootfs_template/etc/profile
+++ b/elkscmd/rootfs_template/etc/profile
@@ -1,7 +1,3 @@
 export PATH=/bin
-# timezone, hostname etc can be set in either /bootopts or here
+# timezone can be set in either /bootopts or here
 #export TZ=GMT0
-#export HOSTNAME=10.0.2.15
-#export GATEWAY=10.0.2.2
-#export NETMASK=255.255.255.0
-#export QEMU=1

--- a/elkscmd/rootfs_template/etc/rc.d/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sys
@@ -50,10 +50,9 @@ cslip)
 	net start cslip
 	;;
 *)
-	# normal network start
-	#net start eth
-	#net start cslip 19200
-	#net start slip 115200 /dev/ttyS0
+	if test "$net" != ""; then
+		echo "Unrecognized /bootopts network option: net=$net"
+	fi
 	;;
 esac
 

--- a/elkscmd/rootfs_template/etc/rc.d/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sys
@@ -38,7 +38,7 @@ fi
 #
 # start networking
 #
-# first check /bootopts "net=" environment variable
+# check /bootopts "net=" env variable
 case "$net" in
 eth)
 	net start eth


### PR DESCRIPTION
Adds new /etc/net.cfg network configuration file discussed in https://github.com/jbruchon/elks/pull/1105#issuecomment-1014894231.

Moves network settings out of /bootopts and /etc/profile (except for possibly QEMU= and net= for automatic network startup at boot).

All network configuration, including custom startup and shutdown code is in /etc/net.cfg. /bin/net should not have to be edited for machine configurations.

The new format allows each daemon's command line to be individually specified, for maximum flexibility and keeping extra environment variables to a minimum. In addition, specific daemons can be easily included or excluded at net startup time.