### PR TITLE
[kernel] Fix mount kernel and command bugs, increase mounts avail to 5

### DIFF
--- a/elks/fs/super.c
+++ b/elks/fs/super.c
@@ -182,11 +182,13 @@ static struct super_block *read_super(kdev_t dev, int t, int flags,
     type = file_systems[0];
 #endif
 
-    for (s = super_blocks; s->s_dev; s++) {
-	if (s >= super_blocks + NR_SUPER) return NULL;
-    }
+    for (s = super_blocks; s->s_dev; s++)
+	continue;
+    if (s >= super_blocks + NR_SUPER)
+	return NULL;
+
     s->s_dev = dev;
-    s->s_flags = (unsigned short int) flags;
+    s->s_flags = flags;
 
     if (!type->read_super(s, data, silent)) {
 	s->s_dev = 0;

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -49,7 +49,7 @@
 
 #define NR_INODE	96	/* this should be bigger than NR_FILE */
 #define NR_FILE 	64	/* this can well be larger on a larger system */
-#define NR_SUPER	4
+#define NR_SUPER	5
 
 #define BLOCK_SIZE	1024
 #define BLOCK_SIZE_BITS 10

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -172,6 +172,7 @@ static struct dev_name_struct {
 	{ "hda",     0x0300 },
 	{ "hdb",     0x0320 },
 	{ "hdc",     0x0340 },
+	{ "hdd",     0x0360 },
 	{ "fd0",     0x0380 },
 	{ "fd1",     0x03a0 },
 	{ "ttyS",    0x0440 },
@@ -194,9 +195,9 @@ static char * INITPROC root_dev_name(int dev)
 	for (i=0; i<5; i++) {
 		if (devices[i].num == (dev & 0xfff0)) {
 			strcpy(&name[NAMEOFF], devices[i].name);
-			if (i < 3) {
-				if (dev & 0x03) {
-					name[NAMEOFF+3] = '0' + (dev & 3);
+			if (i < 4) {
+				if (dev & 0x07) {
+					name[NAMEOFF+3] = '0' + (dev & 7);
 					name[NAMEOFF+4] = 0;
 				}
 			}

--- a/elkscmd/disk_utils/fsck.c
+++ b/elkscmd/disk_utils/fsck.c
@@ -542,6 +542,13 @@ void read_tables(void)
 /*	inode_buffer = malloc(BLOCK_SIZE); RUBOUT
 	if (!inode_buffer)
 		die("Unable to allocate buffer for inodes"); RUBOUT */
+
+	/* check for filesystem too large since libc malloc fails improperly FIXME */
+	if (ZONES > 32767) {
+		fprintf(stderr, "Filesystem too large to check (%u zones, max 32767)\n", ZONES);
+		exit(8);
+	}
+
 	inode_count = malloc(INODES);
 	if (!inode_count)
 		die("Unable to allocate buffer for inode count");

--- a/elkscmd/rootfs_template/etc/mount.cfg
+++ b/elkscmd/rootfs_template/etc/mount.cfg
@@ -1,8 +1,7 @@
 #
 # /etc/mount.cfg - script to check and mount filesystems at boot
 #
-# Currently, can only check MINIX filesystems, not FAT,
-# so check_filesystem below must be manually uncommented for now.
+# check_filesystem below must be manually uncommented for MINIX
 #
 
 fsck="fsck -r"
@@ -41,15 +40,19 @@ fstype()
 # check MINIX root filesystem
 #check_mounted_filesystem $ROOTDEV /
 
-# mount floppy B (MINIX or FAT), ignore mount error
+# mount floppy B (MINIX or FAT)
 #check_filesystem /dev/fd1
 #mount -a /dev/fd1 /mnt || true
 
-# mount HD partition 1
-#mount -a /dev/hda1 /mnt
-#mkdir /mnt2 || true
-#mount -a /dev/hda2 /mnt2
-
-# mount unpartitioned HD
+# various HD mounts
 #check_filesystem /dev/hda
 #mount -a /dev/hda /mnt
+
+#mount -a /dev/hda1 /mnt
+
+#mkdir /mnt2 || true
+#mount -a /dev/hda2 /mnt2
+#mkdir /mnt3 || true
+#mount -a /dev/hda3 /mnt3
+#mkdir /mnt4 || true
+#mount -a /dev/hda4 /mnt4

--- a/elkscmd/sys_utils/mount.c
+++ b/elkscmd/sys_utils/mount.c
@@ -46,9 +46,9 @@ static char *dev_name(dev_t dev)
         for (i=0; i<sizeof(devices)/sizeof(devices[0])-1; i++) {
                 if (devices[i].num == (dev & 0xfff0)) {
                         strcpy(&name[NAMEOFF], devices[i].name);
-                        if (i < 3) {
-                                if (dev & 0x03) {
-                                        name[NAMEOFF+3] = '0' + (dev & 3);
+                        if (i < 4) {
+                                if (dev & 0x07) {
+                                        name[NAMEOFF+3] = '0' + (dev & 7);
                                         name[NAMEOFF+4] = 0;
                                 }
                         }
@@ -65,7 +65,7 @@ static int show_mount(dev_t dev)
 	if (ustatfs(dev, &statfs) < 0)
 		return -1;
 
-	printf("%-8s (%s) blocks %6lu free %6lu mount %s\n",
+	printf("%-9s (%s) blocks %6lu free %6lu mount %s\n",
 		dev_name(statfs.f_dev), fs_typename[statfs.f_type], statfs.f_blocks,
 		statfs.f_bfree, statfs.f_mntonname);
 	return 0;


### PR DESCRIPTION
This should fix all but the `fsck` issue in #1203.

Mount max is now 5, will error if over. Unfortunately, that error is -EINVAL, and is not easy to change, but shouldn't be a big deal (at least no hang).

