### PR TITLE
[cmds] Display informative message on umount /

### DIFF
--- a/elkscmd/disk_utils/fsck.c
+++ b/elkscmd/disk_utils/fsck.c
@@ -527,7 +527,7 @@ void read_tables(void)
 /*		namelen = 14; RUBOUT */
 /*		dirsize = 16; RUBOUT */
 	} else {
-		die("bad magic number in super-block");
+		die("not a MINIX filesystem (perhaps DOS?)");
 	}
 	/*else if (MAGIC == MINIX_SUPER_MAGIC2) { RUBOUT
 		namelen = 30;

--- a/elkscmd/man/man8/mount.8
+++ b/elkscmd/man/man8/mount.8
@@ -6,7 +6,7 @@ mount \- mount a file system
 .B [\-a]
 .B [\-q]
 .B [\-t fstype]
-.B [\-o ro|remount,rw]
+.B [\-o ro|remount,{rw|ro}]
 .I device directory
 .SH DESCRIPTION
 .BR mount
@@ -32,7 +32,8 @@ Specify the type of filesystem to be mounted. Default is
 .B minix .
 .TP
 .B "-o"
-Specify ro (readonly) or remount,rw (remount read/write) options.
+Specify ro (readonly), remount,rw (remount read/write)
+or remount,ro (remount read-only) options.
 .TP
 .B "-q"
 Query filesystem type and set return value based on filesystem.

--- a/elkscmd/man/man8/umount.8
+++ b/elkscmd/man/man8/umount.8
@@ -26,6 +26,10 @@ If this happens, and is discovered before another diskette is inserted, the
 original one can be replaced without harm.
 Attempts to unmount a file system holding working directories or open files
 will be rejected with a \&'device busy\&' message.
+.sp
+As a special case,
+.B umount /
+will attempt to unmount the root filesystem and remount it read-only.
 .SH EXIT STATUS
 .TP
 .I 0

--- a/elkscmd/rootfs_template/etc/mount.cfg
+++ b/elkscmd/rootfs_template/etc/mount.cfg
@@ -3,6 +3,7 @@
 #
 # check_filesystem below must be manually uncommented for MINIX
 #
+#set -x
 
 fsck="fsck -r"
 

--- a/elkscmd/sys_utils/mount.c
+++ b/elkscmd/sys_utils/mount.c
@@ -14,6 +14,8 @@
 #include <stdlib.h>
 #include <sys/mount.h>
 
+#define errmsg(str) write(STDERR_FILENO, str, sizeof(str) - 1)
+
 static char *fs_typename[] = {
 	0, "minix", "msdos", "romfs"
 };
@@ -82,7 +84,7 @@ static void show(void)
 
 static void usage(void)
 {
-	write(STDERR_FILENO, "Usage: mount [-a][-q][-t type] [-o ro|remount,rw] <device> <directory>\n", 71);
+	errmsg("usage: mount [-a][-q][-t type] [-o ro|remount,{rw|ro}] <device> <directory>\n");
 }
 
 int main(int argc, char **argv)
@@ -109,7 +111,7 @@ int main(int argc, char **argv)
 				break;
 			case 't':
 				if ((argc <= 0) || (**argv == '-')) {
-					write(STDERR_FILENO, "mount: missing file system type\n", 32);
+					errmsg("mount: missing file system type\n");
 					return 1;
 				}
 
@@ -125,7 +127,7 @@ int main(int argc, char **argv)
 
 			case 'o':
 				if ((argc <= 0) || (**argv == '-')) {
-					write(STDERR_FILENO, "mount: missing option string\n", 29);
+					errmsg("mount: missing option string\n");
 					return 1;
 				}
 
@@ -137,14 +139,14 @@ int main(int argc, char **argv)
 				else if (!strcmp(option, "remount,ro"))
 					flags |= MS_REMOUNT|MS_RDONLY;
 				else {
-					write(STDERR_FILENO, "mount: bad option string\n", 25);
+					errmsg("mount: bad option string\n");
 					return 1;
 				}
 				argc--;
 				break;
 
 			default:
-				write(STDERR_FILENO, "mount: unknown option\n", 22);
+				errmsg("mount: unknown option\n");
 				return 1;
 		}
 	}

--- a/elkscmd/sys_utils/umount.c
+++ b/elkscmd/sys_utils/umount.c
@@ -9,18 +9,24 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <string.h>
 #include <fcntl.h>
 #include <sys/mount.h>
+
+#define msg(str) write(STDOUT_FILENO, str, sizeof(str) - 1)
+#define errmsg(str) write(STDERR_FILENO, str, sizeof(str) - 1)
 
 int main(int argc, char **argv)
 {
 	if (argc != 2) {
-		write(STDERR_FILENO, "Usage: umount <device>|<directory>\n", 35);
+		errmsg("Usage: umount <device>|<directory>\n");
 		return 1;
 	}
 	if (umount(argv[1]) < 0) {
 		perror(argv[1]);
-		exit(1);
+		return 1;
 	}
+	if (!strcmp(argv[1], "/"))
+		msg("/: Remounted read-only\n");
 	return 0;
 }


### PR DESCRIPTION
As discussed in https://github.com/jbruchon/elks/pull/1204#issuecomment-1063073303.

When `umount /` is executed, the kernel checks for any files opened for write, and fails the command if so.
Displays "/: Remounted read-only" otherwise (rather than nothing, as it did previously).

`umount /` currently acts as a shorthand for `mount -o remount,ro / /` and helps the /etc/mount.cfg shell function for the readonly remount required for fsck-ing the specified filesystem.

Updated man pages for mount and umount.