### PR TITLE
[tools] elf2elks: patch elftoolchain to allow AArch64 host system

### DIFF
--- a/elks/tools/elf2elks/Makefile
+++ b/elks/tools/elf2elks/Makefile
@@ -57,9 +57,10 @@ elf2elks.o: elf2elks.c $(LIBELF)
 # make.  To avoid roping in BSD make as yet another dependency, we directly
 # run the commands to generate and compile the libelf sources here.  This
 # still requires m4 as a dependency though.
-$(LIBELF): $(ELFTOOLCHAIN).tar.bz2
+$(LIBELF): $(ELFTOOLCHAIN).tar.bz2 lib/elftoolchain.patch
 	rm -rf $(ELFTOOLCHAIN)
 	cd lib && tar -xvjf elftoolchain-0.7.1.tar.bz2
+	cd $(ELFTOOLCHAIN) && patch -p1 <'$(abspath lib/elftoolchain.patch)'
 ifeq "Linux" "$(shell uname -s)"
 	set -e; \
 	cd $(ELFTOOLCHAIN)/common; \

--- a/elks/tools/elf2elks/lib/elftoolchain.patch
+++ b/elks/tools/elf2elks/lib/elftoolchain.patch
@@ -1,0 +1,10 @@
+diff -r -U2 elftoolchain-0.7.1/common/native-elf-format elftoolchain-0.7.1-patched/common/native-elf-format
+--- elftoolchain-0.7.1/common/native-elf-format	2016-01-07 19:26:27.000000000 +0000
++++ elftoolchain-0.7.1-patched/common/native-elf-format	2022-01-31 17:16:11.523876114 +0000
+@@ -38,4 +38,6 @@
+         } else if (match($0, ".*[xX]86-64")) {
+             elfarch = "EM_X86_64";
++        } else if (match($0, "AArch64")) {
++            elfarch = "EM_AARCH64";
+         } else {
+             elfarch = "unknown";


### PR DESCRIPTION
See https://github.com/jbruchon/elks/issues/1127 .