### PR TITLE
[kernel] Another fix for 1K sector size

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -767,7 +767,7 @@ static int do_bios_readwrite(struct drive_infot *drivep, sector_t start, char *b
 			BD_ES = DMASEG;		/* if xms buffer use DMASEG*/
 			BD_BX = 0;
 			if (cmd == WRITE)	/* copy xms buffer down before write*/
-				xms_fmemcpyw(0, DMASEG, buf, seg, this_pass*512/2);
+				xms_fmemcpyw(0, DMASEG, buf, seg, this_pass*(drivep->sector_size >> 1));
 			set_cache_invalid();
 		} else
 #endif
@@ -797,7 +797,7 @@ static int do_bios_readwrite(struct drive_infot *drivep, sector_t start, char *b
 #ifdef CONFIG_FS_XMS_BUFFER
 	if (seg >> 16) {
 		if (cmd == READ)	/* copy DMASEG up to xms*/
-			xms_fmemcpyw(buf, seg, 0, DMASEG, this_pass*512/2);
+			xms_fmemcpyw(buf, seg, 0, DMASEG, this_pass*(drivep->sector_size >> 1));
 		set_cache_invalid();
 	}
 #endif
@@ -864,7 +864,7 @@ static int cache_valid(struct drive_infot *drivep, sector_t start, char *buf,
 
 	offset = (int)(start - cache_startsector) * drivep->sector_size;
 	debug_bios("bioshd(%d): cache hit lba %ld\n", hd_drive_map[drivep-drive_info], start);
-	xms_fmemcpyw(buf, seg, (void *)offset, DMASEG, 512/2);
+	xms_fmemcpyw(buf, seg, (void *)offset, DMASEG, drivep->sector_size >> 1);
 	return 1;
 }
 

--- a/elks/arch/i86/drivers/block/ssd-sd.c
+++ b/elks/arch/i86/drivers/block/ssd-sd.c
@@ -352,7 +352,7 @@ static int sd_get_capacity_from_csd(uint8_t * csd, unsigned long * capacity) {
         csd_c_size |= csd[9];
         ++csd_c_size;
 
-        *capacity = csd_c_size * 512UL * 1024UL;
+        *capacity = csd_c_size * SD_FIXED_SECTOR_SIZE * 1024UL;
     } else if (csd_structure == 0x00) {
         // 5
         csd_read_bl_len = csd[5] & 0x0f;
@@ -603,7 +603,7 @@ int ssddev_write_blk(sector_t start, char *buf, ramdesc_t seg)
         return 0;
     }
 
-    ret = sd_write(buf + 512, seg, start + 1);
+    ret = sd_write(buf + SD_FIXED_SECTOR_SIZE, seg, start + 1);
     if (ret != 0) {
         /* just one sector was written */
         return 1;
@@ -628,7 +628,7 @@ int ssddev_read_blk(sector_t start, char *buf, ramdesc_t seg)
         return 0;
     }
 
-    ret = sd_read(buf + 512, seg, start + 1);
+    ret = sd_read(buf + SD_FIXED_SECTOR_SIZE, seg, start + 1);
     if (ret != 0) {
         /* just one sector was read */
         return 1;


### PR DESCRIPTION
Fixes a 1K sector bug when track caching enabled, found by @tyama501 in https://github.com/jbruchon/elks/issues/1047#issuecomment-1021415613.

Also changes to use define for sector size (instead of hard-coded 512) for SSD block driver.

Hello @tyama501,

With this fix, I am able to get PC-98 to boot with CONFIG_TRACK_CACHE=y, but only by forcing disk reads of a single sector each (not 2 or more):
```
/* read from start sector to end of track into DMASEG track buffer, no retries*/
static void bios_readtrack(struct drive_infot *drivep, sector_t start)
{
        unsigned int cylinder, head, sector, num_sectors;
        int drive = drivep - drive_info;
        int errs = 0;
        unsigned short out_ax;

        map_drive(&drive);
        get_chst(drivep, start, &cylinder, &head, &sector, &num_sectors);

        if (num_sectors > (DMASEGSZ / drivep->sector_size))
                num_sectors = DMASEGSZ / drivep->sector_size;
        num_sectors = 1; // <--- ADD THIS LINE 
```
Thus, it seems (finally) the remaining problem may be in the `call_bios` routine for PC-98 as discussed in https://github.com/jbruchon/elks/issues/1047#issuecomment-1019519336.

(BTW, I was wondering how this code could have worked before, when I said that I had tested PC-98 with track caching: I found that I copying an old `fd1232.bin` instead of the newer `fd1232.img` from the suffix change, and wasn't booting the right image! After realizing that, I found that the above forcing of num_sectors is required, and then things work with track caching. (Obviously, this needs more testing, since single sector track caching is hardly caching. What I found strange is that trying to limit num_sectors to max 2 still didn't work, which I thought should, since the fallback BIOS routine will attempt 1 or 2 sectors without track caching. I don't know the reason for that).


