### PR TITLE
[kernel] Rewrite kernel timer routines from scratch

### DIFF
--- a/elks/arch/i86/drivers/char/kbd-poll-pc98.c
+++ b/elks/arch/i86/drivers/char/kbd-poll-pc98.c
@@ -67,7 +67,6 @@ static void restart_timer(void)
 {
     static struct timer_list timer;
 
-    init_timer(&timer);
     timer.tl_expires = jiffies + (8 * HZ/100);	/* every 8/100 second*/
     timer.tl_function = kbd_timer;
     add_timer(&timer);

--- a/elks/arch/i86/drivers/char/kbd-poll.c
+++ b/elks/arch/i86/drivers/char/kbd-poll.c
@@ -73,7 +73,6 @@ static void restart_timer(void)
 {
     static struct timer_list timer;
 
-    init_timer(&timer);
     timer.tl_expires = jiffies + (8 * HZ/100);	/* every 8/100 second*/
     timer.tl_function = kbd_timer;
     add_timer(&timer);

--- a/elks/arch/i86/drivers/char/kbd-scancode.c
+++ b/elks/arch/i86/drivers/char/kbd-scancode.c
@@ -447,7 +447,7 @@ static void kbd_send_cmd(int data)
 /* Arrange to call kbd_send_cmd() after a short period of time. */
 static void restart_timer(void)
 {
-    init_timer(&kb_cmd_timer);
+    del_timer(&kb_cmd_timer);	/* required in case set_leds called before expiration*/
     kb_cmd_timer.tl_expires = jiffies + (2 * HZ/100);	/* every 2/100 second*/
     kb_cmd_timer.tl_function = kbd_send_cmd;
     add_timer(&kb_cmd_timer);

--- a/elks/include/linuxmt/limits.h
+++ b/elks/include/linuxmt/limits.h
@@ -7,6 +7,7 @@
 
 #define POLL_MAX	6	/* Maximum number of polled queues per process */
 
+#define NR_ALARMS	5	/* Max number of simultaneous alarms system-wide */
 #define NGROUPS		13	/* Supplementary groups */
 
 #define MAX_PACKET_ETH 1536	/* Max packet size, 6 blocks of 256 bytes */

--- a/elks/include/linuxmt/timer.h
+++ b/elks/include/linuxmt/timer.h
@@ -17,7 +17,6 @@
  */
 struct timer_list {
     struct timer_list *tl_next;
-    struct timer_list *tl_prev;
     jiff_t tl_expires;
     int tl_data;
     void (*tl_function) ();
@@ -26,10 +25,9 @@ struct timer_list {
 struct pt_regs;
 
 /* sched.c*/
-extern void init_timer(struct timer_list *);
-extern void add_timer(struct timer_list *);
-extern int del_timer(struct timer_list *);
-extern void do_timer(struct pt_regs *);
+void add_timer(struct timer_list *);
+int del_timer(struct timer_list *);
+void do_timer(struct pt_regs *);
 
 /* timer.c*/
 void timer_tick(int, struct pt_regs *);

--- a/elks/kernel/sys2.c
+++ b/elks/kernel/sys2.c
@@ -12,9 +12,9 @@
  * Feb 2022 Greg Haerr
  */
 
-static struct timer_list alarm;
+static struct timer_list alarms[NR_ALARMS];
 
-static void alarm_callback(int data)
+void alarm_callback(int data)
 {
 	struct task_struct *p = (struct task_struct *)data;
 
@@ -22,19 +22,39 @@ static void alarm_callback(int data)
 	send_sig(SIGALRM, p, 1);
 }
 
+static struct timer_list *find_alarm(struct task_struct *task)
+{
+	struct timer_list *ap;
+
+	for (ap = alarms; ap < &alarms[NR_ALARMS]; ap++ ) {
+		if (ap->tl_data == (int)task)
+			return ap;
+	}
+	return NULL;
+}
+
 unsigned int sys_alarm(unsigned int secs)
 {
+	struct timer_list *ap;
+
 	debug("sys_alarm %d\n", secs);
+	ap = find_alarm(current);
 	if (secs == 0) {
-		if (alarm.tl_data)
-			del_timer(&alarm);
-		alarm.tl_data = 0;
+		if (ap) {
+			del_timer(ap);
+			ap->tl_data = 0;
+			return 0;
+		}
 	} else {
-		init_timer(&alarm);
-		alarm.tl_expires = jiffies + (secs * HZ);
-		alarm.tl_function = alarm_callback;
-		alarm.tl_data = (int)current;	/* must delete timer on process exit*/
-		add_timer(&alarm);
+		if (!ap && !(ap = find_alarm(NULL))) {
+			printk("No more alarms\n");
+			return 0;
+		}
+		del_timer(ap);
+		ap->tl_expires = jiffies + (secs * HZ);
+		ap->tl_function = alarm_callback;
+		ap->tl_data = (int)current;	/* must delete timer on process exit*/
+		add_timer(ap);
 	}
 	return 0;
 }

--- a/elks/kernel/sys2.c
+++ b/elks/kernel/sys2.c
@@ -14,7 +14,7 @@
 
 static struct timer_list alarms[NR_ALARMS];
 
-void alarm_callback(int data)
+static void alarm_callback(int data)
 {
 	struct task_struct *p = (struct task_struct *)data;
 


### PR DESCRIPTION
Should fix system hang issue in #1196, which is the result of two things: the `alarm` system call was only implemented for one alarm system-wide which reused a single kernel timer, and secondly, it was found that the system hang occurred because the kernel's system timer routines were were buggy, and had to be rewritten. The kernel was busy-looping when a certain pattern occurred in the doubly-linked kernel timer list.

New limit of five alarms system-wide (and a limit of one of those per-process).
The kernel timer routines were rewritten and now use a simpler single-pointer linked list data structure.

The new "sync=" automatic sync interval uses an alarm in /bin/init, and each telnet or ftp connect will use an alarm. Tested with sync=3 and now telnet returns with "Connection timed out" as it should in 10 seconds.

Tested on QEMU, but could use more system testing, as the keyboard LED lights use a kernel timer (yes, they do!), as well as the polling keyboards (not scan code keyboards). A good test would be to set sync=3, telnet to a non-existent address, and hit the CapsLock key repeatedly. (No joke).
