### PR TITLE
[cmds] Update man page display features

### DIFF
--- a/elks/arch/i86/drivers/char/console-direct.c
+++ b/elks/arch/i86/drivers/char/console-direct.c
@@ -23,6 +23,7 @@
 
 #define A_DEFAULT 	0x07
 #define A_BOLD 		0x08
+#define A_UNDERLINE 	0x07	/* only works on MDA, normal video on EGA */
 #define A_BLINK 	0x80
 #define A_REVERSE	0x70
 #define A_BLANK		0x00

--- a/elks/arch/i86/drivers/char/console.c
+++ b/elks/arch/i86/drivers/char/console.c
@@ -171,6 +171,11 @@ static void AnsiCmd(register Console * C, char c)
 	    case 1:
 		C->attr |= A_BOLD;
 		break;
+	    case 4:
+		n = C->attr;
+		C->attr &= ~(A_DEFAULT | A_REVERSE);
+		C->attr |= A_UNDERLINE;
+		break;
 	    case 5:
 		C->attr |= A_BLINK;
 		break;

--- a/elkscmd/sys_utils/man.c
+++ b/elkscmd/sys_utils/man.c
@@ -34,6 +34,16 @@
 #include <string.h>
 #include <paths.h>
 
+/* default .TH [extra1] value */
+#define DEFAULT_EXTRA1	"ELKS Embeddable Linux Kernel Subset"
+
+/* font translations to ANSI sequences (\fB -> bold, \fI -> underline) */
+#define ANSI_NORMAL	 "\e[0m"	/* no attribute */
+#define ANSI_BOLD	 "\e[1m"	/* bold */
+#define ANSI_UNDERLINE   "\e[4m"	/* underline (normal on console for now) */
+//#define ANSI_UNDERLINE "\e[7m"	/* reverse video */
+//#define ANSI_UNDERLINE "\e[32m"	/* green */
+
 FILE * ofd = stdout;
 FILE * ifd = stdin;
 int ifd_class = 0;		/* Type of ifd, 0=stdin, 1=file, 2=pipe */
@@ -680,6 +690,9 @@ void build_headers(void)
 
    /* Ok we should have upto 5 arguments build the header and footer */
 
+   if (buffer[2][0] == 0)
+      strcpy(buffer[2], DEFAULT_EXTRA1);	/* header middle */
+
    memset(little_header, ' ', right_margin);
 
    memset(line_header, ' ', right_margin);
@@ -695,8 +708,9 @@ void build_headers(void)
    if (ch > right_margin) ch = right_margin-12;
    memcpy(line_header+right_margin/2-ch/2, buffer[4], ch);
 
-   memcpy(little_header, line_header, right_margin/2+ch/2+1);
-   strcpy(little_header+right_margin-strlen(buffer[2]), buffer[2]);
+   //memcpy(little_header, line_header, right_margin/2+ch/2+1);
+   memcpy(little_header, line_header, right_margin);
+   //strcpy(little_header+right_margin-strlen(buffer[2]), buffer[2]);
 
    memset(line_footer, ' ', right_margin-6);
    line_footer[right_margin-6] = 0;
@@ -705,6 +719,7 @@ void build_headers(void)
    ch = strlen(buffer[2]);
    if (ch > right_margin) ch = right_margin-12;
    memcpy(line_footer+right_margin/2-ch/2, buffer[2], ch);
+   memcpy(little_header+right_margin/2-ch/2, buffer[2], ch);
 
    do_skipeol();
 }
@@ -858,12 +873,13 @@ void line_break(void)
 	    fputc(' ', ofd);
       }
       else switch (ch >> 8) {
-      case 2:
-         //fputc(ch&0xFF, ofd); fputc('\b', ofd); fputc(ch&0xFF, ofd); break;
-         fputs("\e[1m", ofd); fputc(ch&0xFF, ofd); fputs("\e[0m", ofd); break;
-      case 3:
-         //fputc('_', ofd); fputc('\b', ofd); fputc(ch&0xFF, ofd); break;
-         fputs("\e[7m", ofd); fputc(ch&0xFF, ofd); fputs("\e[0m", ofd); break;
+      case 2:	/* \fB (bold) -> ANSI bold */
+         /*fputc(ch&0xFF, ofd); fputc('\b', ofd); fputc(ch&0xFF, ofd); break;*/
+         fputs(ANSI_BOLD, ofd); fputc(ch&0xFF, ofd); fputs(ANSI_NORMAL, ofd); break;
+      case 3:	/* \fI (italic) -> ANSI underline */
+         /*fputc('_', ofd); fputc('\b', ofd); fputc(ch&0xFF, ofd); break;*/
+         fputs(ANSI_UNDERLINE, ofd); fputc(ch&0xFF, ofd); fputs(ANSI_NORMAL, ofd); break;
+      case 1:	/* roman -> no action */
       default:
          fputc(ch&0xFF, ofd); break;
       }


### PR DESCRIPTION
Adds more configurable ways of customizing `man` output. The \fB (bold) and \fI (italic) are now translated to ANSI_BOLD and ANSI_UNDERLINE sequences, which are defines for easy changing. Underline does nothing on EGA, but works on MDA and serial output to a terminal emulator. Using reverse video for command parameters rather than underline was removed.

In addition, the .TH (title head) macro is now displayed with the command and section name on both sides of the header, as well as a default "ELKS Embeddable Linux Kernel Subset" displayed in the middle, by default (no parameters). The default middle (extra1) parameter is also easily customizable with the DEFAULT_EXTRA1 define.

`man` outputs a slightly different format for the header line, and adds a footer line, when outputting to a file rather than a TTY.

The ANSI underline sequence ESC [ 4 m was added to direct and BIOS consoles.

Screenshot of terminal emulator on serial port showing working underline:
<img width="752" alt="Screen Shot 2022-02-24 at 7 04 21 PM" src="https://user-images.githubusercontent.com/11985637/155641036-b5af8433-1589-4939-8a1c-9b9325b1fabe.png">

ELKS Console (no underline):
<img width="832" alt="Screen Shot 2022-02-24 at 7 07 27 PM" src="https://user-images.githubusercontent.com/11985637/155641123-b11a4d95-99a7-451c-bbd1-63209e6a8878.png">

(And yes, the login.8 page is definitely out of date and needs updating :)