### PR TITLE
tools/Makefile: add --disable-werror

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -50,7 +50,7 @@ $(BUILDDIR)/.binutils.src: $(DISTDIR)/$(BINUTILS_DIST).tar.gz
 $(BUILDDIR)/.binutils.build: $(BUILDDIR)/.binutils.src
 	cd $(BUILDDIR) && rm -rf binutils-build
 	mkdir -p $(BUILDDIR)/binutils-build
-	cd $(BUILDDIR)/binutils-build && ../binutils-src/configure --target=ia16-elf --prefix="$(CROSSDIR)" --enable-ld=default --enable-gold=yes --enable-targets=ia16-elf --enable-x86-hpa-segelf=yes --disable-gdb --disable-libdecnumber --disable-readline --disable-sim --disable-nls
+	cd $(BUILDDIR)/binutils-build && ../binutils-src/configure --target=ia16-elf --prefix="$(CROSSDIR)" --enable-ld=default --enable-gold=yes --enable-targets=ia16-elf --enable-x86-hpa-segelf=yes --disable-gdb --disable-libdecnumber --disable-readline --disable-sim --disable-nls --disable-werror
 	$(MAKE) -C $(BUILDDIR)/binutils-build $(PARALLEL)
 	touch $(BUILDDIR)/.binutils.build
 


### PR DESCRIPTION
Don't set warnings as errors, as it will fail on newer GCC.

Closes: https://github.com/jbruchon/elks/issues/1169
Signed-off-by: Conrad Kostecki <conikost@gentoo.org>