### PR TITLE
[kernel] Check for 386 CPU before enabling A20 for XMS buffers

### DIFF
--- a/elks/arch/i86/lib/unreal.S
+++ b/elks/arch/i86/lib/unreal.S
@@ -33,6 +33,7 @@
 	.code16
 	.text
 
+	.global	check_unreal_mode
 	.global	enable_unreal_mode
 	.global	enable_a20_gate
 	.global	verify_a20
@@ -40,11 +41,10 @@
 	.global	linear32_fmemcpyw
 	.global	linear32_fmemcpyb
 
-# Try to set unreal mode. Currently requires 386 CPU or better.
-# Returns 0 if OK, otherwise error code (1=not 386, 2=in V86 mode).
-enable_unreal_mode:
-# check for 32-bit CPU
-	pushf
+# Check if unreal mode capable. Currently requires 32-bit CPU (386+)
+# Returns 1 if OK, otherwise error code (-1=not 386, -2=in V86 mode).
+check_unreal_mode:
+	pushf			# check for 32-bit CPU
 		pushf
 		popw %bx        # old FLAGS -> BX
 		movw %bx,%ax
@@ -64,6 +64,17 @@ enable_unreal_mode:
 	andb $1,%bl
 	jne	in_vm86mode
 
+	mov	$1,%ax		# unreal mode capable, return 1
+	ret
+not_32bit:
+	mov	$-1,%ax		# requires 32 bit CPU
+	ret
+in_vm86mode:
+	mov	$-2,%ax		# CPU in V86 mode
+	ret
+
+# Put CPU in unreal mode. Requires 32-bit CPU (386+) to call!
+enable_unreal_mode:
 # point gdt_ptr to gdt
 	xorl %eax,%eax
 	movw %ds,%ax
@@ -101,13 +112,6 @@ enable_unreal_mode:
 	popf			# restore interrupt status
 
 	mov	$1,%ax		# system is in unreal mode, return 1
-	ret
-
-not_32bit:
-	mov	$-1,%ax		# requires 32 bit CPU
-	ret
-in_vm86mode:
-	mov	$-2,%ax		# CPU in V86 mode
 	ret
 
 # Attempt to enable A20 address gate, return 0 on fail

--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -44,21 +44,25 @@ int xms_init(void)
 	int enabled;
 
 	/* display initial A20 and A20 enable result */
-	printk("xms: A20 was %s", verify_a20()? "on" : "off");
+	printk("xms: ");
+#ifndef CONFIG_FS_XMS_INT15
+	if (check_unreal_mode() <= 0) {
+		printk("disabled, requires 386, ");
+		return 0;
+	}
+#endif
+	printk("A20 was %s", verify_a20()? "on" : "off");
 	enable_a20_gate();
 	enabled = verify_a20();
 	printk(" now %s, ", enabled? "on" : "off");
+	if (!enabled) {
+		printk("disabled, A20 error, ");
+		return 0;
+	}
 #ifdef CONFIG_FS_XMS_INT15
 	printk("using int 15/1F, ");
 #else
-	if (!enabled) {
-		printk("xms disabled, A20 error,");
-		return 0;
-	}
-	if (enable_unreal_mode() <= 0) {
-		printk("xms disabled, requires 386,");
-		return 0;
-	}
+	enable_unreal_mode();
 	printk("using unreal mode, ");
 #endif
 	xms_enabled = 1;	/* enables xms_fmemcpyw()*/

--- a/elks/include/linuxmt/memory.h
+++ b/elks/include/linuxmt/memory.h
@@ -32,7 +32,8 @@ word_t fmemcmpw (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg, s
 #define _MK_FP(seg,off)	((void __far *)((((unsigned long)(seg)) << 16) | (off)))
 
 /* unreal mode, A20 gate management */
-int enable_unreal_mode(void);	/* returns > 0 on success */
+int check_unreal_mode(void);	/* check if unreal mode capable, returns > 0 on success */
+void enable_unreal_mode(void);	/* requires 386+ CPU to call */
 int enable_a20_gate(void);	/* returns 0 on fail */
 int verify_a20(void);		/* returns 0 if a20 disabled */
 

--- a/elkscmd/sys_utils/unreal16.S
+++ b/elkscmd/sys_utils/unreal16.S
@@ -54,7 +54,7 @@ _start:
 	mov	$trying_unreal_msg,%si
 	call	puts
 
-	call	enable_unreal_mode
+	call	check_unreal_mode
 	cmp	$-1,%ax
 	jnz	1f
 	mov     $needs_386_msg,%si
@@ -65,7 +65,8 @@ _start:
 	jmp	msg_and_exit
 
 # demo use of 32-bit address by copying stuff directly to memory-mapped screen
-2:      push    %es
+2:      call	enable_unreal_mode
+	push    %es
 	cli			# interrupts off - trashes ESI/EDI/ECX
         xor     %di,%di
         mov     %di,%es


### PR DESCRIPTION
Should fix #1168.

