### PR TITLE
[boot] Add mount.cfg configuration file to mount filesystems at boot

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -456,7 +456,7 @@ static void probe_floppy(int target, struct hd_struct *hdp)
 	static char sector_probe[5] = { 8, 9, 15, 18, 36 };
 	static char track_probe[2] = { 40, 80 };
 #endif
-	int count;
+	int count, found_EPB = 0;
 
 	target &= MAXDRIVES - 1;
 
@@ -476,8 +476,9 @@ static void probe_floppy(int target, struct hd_struct *hdp)
 
 		if (drivep->cylinders != 0 && drivep->sectors != 0
 		    && drivep->heads != 0) {
-		    printk("fd: found valid ELKS disk parameters on /dev/fd%d "
-			   "boot sector\n", target);
+		    found_EPB = 1;
+		    /*printk("fd: found valid ELKS disk parameters on /dev/fd%d "
+			   "boot sector\n", target);*/
 		    goto got_geom;
 		}
 	    }
@@ -522,12 +523,12 @@ static void probe_floppy(int target, struct hd_struct *hdp)
 	if (drivep->cylinders == 0 || drivep->sectors == 0) {
 	    *drivep = fd_types[drivep->fdtype];
 	    printk("fd: Floppy drive autoprobe failed!\n");
-	}
-	else
-	    printk("fd: /dev/fd%d probably has %d sectors, %d heads, and "
-		   "%d cylinders\n",
-		   target, drivep->sectors, drivep->heads, drivep->cylinders);
+	} else {
+	    printk("fd: /dev/fd%d %s has %d cylinders, %d heads, and %d sectors\n",
+		   target, found_EPB? "found ELKS parm block,": "probably",
+		   drivep->cylinders, drivep->heads, drivep->sectors);
 
+	}
 	hdp->start_sect = 0;
 	hdp->nr_sects = ((sector_t)(drivep->sectors * drivep->heads))
 				* ((sector_t)drivep->cylinders);

--- a/elks/fs/minix/inode.c
+++ b/elks/fs/minix/inode.c
@@ -107,8 +107,9 @@ static struct super_operations minix_sops = {
 static void minix_mount_warning(register struct super_block *sb, char *prefix)
 {
 	if ((sb->u.minix_sb.s_mount_state & (MINIX_VALID_FS|MINIX_ERROR_FS)) != MINIX_VALID_FS)
-		printk("MINIX-fs: %smounting %s, running fsck is recommended.\n", prefix,
-	     !(sb->u.minix_sb.s_mount_state & MINIX_VALID_FS) ? "unchecked file system" : "file system with errors");
+		printk("MINIX-fs: %smounting %s 0x%x, running fsck is recommended.\n", prefix,
+	     !(sb->u.minix_sb.s_mount_state & MINIX_VALID_FS) ?
+		 "unchecked file system" : "file system with errors", sb->s_dev);
 }
 
 

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -120,7 +120,7 @@ void INITPROC kernel_init(void)
 #ifdef CONFIG_BOOTOPTS
     if (opts)
 	finalize_options();
-    else printk("/bootopts IGNORED: header not ## or size > %d\n", OPTSEGSZ-1);
+    else printk("/bootopts ignored: header not ##, size > %d or FAT boot\n", OPTSEGSZ-1);
 #endif
 
     mm_stat(base, end);

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -181,7 +181,7 @@ bc/bc							:other					:1440k
 #prems/pres/pres				:other
 #nano/nano-2.0.6/src/nano		:other					:1440k
 #nano-X/bin/nxclock				:nanox					:1440k
-nano-X/bin/nxdemo				:nanox					:1440k
+#nano-X/bin/nxdemo				:nanox					:1440k
 nano-X/bin/nxlandmine			:nanox					:1440k
 nano-X/bin/nxterm				:nanox
 nano-X/bin/nxworld				:nanox					:1440k

--- a/elkscmd/disk_utils/fsck.c
+++ b/elkscmd/disk_utils/fsck.c
@@ -84,7 +84,7 @@
 #define BITS_PER_BLOCK (BLOCK_SIZE<<3)
 
 static char * program_name = "fsck.minix";
-static char * program_version = "1.0.1 - 09/01/20";
+/*static char * program_version = "1.0.1 - 09/01/20";*/
 static char * device_name = NULL;
 static int IN;
 static int repair=0, automatic=0, verbose=0, list=0, show=0, warn_mode=0,
@@ -894,9 +894,9 @@ void check(void)
 
 int main(int argc, char ** argv)
 {
-	struct termios termios,tmp;
 	int count;
 	int retcode = 0;
+	struct termios termios,tmp;
 
 	if (argc && *argv)
 		program_name = *argv;
@@ -934,7 +934,7 @@ int main(int argc, char ** argv)
 	IN = open(device_name,repair?O_RDWR:O_RDONLY);
 	if (IN < 0)
 		die("unable to open '%s'");
-	printf("%s %s\n", program_name, program_version);
+	/*printf("%s %s\n", program_name, program_version);*/
 	for (count=0 ; count<3 ; count++)
 		sync();
 	read_tables();
@@ -946,8 +946,7 @@ int main(int argc, char ** argv)
 	 * command line.
 	 */
 	if (!(SupeP->s_state & MINIX_ERROR_FS) &&
-	      (SupeP->s_state & MINIX_VALID_FS) &&
-	      !force) {
+		(SupeP->s_state & MINIX_VALID_FS) && !force) {
 		if (repair)
 			printf("%s is clean, no check.\n", device_name);
 		if (repair && !automatic)

--- a/elkscmd/rootfs_template/etc/mount.cfg
+++ b/elkscmd/rootfs_template/etc/mount.cfg
@@ -1,0 +1,32 @@
+#
+# /etc/mount.cfg - script to mount and check filesystems at boot
+#
+
+# mount MINIX floppy B, ignore errors
+#mount /dev/fd1 /mnt || true
+
+# mount FAT floppy B, ignore errors
+#mount -t msdos /dev/fd1 /mnt || true
+
+# mount FAT HD partition 1
+#mount -t msdos /dev/hda1 /mnt
+
+# mount MINIX unpartitioned HD
+#mount /dev/hda /mnt
+
+check_filesystem()
+{
+    if test "$ROOTDEV" != ""
+    then
+        echo -n "Checking $ROOTDEV... "
+        umount /
+        fsck $ROOTDEV
+        mount -o remount,rw $ROOTDEV /
+    fi
+}
+
+if test "$ROOTDEV" != "/dev/fd0" -a "$ROOTDEV" != "/dev/fd1"
+then
+#   uncomment next line to check minix HD filesystem, will fail on msdos FAT
+#   check_filesystem
+fi

--- a/elkscmd/rootfs_template/etc/mount.cfg
+++ b/elkscmd/rootfs_template/etc/mount.cfg
@@ -1,32 +1,43 @@
 #
-# /etc/mount.cfg - script to mount and check filesystems at boot
+# /etc/mount.cfg - script to check and mount filesystems at boot
+#
+# Currently, can only check MINIX filesystems, not FAT.
+# Also, we can't (yet) determine the filesystem type, so the
+# check_filesystem calls below must be manually edited for the time being.
 #
 
-# mount MINIX floppy B, ignore errors
+fsck="fsck -r"
+
+# check_mounted_filesystem device mount_point
+check_mounted_filesystem()
+{
+	echo -n "$fsck $1: "
+	umount $1
+	$fsck $1
+	mount -o remount,rw $1 $2
+}
+
+# check_filesystem device
+check_filesystem()
+{
+	echo "$fsck $1: "
+	$fsck $1
+}
+
+# check MINIX root filesystem
+#check_mounted_filesystem $ROOTDEV /
+
+# mount MINIX floppy B, ignore mount error
+#check_filesystem /dev/fd1
 #mount /dev/fd1 /mnt || true
 
-# mount FAT floppy B, ignore errors
+# mount FAT floppy B, ignore mount error
 #mount -t msdos /dev/fd1 /mnt || true
 
 # mount FAT HD partition 1
 #mount -t msdos /dev/hda1 /mnt
 
 # mount MINIX unpartitioned HD
+#check_filesystem /dev/hda
 #mount /dev/hda /mnt
 
-check_filesystem()
-{
-    if test "$ROOTDEV" != ""
-    then
-        echo -n "Checking $ROOTDEV... "
-        umount /
-        fsck $ROOTDEV
-        mount -o remount,rw $ROOTDEV /
-    fi
-}
-
-if test "$ROOTDEV" != "/dev/fd0" -a "$ROOTDEV" != "/dev/fd1"
-then
-#   uncomment next line to check minix HD filesystem, will fail on msdos FAT
-#   check_filesystem
-fi

--- a/elkscmd/rootfs_template/etc/rc.d/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sys
@@ -11,29 +11,10 @@ export PATH=/bin
 source /etc/profile
 clock -s -u
 
-check_filesystem()
-{
-	if test "$ROOTDEV" != ""
-	then
-		echo -n "Checking $ROOTDEV... "
-		umount /
-		fsck $ROOTDEV
-		mount -o remount,rw $ROOTDEV /
-	fi
-}
-
-if test "$ROOTDEV" != "/dev/fd0" -a "$ROOTDEV" != "/dev/fd1"
-then
-#	uncomment next line to check minix HD filesystem, will fail on msdos fat
-#	check_filesystem
+# mount and check filesystems
+if test -f /etc/mount.cfg; then
+	source /etc/mount.cfg
 fi
-
-#
-# mount 2nd filesystem
-#
-#mount -t msdos /dev/fd1 /mnt || true
-#mount -t msdos /dev/hda1 /mnt
-#mount /dev/hda /mnt
 
 #
 # start networking

--- a/elkscmd/rootfs_template/etc/rc.d/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.d/rc.sys
@@ -38,8 +38,7 @@ cslip)
 esac
 
 # View message of day
-if test -f /etc/motd
-then
+if test -f /etc/motd; then
     cat /etc/motd
 fi
 


### PR DESCRIPTION
Edit /etc/mount.cfg instead of /etc/rc.d/rc.sys to control mounting and checking of filesystems at boot time.

/bootopts ignored message changed to indicate not functional on FAT boots.