### PR TITLE
[net] First pass at rewriting ktcp/kernel to use event callbacks

### DIFF
--- a/elks/arch/i86/kernel/syscall.dat
+++ b/elks/arch/i86/kernel/syscall.dat
@@ -45,7 +45,7 @@ setuid		+23	1
 getuid		+24	1	* this gets both uid and euid
 stime		25	2	- this must not exist - even as a libc.
 ptrace		26	4	@ adb/sdb/dbx need this.
-alarm		27	2
+alarm		+27	2
 fstat		+28	2	 
 pause		29	0	 
 utime		+30	2	 

--- a/elks/include/linuxmt/errno.h
+++ b/elks/include/linuxmt/errno.h
@@ -141,6 +141,11 @@
 #define	EDQUOT		122	/* Quota exceeded */
 #define	ENOMEDIUM	123	/* No medium found */
 #define	EMEDIUMTYPE	124	/* Wrong medium type */
+#define ENONAMESERVER	125	/* Nameserver not found */
+#define ENONAME		126	/* Name not found */
+#define EBADQUERY	127	/* Bad query format */
+#define EQUERYREFUSED	128	/* Query refused */
+#define ESERVERERR	129	/* Server error */
 
 /*****************************************************************************/
 

--- a/elks/include/linuxmt/net.h
+++ b/elks/include/linuxmt/net.h
@@ -36,6 +36,7 @@ struct socket {
 
 #if defined(CONFIG_INET)
     int avail_data;
+    int retval;
     sem_t sem;
     __u32 remaddr;		/* all in network byte order */
     __u32 localaddr;
@@ -71,12 +72,13 @@ struct proto_ops {
 };
 
 /* careful: option names are close to public SO_ options in socket.h */
-#define SF_CLOSING	(1 << 0)
-#define SF_ACCEPTCON	(1 << 1)
-#define SF_WAITDATA	(1 << 2)
-#define SF_NOSPACE	(1 << 3)
-#define SF_RST_ON_CLOSE	(1 << 4)
-#define SF_REUSE_ADDR	(1 << 5)
+#define SF_CLOSING	(1 << 0) /* inet */
+#define SF_ACCEPTCON	(1 << 1) /* unix, nano, sockets */
+#define SF_WAITDATA	(1 << 2) /* unix, nano */
+#define SF_NOSPACE	(1 << 3) /* unix, nano */
+#define SF_RST_ON_CLOSE	(1 << 4) /* inet */
+#define SF_REUSE_ADDR	(1 << 5) /* inet */
+#define SF_CONNECT	(1 << 6) /* inet */
 
 struct net_proto {
     char *name;			/* Protocol name */

--- a/elks/include/linuxmt/tcpdev.h
+++ b/elks/include/linuxmt/tcpdev.h
@@ -18,6 +18,7 @@
 
 #define TCPDEV_MAXREAD TCPDEV_INBUFFERSIZE - sizeof(struct tdb_return_data)
 
+/* outgoing ops */
 #define TDC_BIND	1
 #define TDC_ACCEPT	2
 #define TDC_CONNECT	3
@@ -74,11 +75,13 @@ struct tdb_write {
     unsigned char data[TDB_WRITE_MAX];
 };
 
+/* incoming (ktcp to kernel) ops */
 #define	TDT_RETURN	1
 #define	TDT_CHG_STATE	2
 #define	TDT_AVAIL_DATA	3
 #define TDT_ACCEPT	4
 #define TDT_BIND	5
+#define TDT_CONNECT	6
 
 struct tdb_return_data {
     char type;

--- a/elks/kernel/Makefile
+++ b/elks/kernel/Makefile
@@ -36,7 +36,7 @@ include $(BASEDIR)/Makefile-rules
 # Objects to compile.
 # unused: wait.o lock.o
 
-OBJS  = sched.o printk.o sleepwake.o dma.o version.o sys.o fork.o \
+OBJS  = sched.o printk.o sleepwake.o dma.o version.o sys.o sys2.o fork.o \
 	exit.o time.o signal.o
 
 #########################################################################

--- a/elks/kernel/sys2.c
+++ b/elks/kernel/sys2.c
@@ -1,0 +1,40 @@
+#include <linuxmt/sched.h>
+#include <linuxmt/timer.h>
+#include <linuxmt/kernel.h>
+#include <linuxmt/signal.h>
+#include <linuxmt/errno.h>
+#include <linuxmt/debug.h>
+#include <arch/segment.h>
+#include <arch/io.h>
+/*
+ * Alarm system call
+ *
+ * Feb 2022 Greg Haerr
+ */
+
+static struct timer_list alarm;
+
+static void alarm_callback(int data)
+{
+	struct task_struct *p = (struct task_struct *)data;
+
+	debug("kernel ALARM pid %d for %d\n", current->pid, p->pid);
+	send_sig(SIGALRM, p, 1);
+}
+
+unsigned int sys_alarm(unsigned int secs)
+{
+	debug("sys_alarm %d\n", secs);
+	if (secs == 0) {
+		if (alarm.tl_data)
+			del_timer(&alarm);
+		alarm.tl_data = 0;
+	} else {
+		init_timer(&alarm);
+		alarm.tl_expires = jiffies + (secs * HZ);
+		alarm.tl_function = alarm_callback;
+		alarm.tl_data = (int)current;	/* must delete timer on process exit*/
+		add_timer(&alarm);
+	}
+	return 0;
+}

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -65,11 +65,23 @@ int inet_process_tcpdev(register char *buf, int len)
         wake_up(sock->wait);
 	break;
 
+    case TDT_CONNECT:
+	down(&sock->sem);
+	sock->flags |= SF_CONNECT;
+	sock->retval = ((struct tdb_return_data *)buf)->ret_value;
+	debug_net("INET(%d) sock %x connect %d bufin %d\n",
+	current->pid, sock, sock->retval, bufin_sem);
+	up(&sock->sem);
+	tcpdev_clear_data_avail();
+	wake_up(sock->wait);
+	break;
+
     case TDT_RETURN:
     case TDT_ACCEPT:
     case TDT_BIND:
 	debug_net("INET(%d) retval %d bufin %d\n",
 	    current->pid, ((struct tdb_return_data *)buf)->ret_value, bufin_sem);
+	/* tcpdev_clear_data_avail() called by woken process */
         wake_up(sock->wait);
 	break;
     }
@@ -145,12 +157,10 @@ static int inet_bind(register struct socket *sock, struct sockaddr *addr,
     return (ret >= 0 ? 0 : ret);
 }
 
-static int inet_connect(register struct socket *sock,
-			struct sockaddr *uservaddr,
+static int inet_connect(struct socket *sock, struct sockaddr *uservaddr,
 			size_t sockaddr_len, int flags)
 {
     register struct tdb_connect *cmd;
-    int ret;
 
     debug_net("INET(%d) connect sock %x\n", current->pid, sock);
 
@@ -163,10 +173,7 @@ static int inet_connect(register struct socket *sock,
     if (sock->state == SS_CONNECTING)
         return -EINPROGRESS;
 
-/*    if (sock->state == SS_CONNECTED)
-        return -EISCONN;*/	/*Already checked in socket.c*/
-
-    down(&rwlock);
+    sock->flags &= ~SF_CONNECT;
     cmd = (struct tdb_connect *)get_tdout_buf();
     cmd->cmd = TDC_CONNECT;
     cmd->sock = sock;
@@ -174,19 +181,15 @@ static int inet_connect(register struct socket *sock,
 
     tcpdev_inetwrite(cmd, sizeof(struct tdb_connect));
 
-    /* Sleep until tcpdev has news */
-    while (bufin_sem == 0)
-        interruptible_sleep_on(sock->wait);
+    do {
+	interruptible_sleep_on(sock->wait);
+	if (current->signal)
+	    return -EINTR;
+    } while (!(sock->flags & SF_CONNECT));
 
-    ret = ((struct tdb_return_data *)tdin_buf)->ret_value;
-    tcpdev_clear_data_avail();
-    up(&rwlock);
-
-    if (ret >= 0) {
+    if (sock->retval == 0)
 	sock->state = SS_CONNECTED;
-	ret = 0;
-    }
-    return ret;
+    return sock->retval;
 }
 
 
@@ -253,8 +256,7 @@ static int inet_accept(register struct socket *sock, struct socket *newsock, int
     return ret;
 }
 
-static int inet_read(register struct socket *sock, char *ubuf, int size,
-		     int nonblock)
+static int inet_read(struct socket *sock, char *ubuf, int size, int nonblock)
 {
     register struct tdb_read *cmd;
     int ret;
@@ -298,7 +300,6 @@ static int inet_read(register struct socket *sock, char *ubuf, int size,
     debug_net("INET(%d) read wait done bufin_sem %d\n", current->pid, bufin_sem);
 
     down(&sock->sem);
-
     ret = ((struct tdb_return_data *)tdin_buf)->ret_value;
 
     if (ret > 0) {

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -184,7 +184,7 @@ static int inet_connect(struct socket *sock, struct sockaddr *uservaddr,
     do {
 	interruptible_sleep_on(sock->wait);
 	if (current->signal)
-	    return -EINTR;
+	    return -ETIMEDOUT;
     } while (!(sock->flags & SF_CONNECT));
 
     if (sock->retval == 0)

--- a/elks/net/ipv4/af_inet.c
+++ b/elks/net/ipv4/af_inet.c
@@ -93,8 +93,10 @@ static int inet_create(struct socket *sock, int protocol)
 {
     debug_net("INET(%d) create sock %x\n", current->pid, sock);
 
-    if (protocol != 0 || !tcpdev_inuse)
+    if (protocol != 0)
         return -EINVAL;
+    if (!tcpdev_inuse)
+	return -ENETDOWN;
 
     return 0;
 }

--- a/elkscmd/inet/telnet/telnet.c
+++ b/elkscmd/inet/telnet/telnet.c
@@ -174,7 +174,7 @@ int main(int argc, char *argv[])
 	remadr.sin_addr.s_addr = ipaddr;
 
 	printf("Connecting to %s (%s:%u)\n", argv[1], in_ntoa(ipaddr), port);
-	ret = connect(tcp_fd, (struct sockaddr *)&remadr, sizeof(struct sockaddr_in));
+	ret = in_connect(tcp_fd, (struct sockaddr *)&remadr, sizeof(struct sockaddr_in), 10);
 	if (ret < 0){
 		perror("Connection failed");
 		exit(1);

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -57,12 +57,12 @@ static int intfd;	/* interface fd*/
 // tcp_timeruse		timer_retrans		tcp_retrans
 // cbs_in_time_wait	timer_time_wait		tcp_expire_timeouts
 // cbs_in_user_wait	timer_close_wait	tcp_expire_timeouts
-// tcpcb_need_push				tcpcb_push_data -> tcpdev_checkread
+// tcpcb_need_push				tcpcb_push_data -> notify_data_avail
 
 int tcp_timeruse;		/* retrans timer active, call tcp_retrans */
 int cbs_in_time_wait;		/* time_wait timer active, call tcp_expire_timeouts */
 int cbs_in_user_timeout;	/* fin_wait/closing/last_ack active, call " */
-int tcpcb_need_push;		/* push required, tcpcb_push_data/call tcpcb_checkread */
+int tcpcb_need_push;		/* push required, tcpcb_push_data/call notify_data_avail */
 int tcp_retrans_memory;		/* total retransmit memory in use*/
 
 void ktcp_run(void)

--- a/elkscmd/ktcp/tcp.c
+++ b/elkscmd/ktcp/tcp.c
@@ -138,19 +138,18 @@ static void tcp_syn_sent(struct iptcp_s *iptcp, struct tcpcb_s *cb)
     cb->seg_ack = ntohl(h->acknum);
 
     if (h->flags & TF_RST) {
-	retval_to_sock(cb->sock, -ECONNREFUSED);
-	//cb->state = TS_CLOSED;
+	notify_sock(cb->sock, TDT_CONNECT, -ECONNREFUSED);
 	tcpcb_remove_cb(cb); 	/* deallocate*/
 	return;
     }
 
-    if (h->flags & (TF_SYN|TF_ACK)) {
+    if ((h->flags & (TF_SYN|TF_ACK)) == (TF_SYN|TF_ACK)) {
 	if (cb->seg_ack != cb->send_una + 1) {
 	    printf("tcp: SYN sent, wrong ACK (listen port not expired)\n");
 	    /* Send RST */
 	    cb->send_nxt = h->acknum;
 	    //tcp_send_reset(cb);
-	    retval_to_sock(cb->sock, -ECONNREFUSED);
+	    notify_sock(cb->sock, TDT_CONNECT, -ECONNREFUSED);
 	    tcpcb_remove_cb(cb);	/* deallocate*/
 	    return;
 	}
@@ -165,8 +164,7 @@ static void tcp_syn_sent(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 	debug_tcp("TS_ESTABLISHED\n");
 
 	tcp_send_ack(cb);
-	retval_to_sock(cb->sock, 0);
-
+	notify_sock(cb->sock, TDT_CONNECT, 0);	/* success*/
 	return;
     }
 }
@@ -247,9 +245,9 @@ static void tcp_established(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 	if (cb->state == TS_CLOSE_WAIT) {
 	    cbs_in_user_timeout--;
 	    ENTER_TIME_WAIT(cb);
-	    tcpdev_sock_state(cb, SS_DISCONNECTING);	/* wakes up process*/
+	    notify_sock(cb->sock, TDT_CHG_STATE, SS_DISCONNECTING);
 	} else {
-	    tcpdev_sock_state(cb, SS_DISCONNECTING);	/* wakes up process*/
+	    notify_sock(cb->sock, TDT_CHG_STATE, SS_DISCONNECTING);
 	    tcpcb_remove_cb(cb); 	/* deallocate*/
 	}
 	return;
@@ -301,7 +299,7 @@ static void tcp_established(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 	cb->time_wait_exp = Now;	/* used for debug output only*/
 	debug_tcp("tcp: got FIN with data %d buffer %d\n", datasize, cb->buf_used);
 	if (cb->bytes_to_push <= 0)
-	    tcpdev_sock_state(cb, SS_DISCONNECTING);
+	    notify_sock(cb->sock, TDT_CHG_STATE, SS_DISCONNECTING);
     }
 
     if (datasize == 0 && ((h->flags & TF_ALL) == TF_ACK))
@@ -323,7 +321,7 @@ static void tcp_synrecv(struct iptcp_s *iptcp, struct tcpcb_s *cb)
     else {
 	cb->state = TS_ESTABLISHED;
 	debug_tcp("TS_ESTABLISHED\n");
-	tcpdev_checkaccept(cb);
+	tcpdev_notify_accept(cb);
 	tcp_established(iptcp, cb);
     }
 }

--- a/elkscmd/ktcp/tcp.h
+++ b/elkscmd/ktcp/tcp.h
@@ -183,7 +183,7 @@ struct	tcp_retrans_list_s {
 extern int tcp_timeruse;	/* retrans timer active, call tcp_retrans */
 extern int cbs_in_time_wait;	/* time_wait timer active, call tcp_expire_timeouts */
 extern int cbs_in_user_timeout;	/* fin_wait/closing/last_ack active, call " */
-extern int tcpcb_need_push;	/* push required, tcpcb_push_data/call tcpcb_checkread */
+extern int tcpcb_need_push;	/* push required, tcpcb_push_data/call notify_data_avail */
 extern int tcp_retrans_memory;	/* total retransmit memory in use */
 
 struct tcpcb_list_s *tcpcb_new(int bufsize);

--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -265,7 +265,7 @@ void tcpcb_push_data(void)
 
     for (n=tcpcbs; n; n=n->next)
 	if (n->tcpcb.bytes_to_push > 0)
-	    tcpdev_checkread(&n->tcpcb);
+	    notify_data_avail(&n->tcpcb);
 }
 
 /* There must be free space greater-equal than len or will wrap*/

--- a/elkscmd/ktcp/tcpdev.h
+++ b/elkscmd/ktcp/tcpdev.h
@@ -5,9 +5,9 @@ extern int tcpdevfd;
 
 void tcpdev_process(void);
 int tcpdev_init(char *fdev);
+void notify_sock(void *sock, int type, int value);
+void notify_data_avail(struct tcpcb_s *cb);
 void retval_to_sock(void *sock, int r);
-void tcpdev_checkread(struct tcpcb_s *cb);
-void tcpdev_sock_state(struct tcpcb_s *cb, int state);
-void tcpdev_checkaccept(struct tcpcb_s *cb);
+void tcpdev_notify_accept(struct tcpcb_s *cb);
 
 #endif

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,5 +1,5 @@
 ## boot options max size 511 bytes
-#console=ttyS0,57600 debug net=eth 3 # serial console, multiuser, networking
+console=ttyS0,57600 debug net=eth 3 # serial console, multiuser, networking
 #QEMU=1			# to use ftp/ftpd in qemu
 #TZ=MDT7
 #LOCALIP=10.0.2.16

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,5 +1,5 @@
 ## boot options max size 511 bytes
-console=ttyS0,57600 debug net=eth 3 # serial console, multiuser, networking
+#console=ttyS0,57600 debug net=eth 3 # serial console, multiuser, networking
 #QEMU=1			# to use ftp/ftpd in qemu
 #TZ=MDT7
 #LOCALIP=10.0.2.16

--- a/elkscmd/rootfs_template/etc/perror
+++ b/elkscmd/rootfs_template/etc/perror
@@ -119,3 +119,11 @@
 119 No XENIX semaphores available 
 120 Is a named type file 
 121 Remote I/O error 
+122 Quota exceeded 
+123 No medium found 
+124 Wrong medium type 
+125 Nameserver not found 
+126 Name not found 
+127 Bad query format 
+128 Query refused 
+129 Server error 

--- a/libc/include/arpa/inet.h
+++ b/libc/include/arpa/inet.h
@@ -1,5 +1,7 @@
 #include <netinet/in.h>
+#include <sys/socket.h>
 
 ipaddr_t in_aton(const char *str);
 ipaddr_t in_gethostbyname(char *str);
+int in_connect(int socket, const struct sockaddr *address, socklen_t address_len, int secs);
 char *in_ntoa(ipaddr_t in);

--- a/libc/include/unistd.h
+++ b/libc/include/unistd.h
@@ -83,6 +83,7 @@ uid_t geteuid(void);
 char * getcwd (char * buf, size_t size);
 void sync(void);
 void usleep(unsigned long useconds);
+unsigned alarm(unsigned seconds);
 
 int getopt(int argc, char * const argv[], const char *opts);
 extern char *optarg;

--- a/libc/net/Makefile
+++ b/libc/net/Makefile
@@ -2,7 +2,7 @@
 
 include $(TOPDIR)/libc/Makefile.inc
 
-SRCS= in_aton.c in_ntoa.c in_gethostbyname.c getsocknam.c
+SRCS= in_aton.c in_ntoa.c in_gethostbyname.c getsocknam.c in_connect.c
 OBJS= $(SRCS:.c=.o)
 
 $(OBJS): $(SRCS)

--- a/libc/net/in_connect.c
+++ b/libc/net/in_connect.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <signal.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+
+/*
+ * connect with timeout
+ *
+ * Feb 2022 Greg Haerr
+ */
+
+static void alarm_cb(int sig)
+{
+	/* no action */
+}
+
+int in_connect(int socket, const struct sockaddr *address, socklen_t address_len,
+		int secs)
+{
+	int ret;
+	__sighandler_t old;
+
+	old = signal(SIGALRM, alarm_cb);
+	alarm(secs);
+	ret = connect(socket, address, address_len);
+	alarm(0);
+	signal(SIGALRM, old);
+	return ret;
+}


### PR DESCRIPTION
Rewrites ktcp/kernel to use callback for TCP connect events.

With this change, one should be able to ^C out of a connect system call, in the case a bad address was typed. Currently only tested on telnet in QEMU. 

Next step is adding `alarm` system call, which should now to allow connect and read system calls to be interrupted. It will not working with accept, which requires more changes.