### PR TITLE
[net] Fix premature removal of FIN packets from retransmit queue

### DIFF
--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -257,6 +257,7 @@ static void tcp_established(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 
     if (cb->unaccepted && (h->flags & TF_FIN)) {
 	debug_tcp("tcp: FIN received before accept, dropping packet\n");
+	netstats.tcpdropcnt++;
 
 	/* We can't change state before accept processing, so drop packet*/
 	return;
@@ -507,6 +508,7 @@ void tcp_process(struct iphdr_s *iph)
 
 	    debug_tune("tcp: dropping packet, bad seqno: need %ld got %ld size %d\n",
 		cb->rcv_nxt - cb->irs, ntohl(tcph->seqnum) - cb->irs, datalen);
+	    netstats.tcpdropcnt++;
 
 	    if (cb->rcv_nxt != ntohl(tcph->seqnum) + 1)
 		tcp_send_ack(cb);


### PR DESCRIPTION
Fixes #1131.

@Mellvik, the problem wasn't solved by changing the SEQ_LEQ to SEQ_LT, but instead the retransmit expiry code didn't add an extra sequence number for the FIN packet, causing it to be dropped out of the retransmit queue too early, and thus never retransmitting.

Also added code to count more cases of dropped packets for `netstat` reporting, and cleaned up the displayed "unack" debug value to be the unack sequence number rather than the previous amount of unacked data.