### PR TITLE
[kernel] Track caching fix for PC-98 and block_move fix

### DIFF
--- a/elks/arch/i86/lib/bios15.S
+++ b/elks/arch/i86/lib/bios15.S
@@ -44,7 +44,7 @@ block_move:
 1:	xor	%ax,%ax		# success return AX = 0
 2:	pop	%bp
 	pop	%si
-	pop	%ax
+	pop	%es
 	ret
 
 #if 0


### PR DESCRIPTION
Fixes for bugs identified by @tyama501 in https://github.com/jbruchon/elks/issues/1047#issuecomment-1019306533.

I also tested PC-98 with CONFIG_TRACK_CACHE=y and it seems to work for PC-98.