### PR TITLE
image/.gitignore: add *.img

### DIFF
--- a/image/.gitignore
+++ b/image/.gitignore
@@ -1,5 +1,6 @@
 # Image files
 *.bin
+*.img
 
 # Temporary files
 romfs.devices


### PR DESCRIPTION
This adds *.img files to .gitignore, as they are created, when compiling ELKS. As they are re-created on each recompilation, it makes sense to add them here.

Signed-off-by: Conrad Kostecki <conikost@gentoo.org>