### PR TITLE
[net, ftp] Fixes to handle slip problem + bugfixes

### DIFF
--- a/elkscmd/inet/ftp/Makefile
+++ b/elkscmd/inet/ftp/Makefile
@@ -19,10 +19,10 @@ OBJS = $(SRCS:.c=.o)
 all:	$(BINS)
 
 ftp:	ftp.o
-	$(LD) $(LDFLAGS) -maout-stack=8192 -o ftp ftp.o $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-stack=6144 -maout-heap=4096 -o ftp ftp.o $(LDLIBS)
 
 ftpd:	ftpd.o
-	$(LD) $(LDFLAGS) -maout-stack=8192 -o ftpd ftpd.o $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-stack=4096 -maout-heap=4096 -o ftpd ftpd.o $(LDLIBS)
 
 install: ftpd ftp
 	$(INSTALL) $(BINS)  $(DESTDIR)/bin


### PR DESCRIPTION
One big, many small fixes to `ftp` - and optimized stack/heap values for the Makefile (for `ftp`and `ftpd`).
 
The fix to `ftp` to handle zero length files (#1104) turned out to break most file transfers when using `slip` instead of ethernet (#1114). This update eliminates that problem by changing the way the `ftp`-client handles replies from the server (no more buffered IO). 


Also in this update:
- The call to `system()`  now handles error returns properly (reports errors)
- Closes the command connection properly when login fails
- Option processing was ignoring every other option ....

There are still many extra debug printfs and commented out code, a cleanup will come later when these changes have been properly tested on QEMU (my testing has been HW only).