### PR TITLE
[cmds] Add tiny stdio printf/fprintf/vfprintf/sprintf

### DIFF
--- a/elkscmd/disk_utils/Makefile
+++ b/elkscmd/disk_utils/Makefile
@@ -28,17 +28,17 @@ fsck: fsck.o
 fdisk: fdisk.o
 	$(LD) $(LDFLAGS) -o fdisk fdisk.o $(LDLIBS)
 
-mkfs: mkfs.o
-	$(LD) $(LDFLAGS) -o mkfs mkfs.o $(LDLIBS)
+mkfs: mkfs.o ../file_utils/tio_vfprintf.o
+	$(LD) $(LDFLAGS) -o mkfs mkfs.o ../file_utils/tio_vfprintf.o $(LDLIBS)
 
-mkfat: mkfat.o
-	$(LD) $(LDFLAGS) -o mkfat mkfat.o $(LDLIBS)
+mkfat: mkfat.o ../file_utils/tio_vfprintf.o
+	$(LD) $(LDFLAGS) -o mkfat mkfat.o ../file_utils/tio_vfprintf.o $(LDLIBS)
 
 partype: partype.o
 	$(LD) $(LDFLAGS) -o partype partype.o $(LDLIBS)
 
-ramdisk: ramdisk.o
-	$(LD) $(LDFLAGS) -o ramdisk ramdisk.o $(LDLIBS)
+ramdisk: ramdisk.o ../file_utils/tio_vfprintf.o
+	$(LD) $(LDFLAGS) -o ramdisk ramdisk.o ../file_utils/tio_vfprintf.o $(LDLIBS)
 
 clean:
 	rm -f *.o $(FORMATMOD) core $(PRGS)

--- a/elkscmd/disk_utils/ramdisk.c
+++ b/elkscmd/disk_utils/ramdisk.c
@@ -17,36 +17,37 @@ char **argv;
 
 	if ((argc != 4) && (argc != 3)) {
 		fprintf(stderr, "usage: ramdisk /dev/rd? {make | kill} [size in 1 KB blocks]\n");
-		exit(1);
+		return 1;
 	}
 
 	if (argc == 4)
-		sscanf(argv[3], "%d", &size);
+		size = atoi(argv[3]);
 	else
 		size = 64; /* default */
 	
 	if ((size < 1) || (size > MAX_SIZE)) {
 		fprintf(stderr, "ramdisk: invalid size; use integer in range of 1 .. %d\n", MAX_SIZE);
-		exit(1);
+		return 1;
 	}
 	if (( fd = open(argv[1], 0) ) == -1) {
 		perror("ramdisk");
-		exit(1);
+		return 1;
 	}
 	if (strcmp(argv[2],"make") == 0) {
 		if (ioctl(fd, RDCREATE, size)) {
 			perror("ramdisk");
-			exit(1);
+			return 1;
 		}
-		fprintf(stdout,"ramdisk: %d KB ramdisk created on %s\n", size, argv[1]);
-		exit(0);
+		printf("ramdisk: %d KB ramdisk created on %s\n", size, argv[1]);
+		return 0;
 	}
 	if (strcmp(argv[2],"kill") == 0) {
 		if (ioctl(fd, RDDESTROY, 0)) {
 			perror("ramdisk");
-			exit(1);
+			return 1;
 		}
-		fprintf(stdout,"ramdisk destroyed on %s\n", argv[1]);
-		exit(0);
+		printf("ramdisk destroyed on %s\n", argv[1]);
+		return 0;
 	}
+	return 0;
 }

--- a/elkscmd/file_utils/Makefile
+++ b/elkscmd/file_utils/Makefile
@@ -32,8 +32,8 @@ chown: chown.o
 cmp: cmp.o
 	$(LD) $(LDFLAGS) -o cmp cmp.o $(LDLIBS)
 
-cp: cp.o
-	$(LD) $(LDFLAGS) -maout-heap=0xffff -o cp cp.o $(LDLIBS)
+cp: cp.o tio_vfprintf.o
+	$(LD) $(LDFLAGS) -maout-heap=0xffff -o cp cp.o tio_vfprintf.o $(LDLIBS)
 
 df: df.o
 	$(LD) $(LDFLAGS) -o df df.o $(LDLIBS)

--- a/elkscmd/file_utils/cp.c
+++ b/elkscmd/file_utils/cp.c
@@ -331,7 +331,7 @@ static int do_copies(void)
 				char *p = strrchr(inode_build->path, '/');
 				if (p && *++p == '.') {
 					if (opt_verbose)
-						printf("Skipping zero length%s\n", inode_build->path);
+						printf("Skipping zero length %s\n", inode_build->path);
 					continue;
 				}
 			}

--- a/elkscmd/file_utils/tio_vfprintf.c
+++ b/elkscmd/file_utils/tio_vfprintf.c
@@ -1,0 +1,165 @@
+/*
+ * Tiny vfprintf - based on ELKS stdio
+ *
+ * Reduces executable size when linked with app.
+ * Automatically usable with:
+ *  printf, fprintf, sprintf
+ *
+ * Limitations:
+ *	%s, %c, %d, %u, %x, %o, %ld, %lu, %lx only
+ *  No field widths
+ *  Should not mix with stdio input functions or library routines that use fopen
+ *    Replaces stdin, stdout, stderr buffers to single buffer
+ *
+ * Mar 2020 Greg Haerr
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/types.h>
+
+static unsigned char bufout[80];
+
+FILE  stdin[1] =
+{
+   {
+    bufout,
+    bufout,
+    bufout,
+    bufout,
+    bufout + sizeof(bufout),
+    0,
+    _IOFBF | __MODE_READ | __MODE_IOTRAN
+   }
+};
+
+
+FILE  stdout[1] =
+{
+   {
+    bufout,
+    bufout,
+    bufout,
+    bufout,
+    bufout + sizeof(bufout),
+    1,
+    _IOFBF | __MODE_WRITE | __MODE_IOTRAN
+   }
+};
+
+FILE  stderr[1] =
+{
+   {
+    bufout,
+    bufout,
+    bufout,
+    bufout,
+    bufout + sizeof(bufout),
+    2,
+    _IOFBF | __MODE_WRITE | __MODE_IOTRAN
+   }
+};
+
+static void __fflush(FILE *fp)
+{
+   int   len;
+
+   /* Return if this is a fake FILE from sprintf */
+   if (fp->fd < 0)
+      return;
+
+   len = fp->bufpos - fp->bufstart;
+   if (len)
+      write(fp->fd, fp->bufstart, len);
+
+   fp->bufwrite = fp->bufpos = fp->bufstart;
+}
+
+static void __fputc(int ch, FILE *fp)
+{
+   if (fp->bufpos >= fp->bufend)
+     __fflush(fp);
+
+   *(fp->bufpos++) = ch;
+
+   fp->bufwrite = fp->bufend;
+}
+
+int vfprintf(FILE *op, const char *fmt, va_list ap)
+{
+   int cnt = 0;
+   int lval;
+   int radix;
+   char *ptmp;
+   char  tmp[64];
+
+   while (*fmt)
+   {
+      if (*fmt == '%')
+      {
+	 radix = 10;		/* number base */
+	 ptmp = tmp;		/* pointer to area to print */
+	 lval = 0;
+       fmtnxt:
+	 ++fmt;
+
+	 switch (*fmt)
+	 {
+	 case 'l':		/* long data */
+	    lval = 1;
+	    goto fmtnxt;
+
+	 case 'd':		/* Signed decimal */
+	    ptmp = ltostr((long) ((lval)
+			 ? va_arg(ap, long)
+			 : va_arg(ap, int)), 10);
+	    goto printit;
+
+	 case 'o':		/* Unsigned octal */
+	    radix = 8;
+	    goto usproc;
+
+     case 'x':      /* Unsigned hexadecimal */
+        radix = 16;
+        /* fall thru */
+
+	 case 'u':		/* Unsigned decimal */
+	  usproc:
+	    ptmp = ultostr((unsigned long) ((lval)
+			? va_arg(ap, unsigned long)
+			: va_arg(ap, unsigned int)), radix);
+	    goto printit;
+
+	 case 'c':		/* Character */
+	    ptmp[0] = va_arg(ap, int);
+	    ptmp[1] = '\0';
+	    goto nopad;
+
+	 case 's':		/* String */
+	    ptmp = va_arg(ap, char*);
+	  nopad:
+	  printit:
+	    do {
+	    	__fputc(*ptmp++, op);
+		cnt++;
+	    } while (*ptmp);
+	    break;
+
+	 default:		/* unknown character */
+	    goto charout;
+	 }
+      }
+      else
+      {
+       charout:
+	 __fputc(*fmt, op);	/* normal char out */
+	 ++cnt;
+      }
+      ++fmt;
+   }
+   __fflush(op);
+   return cnt;
+}

--- a/elkscmd/misc_utils/Makefile
+++ b/elkscmd/misc_utils/Makefile
@@ -24,8 +24,8 @@ all: $(PRGS) $(PRGS_HOST)
 ed: ed.o
 	$(LD) $(LDFLAGS) -o ed ed.o $(LDLIBS)
 
-fdtest: fdtest.o
-	$(LD) $(LDFLAGS) -o fdtest fdtest.o $(KERNEL_LIBS) $(LDLIBS)
+fdtest: fdtest.o ../file_utils/tio_vfprintf.o
+	$(LD) $(LDFLAGS) -o fdtest fdtest.o ../file_utils/tio_vfprintf.o $(KERNEL_LIBS) $(LDLIBS)
 
 tar: tar.o
 	$(LD) $(LDFLAGS) -o tar tar.o $(LDLIBS)

--- a/elkscmd/sh_utils/Makefile
+++ b/elkscmd/sh_utils/Makefile
@@ -45,8 +45,8 @@ pwd: pwd.o
 true: true.o
 	$(LD) $(LDFLAGS) -o true true.o $(LDLIBS)
 
-which: which.o
-	$(LD) $(LDFLAGS) -o which which.o $(LDLIBS)
+which: which.o ../file_utils/tio_vfprintf.o
+	$(LD) $(LDFLAGS) -o which which.o ../file_utils/tio_vfprintf.o $(LDLIBS)
 
 whoami: whoami.o
 	$(LD) $(LDFLAGS) -o whoami whoami.o $(LDLIBS)
@@ -57,17 +57,17 @@ yes: yes.o
 logname: logname.o
 	$(LD) $(LDFLAGS) -o logname logname.o $(LDLIBS)
 
-tr: tr.o
-	$(LD) $(LDFLAGS) -o tr tr.o $(LDLIBS)
+tr: tr.o ../file_utils/tio_vfprintf.o
+	$(LD) $(LDFLAGS) -o tr tr.o ../file_utils/tio_vfprintf.o $(LDLIBS)
 
 xargs: xargs.o
 	$(LD) $(LDFLAGS) -o xargs xargs.o $(LDLIBS)
 
-mesg: mesg.o
-	$(LD) $(LDFLAGS) -o mesg mesg.o $(LDLIBS)
+mesg: mesg.o ../file_utils/tio_vfprintf.o
+	$(LD) $(LDFLAGS) -o mesg mesg.o ../file_utils/tio_vfprintf.o $(LDLIBS)
 
-stty: stty.o
-	$(LD) $(LDFLAGS) -o stty stty.o $(LDLIBS)
+stty: stty.o ../file_utils/tio_vfprintf.o
+	$(LD) $(LDFLAGS) -o stty stty.o ../file_utils/tio_vfprintf.o $(LDLIBS)
 
 test: test.o
 	$(LD) $(LDFLAGS) -o test test.o $(LDLIBS)

--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -42,8 +42,8 @@ PRGS = \
 init: init.o
 	$(LD) $(LDFLAGS) -maout-heap=4096 -maout-stack=1024 -o init init.o $(LDLIBS)
 
-getty: getty.o
-	$(LD) $(LDFLAGS) -maout-heap=1024 -maout-stack=1024 -o getty getty.o $(LDLIBS)
+getty: getty.o ../file_utils/tio_vfprintf.o
+	$(LD) $(LDFLAGS) -maout-heap=1024 -maout-stack=1024 -o getty getty.o ../file_utils/tio_vfprintf.o $(LDLIBS)
 
 login: login.o
 	$(LD) $(LDFLAGS) -maout-stack=2048 -o login login.o $(LDLIBS)
@@ -93,8 +93,8 @@ poweroff: poweroff.o
 chmem: chmem.o
 	$(LD) $(LDFLAGS) -o chmem chmem.o $(LDLIBS)
 
-mouse: mouse.o
-	$(LD) $(LDFLAGS) -o mouse mouse.o $(LDLIBS)
+mouse: mouse.o ../file_utils/tio_vfprintf.o
+	$(LD) $(LDFLAGS) -o mouse mouse.o ../file_utils/tio_vfprintf.o $(LDLIBS)
 
 sercat: sercat.o
 	$(LD) $(LDFLAGS) -o sercat sercat.o $(LDLIBS)
@@ -102,8 +102,8 @@ sercat: sercat.o
 console: console.o
 	$(LD) $(LDFLAGS) -o console console.o $(LDLIBS)
 
-makeboot: makeboot.o
-	$(LD) $(LDFLAGS) -o makeboot makeboot.o $(LDLIBS)
+makeboot: makeboot.o ../file_utils/tio_vfprintf.o
+	$(LD) $(LDFLAGS) -o makeboot makeboot.o ../file_utils/tio_vfprintf.o $(LDLIBS)
 
 unreal.o: $(ELKS_LIB)/unreal.S
 	$(LD) -melks-libc -mcmodel=small -c $(ELKS_LIB)/unreal.S -o unreal.o


### PR DESCRIPTION
Very small stdio `vfprintf` libc replacement works to reduce executable sizes for certain programs that don't use stdio reading (fopen, getc, getchar).

Automatically works with printf, fprintf, sprintf.

Used to further reduce program sizes around 700-800 bytes each for: mkfs, mkfat, ramdisk, cp, which, tr, mesg, stty, getty, mouse, makeboot.