### PR TITLE
[cmds] Add compress/decompress utility, man pages now compressed

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -104,6 +104,7 @@ sh_utils/which					:shutil					:1200k	:1440k
 #sh_utils/whoami				:shutil					:1200k	:1440k
 sh_utils/xargs					:shutil					:1200k	:1440k
 sh_utils/yes					:shutil				:720k
+misc_utils/compress				:miscutil						:1440k
 misc_utils/miniterm				:miscutil			:720k
 misc_utils/fdtest				:miscutil				:1200k	:1440k
 misc_utils/tar					:miscutil				:1200k	:1440k

--- a/elkscmd/Make.install
+++ b/elkscmd/Make.install
@@ -199,9 +199,12 @@ ifdef CONFIG_APP_CGATEXT
 	make -C cgatext install
 endif
 ifdef CONFIG_APP_MAN_PAGES
-	mkdir $(DESTDIR)/lib/man1; cp -rp man/man1 $(DESTDIR)/lib
-	mkdir $(DESTDIR)/lib/man5; cp -rp man/man5 $(DESTDIR)/lib
-	mkdir $(DESTDIR)/lib/man8; cp -rp man/man8 $(DESTDIR)/lib
+	mkdir $(DESTDIR)/lib/man1
+	cp -rp man/man1 $(DESTDIR)/lib; compress -b 12 $(DESTDIR)/lib/man1/*
+	mkdir $(DESTDIR)/lib/man5;
+	cp -rp man/man5 $(DESTDIR)/lib; compress -b 12 $(DESTDIR)/lib/man5/*
+	mkdir $(DESTDIR)/lib/man8;
+	cp -rp man/man8 $(DESTDIR)/lib; compress -b 12 $(DESTDIR)/lib/man8/*
 endif
 
 

--- a/elkscmd/man/man1/compress.1
+++ b/elkscmd/man/man1/compress.1
@@ -1,4 +1,3 @@
-.PU
 .TH COMPRESS 1
 .SH NAME
 compress, uncompress, zcat \- compress and expand data (version 4.1)
@@ -12,6 +11,8 @@ compress, uncompress, zcat \- compress and expand data (version 4.1)
 .B \-c
 ] [
 .B \-V
+] [
+.B \-d
 ] [
 .B \-r
 ] [
@@ -41,7 +42,7 @@ compress, uncompress, zcat \- compress and expand data (version 4.1)
 .I "name \&..."
 ]
 .SH DESCRIPTION
-.I Compress
+.B Compress
 reduces the size of the named files using adaptive Lempel-Ziv coding.
 Whenever possible,
 each file is replaced by one with the extension
@@ -49,11 +50,11 @@ each file is replaced by one with the extension
 while keeping the same ownership modes, access and modification times.
 If no files are specified, the standard input is compressed to the
 standard output.
-.I Compress
+.B Compress
 will only attempt to compress regular files.
 In particular, it will ignore symbolic links. If a file has multiple
 hard links,
-.I compress
+.B compress
 will refuse to compress it unless the
 .B \-f
 flag is given.
@@ -66,11 +67,11 @@ is run in the foreground,
 the user is prompted as to whether an existing file should be overwritten.
 .PP
 Compressed files can be restored to their original form using
-.I uncompress
+.B uncompress
 or
-.I zcat.
+.B zcat.
 .PP
-.I uncompress
+.B uncompress
 takes a list of files on its command line and replaces each
 file whose name ends with
 .B "\&.Z"
@@ -83,29 +84,36 @@ timestamps of the compressed file.
 The
 .B \-c
 option makes
-.I compress/uncompress
+.B compress/uncompress
 write to the standard output; no files are changed.
 .PP
-.I zcat
+.B zcat
 is identical to
-.I uncompress
+.B uncompress
 .B \-c.
-.I zcat
+.B zcat
 uncompresses either a list of files on the command line or its
 standard input and writes the uncompressed data on standard output.
-.I zcat
+.B zcat
 will uncompress files that have the correct magic number whether
 they have a
 .B "\&.Z"
 suffix or not.
 .PP
 If the
+.B \-d
+flag is specified,
+.B compress
+will decompress the file, acting just like
+.B decompress.
+.PP
+If the
 .B \-r
 flag is specified, 
-.I compress
+.B compress
 will operate recursively. If any of the file names specified on the command
 line are directories, 
-.I compress
+.B compress
 will descend into the directory and compress all the files it finds there.
 .PP
 The
@@ -114,7 +122,7 @@ flag tells each of these programs to print its version and patchlevel,
 along with any preprocessor flags specified during compilation, on
 stderr before doing any compression or uncompression.
 .PP
-.I Compress
+.B Compress
 uses the modified Lempel-Ziv algorithm popularized in
 "A Technique for High Performance Data Compression",
 Terry A. Welch,
@@ -128,27 +136,27 @@ limit specified by the
 flag is reached (default 16).
 .I Bits
 must be between 9 and 16.  The default can be changed in the source to allow
-.I compress
+.B compress
 to be run on a smaller machine.
 .PP
 After the
 .I bits
 limit is attained,
-.I compress
+.B compress
 periodically checks the compression ratio.  If it is increasing,
-.I compress
+.B compress
 continues to use the existing code dictionary.  However,
 if the compression ratio decreases,
-.I compress
+.B compress
 discards the table of substrings and rebuilds it from scratch.  This allows
 the algorithm to adapt to the next "block" of the file.
 .PP
 Note that the
 .B \-b
 flag is omitted for
-.I uncompress,
+.B uncompress,
 since the 
-.I bits
+.B bits
 parameter specified during compression
 is encoded within the output, along with
 a magic number to ensure that neither decompression of random data nor
@@ -157,7 +165,7 @@ recompression of compressed data is attempted.
 .ne 8
 The amount of compression obtained depends on the size of the
 input, the number of
-.I bits
+.B bits
 per code, and the distribution of common substrings.
 Typically, text such as source code or English
 is reduced by 50\-60%.
@@ -193,7 +201,7 @@ Maxbits must follow
 not in compressed format
 .RS
 The file specified to
-.I uncompress
+.B uncompress
 has not been compressed.
 .RE
 .IR file :

--- a/elkscmd/man/man1/man.1
+++ b/elkscmd/man/man1/man.1
@@ -3,7 +3,8 @@
 man \- display on-line reference manuals
 .SH SYNOPSIS
 .B man
-[\-w] [\-b|\-q] [section-number] page ...
+[\fB\-w\fR] [\fB\-b\fR|\fB\-q\fR]
+.I [section-number] page ...
 .SH DESCRIPTION
 This document describes the ELKS version of
 .BR man .
@@ -49,22 +50,21 @@ as nroff, as we currently do not have one. It supports a subset of nroff
 -man features which are sufficient for displaying ELKS manual pages.
 .SS OPTIONS
 .TP
-.I "-w"
+.B "-w"
 Do not display any manual pages, but print the location of each one found.
 .TP
-.I "-v"
+.B "-v"
 Force verbose output. (default)
 .TP
-.I "-q"
+.B "-q"
 Force quiet output.
 .SH EXAMPLES
 .IP
-man ls
+.B man ls
+# Display the manual page for ls
 .IP
-man -w cp
-.LP
-Display the manual page for ls, and the location of the manual page for cp
-respectively.
+.B man -w cp
+# Display the location of man page for cp
 .SH ENVIRONMENT
 .B man
 obeys the following environment variables.
@@ -105,4 +105,5 @@ Rob de Bath
 Al Riddoch (ajr@ecs.soton.ac.uk) (this manpage)
 .SH SEE ALSO
 .BR more (1),
+.BR compress (1),
 .BR cat (1).

--- a/elkscmd/misc_utils/Makefile
+++ b/elkscmd/misc_utils/Makefile
@@ -14,8 +14,8 @@ KERNEL_LIBS = $(TOPDIR)/elks/arch/i86/lib/lib86.a
 
 ###############################################################################
 
-#TODO: fix compress uncompress zcat lpfilter disabled
-PRGS = tar miniterm ed fdtest od hd time kilo mined sleep tty uuencode uudecode
+#TODO: fix uncompress zcat lpfilter disabled
+PRGS = tar miniterm ed fdtest od hd time kilo mined sleep tty uuencode uudecode compress
 
 #PRGS_HOST=compress.host
 

--- a/elkscmd/misc_utils/compress.c
+++ b/elkscmd/misc_utils/compress.c
@@ -292,6 +292,7 @@ static char ident[] = "(N)compress 4.2.4";
 #endif /* DOS */
 
 #ifdef ELKS
+#  pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #  define BITS 12		/* 16-bits processor max 12 bits	*/
 #  undef BYTEORDER
 #  define BYTEORDER 4321	/* CM: FIXME: Assumes little-endian ELKS */
@@ -722,7 +723,7 @@ main(argc, argv)
     	REG3	char	**filelist;
 	REG4	char	**fileptr;
 
-    	if (fgnd_flag = (signal(SIGINT, SIG_IGN) != SIG_IGN))
+	if ((fgnd_flag = (signal(SIGINT, SIG_IGN)) != SIG_IGN))
 		signal(SIGINT, (SIG_TYPE)abort_compress);
 
 	signal(SIGTERM, (SIG_TYPE)abort_compress);
@@ -957,9 +958,9 @@ comprexx(fileptr)
 #endif
 			if (!quiet)
 			    	fprintf(stderr,"%s is a directory -- ignored\n", tempname);
-		  	break;
+		break;
 
-		case S_IFREG:	/* regular file */
+	case S_IFREG:	/* regular file */
 		  	if (do_decomp != 0)
 			{/* DECOMPRESSION */
 		    	if (!zcat_flg) {
@@ -1243,7 +1244,7 @@ compdir(dir)
 	** think it's worth it. -- Dave Mack
 	*/
 
-	while (dp = readdir(dirp)) {
+	while ((dp = readdir(dirp)) != NULL) {
 		if (dp->d_ino == 0)
 			continue;
 

--- a/elkscmd/sys_utils/man.c
+++ b/elkscmd/sys_utils/man.c
@@ -107,7 +107,7 @@ int find_page(char *name, char *sect)
 {
 static char defpath[] = _PATH_MANPAGES;
 static char defsect[] = "1:2:3:4:5:6:7:8:9";
-static char defsuff[] = ":.gz:.Z";
+static char defsuff[] = ":.Z:.gz";
 static char manorcat[] = "man:cat";
 
    char fbuf[256];
@@ -421,11 +421,11 @@ int fetch_word(void)
    ungetc(ch, ifd);
 
    while ((ch=fgetc(ifd)) != EOF && !isspace(ch)) {
-      if (p<word+sizeof(word)-1) *p++ = ch; col++;
+      if (p<word+sizeof(word)-1) *p++ = ch, col++;
       if (ch == '\\') {
          if ((ch=fgetc(ifd)) == EOF) break;
 	 /* if (ch == ' ') ch = ' ' + 0x80;*/	/* XXX Is this line needed? */
-         if (p<word+sizeof(word)-1) *p++ = ch; col++;
+         if (p<word+sizeof(word)-1) *p++ = ch, col++;
       }
    }
    *p = 0;
@@ -769,8 +769,10 @@ void print_word(char *pword)
 	 {
 	    /* XXX Humm character xlate */
 
-	    if (*s == '*') if (s[1]) ++s;
-	    if (s[1]) ++s; if (s[1]) ++s;
+	    if (*s == '*')
+		if (s[1]) ++s;
+	    if (s[1]) ++s;
+	    if (s[1]) ++s;
 	    *d++ = '*' + cur_font;
 	    length++;
 	    continue;

--- a/elkscmd/sys_utils/man.c
+++ b/elkscmd/sys_utils/man.c
@@ -194,7 +194,7 @@ int open_page(char * name)
    p = strrchr(name, '.');
    if (p) {
       if (strcmp(p, ".gz") == 0) command = "gzip -dc ";
-      if (strcmp(p, ".Z") == 0)  command = "uncompress -c ";
+      if (strcmp(p, ".Z") == 0)  command = "compress -dc ";
    }
 
    if (command) {


### PR DESCRIPTION
Adds `compress` (and `compress -d` for decompress) to ELKS. This program was already part of ELKS distribution, just not activated. Uses modified LZW compression and is compatible with host `compress -b 12`, which is used to compress man pages for ELKS build.

Uses 12-bit compression, which works with 4K tables and ELKS. 

Update compress man page.

Man pages now all compress to .Z versions (including compress.1.Z :)
