### PR TITLE
[kernel] Add bios_disk wrapper function around call_bios

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -164,7 +164,7 @@ static void set_cache_invalid(void)
 	cache_drive = NULL;
 }
 
-static int bios_disk(unsigned cmd, unsigned num_sectors, unsigned drive,
+static int bios_disk_rw(unsigned cmd, unsigned num_sectors, unsigned drive,
 	unsigned cylinder, unsigned head, unsigned sector, unsigned seg, unsigned offset)
 {
 #ifdef CONFIG_ARCH_PC98
@@ -434,7 +434,7 @@ static int read_sector(int drive, int cylinder, int sector)
     do {
 	set_irq();
 	set_ddpt(36);		/* set to large value to avoid BIOS issues*/
-	if (!bios_disk(BIOSHD_READ, 1, drive, cylinder, 0, sector, DMASEG, 0))
+	if (!bios_disk_rw(BIOSHD_READ, 1, drive, cylinder, 0, sector, DMASEG, 0))
 	    return 0;			/* everything is OK */
 	reset_bioshd(drive);
     } while (--count > 0);
@@ -810,8 +810,8 @@ static int do_bios_readwrite(struct drive_infot *drivep, sector_t start, char *b
 		out_ax = 0;
 
 		set_ddpt(drivep->sectors);
-		if (bios_disk(cmd == WRITE? BIOSHD_WRITE: BIOSHD_READ, this_pass, drive,
-					cylinder, head, sector, segment, offset)) {
+		if (bios_disk_rw(cmd == WRITE? BIOSHD_WRITE: BIOSHD_READ, this_pass,
+					drive, cylinder, head, sector, segment, offset)) {
 			printk("bioshd(%d): cmd %d retry #%d CHS %d/%d/%d count %d\n",
 			    drive, cmd, MAX_ERRS - errs + 1, cylinder, head, sector, this_pass);
 		    out_ax = BD_AX;
@@ -859,7 +859,7 @@ static void bios_readtrack(struct drive_infot *drivep, sector_t start)
 			drive, cylinder, head, sector, num_sectors);
 
 		set_ddpt(drivep->sectors);
-		if (bios_disk(BIOSHD_READ, num_sectors, drive,
+		if (bios_disk_rw(BIOSHD_READ, num_sectors, drive,
 						cylinder, head, sector, DMASEG, 0)) {
 			printk("bioshd(%d): track read retry #%d CHS %d/%d/%d count %d\n",
 			    drive, errs + 1, cylinder, head, sector, num_sectors);

--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -61,6 +61,7 @@ struct drive_infot {            /* CHS per drive*/
     int sector_size;
     int fdtype;                 /* floppy fd_types[] index  or -1 if hd */
 };
+extern struct drive_infot *last_drive;	/* set to last drivep-> used in read/write */
 
 extern struct blk_dev_struct blk_dev[MAX_BLKDEV];
 extern void resetup_one_dev(struct gendisk *dev, int drive);

--- a/elks/arch/i86/drivers/char/console-bios.c
+++ b/elks/arch/i86/drivers/char/console-bios.c
@@ -23,6 +23,7 @@
 
 #define A_DEFAULT 	0x07
 #define A_BOLD 		0x08
+#define A_UNDERLINE 	0x07	/* only works on MDA, normal video on EGA */
 #define A_BLINK 	0x80
 #define A_REVERSE	0x70
 #define A_BLANK		0x00

--- a/elks/arch/i86/drivers/char/console-direct-pc98.c
+++ b/elks/arch/i86/drivers/char/console-direct-pc98.c
@@ -28,6 +28,7 @@
 
 #define A_DEFAULT 	0x07
 #define A_BOLD 		0x08
+#define A_UNDERLINE 	0x07
 #define A_BLINK 	0x80
 #define A_REVERSE	0x70
 #define A_BLANK		0x00


### PR DESCRIPTION
Adds wrapper function for PC-98 call_bios cylinder size > 10 bits discussed in https://github.com/jbruchon/elks/issues/1047#issuecomment-1051112258.

Hello @tyama501, this should allow you to submit your PC-98 partition code with only one modification, that of using "last_drive" rather than "cache_drive". This will work whether track caching is enabled or not. It is already extern for you as well.

When you are ready, go ahead and modify bios_disk_rw in bioshd.c, as well as bios1B.S to fix the cylinder size issue. This PR uses the older method until you have time for that.

Thank you!