### PR TITLE
[kernel] Move autosync from kernel to /bin/init

### DIFF
--- a/elks/arch/i86/kernel/signal.c
+++ b/elks/arch/i86/kernel/signal.c
@@ -70,6 +70,9 @@ int do_signal(void)
 	    //debug_sig("Stack at %x\n", currentp->t_regs.sp);
 	    *sd = SIGDISP_DFL;
 	    debug_sig("SIGNAL reset pending signals\n");
+	    if (currentp->signal)
+		printk("SIGNAL(%d) ignoring signal (mask=%s)\n",
+		    currentp->pid, currentp->signal);
 	    currentp->signal = 0;
 
 	    return 1;

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -172,7 +172,7 @@ printk("FAT: me=%x,csz=%d,#f=%d,floc=%d,fsz=%d,rloc=%d,#d=%d,dloc=%d,#s=%ld,ts=%
 	sb->data_start, total_sectors, b->total_sect);
 
 	/* calculate max clusters based on FAT table size */
-	max_clusters = (unsigned long)sb->fat_length *
+	max_clusters = (cluster_t)sb->fat_length *
 		(SECTOR_SIZE_SB(s) * 8 / sb->fat_bits) - 2;
 	/*
 	 * Allow disks created with too small a FAT to be mounted, but limit free space.

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -29,7 +29,6 @@ int root_mountflags = 0;
 #endif
 int net_irq, net_port;
 static int boot_console;
-static int sync_interval;
 static char bininit[] = "/bin/init";
 static char *init_command = bininit;
 
@@ -71,17 +70,11 @@ void start_kernel(void)
     /*
      * We are now the idle task. We won't run unless no other process can run.
      */
-	jiff_t wake = jiffies;
     while (1) {
         schedule();
 #ifdef CONFIG_IDLE_HALT
         idle_halt ();
 #endif
-		/* sync all devices if sync= set in /bootopts */
-		if (sync_interval && jiffies >= wake) {
-			fsync_dev(0);
-			wake = jiffies + sync_interval * HZ;
-		}
     }
 }
 
@@ -328,10 +321,6 @@ static int INITPROC parse_options(void)
 		}
 		if (!strncmp(line,"bufs=",5)) {
 			boot_bufs = (int)simple_strtol(line+5, 10);
-			continue;
-		}
-		if (!strncmp(line,"sync=",5)) {
-			sync_interval = (int)simple_strtol(line+5, 10);
 			continue;
 		}
 		

--- a/elkscmd/sys_utils/init.c
+++ b/elkscmd/sys_utils/init.c
@@ -34,6 +34,7 @@
 #include <memory.h>
 #include <errno.h>
 #include <time.h>
+#include <paths.h>
 
 #define USE_UTMP	0	/* =1 to use /var/run/utmp*/
 #define DEBUG		0	/* =1 for debug messages*/
@@ -47,10 +48,12 @@
 #endif
 
 #define BUFSIZE      256
-#define INITTAB      "/etc/inittab"
-#define INITLVL      "/etc/initlvl"
-#define SHELL        "/bin/sh"
-#define GETTY        "/bin/getty"
+#define INITTAB      _PATH_INITTAB
+#define INITLVL      _PATH_INITLVL
+#define SHELL        _PATH_BSHELL
+#define GETTY        _PATH_GETTY
+#define ENV_SYNC     "sync"		/* sync= /bootopts env var override */
+#define SYNC_DEFAULT 0			/* default sync timer */
 #define MAXCHILD     8
 
 /* 'hashed' strings */
@@ -94,6 +97,7 @@ static struct tabentry children[MAXCHILD], *nextchild=children, *thisOne;
 static char runlevel;
 static char prevRunlevel;
 static char nosysinit;
+static int sync_interval = SYNC_DEFAULT;
 #if USE_UTMP
 static struct utmp utentry;
 #endif
@@ -464,9 +468,10 @@ void handle_signal(int sig)
 	char c;
 
 	debug("signaled %d\r\n", sig);
-	signal(SIGHUP, handle_signal);
 	switch(sig) {
 	case SIGHUP:
+		signal(SIGHUP, handle_signal);
+
 		/* got signaled by another instance of init, change runlevel! */
 		fd = open(INITLVL, O_RDONLY);
 		if (fd < 0) {
@@ -491,6 +496,11 @@ void handle_signal(int sig)
 			scanFile(enterRunlevel);
 		}
 		break;
+	case SIGALRM:
+		signal(SIGALRM, handle_signal);
+		sync();
+		alarm(sync_interval);
+		break;
 	}
 }
 
@@ -499,6 +509,7 @@ int main(int argc, char **argv)
 	pid_t pid;
 	int ac = argc;
 	char **av = argv;
+	char *p;
 
 //	argv[0] = "init";
 	initname = argv[0];
@@ -537,6 +548,7 @@ int main(int argc, char **argv)
 	/* am I the No.1 init? */
 	if (getpid() == 1) {
 		signal(SIGHUP, handle_signal);
+		signal(SIGALRM, handle_signal);
 #if USE_UTMP
 		setutent();
 #endif
@@ -565,6 +577,11 @@ int main(int argc, char **argv)
 		close(1);
 		close(2);
 #endif
+		/* setup buffer auto-sync using /bootopts env var */
+		if ((p = getenv(ENV_SYNC)) != NULL)
+			sync_interval = atoi(p);
+		alarm(sync_interval);
+
 		/* endless loop waiting for signals or child exit*/
 		while (1) {
 			pid = wait(NULL);

--- a/elkscmd/sys_utils/init.c
+++ b/elkscmd/sys_utils/init.c
@@ -200,6 +200,7 @@ void scanFile(void func())
 	char buf[BUFSIZE+1];
 	FILE *fp;
 
+	alarm(0);	/* eliminate possibility of interrupted fgets read */
 	fp = fopen(INITTAB, "r");
 	if (!fp) fatalmsg("Missing %s\r\n", INITTAB);
 
@@ -209,6 +210,7 @@ void scanFile(void func())
 		parseLine(buf, func);
 	}
 	fclose(fp);
+	alarm(sync_interval);
 }
 
 /* returns a pointer to the child or NULL */
@@ -498,6 +500,7 @@ void handle_signal(int sig)
 		break;
 	case SIGALRM:
 		signal(SIGALRM, handle_signal);
+		debug("SYNC\r\n");
 		sync();
 		alarm(sync_interval);
 		break;

--- a/libc/include/paths.h
+++ b/libc/include/paths.h
@@ -4,6 +4,7 @@
 #define	___PATHS_H
 
 
+#define	_PATH_GETTY	"/bin/getty"
 #define	_PATH_LOGIN	"/bin/login"
 #define	_PATH_BSHELL	"/bin/sh"
 #define	_PATH_DEFPATH	"/bin:."
@@ -15,6 +16,8 @@
 #define _PATH_LOCALE	"/lib/locale"
 #define _PATH_MANPAGES	"/lib"
 #define _PATH_HOSTNAME	"/etc/hostname"
+#define _PATH_INITLVL	"/etc/initlvl"
+#define _PATH_INITTAB	"/etc/inittab"
 #define _PATH_ISSUE	"/etc/issue"
 #define _PATH_MOTD	"/etc/motd"
 #define _PATH_ERRSTRING	"/etc/perror"

--- a/libc/stdio/vfprintf.c
+++ b/libc/stdio/vfprintf.c
@@ -224,6 +224,7 @@ vfprintf(FILE *op, const char *fmt, va_list ap)
 
 	 case 's':		/* String */
 	    ptmp = va_arg(ap, char*);
+	    if (!ptmp) ptmp = "(null)";
 	  nopad:
 	    sign = '\0';
 	    pad = ' ';


### PR DESCRIPTION
Moves kernel buffer auto-sync code out of idle task into /bin/init. Takes same sync= /bootopts parameter, so no change to the user. If it is decided that auto-sync should be turned on without /bootopts, this is also easily possible by setting a define in init.c.

It was realized that the idle task cannot be actually call sync, the way a user program does, as there is a possibility that the kernel sync code may sleep the task, which is not allowed for the idle task. So, sync() is now called from /bin/init, which uses an alarm() signal for its timer callback.

@Mellvik, the auto-sync is now in application code, so it can be played with more easily, if desired. Unfortunately, there is no easy way to determine the number of dirty (need-to-be-written) system buffers, so a fancy algorithm isn't (yet) possible. We couldn't easily do this in the kernel either, without an expensive count through all the buffer headers every second or so either, so an improvement is yet unsolved. Perhaps the timer should be set equal to the max amount of time considered acceptable for a user to wait for writing disk sectors at full speed. That will certainly be less than 30 seconds, and the sectors need to be written eventually anyways and doesn't slow down an end-to-end copy. Setting to a value like 10 seconds may be help, and also allow for more interactivity (echo) in between intensive writing.

Also fixes a few small other issues:
- C library actually dereferenced NULL pointer when calling printf("%s", 0).
- Added kernel printk in the case that multiple signals are accumulated, waiting for application callback; this is not currently supported, but no indication was given to user. (May not ever happen).
- /bin/init uses new paths.h header for common system file locations.
- Minor cleanup in FAT code.