### PR TITLE
[net] Improve connect return message on ICMP Destination unreachable

### DIFF
--- a/elkscmd/ktcp/icmp.c
+++ b/elkscmd/ktcp/icmp.c
@@ -71,7 +71,10 @@ void icmp_process(struct iphdr_s *iph, unsigned char *packet)
 	cbnode = tcpcb_find(dpip->daddr, ntohs(dptcp->sport), ntohs(dptcp->dport));
 	if (cbnode) {
 	    struct tcpcb_s *cb = &cbnode->tcpcb;
-	    notify_sock(cb->sock, TDT_CONNECT, -EHOSTUNREACH);
+	    int err = (dp->code == 1)? -EHOSTUNREACH :
+		      (dp->code >= 9)? -ECONNREFUSED : -ENETUNREACH;
+
+	    notify_sock(cb->sock, TDT_CONNECT, err);
 	    tcpcb_remove_cb(cb);	/* deallocate */
 	} else debug_ip("icmp: Connection not found\n");
 	break;


### PR DESCRIPTION
Enhances error message displayed on telnet/ftp connect to systems returning ICMP destination unreachable.

Discussed in https://github.com/jbruchon/elks/pull/1207#issuecomment-1062949316.
 
@Mellvik, for your particular host, you should get a "Connection refused" after this commit.