### PR TITLE
[cmds] Cleanup tiny printf and Makefiles

### DIFF
--- a/elks/fs/super.c
+++ b/elks/fs/super.c
@@ -182,10 +182,12 @@ static struct super_block *read_super(kdev_t dev, int t, int flags,
     type = file_systems[0];
 #endif
 
-    for (s = super_blocks; s->s_dev; s++)
-	continue;
-    if (s >= super_blocks + NR_SUPER)
-	return NULL;
+    for (s = super_blocks; ; s++) {
+	if (s >= super_blocks + NR_SUPER)
+	    return NULL;
+	if (s->s_dev == 0)
+	    break;
+    }
 
     s->s_dev = dev;
     s->s_flags = flags;

--- a/elkscmd/Make.defs
+++ b/elkscmd/Make.defs
@@ -95,6 +95,12 @@ CFLAGS=$(CFLBASE) $(WARNINGS) $(LOCALFLAGS) $(INCLUDES) -D__ELKS__ -DELKS_VERSIO
 
 ###############################################################################
 #
+# Special libraries for some programs
+TINYPRINTF=$(ELKSCMD_DIR)/lib/tiny_vfprintf.o
+
+
+###############################################################################
+#
 # Standard compilation rules.
 
 .S.s:

--- a/elkscmd/disk_utils/Makefile
+++ b/elkscmd/disk_utils/Makefile
@@ -28,17 +28,17 @@ fsck: fsck.o
 fdisk: fdisk.o
 	$(LD) $(LDFLAGS) -o fdisk fdisk.o $(LDLIBS)
 
-mkfs: mkfs.o ../file_utils/tio_vfprintf.o
-	$(LD) $(LDFLAGS) -o mkfs mkfs.o ../file_utils/tio_vfprintf.o $(LDLIBS)
+mkfs: mkfs.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o mkfs mkfs.o $(TINYPRINTF) $(LDLIBS)
 
-mkfat: mkfat.o ../file_utils/tio_vfprintf.o
-	$(LD) $(LDFLAGS) -o mkfat mkfat.o ../file_utils/tio_vfprintf.o $(LDLIBS)
+mkfat: mkfat.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o mkfat mkfat.o $(TINYPRINTF) $(LDLIBS)
 
 partype: partype.o
 	$(LD) $(LDFLAGS) -o partype partype.o $(LDLIBS)
 
-ramdisk: ramdisk.o ../file_utils/tio_vfprintf.o
-	$(LD) $(LDFLAGS) -o ramdisk ramdisk.o ../file_utils/tio_vfprintf.o $(LDLIBS)
+ramdisk: ramdisk.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o ramdisk ramdisk.o $(TINYPRINTF) $(LDLIBS)
 
 clean:
 	rm -f *.o $(FORMATMOD) core $(PRGS)

--- a/elkscmd/file_utils/Makefile
+++ b/elkscmd/file_utils/Makefile
@@ -32,8 +32,8 @@ chown: chown.o
 cmp: cmp.o
 	$(LD) $(LDFLAGS) -o cmp cmp.o $(LDLIBS)
 
-cp: cp.o tio_vfprintf.o
-	$(LD) $(LDFLAGS) -maout-heap=0xffff -o cp cp.o tio_vfprintf.o $(LDLIBS)
+cp: cp.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -maout-heap=0xffff -o cp cp.o $(TINYPRINTF) $(LDLIBS)
 
 df: df.o
 	$(LD) $(LDFLAGS) -o df df.o $(LDLIBS)

--- a/elkscmd/lib/tiny_vfprintf.c
+++ b/elkscmd/lib/tiny_vfprintf.c
@@ -8,8 +8,7 @@
  * Limitations:
  *	%s, %c, %d, %u, %x, %o, %ld, %lu, %lx only
  *  No field widths
- *  Should not mix with stdio input functions or library routines that use fopen
- *    Replaces stdin, stdout, stderr buffers to single buffer
+ *    Replaces stdout and stderr buffers with single buffer
  *
  * Mar 2020 Greg Haerr
  */
@@ -22,20 +21,6 @@
 #include <sys/types.h>
 
 static unsigned char bufout[80];
-
-FILE  stdin[1] =
-{
-   {
-    bufout,
-    bufout,
-    bufout,
-    bufout,
-    bufout + sizeof(bufout),
-    0,
-    _IOFBF | __MODE_READ | __MODE_IOTRAN
-   }
-};
-
 
 FILE  stdout[1] =
 {

--- a/elkscmd/misc_utils/Makefile
+++ b/elkscmd/misc_utils/Makefile
@@ -24,8 +24,8 @@ all: $(PRGS) $(PRGS_HOST)
 ed: ed.o
 	$(LD) $(LDFLAGS) -o ed ed.o $(LDLIBS)
 
-fdtest: fdtest.o ../file_utils/tio_vfprintf.o
-	$(LD) $(LDFLAGS) -o fdtest fdtest.o ../file_utils/tio_vfprintf.o $(KERNEL_LIBS) $(LDLIBS)
+fdtest: fdtest.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o fdtest fdtest.o $(TINYPRINTF) $(KERNEL_LIBS) $(LDLIBS)
 
 tar: tar.o
 	$(LD) $(LDFLAGS) -o tar tar.o $(LDLIBS)

--- a/elkscmd/sh_utils/Makefile
+++ b/elkscmd/sh_utils/Makefile
@@ -45,8 +45,8 @@ pwd: pwd.o
 true: true.o
 	$(LD) $(LDFLAGS) -o true true.o $(LDLIBS)
 
-which: which.o ../file_utils/tio_vfprintf.o
-	$(LD) $(LDFLAGS) -o which which.o ../file_utils/tio_vfprintf.o $(LDLIBS)
+which: which.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o which which.o $(TINYPRINTF) $(LDLIBS)
 
 whoami: whoami.o
 	$(LD) $(LDFLAGS) -o whoami whoami.o $(LDLIBS)
@@ -57,17 +57,17 @@ yes: yes.o
 logname: logname.o
 	$(LD) $(LDFLAGS) -o logname logname.o $(LDLIBS)
 
-tr: tr.o ../file_utils/tio_vfprintf.o
-	$(LD) $(LDFLAGS) -o tr tr.o ../file_utils/tio_vfprintf.o $(LDLIBS)
+tr: tr.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o tr tr.o $(TINYPRINTF) $(LDLIBS)
 
 xargs: xargs.o
 	$(LD) $(LDFLAGS) -o xargs xargs.o $(LDLIBS)
 
-mesg: mesg.o ../file_utils/tio_vfprintf.o
-	$(LD) $(LDFLAGS) -o mesg mesg.o ../file_utils/tio_vfprintf.o $(LDLIBS)
+mesg: mesg.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o mesg mesg.o $(TINYPRINTF) $(LDLIBS)
 
-stty: stty.o ../file_utils/tio_vfprintf.o
-	$(LD) $(LDFLAGS) -o stty stty.o ../file_utils/tio_vfprintf.o $(LDLIBS)
+stty: stty.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o stty stty.o $(TINYPRINTF) $(LDLIBS)
 
 test: test.o
 	$(LD) $(LDFLAGS) -o test test.o $(LDLIBS)

--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -42,8 +42,8 @@ PRGS = \
 init: init.o
 	$(LD) $(LDFLAGS) -maout-heap=4096 -maout-stack=1024 -o init init.o $(LDLIBS)
 
-getty: getty.o ../file_utils/tio_vfprintf.o
-	$(LD) $(LDFLAGS) -maout-heap=1024 -maout-stack=1024 -o getty getty.o ../file_utils/tio_vfprintf.o $(LDLIBS)
+getty: getty.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -maout-heap=1024 -maout-stack=1024 -o getty getty.o $(TINYPRINTF) $(LDLIBS)
 
 login: login.o
 	$(LD) $(LDFLAGS) -maout-stack=2048 -o login login.o $(LDLIBS)
@@ -93,8 +93,8 @@ poweroff: poweroff.o
 chmem: chmem.o
 	$(LD) $(LDFLAGS) -o chmem chmem.o $(LDLIBS)
 
-mouse: mouse.o ../file_utils/tio_vfprintf.o
-	$(LD) $(LDFLAGS) -o mouse mouse.o ../file_utils/tio_vfprintf.o $(LDLIBS)
+mouse: mouse.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o mouse mouse.o $(TINYPRINTF) $(LDLIBS)
 
 sercat: sercat.o
 	$(LD) $(LDFLAGS) -o sercat sercat.o $(LDLIBS)
@@ -102,8 +102,8 @@ sercat: sercat.o
 console: console.o
 	$(LD) $(LDFLAGS) -o console console.o $(LDLIBS)
 
-makeboot: makeboot.o ../file_utils/tio_vfprintf.o
-	$(LD) $(LDFLAGS) -o makeboot makeboot.o ../file_utils/tio_vfprintf.o $(LDLIBS)
+makeboot: makeboot.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o makeboot makeboot.o $(TINYPRINTF) $(LDLIBS)
 
 unreal.o: $(ELKS_LIB)/unreal.S
 	$(LD) -melks-libc -mcmodel=small -c $(ELKS_LIB)/unreal.S -o unreal.o

--- a/elkscmd/sys_utils/makeboot.c
+++ b/elkscmd/sys_utils/makeboot.c
@@ -301,7 +301,7 @@ void fatalmsg(const char *s, ...)
 int main(int ac, char **av)
 {
 	char *rootdevice, *targetdevice;
-	char *bootfile;
+	char *bootfile = 0;
 	int rootfstype, fstype, fd, n;
 	int opt_writembr = 0;
 	int opt_writeflat = 0;


### PR DESCRIPTION
Cleans up command Makefiles by moving tiny stdio into elkscmd/lib.

Also cleans up kernel code for max filesystems mounted, which was incorrectly coded (even though no failure).