### PR TITLE
[fat] Allow mount of some incorrectly formatted FAT volumes

### DIFF
--- a/elks/include/linuxmt/msdos_fs.h
+++ b/elks/include/linuxmt/msdos_fs.h
@@ -41,7 +41,7 @@
 #define MSDOS_DOT    ".          " /* ".", padded to MSDOS_NAME chars */
 #define MSDOS_DOTDOT "..         " /* "..", padded to MSDOS_NAME chars */
 
-#define MSDOS_FAT12 4078 /* maximum number of clusters in a 12 bit FAT */
+#define MSDOS_FAT12_MAX_CLUSTERS    4084 /* maximum number of clusters in a 12 bit FAT */
 
 typedef long cluster_t;
 

--- a/elkscmd/rootfs_template/etc/mount.cfg
+++ b/elkscmd/rootfs_template/etc/mount.cfg
@@ -47,6 +47,8 @@ fstype()
 
 # mount HD partition 1
 #mount -a /dev/hda1 /mnt
+#mkdir /mnt2 || true
+#mount -a /dev/hda2 /mnt2
 
 # mount unpartitioned HD
 #check_filesystem /dev/hda


### PR DESCRIPTION
Allows mounting of FAT disk images with FAT table too small for number of clusters available, identified in https://github.com/jbruchon/elks/issues/1047#issuecomment-1046288133. This appears to be a problem with a FreeDOS mkfat program. 

Allows mounting of image, but limits free space available to prevent eventual FAT table overwrite.

Also fixes slight calculation error in identification of large FAT12 volumes (max 4084 clusters).