### PR TITLE
[kernel] First pass at working /bootopts on FAT boot volumes

### DIFF
--- a/bootblocks/boot_sect_fat.h
+++ b/bootblocks/boot_sect_fat.h
@@ -154,7 +154,7 @@ bpb_fil_sys_type:			// Filesystem type (8 bytes)
 
 	// Load the first sector of the root directory
 	movb bpb_num_fats,%al
-	cbtw
+	xor %ah,%ah
 	mov bpb_fat_sz_16,%bx		// check FAT16 fat size
 	and %bx,%bx
 	jnz 1f				// nonzero means FAT16 filesystem

--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -29,21 +29,23 @@
 ! changes to support .fartext headers and relocation
 ! Sep 2020 Greg Haerr
 !
+! load /bootopts file for FAT fs using boot sector's ram buffers
+! Feb 2022 Greg Haerr
+!
 ! The following data is passed to the main kernel (relative to INITSEG)
 !
 ! index
 !	...
 !	4:	display page
 !	6:	video mode, 1 byte
-!	7:	window width, 1 byte
+!	7:	screen_cols	byte window width
 !	8:	video data, 2 bytes
 !	10:	mono/color, video memory size, 2 bytes 
-!	12:	feature bits, switch settings, 2 bytes
-!	14:	window height, 1 byte
+!	14:	screen_lines	byte window height
 !	15:	VGA present, 1 byte
 !			0 = not present
 !			1 = present
-!	0x20:	Processor type, 1 byte
+!	0x20:	cpu_type	byte Processor type
 !			0  = 8088
 !			1  = 8086
 !			2  = NEC V20
@@ -57,10 +59,9 @@
 !			10 = Pentium PRO
 !			255 = VM86 mode
 !	...
-!	0x2a:	size of the base memory, in kbytes, 2 bytes
-!	0x30:	zero terminated string containing the processor's name, 16 bytes
-!	...
-!	0x50:	zero terminated string containing the cpuid, 13 bytes
+!	0x2a:	mem_kbytes	word	size of base memory in kbytes
+!	0x30:	proc_name	byte[16] processor name string
+!	0x50:	cpu_id		byte[13] cpuid string
 !	...
 !	0x1e2:	part_offset	long Sector offset of booted MBR partition
 !	0x1e6:	elks_magic	long "ELKS"
@@ -92,8 +93,8 @@
 #define KERNEL_MAGICNUMBER MINIX_SPLITID_LOW
 
 #ifndef CONFIG_ROMCODE
-  INITSEG  = DEF_INITSEG	// (DATASEG) we move boot here - out of the way
-  SYSSEG   = DEF_SYSSEG 	// system loaded at 0x10000 (65536).
+  INITSEG  = DEF_INITSEG	// initial setup data seg, we move boot here - out of the way
+  SYSSEG   = DEF_SYSSEG 	// first kernel blob load point before relocation
   SETUPSEG = DEF_SETUPSEG	// this is the current code segment
 #else
   INITSEG  = CONFIG_ROM_SETUP_DATA
@@ -812,7 +813,7 @@ novga:	mov	%al,14		// CGA 25 rows
 	mov	$INITSEG,%ax
 	mov	%ax,%ds
 	call	arch_get_mem	// save base memory size
-	mov	%ax,0x2a
+	mov	%ax,mem_kbytes
 
 	call	bootopts	// load /bootopts into DEF_OPTSEG (0050:0000)
 	ret
@@ -1039,10 +1040,12 @@ v_id3:	.byte 0,0,0,0
 
 #if defined(CONFIG_ARCH_IBMPC) || defined(CONFIG_ARCH_PC98)
 //
-// load /bootopts if FAT filesystem boot
+// load /bootopts for FAT filesystem boot
 //
 // Uses previous boot sector's BPB contents for disk geometry
 // and previous boot sector's buffer which still holds root directory sector.
+// No disk I/O is performed unless /bootopts found.
+// Will fail gracefully on MINIX filesystems, no need for check of fs fstype.
 bootopts:
 	push	%ds
 	push	%es
@@ -1050,7 +1053,7 @@ bootopts:
 	// set ES = boot sector (BPB) address in high memory
 	mov	$INITSEG,%ax
 	mov	%ax,%ds
-	mov	0x2a,%ax	// Kbytes of memory
+	mov	mem_kbytes,%ax	// Kbytes of memory
 	mov	$6,%cl		// to paras
 	shl	%cl,%ax
 	sub	$0x1000,%ax	// find highest aligned 64K
@@ -1076,7 +1079,7 @@ bootopts:
 #else
 	mov	$INITSEG,%ax
 	mov	%ax,%ds
-	mov	0x1fc,%dl	// DL = boot drive
+	mov	root_dev,%dl	// DL = boot drive
 
 	mov	$DEF_OPTSEG,%ax	// ES:BX = DEF_OPTSEG:0
 	mov	%ax,%es
@@ -1110,7 +1113,7 @@ root_ents_to_check = 8			// # dir entries to check for /bootopts
 
 // return logical sector number (LBA) for bootopts file in AX
 //
-// Searches root directory already read into boot sector's buffer to
+// Searches root directory previously read into boot sector's buffer to
 // find starting cluster, then converts to LBA based on boot sector's BPB info.
 get_bootopts_sector:
 	push	%es
@@ -1118,7 +1121,7 @@ get_bootopts_sector:
 	mov	%es:root_ent_cnt,%ax	// push root directory entry count
 	push	%ax
 
-	mov	%es:num_fats,%al	// calculate sectors before root directory
+	mov	%es:num_fats,%al	// calculate # sectors before root directory
 	xor	%ah,%ah
 	mov	%es:fat_sz_16,%bx	// check FAT16 fat size
 	and	%bx,%bx
@@ -1126,7 +1129,7 @@ get_bootopts_sector:
 	mov	%es:fat_sz_32,%bx	// get loword FAT32 fat size instead
 1:	mulw	%bx
 	add	%es:rsvd_sec_cnt,%ax
-	push	%ax			// push sectors before root directory
+	push	%ax			// push # sectors before root directory
 
 	mov	%es:sec_per_clus,%bl	// BL = sectors per cluster
 
@@ -1155,7 +1158,7 @@ find:	add	$0x20,%si		// look for /bootopts in root directory at DS:SI
 	dec	%ax
 	mov	%bl,%cl			// CH = 0, CX = sectors per cluster
 	mul	%cx
-	pop	%bx			// BX = sectors before root directory
+	pop	%bx			// BX = # sectors before root directory
 	add	%ax,%bx
 	pop	%ax			// AX = root directory entry count
 #ifdef CONFIG_IMG_FD1232
@@ -1303,7 +1306,7 @@ arch_set_initseg:
    mov $INITSEG,%ax
    mov %ax,%ds
    call arch_get_mem		// save base memory for bootopts routine
-   mov %ax,0x2a
+   mov %ax,mem_kbytes
 
    call bootopts		// attempting loading /bootopts config file
 

--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -359,7 +359,7 @@ size_error:
 	mov %ax,%es
 
 	mov setup_sects,%al  // setup sector count
-	cbw
+	xor %ah,%ah
 	mov $8,%cl     // to words
 	shl %cl,%ax
 	mov %ax,%cx
@@ -811,8 +811,10 @@ novga:	mov	%al,14		// CGA 25 rows
 
 	mov	$INITSEG,%ax
 	mov	%ax,%ds
-	int	$0x12		// determine the size of the basememory
+	call	arch_get_mem	// save base memory size
 	mov	%ax,0x2a
+
+	call	bootopts	// load /bootopts into DEF_OPTSEG (0050:0000)
 	ret
 
 // Write AL to console, save all other registers
@@ -1035,6 +1037,204 @@ v_id3:	.byte 0,0,0,0
 #endif /* !defined(CONFIG_ROMCODE) || defined(CONFIG_CPU_8086)*/
 #endif /* CONFIG_ARCH_IBMPC*/
 
+#if defined(CONFIG_ARCH_IBMPC) || defined(CONFIG_ARCH_PC98)
+//
+// load /bootopts if FAT filesystem boot
+//
+// Uses previous boot sector's BPB contents for disk geometry
+// and previous boot sector's buffer which still holds root directory sector.
+bootopts:
+	push	%ds
+	push	%es
+
+	// set ES = boot sector (BPB) address in high memory
+	mov	$INITSEG,%ax
+	mov	%ax,%ds
+	mov	0x2a,%ax	// Kbytes of memory
+	mov	$6,%cl		// to paras
+	shl	%cl,%ax
+	sub	$0x1000,%ax	// find highest aligned 64K
+	and	$0xf000,%ax
+	mov	%ax,%es		// ES = boot sector w/BPB
+
+	// set DS = boot sector buffer (rootdir) address in high memory
+#ifdef CONFIG_IMG_FD1232
+	add	$0x40,%ax	// buffer follows boot block in high mem
+#else
+	add	$0x20,%ax	// buffer follows boot block in high mem
+#endif
+	mov	%ax,%ds
+
+	// get bootopts logical sector address (LBA)
+	call	get_bootopts_sector
+	and	%ax,%ax
+	jz	0f
+	call	getchs		// convert LBA in AX to CHS in CX,DH
+
+#ifdef CONFIG_ARCH_PC98
+	stc			// FIXME force error for now
+#else
+	mov	$INITSEG,%ax
+	mov	%ax,%ds
+	mov	0x1fc,%dl	// DL = boot drive
+
+	mov	$DEF_OPTSEG,%ax	// ES:BX = DEF_OPTSEG:0
+	mov	%ax,%es
+	xor	%bx,%bx
+	mov	$0x0201,%ax	// BIOS read disk, 1 sector
+	int	$0x13		// BIOS disk interrupt
+#endif
+
+	jnc	1f
+0:	mov	$'F',%al
+	call	putc
+	jmp	2f
+1:	mov	$' ',%al
+	call	putc
+2:	pop	%es
+	pop	%ds
+	ret
+
+// BPB offsets in boot sector already in high memory
+sec_per_clus	= 13
+rsvd_sec_cnt	= 14
+num_fats	= 16
+root_ent_cnt	= 17
+fat_sz_16	= 22
+sec_per_trk	= 24
+sect_offset	= 28
+num_heads	= 26
+fat_sz_32	= 36
+
+root_ents_to_check = 8			// # dir entries to check for /bootopts
+
+// return logical sector number (LBA) for bootopts file in AX
+//
+// Searches root directory already read into boot sector's buffer to
+// find starting cluster, then converts to LBA based on boot sector's BPB info.
+get_bootopts_sector:
+	push	%es
+
+	mov	%es:root_ent_cnt,%ax	// push root directory entry count
+	push	%ax
+
+	mov	%es:num_fats,%al	// calculate sectors before root directory
+	xor	%ah,%ah
+	mov	%es:fat_sz_16,%bx	// check FAT16 fat size
+	and	%bx,%bx
+	jnz	1f			// nonzero means FAT16 filesystem
+	mov	%es:fat_sz_32,%bx	// get loword FAT32 fat size instead
+1:	mulw	%bx
+	add	%es:rsvd_sec_cnt,%ax
+	push	%ax			// push sectors before root directory
+
+	mov	%es:sec_per_clus,%bl	// BL = sectors per cluster
+
+	push	%cs			// ES = our code segment
+	pop	%es
+
+	mov	$-0x20,%si
+find:	add	$0x20,%si		// look for /bootopts in root directory at DS:SI
+	mov	$'.',%ax
+	call	putc
+	cmp	$root_ents_to_check*0x20,%si
+	jz	no_find
+	mov	$bootopts_name,%di
+	mov	$8+3,%cx
+	push	%si
+	repz
+	cmpsb				// %ds:(%si) with %es:(%di)
+	lodsb				// AL = %ds:(%si)
+	pop	%si
+	jnz	find
+	test	$0b11011000,%al		// check attr for normal (non-dir/volume)
+	jnz	find
+
+	mov	26(%si),%ax		// first cluster number
+	dec	%ax
+	dec	%ax
+	mov	%bl,%cl			// CH = 0, CX = sectors per cluster
+	mul	%cx
+	pop	%bx			// BX = sectors before root directory
+	add	%ax,%bx
+	pop	%ax			// AX = root directory entry count
+#ifdef CONFIG_IMG_FD1232
+	add	$0x1f,%ax
+	mov	$5,%cl
+#else
+	add	$0xf,%ax
+	mov	$4,%cl
+#endif
+	shr	%cl,%ax			// AX = # sectors of root directory
+	add	%bx,%ax			// AX = sector of /bootopts file
+
+	pop	%es
+	ret
+
+no_find:pop	%ax
+	pop	%ax
+	xor	%ax,%ax
+	pop	%es
+	ret
+
+bootopts_name:
+	.ascii	"BOOTOPTS   "
+
+// translate LBA in AX to CHS in CX,DH (for IBM PC)
+getchs:
+	push	%ax
+	mov	$'L',%ax
+	call	putc
+	pop	%ax
+	call	hex4
+
+	xchg	%ax,%bx			// BX = LBA
+	mov	%es:num_heads,%cl	// head max
+	mov	%es:sec_per_trk,%al	// sect max
+	mulb	%cl			// AX = H*S
+	xchg	%ax,%bx			// AX = LBA, BX = H*S
+	xor	%dx,%dx
+	add	%es:sect_offset,%ax	// sect_offset
+	adc	%es:sect_offset+2,%dx	// DX:AX = disk LBA
+	div	%bx			// AX = cylinder, DX = head
+#ifdef CONFIG_ARCH_PC98
+	mov	%al,%cl			// PC-98 cylinder
+#else
+	mov	%al,%ch			// CH = low 8 bits of cylinder
+	ror	%ah
+	ror	%ah
+	mov	%ah,%cl			// CL = high 2 bits of cylinder
+#endif
+	xchg	%ax,%dx			// move head to AX
+	xor	%dx,%dx
+	mov	%es:sec_per_trk,%bx	// BX = sect max
+	div	%bx			// DL = sector - 1
+#ifdef CONFIG_ARCH_PC98
+	inc	%dl			// PC-98 sector
+#else
+	or	%dl,%cl			// stash sector - 1 in CL
+	inc	%cx			// CX = sector
+#endif
+	mov	%al,%dh			// DH = head
+
+	mov	$'C',%ax
+	call	putc
+	mov	%ch,%al
+	call	hex2
+
+	mov	$'H',%ax
+	call	putc
+	mov	%dh,%al
+	call	hex2
+
+	mov	$'S',%ax
+	call	putc
+	mov	%cl,%al
+	call	hex2
+
+	ret
+#endif /* defined(CONFIG_ARCH_IBMPC) || defined(CONFIG_ARCH_PC98)
+
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Architecture specific routines for 8018X
 //	Entry points specific for platform setup of SETUP_xxx variables (see config.h)
@@ -1102,6 +1302,11 @@ arch_set_initseg:
 
    mov $INITSEG,%ax
    mov %ax,%ds
+   call arch_get_mem		// save base memory for bootopts routine
+   mov %ax,0x2a
+
+   call bootopts		// attempting loading /bootopts config file
+
    ret
 
 putc:

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -8,5 +8,5 @@
 #sync=30		# autosync secs
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.sys
 #init=/bin/sh		# singleuser shell
-#console=ttyS0,19200	# serial console
+#console=ttyS0,19200 3	# serial console
 #root=hda1 ro		# root hd partition 1, read-only


### PR DESCRIPTION
First pass, but works well on QEMU.

There is no space left in the FAT boot sector to load /bootopts, so all code was added is in setup.S, which runs directly after the boot sector code. The /bootopt loading routine needs to run prior to setup copying the kernel "blob" or itself to other memory locations due to previous buffer contents being used.

It's a bit tricky, since it uses the leftover memory from the boot sector (for the BPB info) as well as the boot sector buffer (which still contains the volume root directory) to search again and find the starting logical sector number (LBA) of any /bootopts file, then converts that to CHS using the BPB info. This is all done without reading the floppy/hard disk again, for speed. Once found, a single sector read on /bootopts is done directly to the kernel boot options segment 0050:0000.

It seems to work well on all ELKS FAT volumes, including HD and HD MBR, but has been tested on QEMU only.

A PC-98 FAT volume was tested and it seems to find the LBA and convert to CHS (debug display on console of LBA and CHS), but the int 1Bh disk read routine needs to be written, and likely convert the registers from the IBM PC INT 13h CHS format to the int 1bh format. This will likely have to be done by @tyama501 after this PR is committed.

Also found and fixed a few "convert byte to word" errors in boot code.

There will likely be several more cleanup commits of things found during this work, before committing.