### PR TITLE
[kernel] Add auto-sync devices to kernel using sync= in /bootopts

### DIFF
--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -29,6 +29,7 @@ int root_mountflags = 0;
 #endif
 int net_irq, net_port;
 static int boot_console;
+static int sync_interval;
 static char bininit[] = "/bin/init";
 static char *init_command = bininit;
 
@@ -70,12 +71,17 @@ void start_kernel(void)
     /*
      * We are now the idle task. We won't run unless no other process can run.
      */
+	jiff_t wake = jiffies;
     while (1) {
         schedule();
-
 #ifdef CONFIG_IDLE_HALT
         idle_halt ();
 #endif
+		/* sync all devices if sync= set in /bootopts */
+		if (sync_interval && jiffies >= wake) {
+			fsync_dev(0);
+			wake = jiffies + sync_interval * HZ;
+		}
     }
 }
 
@@ -322,6 +328,10 @@ static int INITPROC parse_options(void)
 		}
 		if (!strncmp(line,"bufs=",5)) {
 			boot_bufs = (int)simple_strtol(line+5, 10);
+			continue;
+		}
+		if (!strncmp(line,"sync=",5)) {
+			sync_interval = (int)simple_strtol(line+5, 10);
 			continue;
 		}
 		

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -94,7 +94,7 @@ reject:
 	    if (n2->tcpcb.state == TS_TIME_WAIT) {
 		LEAVE_TIME_WAIT(&n2->tcpcb);	/* entered via FIN_WAIT_2 state on FIN rcvd*/
 		tcpcb_remove(n2);
-		printf("tcp: port %u REUSED, freeing previous socket in time_wait\n", port);
+		debug_tune("tcp: port %u REUSED, freeing previous socket in time_wait\n", port);
 	    } else {
 		printf("tcp: port %u NOT reused, previous socket in state %d\n",
 			port, n2->tcpcb.state);

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -4,6 +4,7 @@
 #TZ=MDT7		# timezone
 #netirq=9 netport=0x300 # NIC
 #bufs=2500		# XMS max, EXT max is 256
+#sync=30		# sync seconds
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.sys
 #init=/bin/sh		# singleuser shell
 #console=ttyS0,19200	# serial console


### PR DESCRIPTION
Will sync all devices if sync=[# seconds] set in /bootopts.

Default off for now, pending more usage testing and usability.