### PR TITLE
Cleanup buffer_head access functions when in far memory

### DIFF
--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -40,7 +40,16 @@ ext_buffer_head *EBH(struct buffer_head *bh)
 	int idx = bh - buffer_heads;
 	return ext_buffer_heads + idx;
 }
-#endif
+
+/* functions for buffer_head points called outside of buffer.c */
+void mark_buffer_dirty(struct buffer_head *bh)     { EBH(bh)->b_dirty = 1; }
+void mark_buffer_clean(struct buffer_head *bh)     { EBH(bh)->b_dirty = 0; }
+ramdesc_t buffer_seg(struct buffer_head *bh)       { return EBH(bh)->b_seg; }
+unsigned char buffer_count(struct buffer_head *bh) { return EBH(bh)->b_count; }
+block32_t buffer_blocknr(struct buffer_head *bh)   { return EBH(bh)->b_blocknr; }
+kdev_t buffer_dev(struct buffer_head *bh)          { return EBH(bh)->b_dev; }
+
+#endif /* CONFIG_FAR_BUFHEADS */
 
 /* Internal L1 buffers, must be kernel DS addressable */
 static char L1buf[NR_MAPBUFS][BLOCK_SIZE];

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -147,20 +147,32 @@ struct ext_buffer_head_s {
 };
 
 #ifdef CONFIG_FAR_BUFHEADS
+/* buffer heads allocated in main (far) memory */
 #define ext_buffer_head		struct ext_buffer_head_s __far
 ext_buffer_head *EBH(struct buffer_head *);	/* convert bh to ebh */
-#else
-#define EBH(bh)		(bh)
-typedef struct buffer_head	ext_buffer_head;
-#endif
 
-/* macros for buffer_head pointers called outside of buffer.c*/
-#define mark_buffer_dirty(bh)	(EBH(bh)->b_dirty = 1)
-#define mark_buffer_clean(bh)	(EBH(bh)->b_dirty = 0)
-#define buffer_seg(bh)		(EBH(bh)->b_seg)
-#define buffer_count(bh)	(EBH(bh)->b_count)
-#define buffer_blocknr(bh)	(EBH(bh)->b_blocknr)
-#define buffer_dev(bh)		(EBH(bh)->b_dev)
+/* functions for buffer_head pointers called outside of buffer.c */
+void mark_buffer_dirty(struct buffer_head *bh);
+void mark_buffer_clean(struct buffer_head *bh);
+ramdesc_t buffer_seg(struct buffer_head *bh);
+unsigned char buffer_count(struct buffer_head *bh);
+block32_t buffer_blocknr(struct buffer_head *bh);
+kdev_t buffer_dev(struct buffer_head *bh);
+
+#else
+/* buffer heads in kernel data segment */
+typedef struct buffer_head	ext_buffer_head;
+#define EBH(bh)		(bh)
+
+/* macros for buffer_head pointers called outside of buffer.c */
+#define mark_buffer_dirty(bh)	((bh)->b_dirty = 1)
+#define mark_buffer_clean(bh)	((bh)->b_dirty = 0)
+#define buffer_seg(bh)		((bh)->b_seg)
+#define buffer_count(bh)	((bh)->b_count)
+#define buffer_blocknr(bh)	((bh)->b_blocknr)
+#define buffer_dev(bh)		((bh)->b_dev)
+
+#endif /* CONFIG_FAR_BUFHEADS */
 
 #define BLOCK_READ	0
 #define BLOCK_WRITE	1

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -79,7 +79,7 @@ sys_utils/kill					:sysutil			:720k
 sys_utils/ps			:sash	:sysutil		:360
 sys_utils/reboot				:sysutil		:360k
 sys_utils/makeboot				:sysutil		:360k
-sys_utils/man					:sysutil				:1200k	:1440k
+sys_utils/man			:man	:sysutil				:1200k	:1440k
 sys_utils/meminfo		:sash	:sysutil		:360k
 sys_utils/mouse					:sysutil				:1200k	:1440k
 sys_utils/passwd				:sysutil				:1200k	:1440k


### PR DESCRIPTION
Cleanup saves ~400 bytes kernel code and keeps far pointer inside fs/buffer.c.