### PR TITLE
Use ia16-elf-gcc -E for .S files, fix addr32 warnings in unreal.S

### DIFF
--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -232,7 +232,7 @@ endif
 .S.s: ;
 
 .S.o:
-	gcc -E -traditional $(INCLUDES) $(CCDEFS) -o $*.tmp $<
+	$(CC) -E -traditional $(INCLUDES) $(CCDEFS) -o $*.tmp $<
 	$(AS) $(ASFLAGS) -o $*.o $*.tmp
 	rm $*.tmp
 

--- a/elks/arch/i86/lib/unreal.S
+++ b/elks/arch/i86/lib/unreal.S
@@ -294,8 +294,7 @@ linear32_peekw:
 	mov    %bx,%ds
 
 	cld
-	addr32                // 32-bit address prefix
-	lodsw                 // AX = [DS:ESI++]
+	addr32 lodsw          // AX = [DS:ESI++]
 	//popf                // restore interrupt status
 
 	mov    %dx,%si
@@ -338,11 +337,8 @@ linear32_fmemcpyw:
 	mov    %bx,%ds
 
 	cld
-	addr32                // 32-bit address prefix
-	rep
-	movsw                 // word [ES:EDI++] <- [DS:ESI++], ECX times
-	.byte  0x67           // 80386 B1 step chip bug on address size mixing
-	nop
+	addr32 rep movsw      // word [ES:EDI++] <- [DS:ESI++], ECX times
+	addr32 nop            // 80386 B1 step chip bug on address size mixing
 
 	//popf                // restore interrupt status
 
@@ -388,18 +384,12 @@ linear32_fmemcpyb:
 
 	cld
 	shrl   $1,%ecx        // copy words
-	addr32                // 32-bit address prefix
-	rep
-	movsw                 // word [ES:EDI++] <- [DS:ESI++], ECX times
-	.byte  0x67           // 80386 B1 step chip bug on address size mixing
-	nop
+	addr32 rep movsw      // word [ES:EDI++] <- [DS:ESI++], ECX times
+	addr32 nop            // 80386 B1 step chip bug on address size mixing
 
 	rcll    $1,%ecx       // then possibly final byte
-	addr32                // 32-bit address prefix
-	rep
-	movsb                 // byte [ES:EDI++] <- [DS:ESI++], ECX times
-	.byte  0x67           // 80386 B1 step chip bug on address size mixing
-	nop
+	addr32 rep movsb      // byte [ES:EDI++] <- [DS:ESI++], ECX times
+	addr32 nop            // 80386 B1 step chip bug on address size mixing
 
 	//popf                // restore interrupt status
 

--- a/elkscmd/Make.defs
+++ b/elkscmd/Make.defs
@@ -98,7 +98,7 @@ CFLAGS=$(CFLBASE) $(WARNINGS) $(LOCALFLAGS) $(INCLUDES) -D__ELKS__ -DELKS_VERSIO
 # Standard compilation rules.
 
 .S.s:
-	gcc -E -traditional $(INCLUDES) $(CCDEFS) -o $*.s $<
+	$(CC) -E -traditional $(INCLUDES) $(CCDEFS) -o $*.s $<
 
 .s.o:
 	$(AS) $(ASFLAGS) -o $*.o $<


### PR DESCRIPTION
Fixes #1134.

Thanks @tkchia and @toncho11!

