### PR TITLE
[cmds] Rewrite nslookup - now works

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -156,7 +156,6 @@ inet/httpd/sample_index.html	::var/www/index.html	:net
 ktcp/ktcp						:net
 inet/nettools/netstat			:net
 inet/nettools/nslookup			:net
-#inet/nettools/resolv.cfg	::etc/resolv.cfg	:net
 inet/nettools/arp				:net
 inet/telnet/telnet				:net
 inet/telnetd/telnetd			:net

--- a/elkscmd/inet/nettools/Makefile
+++ b/elkscmd/inet/nettools/Makefile
@@ -18,7 +18,7 @@ all: $(PRGS)
 
 install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
-	$(INSTALL) resolv.cfg $(DESTDIR)/etc
+#	$(INSTALL) resolv.cfg $(DESTDIR)/etc
 
 netstat: netstat.o
 	$(LD) $(LDFLAGS) netstat.o -o netstat $(LDLIBS)

--- a/elkscmd/inet/nettools/nslookup.c
+++ b/elkscmd/inet/nettools/nslookup.c
@@ -1,3 +1,8 @@
+/*
+ * DNS Name Lookup
+ *
+ * Entirely rewritten by Greg Haerr Feb 2022
+ */
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -6,160 +11,187 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 
-struct DNS_HEADER
-{
-  __u16 len;  
-  __u16 id; 	   /* identification number */
-  __u16 flags;
-  __u16 q_count;   /* number of questions */
-  __u16 ans_count; /* number of answer RRs */
-  __u16 auth_count;/* number of authority RRs */
-  __u16 add_count; /* number of additional RRs */    
+#define DEBUG		0		/* =1 to display debug messages */
+
+#define DEFAULT_DNS	"208.67.222.222"	/* DNS server IP */
+
+/* flag codes */
+#define QUERY		0x0000	/* DNS query (opcode 0) */
+#define RESPONSE	0x8000	/* DNS response */
+#define RD			0x0100	/* recursion desired */
+#define RC			0x000F	/* response code */
+#define NO_ERROR		0
+#define FORMAT_ERROR	1	/* bad query */
+#define SERVER_FAIL		2	/* server failed */
+#define NAME_ERROR		3	/* name doesn't exist */
+#define NOT_IMPL		4	/* not implemented */
+#define REFUSED			5	/* query refused */
+
+struct DNS_HEADER {
+	__u16	len;		/* length for TCP only */
+	__u16	id;
+	__u16	flags;
+	__u16	qdcount;	/* question count */
+	__u16	ancount;	/* answer count */
+	__u16	nscount;	/* name server count in auth section */
+	__u16	arcount;	/* RR count in addditional section */
 };
 
-struct QUESTION
-{
-    __u16 qtype;
-    __u16 qclass;
+#define TYPE_A		1	/* IPv4 host address */
+#define CLASS_IN	1	/* The ARPA Internet */
+
+struct QUESTION {
+	//char	name[];		/* DNS-encoded name */
+	__u16	qtype;		/* always TYPE_A */
+	__u16	qclass;		/* always CLASS_IN */
+};
+
+struct RR {				/* resource record */
+	//char	name[];		/* DNS-encoded name */
+	__u16	type;		/* always TYPE_A */
+	__u16	class;		/* always CLASS_IN */
+	__u32	ttl;		/* TTL in seconds to discard */
+	__u16	rdlength;	/* size of rdata (always 4) */
+	__u32	rdata;		/* IP address for TYPE_A */
 };
 
 /* convert e.g. www.google.com (host) to 3www6google3com (dns) */
-void ChangetoDnsNameFormat(unsigned char* dns,unsigned char* host) 
+static void format_dns(char *dns, char *host)
 {
-    int lock = 0 , i;
-    strcat((char*)host,".");
-     
-    for(i = 0 ; i < strlen((char*)host) ; i++) 
-    {
-        if(host[i]=='.') 
-        {
-            *dns++ = i-lock;
-            for(;lock<i;lock++) 
-            {
-                *dns++=host[lock];
-            }
-            lock++; /*or lock=i+1; */
-        }
-    }
-    *dns++='\0';
+	int i, next = 0;
+
+	for(i = 0;; i++) {
+		if (host[i] == '.' || !host[i]) {
+			*dns++ = i-next;
+			while (next < i)
+				*dns++ = host[next++];
+			if (!host[next])
+				break;
+			next++;
+		}
+	}
+	*dns++ = '\0';
 }
 
-/* Get the DNS server from the /etc/resolv.cfg file */
-char* get_dns_server()
+/* resolve a name to an IP address, optionally use DNS 'server' */
+ipaddr_t in_resolve(char *hostname, char *server)
 {
-    FILE *fp;
-    static char line[200];
-    char ipaddress[200];
-    char* ptr;
-    if((fp = fopen(_PATH_RESOLV , "r")) == NULL)
-    {
-        //printf("failed to read resolv.cfg\n");
-	sprintf(line,"208.67.222.222"); /*nameserver*/
-	return &line;
-    }
-     
-    while(fgets(line , 200 , fp))
-    {
-        if(line[0] == '#')
-        {
-            continue;
-        }
-        if(strncmp(line , "nameserver" , 10) == 0)
-        {
-	    sprintf(ipaddress,"%s",line); /*strtok modifies the string, use copy*/
-            ptr = strtok(ipaddress, " "); /*first part = "nameserver"*/
-            ptr = strtok(NULL , " "); /*second part = ip address */
-	    sprintf(line,"%s",ptr);
-	    line[strlen(line)-1]='\0'; /*strtok adds trailing blank*/
-	    if (strlen(ipaddress)<8) {
-	      //printf("ip adress not read\n");
-	      sprintf(line,"208.67.222.222"); /*default nameserver*/
-	    }
-	    fclose (fp);
-	    return &line;
-        }
-    }
-     
-}
+	int fd, rc, len;
+	struct DNS_HEADER *dns;
+	struct QUESTION *qd;
+	struct RR *rr;
+	char *dnsname;
+	struct sockaddr_in addr;
+	unsigned short flags;
+	char buf[256];
 
+	if ((fd = socket(AF_INET, SOCK_STREAM, 0)) < 0)
+		return 0;
 
-int main(int argc, char *argv[]) {
-  static char outbuf[200];
-  char inbuf[200];
-  char hostname[200];
-  const char* nameserver;
-  unsigned char *qname;
-  int query_type;  
-  int fd,rc;
-  struct sockaddr_in addr;  
-  struct DNS_HEADER *dns = NULL;
-  struct QUESTION *qinfo = NULL;
+	addr.sin_family = AF_INET;
+	addr.sin_port = PORT_ANY;
+	addr.sin_addr.s_addr = INADDR_ANY;
+	if (bind(fd, (struct sockaddr *)&addr, sizeof(struct sockaddr_in)) < 0) {
+		close(fd);
+		return 0;
+	}
 
-  printf("Please enter hostname to lookup : ");
-  scanf("%s" , hostname);
-  
-  if ( (fd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
-    perror("socket error");
-    exit(-1);
-  }
-  memset(&addr, 0, sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = in_aton(server? server: DEFAULT_DNS);
+	addr.sin_port = htons(53);
+	if (connect(fd, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+		printf("Can't connect to %s\n", in_ntoa(addr.sin_addr.s_addr));
+		close(fd);
+		return 0;
+	}
 
-  addr.sin_family = AF_INET;
-  addr.sin_port = PORT_ANY;
-  addr.sin_addr.s_addr = INADDR_ANY;
+	dns = (struct DNS_HEADER *)buf;
+	dns->id = htons(0xABCD);
+	dns->flags = htons(QUERY | RD);
+	dns->qdcount = htons(1);
+	dns->ancount = 0;
+	dns->nscount = 0;
+	dns->arcount = 0;
 
-  if (bind(fd, (struct sockaddr *)&addr, sizeof(struct sockaddr_in))==-1) {
-        perror("Bind failed");
-	exit(1);
-  }
-  
-  addr.sin_family = AF_INET;
-  nameserver=get_dns_server();
-  printf("Nameserver queried:%s\n",nameserver);
-  addr.sin_addr.s_addr = in_gethostbyname(nameserver);
-  addr.sin_port = htons(53);
-  
-  if (connect(fd, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
-    perror("connect error");
-    close(fd);
-    exit(-1);
-  }
+	dnsname = &buf[sizeof(struct DNS_HEADER)];
+	format_dns(dnsname, hostname);
 
-  dns = (struct DNS_HEADER *)&outbuf;
-  /*dns->len:  set at end */
-  dns->id = (__u16) htons(getpid());
-  dns->flags = 0x01; /*This is a standard query */
-  dns->q_count = htons(1); /*we have only 1 question */
-  dns->ans_count = 0;
-  dns->auth_count = 0;
-  dns->add_count = 0;
-       
-  qname =(unsigned char*)&outbuf[sizeof(struct DNS_HEADER)];   /*point to the query portion */
-    
-  ChangetoDnsNameFormat(qname , hostname);
-    
-  qinfo =(struct QUESTION*)&outbuf[sizeof(struct DNS_HEADER) + (strlen((const char*)qname) + 1)]; /*fill it */
-  query_type=1; /*IPv4 address */
-  qinfo->qtype = htons(query_type); 
-  qinfo->qclass = htons(1); /* internet */
- 
-  dns->len = (sizeof(struct DNS_HEADER) + strlen((const char*)qname) + sizeof(struct QUESTION) -1) * 0x0100;
-  
-  rc = write(fd, outbuf, dns->len+1); 
-      
-  if (rc < 0) {
-        perror("write error");
+	len = strlen(dnsname) + 1;
+	qd = (struct QUESTION*)&buf[sizeof(struct DNS_HEADER) + len];
+	qd->qtype = htons(TYPE_A);
+	qd->qclass = htons(CLASS_IN);
+
+	len += sizeof(struct DNS_HEADER) + sizeof(struct QUESTION) - 2;
+	dns->len = htons(len);
+
+	write(fd, buf, len + 2);
+	rc = read(fd,buf,200);
 	close(fd);
-        exit(-1);
-    }
 
-  bzero( inbuf, sizeof(inbuf));  
-  rc=read(fd,inbuf,200);
-  //printf("\n%d bytes read\n",rc);
-  //for (i=0;i<50;i++) printf("%2X,",inbuf[i]);
-  printf("%s has the ip address: ",hostname);
-  printf("%d.%d.%d.%d\n",inbuf[rc-4],inbuf[rc-3],inbuf[rc-2],inbuf[rc-1]);
-  
-  close(fd);
-  return 0;
+#if DEBUG
+	printf("DNS: %d message bytes\n", rc);
+	for (int i=0;i<rc;i++) printf("%2x,",buf[i] & 0xff);
+	printf("\n");
+#endif
+	if (rc < sizeof(struct DNS_HEADER) + sizeof(struct RR))
+		return 0;
+
+	dns = (struct DNS_HEADER *)buf;
+	flags = htons(dns->flags);
+#if DEBUG
+	printf("response id %04x\n", htons(dns->id));
+	printf("response code %04x\n", flags);
+	printf("response qd count %04x\n", htons(dns->qdcount));
+	printf("response an count %04x\n", htons(dns->ancount));
+	printf("response ns count %04x\n", htons(dns->nscount));
+	printf("response ar count %04x\n", htons(dns->arcount));
+#endif
+	if ((flags & RC) != NO_ERROR) {
+		char *str;
+
+		switch (flags & RC) {
+		case FORMAT_ERROR:	str = "Bad format"; break;
+		case NAME_ERROR:	str = "Name not found"; break;
+		case REFUSED:		str = "Query refused"; break;
+		default:			str = "Server error"; break;
+		}
+		printf("DNS: %s: %s\n", hostname, str);
+		return 0;
+	}
+
+	rr = (struct RR *)&buf[rc - sizeof(struct RR)];
+#if DEBUG
+	printf("response type %04x\n", htons(rr->type));
+	printf("response class %04x\n", htons(rr->class));
+	printf("response ttl %ld\n", htonl(rr->ttl));
+	printf("response rdlength %04x\n", htons(rr->rdlength));
+	printf("response rdata %08lx\n", htonl(rr->rdata));
+	printf("response IP %s\n", in_ntoa(rr->rdata));
+#endif
+	/* dns may return auth data but not answer */
+	if (htons(dns->ancount) == 0)
+		return 0;
+
+	return rr->rdata;
+}
+
+int main(int ac, char **av)
+{
+	ipaddr_t result;
+	char *server;
+
+	if (ac < 2) {
+		printf("Usage: nslookup <domain> [nameserver]\n");
+		return 1;
+	}
+	if (ac > 2)
+		server = av[2];
+	else
+		server = getenv("DNS");
+
+	result = in_resolve(av[1], server);
+	if (result)
+		printf("%s is %s\n", av[1], in_ntoa(result));
+	else printf("%s: Name not found\n", av[1]);
+	return (result == 0);
 }


### PR DESCRIPTION
Rewrote nslookup.c from scratch. Now works!

Usage: nslookup \<domain> [server]

This is the beginning of having real DNS capabilities on ELKS, as nslookup was rewritten so the DNS resolver can be moved to the C library, and used to greatly enhance the current `in_gethostbyname` call to resolve hostnames. This is a *very* simple implementation.

However, there are problems which may have to be "resolved" in order for this to work well:
- We have to use a TCP connection to name server since ktcp doesn't have UDP, which could hang
- There is not (yet) a way to timeout on `connect` to DNS (or any other host), which could cause DNS lookups to hang

I am working on a solution for connect timeouts, but it involves a heavy change to the kernel/ktcp interface to be completely event-driven, rather than waiting for an individual reply (or not), as it does now. This change will also allow the previous `accept` problem of the timing between application accept calls and ktcp SYN received to be fixed as well. More on that later.

Nonetheless, I'd like to get more comments on nslookup now, and plan to add it to the C library so that ELKS network applications can access the net more widely, even before the above problems are fixed.

Here's a screenshot. Most addresses match my desktop's nslookup, except GitHub.com, which is returning a 192.30.255.113 address, which doesn't match (and my browser also refuses to connect to that address because of an invalid certificate). I'm not sure that the reasons are behind this yet. For those that are familiar with DNS records, they can be inspected more deeply by turning on DEBUG in nslookup.c.
<img width="832" alt="Screen Shot 2022-02-14 at 8 22 44 AM" src="https://user-images.githubusercontent.com/11985637/153906512-4d2ffd19-36d3-4d3d-ac8a-b3a108006de4.png">

