### PR TITLE
[boot] Add LOCALIP= and getty= to /bootopts

### DIFF
--- a/elkscmd/rootfs_template/bin/net
+++ b/elkscmd/rootfs_template/bin/net
@@ -1,12 +1,13 @@
 # Start/stop ELKS networking
 #
-# Usage: net [start|stop] [eth|slip|cslip] [baud] [device]
+# Usage: net [start|stop|show] [eth|slip|cslip] [baud] [device]
 #
 # Examples:
 #	net start eth			start ethernet networking
 #	net start slip			start slip networking
 #	net start slip 19200	start slip at 19200 baud
 #	net start cslip 4800 /dev/ttyS1
+#	net show				shows settings for 'net start'
 #
 # See slattach.sh for Linux slip setup
 # See qemu.sh NET= line for host forwarding into ELKS using QEMU
@@ -17,7 +18,7 @@ source /etc/net.cfg
 
 usage()
 {
-	echo "Usage: net [start|stop] [eth|slip|cslip] [baud] [device]"
+	echo "Usage: net [start|stop|show] [eth|slip|cslip] [baud] [device]"
 	exit 1
 }
 
@@ -82,6 +83,9 @@ start)
 	if test "$4" != ""; then device=$4; fi
 	start_network ;;
 stop) stop_network ;;
+show)
+	echo -n ip $localip gateway $gateway mask $netmask $link
+	if test "$link" != "eth"; then echo "" $baud $device; else echo; fi ;;
 *) usage ;;
 esac
 

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,5 +1,5 @@
 ## boot options max size 511 bytes
-#console=ttyS0 debug net=eth 3 # serial console, multiuser, networking
+#console=ttyS0,57600 debug net=eth 3 # serial console, multiuser, networking
 #QEMU=1			# to use ftp/ftpd in qemu
 #TZ=MDT7
 #LOCALIP=10.0.2.16
@@ -8,6 +8,5 @@
 #sync=30		# autosync secs
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.sys
 #init=/bin/sh		# singleuser shell
-#getty=300		# getty baud override
 #console=ttyS0,19200	# serial console
 #root=hda1 ro		# root hd partition 1, read-only

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,11 +1,13 @@
 ## boot options max size 511 bytes
 #console=ttyS0 debug net=eth 3 # serial console, multiuser, networking
 #QEMU=1			# to use ftp/ftpd in qemu
-#TZ=MDT7		# timezone
+#TZ=MDT7
+#LOCALIP=10.0.2.16
 #netirq=9 netport=0x300 # NIC
-#bufs=2500		# XMS max, EXT max is 256
-#sync=30		# sync seconds
+#bufs=2500		# system buffers
+#sync=30		# autosync secs
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.sys
 #init=/bin/sh		# singleuser shell
+#getty=300		# getty baud override
 #console=ttyS0,19200	# serial console
 #root=hda1 ro		# root hd partition 1, read-only

--- a/elkscmd/rootfs_template/etc/inittab
+++ b/elkscmd/rootfs_template/etc/inittab
@@ -3,7 +3,7 @@ id:1:initdefault:
 si::sysinit:/etc/rc.sys
 
 #l1:1:wait:/etc/rc 1
-#ud::once:/bin/update
+#ud::once:/bin/printenv
 
 # getty runlevels
 # 1 single user tty1 only

--- a/elkscmd/rootfs_template/etc/inittab
+++ b/elkscmd/rootfs_template/etc/inittab
@@ -15,5 +15,5 @@ si::sysinit:/etc/rc.sys
 t1:1356:respawn:/bin/getty /dev/tty1
 t2:56:respawn:/bin/getty /dev/tty2
 t3:56:respawn:/bin/getty /dev/tty3
-s0:2346:respawn:/bin/getty /dev/ttyS0 9600
+s0:2346:respawn:/bin/getty /dev/ttyS0
 s1:46:respawn:/bin/getty /dev/ttyS1 9600

--- a/elkscmd/rootfs_template/etc/net.cfg
+++ b/elkscmd/rootfs_template/etc/net.cfg
@@ -5,8 +5,7 @@
 
 # Default IP address, gate and network mask.
 # These can be IP addresses or names in /etc/hosts.
-localip=10.0.2.15
-#localip=elks1			# set network IP from /etc/hosts
+if test "$LOCALIP" != ""; then localip=$LOCALIP; else localip=10.0.2.15; fi
 gateway=10.0.2.2
 netmask=255.255.255.0
 
@@ -20,8 +19,8 @@ baud=38400
 # to use ftp/ftpd in qemu
 #export QEMU=1
 
-# daemons to start are actually environment variable command lines specified below
-netstart="telnetd ftpd httpd"
+# daemons to start are actually shell variable command lines see below
+netstart="telnetd ftpd"
 #netstart="ftpd"
 
 # specific daemon command lines, named in netstart=

--- a/elkscmd/sys_utils/init.c
+++ b/elkscmd/sys_utils/init.c
@@ -268,18 +268,14 @@ pid_t respawn(const char **a)
 	setsid();
 	strcpy(buf, a[3]);
 	if (!strncmp(buf, GETTY, sizeof(GETTY)-1)) {
-	    char *baudrate, *p;
+	    char *baudrate;
 	    devtty = strchr(buf, ' ');
 
 	    if (!devtty) fatalmsg("Bad getty line: '%s'\r\n", buf);
 	    *devtty++ = 0;
 	    baudrate = strchr(devtty, ' ');
-	    if (baudrate) {
+	    if (baudrate)
 		*baudrate++ = 0;
-		/* if baud specified on cmdline, override if getty= env var in /bootopts*/
-		if ((p = getenv("getty")) != NULL)
-		    baudrate = p;
-	    }
 	    if ((fd = open(devtty, O_RDWR)) < 0)
 			fatalmsg("Can't open %s (errno %d)\r\n", devtty, errno);
 

--- a/libc/getent/__getpwent.c
+++ b/libc/getent/__getpwent.c
@@ -87,6 +87,7 @@ restart:
 	  *field_begin++='\0';
 	}
     }
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
   passwd.pw_gid=(gid_t) strtoul(gid_ptr, &endptr, 10);
   if (*endptr!='\0') goto restart;
   

--- a/libc/system/signal.c
+++ b/libc/system/signal.c
@@ -44,6 +44,7 @@ Sig signal(int number, Sig pointer)
    int rv;
    if( number < 1 || number > _NSIG ) { errno=EINVAL; return SIG_ERR; }
 
+#pragma GCC diagnostic ignored "-Wpointer-to-int-cast"
    if( pointer == SIG_DFL || pointer == SIG_IGN )
       rv = _signal(number, (__kern_sighandler_t) (long) (int) pointer);
    else


### PR DESCRIPTION
Adds two items requested in #1155.

LOCALIP= specifies ktcp local IP address, and works whenever `net start` is run.

getty=19200 (or other baud rate) overrides any /bin/getty line in /etc/inittab that also specifies a baud rate. This allows /etc/inittab to remain unchanged, yet be overidden at boot when desired.
/etc/net.cfg defaults to not running httpd for now.

Also fixes ":once:" and non-/bin/getty commands, they were broken, now run correctly using "sh -c" to run from init.
Various other compilation warnings addressed.