### PR TITLE
[build] Add man pages to all extra image builds 2880K or larger

### DIFF
--- a/elkscmd/Make.install
+++ b/elkscmd/Make.install
@@ -141,6 +141,7 @@ endif
 
 ifdef CONFIG_APPS_2880K
 	TAGS = :*|
+	CONFIG_APP_MAN_PAGES=y
 endif
 
 TAGS += :end


### PR DESCRIPTION
Adds man pages to all extra image builds (`cd image; make images`) for floppy and hard drives 2880K and larger.