### PR TITLE
[kernel] Add ustatfs syscall, allows mount to display free space and mount points

### DIFF
--- a/elks/arch/i86/kernel/syscall.dat
+++ b/elks/arch/i86/kernel/syscall.dat
@@ -89,7 +89,8 @@ insmod		65	1	- Removed support for modules
 fchown		+66	3
 dlload		+67	2	- Removed support for dynamic libraries
 setsid		+68	0
-sbrk        +69 2	* Legacy number from Linux
+sbrk		+69	2	* Legacy number from Linux
+ustatfs		+70	2
 knlvsn		+74	1
 #
 # From /usr/include/asm-generic/unistd.h

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -28,7 +28,6 @@
  *			for details.
  */
 
-#include <linuxmt/vfs.h>
 #include <linuxmt/types.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/fcntl.h>

--- a/elks/fs/minix/bitmap.c
+++ b/elks/fs/minix/bitmap.c
@@ -17,8 +17,6 @@
 
 #include <arch/bitops.h>
 
-#ifdef BLOAT_FS
-
 static char nibblemap[] = { 0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4 };
 
 static unsigned short count_used(struct buffer_head *map[],
@@ -41,8 +39,7 @@ static unsigned short count_used(struct buffer_head *map[],
 	    numbits = 0;
 	}
 	for (j = 0; j < end; j++)
-	    sum += nibblemap[bh->b_data[j] & 0xf]
-		+ nibblemap[(bh->b_data[j] >> 4) & 0xf];
+	    sum += nibblemap[bh->b_data[j] & 0xf] + nibblemap[(bh->b_data[j] >> 4) & 0xf];
 	unmap_buffer(bh);
     }
     return sum;
@@ -51,18 +48,16 @@ static unsigned short count_used(struct buffer_head *map[],
 unsigned short minix_count_free_blocks(register struct super_block *sb)
 {
     return (sb->u.minix_sb.s_nzones -
-			count_used(sb->u.minix_sb.s_zmap, sb->u.minix_sb.s_zmap_blocks, sb->u.minix_sb.s_nzones))
-			<< sb->u.minix_sb.s_log_zone_size;
+	count_used(sb->u.minix_sb.s_zmap, sb->u.minix_sb.s_zmap_blocks,
+	    sb->u.minix_sb.s_nzones)) << sb->u.minix_sb.s_log_zone_size;
 }
-
 
 unsigned short minix_count_free_inodes(register struct super_block *sb)
 {
     return (sb->u.minix_sb.s_ninodes -
-			count_used(sb->u.minix_sb.s_imap, sb->u.minix_sb.s_imap_blocks, sb->u.minix_sb.s_ninodes));
+	count_used(sb->u.minix_sb.s_imap, sb->u.minix_sb.s_imap_blocks,
+	    sb->u.minix_sb.s_ninodes));
 }
-
-#endif
 
 void minix_free_block(register struct super_block *sb, unsigned short block)
 {

--- a/elks/fs/minix/inode.c
+++ b/elks/fs/minix/inode.c
@@ -98,10 +98,8 @@ static struct super_operations minix_sops = {
     minix_put_inode,
     minix_put_super,
     minix_write_super,
-    minix_remount
-#ifdef BLOAT_FS
+    minix_remount,
     minix_statfs
-#endif
 };
 
 static void minix_mount_warning(register struct super_block *sb, char *prefix)
@@ -238,22 +236,16 @@ struct super_block *minix_read_super(register struct super_block *s, char *data,
     return NULL;
 }
 
-#ifdef BLOAT_FS
-void minix_statfs(register struct super_block *sb, struct statfs *buf, int bufsiz)
+void minix_statfs(struct super_block *s, struct statfs *sf)
 {
-    struct statfs tmp;
-
-    tmp.f_type = sb->s_magic;
-    tmp.f_bsize = BLOCK_SIZE;
-    tmp->f_blocks = (sb->u.minix_sb.s_nzones - sb->u.minix_sb.s_firstdatazone) << sb->u.minix_sb.s_log_zone_size;
-    tmp.f_bfree = minix_count_free_blocks(sb);
-    tmp.f_bavail = tmp.f_bfree;
-    tmp.f_files = (long) sb->u.minix_sb.s_ninodes;
-    tmp.f_ffree = minix_count_free_inodes(sb);
-    tmp.f_namelen = sb->u.minix_sb.s_namelen;
-    memcpy(buf, &tmp, bufsiz);
+    sf->f_bsize = BLOCK_SIZE;
+    sf->f_blocks = (s->u.minix_sb.s_nzones - s->u.minix_sb.s_firstdatazone)
+		<< s->u.minix_sb.s_log_zone_size;
+    sf->f_bfree = 0; //minix_count_free_blocks(s);
+    sf->f_bavail = 0; //sf->f_bfree;
+    sf->f_files = s->u.minix_sb.s_ninodes;
+    sf->f_ffree = 0; //minix_count_free_inodes(s);
 }
-#endif
 
 /* Adapted from Linux 0.12's inode.c.  _bmap() is a big function, I know
 

--- a/elks/fs/minix/inode.c
+++ b/elks/fs/minix/inode.c
@@ -239,12 +239,11 @@ struct super_block *minix_read_super(register struct super_block *s, char *data,
 void minix_statfs(struct super_block *s, struct statfs *sf)
 {
     sf->f_bsize = BLOCK_SIZE;
-    sf->f_blocks = (s->u.minix_sb.s_nzones - s->u.minix_sb.s_firstdatazone)
-		<< s->u.minix_sb.s_log_zone_size;
-    sf->f_bfree = 0; //minix_count_free_blocks(s);
-    sf->f_bavail = 0; //sf->f_bfree;
+    sf->f_blocks = s->u.minix_sb.s_nzones << s->u.minix_sb.s_log_zone_size;
+    sf->f_bfree = minix_count_free_blocks(s);
+    sf->f_bavail = sf->f_bfree;
     sf->f_files = s->u.minix_sb.s_ninodes;
-    sf->f_ffree = 0; //minix_count_free_inodes(s);
+    sf->f_ffree = minix_count_free_inodes(s);
 }
 
 /* Adapted from Linux 0.12's inode.c.  _bmap() is a big function, I know

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -241,15 +241,17 @@ printk("FAT: me=%x,csz=%d,#f=%d,floc=%d,fsz=%d,rloc=%d,#d=%d,dloc=%d,#s=%ld,ts=%
 
 static void msdos_statfs(struct super_block *s,struct statfs *sf)
 {
-	cluster_t cluster, cluster_size, free;
+	cluster_t cluster, cluster_size, total, free;
 
 	cluster_size = MSDOS_SB(s)->cluster_size;
 	sf->f_bsize = SECTOR_SIZE_SB(s);
-	sf->f_blocks = MSDOS_SB(s)->clusters * cluster_size;
+	total  = (MSDOS_SB(s)->clusters * cluster_size) + MSDOS_SB(s)->data_start;
+	sf->f_blocks = total >> (BLOCK_SIZE_BITS - SECTOR_BITS_SB(s));
 	free = 0;
 	for (cluster = 2; cluster < MSDOS_SB(s)->clusters + 2; cluster++)
 		if (!fat_access(s, cluster, -1))
 			free += cluster_size;
+	free >>= (BLOCK_SIZE_BITS - SECTOR_BITS_SB(s));
 	sf->f_bfree = free;
 	sf->f_bavail = free;
 	sf->f_files = 0;

--- a/elks/fs/open.c
+++ b/elks/fs/open.c
@@ -4,7 +4,6 @@
  *  Copyright (C) 1991, 1992  Linus Torvalds
  */
 
-#include <linuxmt/vfs.h>
 #include <linuxmt/types.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/fcntl.h>
@@ -24,15 +23,13 @@
 
 #if 0
 
-int sys_statfs(char *path, register struct statfs *buf)
+int sys_statfs(char *path, register struct statfs *ubuf)
 {
-    register struct inode *inode;
+    struct super_block *s;
+    struct inode *inode;
     int error;
-    struct statfs tmp;
+    struct statfs sbuf;
 
-    error = verify_area(VERIFY_WRITE, buf, sizeof(struct statfs));
-    if (error)
-	return error;
     error = namei(path, &inode, 0, 0);
     if (error)
 	return error;
@@ -40,10 +37,15 @@ int sys_statfs(char *path, register struct statfs *buf)
 	iput(inode);
 	return -ENOSYS;
     }
-    inode->i_sb->s_op->statfs_kern(inode->i_sb, &tmp, sizeof(struct statfs));
+    s = inode->i_sb;
+    s->s_op->statfs_kern(inode->i_sb, &sbuf);
+    sbuf.f_type = s->s_type->type;
+    sbuf.f_flags = s->s_flags;
+    memcpy(sbuf.f_mntonname, s->s_mntonname, MNAMELEN);
+
     iput(inode);
-    memcpy(buf, &tmp, sizeof(tmp));
-    return 0;
+
+    return verified_memcpy_tofs(ubuf, &sbuf, sizeof(sbuf));
 }
 
 int do_truncate(register struct inode *inode, loff_t length)

--- a/elks/fs/open.c
+++ b/elks/fs/open.c
@@ -41,6 +41,7 @@ int sys_statfs(char *path, register struct statfs *ubuf)
     s->s_op->statfs_kern(inode->i_sb, &sbuf);
     sbuf.f_type = s->s_type->type;
     sbuf.f_flags = s->s_flags;
+    sbuf.f_dev = s->s_dev;
     memcpy(sbuf.f_mntonname, s->s_mntonname, MNAMELEN);
 
     iput(inode);

--- a/elks/fs/romfs/romfs.c
+++ b/elks/fs/romfs/romfs.c
@@ -285,25 +285,19 @@ static void romfs_read_inode (struct inode * i)
 /* Nothing to do */
 
 static void romfs_put_super (struct super_block * sb)
-	{
+{
 	lock_super (sb);
 	sb->s_dev = 0;
 	unlock_super (sb);
-	}
-
-
-#ifdef BLOAT_FS
-static void romfs_statfs(struct super_block *sb, struct statfs *buf, size_t bufsize)
-{
-    struct statfs tmp;
-
-    memset(&tmp, 0, sizeof(tmp));
-    tmp.f_type = ROMFS_MAGIC;
-    tmp.f_bsize = ROMBSIZE;
-    tmp.f_blocks = (sb->u.romfs_sb.s_maxsize + ROMBSIZE - 1) >> ROMBSBITS;
-    memcpy(buf, &tmp, bufsize);
 }
-#endif
+
+
+static void romfs_statfs(struct super_block *s, struct statfs *sf)
+{
+	memset(sf, 0, sizeof(struct statfs));
+	sf->f_bsize = ROMBSIZE;
+	sf->f_blocks = (sb->u.romfs_sb.s_maxsize + ROMBSIZE - 1) >> ROMBSBITS;
+}
 
 
 static struct super_operations romfs_super_ops =
@@ -313,10 +307,8 @@ static struct super_operations romfs_super_ops =
 	NULL,  /* put inode */
 	romfs_put_super,
 	NULL,  /* write super */
-	NULL   /* remount */
-#ifdef BLOAT_FS
+	NULL,  /* remount */
 	romfs_statfs
-#endif
 };
 
 

--- a/elks/include/arch/statfs.h
+++ b/elks/include/arch/statfs.h
@@ -6,10 +6,11 @@
 struct statfs {
 	int	f_type;		/* filesystem type */
 	unsigned short f_flags;	/* copy of mount flags */
-	long	f_bsize;	/* block (or sector) size */
-	long	f_blocks;	/* total data blocks in filesystem */
-	long	f_bfree;	/* free data blocks in filesystem */
-	long	f_bavail;	/* free blocks available to non-superuser */
+	dev_t	f_dev;		/* device number */
+	long	f_bsize;	/* sector size */
+	long	f_blocks;	/* total 1K blocks in filesystem */
+	long	f_bfree;	/* free 1K blocks in filesystem */
+	long	f_bavail;	/* free 1K blocks available to non-superuser */
 	long	f_files;	/* total file nodes (inodes) in filesystem */
 	long	f_ffree;	/* free file nodes in filesystem */
 	char	f_mntonname[MNAMELEN]; /* directory on which mounted */

--- a/elks/include/arch/statfs.h
+++ b/elks/include/arch/statfs.h
@@ -1,21 +1,18 @@
 #ifndef __ARCH_8086_STATFS_H
 #define __ARCH_8086_STATFS_H
 
-typedef struct {
-    long	val[2];
-} fsid_t;
+#define MNAMELEN	32	/* length of buffer for returned name */
 
 struct statfs {
-    long	f_type;
-    long	f_bsize;
-    long	f_blocks;
-    long	f_bfree;
-    long	f_bavail;
-    long	f_files;
-    long	f_ffree;
-    fsid_t	f_fsid;
-    long	f_namelen;
-    long	f_spare[6];
+	int	f_type;		/* filesystem type */
+	unsigned short f_flags;	/* copy of mount flags */
+	long	f_bsize;	/* block (or sector) size */
+	long	f_blocks;	/* total data blocks in filesystem */
+	long	f_bfree;	/* free data blocks in filesystem */
+	long	f_bavail;	/* free blocks available to non-superuser */
+	long	f_files;	/* total file nodes (inodes) in filesystem */
+	long	f_ffree;	/* free file nodes in filesystem */
+	char	f_mntonname[MNAMELEN]; /* directory on which mounted */
 };
 
 #endif

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -10,13 +10,13 @@
 #include <linuxmt/config.h>
 #include <linuxmt/types.h>
 #include <linuxmt/wait.h>
-#include <linuxmt/vfs.h>
 #include <linuxmt/kdev_t.h>
 #include <linuxmt/ioctl.h>
 #include <linuxmt/net.h>
 #include <linuxmt/memory.h>
 
 #include <arch/bitops.h>
+#include <arch/statfs.h>
 
 #ifdef CONFIG_PIPE
 #include <linuxmt/pipe_fs_i.h>
@@ -260,10 +260,11 @@ struct super_block {
     unsigned char		s_dirt;
     struct file_system_type	*s_type;
     struct super_operations	*s_op;
-    unsigned short int		s_flags;
+    unsigned short 		s_flags;
     struct inode		*s_covered;
     struct inode		*s_mounted;
     struct wait_queue		s_wait;
+    char			s_mntonname[MNAMELEN];
 #ifdef BLOAT_FS
     unsigned char		s_rd_only;
     __u32			s_magic;
@@ -340,8 +341,8 @@ struct super_operations {
     void			(*put_super) ();
     void			(*write_super) ();
     int 			(*remount_fs) ();
-#ifdef BLOAT_FS	/* i8086 statfs goes to kernel, then user */
     void			(*statfs_kern) ();
+#ifdef BLOAT_FS
     int 			(*notify_change) ();
 #endif
 };

--- a/elks/include/linuxmt/minix_fs.h
+++ b/elks/include/linuxmt/minix_fs.h
@@ -75,8 +75,8 @@ struct minix_dir_entry {
 
 extern unsigned short minix_bmap(register struct inode *,block_t,int);
 extern struct buffer_head *minix_bread(struct inode *,block_t,int);
-extern unsigned long minix_count_free_blocks(register struct super_block *);
-extern unsigned long minix_count_free_inodes(register struct super_block *);
+extern unsigned short minix_count_free_blocks(register struct super_block *);
+extern unsigned short minix_count_free_inodes(register struct super_block *);
 extern int minix_create(register struct inode *,char *,size_t,int,
 			struct inode **);
 extern void minix_free_block(register struct super_block *,block_t);

--- a/elks/include/linuxmt/minix_fs.h
+++ b/elks/include/linuxmt/minix_fs.h
@@ -98,7 +98,7 @@ extern struct super_block *minix_read_super(register struct super_block *,
 extern int minix_remount(register struct super_block *,int *,char *);
 extern int minix_rmdir(register struct inode *,char *,size_t);
 extern void minix_set_ops(struct inode *);
-extern void minix_statfs(register struct super_block *,struct statfs *,size_t);
+extern void minix_statfs(struct super_block *,struct statfs *);
 extern int minix_symlink(struct inode *,char *,size_t,char *);
 extern int minix_sync_inode(register struct inode *);
 extern void minix_truncate(register struct inode *);

--- a/elks/include/linuxmt/types.h
+++ b/elks/include/linuxmt/types.h
@@ -8,9 +8,7 @@
 typedef __s32			loff_t;
 typedef __s32			off_t;
 
-typedef __u32			daddr_t;
 typedef __u32			jiff_t;
-typedef __u32			lflag_t;
 typedef __u32			lsize_t;
 typedef __u32			speed_t;
 typedef __u32			tcflag_t;
@@ -59,12 +57,5 @@ typedef __u32			fd_mask_t;
 #include <linuxmt/posix_types.h>
 
 typedef __kernel_fd_set 	fd_set;
-
-struct ustat {
-    daddr_t			f_tfree;
-    ino_t			f_tinode;
-    char			f_fname[6];
-    char			f_fpack[6];
-};
 
 #endif

--- a/elks/include/linuxmt/vfs.h
+++ b/elks/include/linuxmt/vfs.h
@@ -1,6 +1,0 @@
-#ifndef __LINUXMT_VFS_H
-#define __LINUXMT_VFS_H
-
-#include <arch/statfs.h>
-
-#endif

--- a/elkscmd/sys_utils/mount.c
+++ b/elkscmd/sys_utils/mount.c
@@ -61,7 +61,7 @@ static int show_mount(dev_t dev)
 	if (ustatfs(dev, &statfs) < 0)
 		return -1;
 
-	printf("%s (%04x): blocks %6lu free %6lu mount %s\n",
+	printf("%-10s (%04x): blocks %6lu free %6lu mount %s\n",
 		dev_name(statfs.f_dev), statfs.f_dev, statfs.f_blocks, statfs.f_bfree,
 		statfs.f_mntonname);
 	return 0;

--- a/elkscmd/sys_utils/mount.c
+++ b/elkscmd/sys_utils/mount.c
@@ -14,6 +14,73 @@
 #include <stdlib.h>
 #include <sys/mount.h>
 
+struct dev_name_struct {
+        char *name;
+        dev_t num;
+} devices[] = {
+        /* root_dev_name needs first 5 in order*/
+        { "hda",     0x0300 },
+        { "hdb",     0x0320 },
+        { "hdc",     0x0340 },
+        { "hdd",     0x0360 },
+        { "fd0",     0x0380 },
+        { "fd1",     0x03a0 },
+        { "ssd",     0x0200 },
+        { "rd",      0x0100 },
+        { NULL,           0 }
+};
+
+/*
+ * Convert a block device number to name.
+ */
+static char *dev_name(dev_t dev)
+{
+        int i;
+#define NAMEOFF 5
+        static char name[10] = "/dev/";
+
+        for (i=0; i<8; i++) {
+                if (devices[i].num == (dev & 0xfff0)) {
+                        strcpy(&name[NAMEOFF], devices[i].name);
+                        if (i < 3) {
+                                if (dev & 0x03) {
+                                        name[NAMEOFF+3] = '0' + (dev & 3);
+                                        name[NAMEOFF+4] = 0;
+                                }
+                        }
+                        return name;
+                }
+        }
+        return NULL;
+}
+
+static int show_mount(dev_t dev)
+{
+	struct statfs statfs;
+
+	if (ustatfs(dev, &statfs) < 0)
+		return -1;
+
+	printf("%s (%04x): blocks %6lu free %6lu mount %s\n",
+		dev_name(statfs.f_dev), statfs.f_dev, statfs.f_blocks, statfs.f_bfree,
+		statfs.f_mntonname);
+	return 0;
+}
+
+static void show(void)
+{
+	int i = 0;
+
+	for (;;)
+		if (show_mount(i++) < 0)
+			break;
+}
+
+static void usage(void)
+{
+	write(STDERR_FILENO, "Usage: mount [-a][-q][-t type] [-o ro|remount,rw] <device> <directory>\n", 71);
+}
+
 int main(int argc, char **argv)
 {
 	char	*str;
@@ -78,8 +145,13 @@ int main(int argc, char **argv)
 		}
 	}
 
+	if (argc == 0) {
+		show();
+		return 0;
+	}
+
 	if (argc != 2) {
-		write(STDERR_FILENO, "Usage: mount [-a][-q][-t type] [-o ro|remount,rw] <device> <directory>\n", 71);
+		usage();
 		return 1;
 	}
 

--- a/libc/include/features.h
+++ b/libc/include/features.h
@@ -26,6 +26,7 @@
 /* Use with #include __SYSINC__(errno.h) */
 
 #define __SYSINC__(_h_file_) <linuxmt/_h_file_>
+#define __SYSARCHINC__(_h_file_) <arch/_h_file_>
 
 /* No C++ */
 #define __BEGIN_DECLS

--- a/libc/include/sys/mount.h
+++ b/libc/include/sys/mount.h
@@ -1,5 +1,9 @@
 /* sys/mount.h*/
 
+#include <features.h>
+#include <sys/types.h>
+#include __SYSARCHINC__(statfs.h)
+
 /* filesystem types*/
 #define FST_MINIX	1
 #define FST_MSDOS	2
@@ -16,5 +20,7 @@
 
 int mount(const char *dev, const char *dir, int type, int flags);
 int umount(const char *dir);
+
+int ustatfs(dev_t dev, struct statfs *statfs);
 
 int reboot(int magic1, int magic2, int magic3);


### PR DESCRIPTION
Adds new `ustatfs` system call, which allows programs to:
- Query each mounted filesystem
- Return type of mounted filesystem (MINIX, FAT, ROMFS)
- Return total and free blocks of filesystem
- Return total and free number of files nodes (inodes) on filesystem
- Return mount point of filesystem

This then allowed `mount` to be enhanced to display all mounted filesystems and their mount points.

For mount speed, the kernel no longer calculates FAT filesystem free space at mount time. Instead use `mount` (or soon, an update to `df` for FAT filesystems).

Here's a screenshot showing a 2880K MINIX floppy ELKS boot, then auto-mounting a 1440K FAT floppy, and running `mount`:
<img width="832" alt="Screen Shot 2022-02-24 at 10 56 32 PM" src="https://user-images.githubusercontent.com/11985637/155664707-6befb9b8-5171-48b9-a8f4-438710a7f8cd.png">

The displayed mount information will be improved to show the filesystem type, along with `df` enhancements for FAT filesystems in a subsequent commit.
