### PR TITLE
Supported multiple bytes read for TRACK_CACHE in bios1B for PC-98

### DIFF
--- a/elks/arch/i86/lib/bios1B.S
+++ b/elks/arch/i86/lib/bios1B.S
@@ -59,7 +59,6 @@ call_bios:
 	xchg %ch,%dl     // sector number for PC_98
 	xchg %bx,%bp
 
-
 	push %ax
 	mov %ch,%al
 	and $0x80,%al
@@ -69,10 +68,14 @@ call_bios:
 hd:
 	pop %ax
 	mov $0x200,%bx   // 512Bytes
-	cmp $2,%al
-	jnz ch_hd
-	shl %bx          // 1024Bytes
-ch_hd:
+	push %ax
+	mov $0,%ah
+	push %dx
+	mul %bx
+	mov %ax,%bx
+	pop %dx
+	pop %ax
+	jc  detect_err
 	mov %ch,%al
 	and $0x0F,%al
 	or  $0xA0,%al    // Physical Device Address
@@ -88,18 +91,23 @@ fd:
 	pop %ax
 #ifdef CONFIG_IMG_FD1232
 	mov $0x400,%bx   // 1024Bytes
+#else
+	mov $0x200,%bx   // 512Bytes
+#endif
+	push %ax
+	mov $0,%ah
+	push %dx
+	mul %bx
+	mov %ax,%bx
+	pop %dx
+	pop %ax
+	jc  detect_err
 	mov %ch,%al
 	and $0x0F,%al
+#ifdef CONFIG_IMG_FD1232
 	or  $0x90,%al    // Physical Device Address
 	mov $0x03,%ch    // 1024Bytes per sector
 #else
-	mov $0x200,%bx   // 512Bytes
-	cmp $2,%al
-	jnz ch_1440
-	shl %bx          // 1024Bytes
-ch_1440:
-	mov %ch,%al
-	and $0x0F,%al
 	or  $0x30,%al    // Physical Device Address
 	mov $0x02,%ch    // 512Bytes per sector
 #endif
@@ -107,11 +115,16 @@ ch_1440:
 call_1B:
 	int $0x1B
 
+pop_result:
 	pop %bp
 	pop %dx
 	pop %cx
 	pop %bx
 	jmp result
+
+detect_err:
+	mov $0x80,%ah
+	jmp pop_result
 
 sense:
 	mov %dl,%al

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -127,8 +127,8 @@
 #define DMASEG		0xA0  /* 0x400 bytes floppy sector buffer */
 
 #ifdef CONFIG_TRACK_CACHE     /* floppy track buffer in low mem */
-#define DMASEGSZ 0x2000	      /* SECTOR_SIZE * 8 (8192) */
-#define REL_SYSSEG	0x2A0 /* kernel code segment */
+#define DMASEGSZ 0x2400	      /* SECTOR_SIZE * 18 (9216) > SECTOR_SIZE * 8 (8192) */
+#define REL_SYSSEG	0x2E0 /* kernel code segment */
 #else
 #define DMASEGSZ 0x0400	      /* BLOCK_SIZE (1024) */
 #define REL_SYSSEG	0x0E0 /* kernel code segment */


### PR DESCRIPTION
Hello @ghaerr ,

I could boot FD1232 and FD1440 with TRACK_CACHE and No TRACK_CACHE on the emulator.
The single bios1B code without ifdef TRACK_CACHE worked.

I also tested FD1232 disk with PC-9801RX and I could feel the effect of TRACK_CACHE using "more" command.
Very nice to see the disk access decrease.

Thank you for your support for this work. 