### PR TITLE
Add int1F for PC-98 xms

### DIFF
--- a/elks/arch/i86/lib/Makefile
+++ b/elks/arch/i86/lib/Makefile
@@ -35,16 +35,14 @@ SRCS1 = \
 	fmemory.S \
 	peekpoke.S \
 	string.S \
-	bios15.S \
-	unreal.S \
 	printreg.S \
 	atomic.S \
 	# end of list
 
 ifeq ($(CONFIG_ARCH_PC98), y)
-SRCS1 += bios1B.S
+SRCS1 += bios1B.S bios-xms-pc98.S
 else
-SRCS1 += bios13.S
+SRCS1 += bios13.S bios15.S unreal.S
 endif
 
 OBJS1 = $(SRCS1:.S=.o)

--- a/elks/arch/i86/lib/bios-xms-pc98.S
+++ b/elks/arch/i86/lib/bios-xms-pc98.S
@@ -1,0 +1,88 @@
+####################################################################################
+# BIOS INT 1FH Block Move and A20 enable for PC-98
+
+	.arch	i8086, nojumps
+	.code16
+	.text
+
+	.global	block_move
+	.global	enable_a20_gate
+	.global	verify_a20
+
+#
+# int block_move(struct gdt_table *gdtp, size_t words)
+# Uses BIOS INT 1Fh AH=90h Block Move
+# ES:BX gdtp
+# CX    byte count
+# SI    0000h
+# DI    0000h
+#
+block_move:
+	push	%es
+	push	%si
+	push	%di
+	push	%bp
+	mov	%sp,%bp
+
+	xor	%si,%si
+	xor	%di,%di
+
+	mov	12(%bp),%cx	# word count
+	shl	%cx		# byte count -> CX
+	mov	10(%bp),%bx	# gdtp -> ES:BX
+	push	%ds
+	pop	%es
+
+	mov	$0x90,%ah	# BIOS Block Move
+	int	$0x1F
+	jnc	1f
+	sti			# ensure we've got interrupts
+	mov	$-1,%ax		# fail return AX < 0
+	jmp	2f
+1:	xor	%ax,%ax		# success return AX = 0
+2:	pop	%bp
+	pop	%di
+	pop	%si
+	pop	%es
+	ret
+
+# Attempt to enable A20 address gate, return 0 on fail
+enable_a20_gate:
+	mov	$0,%al
+	out	%al,$0xF2
+	mov	$2,%al
+	out	%al,$0xF6
+	call	verify_a20	# returns 1 if enabled, 0 if disabled
+	ret
+
+# verify if A20 gate is enabled, return 0 if disabled
+verify_a20:
+	push	%ds
+	push	%es
+
+	xor	%ax,%ax
+	mov	%ax,%ds
+	dec	%ax
+	mov	%ax,%es
+
+	pushf			# save interrupt status
+	cli			# interrupts off
+
+	mov	%es:0x10,%ax	# read word at FFFF:0010 (1 meg)
+	not	%ax		# 1's complement
+	pushw	0		# save word at 0000:0000 (0)
+
+	mov	%ax,0		# word at 0 = ~(word at 1 meg)
+	mov	0,%ax		# read it back
+	cmp	%es:0x10,%ax	# fail if word at 0 == word at 1 meg
+
+	popw	0
+
+	jz	1f		# if ZF=1, the A20 gate is NOT enabled
+	mov	$1,%ax		# return 1 if enabled
+9:	popf			# restore interrupt status
+	pop	%es
+	pop	%ds
+	ret
+1:	mov	$0,%ax		# return 0 if disabled
+	jmp	9b

--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -49,7 +49,11 @@ int xms_init(void)
 	enabled = verify_a20();
 	printk(" now %s, ", enabled? "on" : "off");
 #ifdef CONFIG_FS_XMS_INT15
+#ifdef CONFIG_ARCH_PC98
+	printk("using int 1F, ");
+#else
 	printk("using int 15, ");
+#endif
 #else
 	if (!enabled) {
 		printk("xms disabled, A20 error,");


### PR DESCRIPTION
Hello @ghaerr ,

Int1F and enable_A20 worked on PC-9801RX21 with xms, so I created this PR.

![IMG_20220205_031117](https://user-images.githubusercontent.com/61556504/152584715-d54f4580-25cb-4aee-9c76-cd136de0a6ad.jpg)

Thank you! 