### PR TITLE
[net] Return from connect on ICMP dest unreachable packet

### DIFF
--- a/elks/include/linuxmt/errno.h
+++ b/elks/include/linuxmt/errno.h
@@ -129,7 +129,7 @@
 #define	ETIMEDOUT	110	/* Connection timed out */
 #define	ECONNREFUSED	111	/* Connection refused */
 #define	EHOSTDOWN	112	/* Host is down */
-#define	EHOSTUNREACH	113	/* No route to host */
+#define	EHOSTUNREACH	113	/* Host not reachable */
 #define	EALREADY	114	/* Operation already in progress */
 #define	EINPROGRESS	115	/* Operation now in progress */
 #define	ESTALE		116	/* Stale NFS file handle */

--- a/elkscmd/ktcp/icmp.c
+++ b/elkscmd/ktcp/icmp.c
@@ -62,19 +62,18 @@ void icmp_process(struct iphdr_s *iph, unsigned char *packet)
    case ICMP_TYPE_DST_UNRCH:
 	dp = (struct icmp_dest_unreachable_s *)packet;
 	dpip = (struct iphdr_s *)dp->iphdr;
-	len = ntohs(dpip->tot_len) - 4 * IP_HLEN(dpip);
-	dptcp = (struct tcphdr_s *)dp->iphdr + len;
-	printf("icmp: len %d\n", len);
+	len = 4 * IP_HLEN(dpip);
+	dptcp = (struct tcphdr_s *)(dp->iphdr + len);
 	printf("icmp: destination unreachable code %d from %s\n",
 		dp->code, in_ntoa(iph->saddr));
-	printf("icmp: src %s:%u ", in_ntoa(dpip->saddr), ntohs(dptcp->sport));
-	printf("dst %s:%u\n", in_ntoa(dpip->daddr), ntohs(dptcp->dport));
+	debug_ip("icmp: src %s:%u ", in_ntoa(dpip->saddr), ntohs(dptcp->sport));
+	debug_ip("dst %s:%u\n", in_ntoa(dpip->daddr), ntohs(dptcp->dport));
 	cbnode = tcpcb_find(dpip->daddr, ntohs(dptcp->sport), ntohs(dptcp->dport));
 	if (cbnode) {
 	    struct tcpcb_s *cb = &cbnode->tcpcb;
 	    notify_sock(cb->sock, TDT_CONNECT, -EHOSTUNREACH);
 	    tcpcb_remove_cb(cb);	/* deallocate */
-	} else printf("icmp: Connection not found\n");
+	} else debug_ip("icmp: Connection not found\n");
 	break;
     default:
 	printf("icmp: unrecognized ICMP type %d\n", packet[0]);

--- a/elkscmd/ktcp/icmp.c
+++ b/elkscmd/ktcp/icmp.c
@@ -11,13 +11,16 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
 #include <stdio.h>
+#include <fcntl.h>
+#include <errno.h>
 #include <arpa/inet.h>
 #include "config.h"
 #include "ip.h"
 #include "tcp.h"
 #include "icmp.h"
+#include "tcp_cb.h"
+#include "tcpdev.h"
 #include "netconf.h"
 
 int icmp_init(void)
@@ -25,14 +28,21 @@ int icmp_init(void)
     return 0;
 }
 
-void icmp_process(struct iphdr_s *iph,unsigned char *packet)
+void icmp_process(struct iphdr_s *iph, unsigned char *packet)
 {
-    struct icmp_echo_s *ep = (struct icmp_echo_s *)packet;
+    struct icmp_echo_s *ep;
     struct addr_pair apair;
+
+    struct icmp_dest_unreachable_s *dp;
+    struct iphdr_s *dpip;
+    struct tcphdr_s *dptcp;
+    struct tcpcb_list_s *cbnode;
+
     int len;
 
     switch (packet[0]){
     case ICMP_TYPE_ECHO_REQ:
+	ep = (struct icmp_echo_s *)packet;
 	len = ntohs(iph->tot_len) - 4 * IP_HLEN(iph);
 	debug_ip("icmp: PING from %s (len %d id %u seqnum %u)\n",
 	    in_ntoa(iph->saddr), len, ntohs(ep->id), ntohs(ep->seqnum));
@@ -50,11 +60,24 @@ void icmp_process(struct iphdr_s *iph,unsigned char *packet)
 	netstats.icmpsndcnt++;
 	break;
    case ICMP_TYPE_DST_UNRCH:
+	dp = (struct icmp_dest_unreachable_s *)packet;
+	dpip = (struct iphdr_s *)dp->iphdr;
+	len = ntohs(dpip->tot_len) - 4 * IP_HLEN(dpip);
+	dptcp = (struct tcphdr_s *)dp->iphdr + len;
+	printf("icmp: len %d\n", len);
 	printf("icmp: destination unreachable code %d from %s\n",
-		ep->code, in_ntoa(iph->saddr));
+		dp->code, in_ntoa(iph->saddr));
+	printf("icmp: src %s:%u ", in_ntoa(dpip->saddr), ntohs(dptcp->sport));
+	printf("dst %s:%u\n", in_ntoa(dpip->daddr), ntohs(dptcp->dport));
+	cbnode = tcpcb_find(dpip->daddr, ntohs(dptcp->sport), ntohs(dptcp->dport));
+	if (cbnode) {
+	    struct tcpcb_s *cb = &cbnode->tcpcb;
+	    notify_sock(cb->sock, TDT_CONNECT, -EHOSTUNREACH);
+	    tcpcb_remove_cb(cb);	/* deallocate */
+	} else printf("icmp: Connection not found\n");
 	break;
     default:
-	debug_ip("icmp: unrecognized ICMP request %d\n", ep->type);
+	printf("icmp: unrecognized ICMP type %d\n", packet[0]);
 	break;
     }
 }

--- a/elkscmd/ktcp/icmp.h
+++ b/elkscmd/ktcp/icmp.h
@@ -39,6 +39,15 @@ struct icmp_echo_s {
 	__u16	seqnum;
 };
 
+struct icmp_dest_unreachable_s {
+	__u8	type;
+	__u8	code;
+	__u16	chksum;
+	__u16	unused;
+	__u16	nexthop_mtu;
+	unsigned char iphdr[];
+};
+
 int icmp_init(void);
 void icmp_process(struct iphdr_s *iph, unsigned char *packet);
 

--- a/elkscmd/rootfs_template/etc/perror
+++ b/elkscmd/rootfs_template/etc/perror
@@ -110,7 +110,7 @@
 110 Connection timed out 
 111 Connection refused 
 112 Host is down 
-113 No route to host 
+113 Host not reachable 
 114 Operation already in progress 
 115 Operation now in progress 
 116 Stale NFS file handle 


### PR DESCRIPTION
Possible fix for ending `connect` socket call in #1196 when ICMP destination unreachable message received.

@Mellvik, I have written this without any testing at all, but included various debug messages so that we can see what is happening on the ICMP message. Can you please test?

The intent is for ktcp to return from connect with a "No route to host" (EHOSTUNREACH) errno.

I can't move forward with the other problem reported in #1196, "system hang when connecting outside LAN directly after boot" without DEBUG_ARP and DEBUG_ETH (or other link level) traces.

Thank you!