### PR TITLE
Add CONFIG_ARCH_PC98 in porting-guide

### DIFF
--- a/Documentation/text/porting-guide.txt
+++ b/Documentation/text/porting-guide.txt
@@ -45,6 +45,17 @@ Orckit OR556 (or556)
 		PIT
 		Serial
 
+NEC PC-9801 Personal Computer (CONFIG_ARCH_PC98)
+	System
+		640K RAM
+		8259 PIC
+		8253 PIT
+	Keyboard
+		8251 keyboard controller
+		BIOS INT 18h polled keyboard
+	Disk Filesystem
+		BIOS INT 1Bh Floppy/Hard Disk(SCSI)
+
 SIBO (discontinued)
 
 


### PR DESCRIPTION
Hello @ghaerr ,

I added about CONFIG_ARCH_PC98 above the SIBO.
Please move it to appropriate place if necessary.

Thank you. 
