### PR TITLE
[tools] Add eman to display ELKS man pages from host system

### DIFF
--- a/elks/tools/.gitignore
+++ b/elks/tools/.gitignore
@@ -6,4 +6,5 @@ bin/objdump86
 bin/elf2elks
 bin/elks-compress
 bin/exomizer
+bin/eman
 elftoolchain-0.7.1

--- a/elks/tools/Makefile
+++ b/elks/tools/Makefile
@@ -34,6 +34,7 @@ all:
 	$(MAKE) -C objdump86 all
 	$(MAKE) -C elf2elks all
 	$(MAKE) -C elks-compress all
+	$(MAKE) -C eman all
 
 
 #########################################################################

--- a/elks/tools/eman/Makefile
+++ b/elks/tools/eman/Makefile
@@ -1,0 +1,51 @@
+# eman - display ELKS manual pages on host
+#
+#########################################################################
+#
+# Note! Dependencies are done automagically by 'make dep', which also
+# removes any old dependencies. DON'T put your own dependencies here
+# unless it's something special (ie not a .c file).
+#
+#########################################################################
+# Relative path to base directory.
+
+BASEDIR 	= ../..
+
+#########################################################################
+# Define the variables required by the standard rules - see the standard
+# rules file (below) for details of these variables.
+
+USEBCC 		= N
+
+CLEANDEP	=
+
+CLEANME 	= ../bin/eman
+
+DEPEND  	=
+
+DISTFILES	=
+
+NOINDENT	=
+
+#########################################################################
+# Include standard commands.
+
+include $(BASEDIR)/Makefile-rules
+
+#########################################################################
+# Objects to be compiled.
+
+SRCS=$(TOPDIR)/elkscmd/sys_utils/man.c
+
+#OBJS=$(SRCS:.c=.o)
+
+#########################################################################
+# Commands.
+
+all:	../bin/eman
+
+../bin/eman: $(SRCS)
+	$(CC) -D_PATH_MANPAGES=\"$(TOPDIR)/elkscmd/man\" -o ../bin/eman $(CFLAGS) $(SRCS)
+
+#########################################################################
+### Dependencies:

--- a/elkscmd/sys_utils/man.c
+++ b/elkscmd/sys_utils/man.c
@@ -37,8 +37,7 @@
 #include <paths.h>
 #define MORE			"more"
 #else					/* Host */
-#define _PATH_MANPAGES	"."
-#define MORE			"more -R"
+#define MORE			"less -R"
 #endif
 
 /* default .TH [extra1] value */


### PR DESCRIPTION
Adds `eman` (which is actually the ELKS man pager compiled on the host system) to allow display of ELKS man pages for developers, without having to run ELKS.

Usage is exactly like `man`, e.g. `eman accept`, or `eman ftp`.

This enhancement is quite useful for quickly checking new man pages while writing them, as well as a reference for writing programs for ELKS, for developers.

@Mellvik, I was looking at the ftp and ftpd man pages and saw some errors with respect to bold text; I thought this tool might help make it easier for you to see the pages yourself, without having to create a QEMU or physical hardware version each time.