### PR TITLE
[cmds] Add mount options: -a automount, -q query fstype

### DIFF
--- a/elks/fs/super.c
+++ b/elks/fs/super.c
@@ -326,7 +326,7 @@ int do_mount(kdev_t dev, char *dir, int type, int flags, char *data)
     dirp = dir_i;
     if ((dirp->i_count != 1 || dirp->i_mount) || (!fs_may_mount(dev)))
  	goto BUSY;
-    sb = read_super(dev, type, flags, data, 0);
+    sb = read_super(dev, type, flags, data, flags & MS_AUTOMOUNT);
     if (!sb) {
 	error = -EINVAL;
 	goto ERROUT1;

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -89,6 +89,7 @@
 #define MS_NOEXEC	    8	/* disallow program execution */
 #define MS_SYNCHRONOUS	   16	/* writes are synced at once */
 #define MS_REMOUNT	   32	/* alter flags of a mounted FS */
+#define MS_AUTOMOUNT	   64	/* auto mount based on superblock */
 
 #define S_APPEND	  256	/* append-only file */
 #define S_IMMUTABLE	  512	/* immutable file */

--- a/elkscmd/rootfs_template/etc/mount.cfg
+++ b/elkscmd/rootfs_template/etc/mount.cfg
@@ -1,14 +1,13 @@
 #
 # /etc/mount.cfg - script to check and mount filesystems at boot
 #
-# Currently, can only check MINIX filesystems, not FAT.
-# Also, we can't (yet) determine the filesystem type, so the
-# check_filesystem calls below must be manually edited for the time being.
+# Currently, can only check MINIX filesystems, not FAT,
+# so check_filesystem below must be manually uncommented for now.
 #
 
 fsck="fsck -r"
 
-# check_mounted_filesystem device mount_point
+# check a mounted filesystem
 check_mounted_filesystem()
 {
 	echo -n "$fsck $1: "
@@ -17,27 +16,39 @@ check_mounted_filesystem()
 	mount -o remount,rw $1 $2
 }
 
-# check_filesystem device
+# check unmounted filesystem
 check_filesystem()
 {
 	echo "$fsck $1: "
 	$fsck $1
 }
 
+# determine fs type
+fstype()
+{
+	if mount -q $1 $2; then echo ""; else
+		case "$?" in
+		2) echo "minix" ;;
+		3) echo "fat" ;;
+		*) echo "" ;;
+		esac
+	umount /dev/hda || true
+	fi
+}
+#a=$(fstype /dev/hda /mnt)
+#echo /dev/hda is a $a filesystem
+
 # check MINIX root filesystem
 #check_mounted_filesystem $ROOTDEV /
 
-# mount MINIX floppy B, ignore mount error
+# mount floppy B (MINIX or FAT), ignore mount error
 #check_filesystem /dev/fd1
-#mount /dev/fd1 /mnt || true
+#mount -a /dev/fd1 /mnt || true
 
-# mount FAT floppy B, ignore mount error
-#mount -t msdos /dev/fd1 /mnt || true
+# mount HD partition 1
+#mount -a /dev/hda1 /mnt
 
-# mount FAT HD partition 1
-#mount -t msdos /dev/hda1 /mnt
-
-# mount MINIX unpartitioned HD
+# mount unpartitioned HD
 #check_filesystem /dev/hda
-#mount /dev/hda /mnt
+#mount -a /dev/hda /mnt
 

--- a/elkscmd/sys_utils/mount.c
+++ b/elkscmd/sys_utils/mount.c
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
 	}
 
 	if (argc != 2) {
-		write(STDERR_FILENO, "Usage: mount [-t type] [-o ro|remount,rw] <device> <directory>\n", 63);
+		write(STDERR_FILENO, "Usage: mount [-a][-q][-t type] [-o ro|remount,rw] <device> <directory>\n", 63);
 		return 1;
 	}
 

--- a/elkscmd/sys_utils/mount.c
+++ b/elkscmd/sys_utils/mount.c
@@ -4,6 +4,7 @@
  * provided that this copyright notice remains intact.
  *
  * Sep 2020 - added ro and remount,rw options - ghaerr
+ * Feb 2022 - add -a auto mount w/o type specifier, -q query fs type
  */
 
 #include <stdio.h>
@@ -18,6 +19,7 @@ int main(int argc, char **argv)
 	char	*str;
 	int		type = 0;		/* default fs*/
 	int		flags = 0;
+	int		query = 0;
 	char	*option;
 
 	argc--;
@@ -28,6 +30,12 @@ int main(int argc, char **argv)
 		str = *argv++ ;
 
 		while (*++str) switch (*str) {
+			case 'q':
+				query = 1;
+				/* fall through and automount */
+			case 'a':
+				flags |= MS_AUTOMOUNT;
+				break;
 			case 't':
 				if ((argc <= 0) || (**argv == '-')) {
 					write(STDERR_FILENO, "mount: missing file system type\n", 32);
@@ -52,11 +60,11 @@ int main(int argc, char **argv)
 
 				option = *argv++;
 				if (!strcmp(option, "ro"))
-					flags = MS_RDONLY;
+					flags |= MS_RDONLY;
 				else if (!strcmp(option, "remount,rw"))
-					flags = MS_REMOUNT;
+					flags |= MS_REMOUNT;
 				else if (!strcmp(option, "remount,ro"))
-					flags = MS_REMOUNT|MS_RDONLY;
+					flags |= MS_REMOUNT|MS_RDONLY;
 				else {
 					write(STDERR_FILENO, "mount: bad option string\n", 25);
 					return 1;
@@ -76,8 +84,19 @@ int main(int argc, char **argv)
 	}
 
 	if (mount(argv[0], argv[1], type, flags) < 0) {
-		perror("mount failed");
+		if (flags & MS_AUTOMOUNT) {
+			type = (!type || type == FST_MINIX)? FST_MSDOS: FST_MINIX;
+			if (mount(argv[0], argv[1], type, flags) >= 0)
+				goto mount_ok;
+		}
+		if (!query)
+			perror("mount failed");
 		return 1;
 	}
+
+mount_ok:
+	/* if query return type: 1=fail, 2=MINIX, 3=FAT */
+	if (query)
+		return (!type || type == FST_MINIX)? 2: 3;
 	return 0;
 }

--- a/libc/include/sys/mount.h
+++ b/libc/include/sys/mount.h
@@ -12,6 +12,7 @@
 #define MS_NOEXEC	    8	/* disallow program execution */
 #define MS_SYNCHRONOUS	   16	/* writes are synced at once */
 #define MS_REMOUNT	   32	/* alter flags of a mounted FS */
+#define MS_AUTOMOUNT	   64	/* auto mount based on superblock */
 
 int mount(const char *dev, const char *dir, int type, int flags);
 int umount(const char *dir);


### PR DESCRIPTION
One can now mount a floppy or hard drive automatically at boot without having to know what filesystem type it is first.

Use `mount -a /dev/fd1 /mnt` instead of previous `mount -t msdos /dev/fd1 /mnt`, for instance.
Use `mount -q {device} {mount_point}` to return filesystem type as exit code. See shell function in /etc/mount.cfg for suggested usage.