### PR TITLE
[kernel] Fix strace and reduce kernel stack in FAT filesystem

### DIFF
--- a/elks/arch/i86/kernel/strace.h
+++ b/elks/arch/i86/kernel/strace.h
@@ -49,7 +49,7 @@ struct syscall_info elks_table[] = {
     { "fork",		packinfo(0, P_NONE,   P_NONE,    P_NONE   ) },
     { "read",		packinfo(3, P_USHORT, P_PDATA,   P_USHORT ) },
     { "write",		packinfo(3, P_USHORT, P_PDATA,   P_USHORT ) },
-    { "open",		packinfo(3, P_PSTR,   P_SSHORT,  P_SSHORT ) },
+    { "open",		packinfo(3, P_PSTR,   P_USHORT,  P_USHORT ) },
     { "close",		packinfo(1, P_USHORT, P_NONE,    P_NONE   ) },
     { "wait4",		packinfo(3, P_SSHORT, P_PSSHORT, P_SSHORT ) },
     { "creat",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },

--- a/elks/arch/i86/kernel/strace.h
+++ b/elks/arch/i86/kernel/strace.h
@@ -71,7 +71,7 @@ struct syscall_info elks_table[] = {
     { "getuid",		packinfo(0, P_NONE,   P_NONE,    P_NONE   ) },
     { "stime",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
     { "ptrace",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "alarm",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
+    { "alarm",		packinfo(1, P_USHORT, P_NONE,    P_NONE   ) },
     { "fstat",		packinfo(2, P_USHORT, P_PDATA,   P_NONE   ) },
     { "pause",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
     { "utime",		packinfo(2, P_PSTR,   P_PDATA,   P_NONE   ) },
@@ -114,7 +114,7 @@ struct syscall_info elks_table[] = {
     { "dlload",		packinfo(2, P_DATA,   P_DATA,    P_NONE   ) },
     { "setsid",		packinfo(0, P_NONE,   P_NONE,    P_NONE   ) },
     { "sbrk",		packinfo(1, P_SSHORT, P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
+    { "ustatfs",	packinfo(2, P_USHORT, P_PDATA,   P_NONE   ) },
     { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
     { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
     { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
@@ -248,8 +248,8 @@ struct syscall_info elks_table[] = {
     { "listen",		packinfo(2, P_SSHORT, P_SSHORT,  P_NONE   ) },
     { "accept",		packinfo(3, P_SSHORT, P_DATA,    P_PUSHORT) },
     { "connect",	packinfo(3, P_SSHORT, P_PDATA,   P_SSHORT ) },
-    { "setsockopt",	packinfo(5, P_SSHORT, P_SSHORT,  P_SSHORT, P_PDATA, P_PUSHORT ) },
-    { "getsocknam",	packinfo(4, P_SSHORT, P_DATA,    P_PUSHORT, P_SSHORT) },
+    { "setsockopt",	packinfo(5, P_SSHORT, P_SSHORT,  P_SSHORT ) }, /* +2 args*/
+    { "getsocknam",	packinfo(4, P_SSHORT, P_DATA,    P_PUSHORT) }, /* +1 arg*/
 };
 
 #endif

--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -228,7 +228,8 @@ static int msdos_readdir(struct inode *dir, struct file *filp, char *dirbuf,
 	ino_t ino;
 	off_t dirpos;
 	int res, namelen;
-	char name[14];
+	/* static not reentrant: conserve stack usage*/
+	static char name[14];
 
 	if (!dir || !S_ISDIR(dir->i_mode)) return -EBADF;
 	if (dir->i_ino == MSDOS_ROOT_INO) {

--- a/elks/fs/msdos/namei.c
+++ b/elks/fs/msdos/namei.c
@@ -68,7 +68,8 @@ static int FATPROC msdos_find(struct inode *dir,const char *name,int len,
     struct buffer_head **bh,struct msdos_dir_entry **de,ino_t *ino)
 {
 	int res;
-	char msdos_name[MSDOS_NAME+1];
+	/* static not reentrant: conserve stack usage*/
+	static char msdos_name[MSDOS_NAME+1];
 
 	if ((res = msdos_format_name(name,len, msdos_name)) < 0) return res;
 	res = msdos_scan(dir,msdos_name,bh,de,ino);
@@ -206,9 +207,10 @@ int msdos_create(register struct inode *dir,const char *name,int len,int mode,
 {
 	struct buffer_head *bh;
 	struct msdos_dir_entry *de;
-	char msdos_name[MSDOS_NAME];
 	ino_t ino;
 	int res;
+	/* static not reentrant: conserve stack usage*/
+	static char msdos_name[MSDOS_NAME];
 
 	if ((res = msdos_format_name(name,len, msdos_name)) < 0) {
 		iput(dir);
@@ -234,9 +236,10 @@ int msdos_mkdir(struct inode *dir,const char *name,int len,int mode)
 	struct buffer_head *bh;
 	struct msdos_dir_entry *de;
 	struct inode *inode,*dot;
-	char msdos_name[MSDOS_NAME];
 	ino_t ino;
 	int res;
+	/* static not reentrant: conserve stack usage*/
+	static char msdos_name[MSDOS_NAME];
 
 	if ((res = msdos_format_name(name,len, msdos_name)) < 0) {
 		iput(dir);


### PR DESCRIPTION
Hello @tyama501,

This PR attempts to reduce the kernel stack size used when using the FAT filesystem by changing a few of the larger (remaining) stack variables in the FAT filesystem driver to static, which works only because the kernel is not reentrant. However, on my system, this did not reduce the kernel stack usage from a max used of 414 bytes (of 640 max).

There is a pretty cool method of observing kernel stack usage - the CONFIG_STRACE option. When turned on (and most useful when able to redirect output to a serial console), every system call that is executed by user programs is displayed on the console. This information is invaluable for debugging and watching system operation, but it also includes the kernel stack usage on each call, along with the max kernel stack seen since boot. (ks=X/MAX values)

Here is a display when CONFIG_STRACE=y, from system startup:
```
ELKS kernel 0.5.0 (56112 text, 12912 ftext, 9856 data, 42544 bss, 13134 heap)
Kernel text at 2d0:0000, ftext 1083:0000, data 13aa:0000, top 9fc0:0, 496K free
fd: /dev/fd0 ELKS bootable, has 80 cylinders, 2 heads, and 36 sectors
FAT: me=f0,csz=2,#f=2,floc=1,fsz=9,rloc=19,#d=224,dloc=33,#s=5760,ts=0
FAT: total 2880k, fat12 format
VFS: Mounted root 0x0380 (msdos filesystem).
[1/16b2: 20 getpid      ()][1:getpid/ret=1,ks=126/126]
[1/16a8: 48 signal      (1, 0x86B)][1:signal/ret=0,ks=126/126]
[1/16a4: 48 signal      (14, 0x86B)][1:signal/ret=0,ks=126/126]
[1/15aa: 27 alarm       (0)][1:alarm/ret=0,ks=126/126]
[1/156c: 69 sbrk        (0)][1:sbrk/ret=0,ks=126/126]
[1/156c: 69 sbrk        (1024)][1:sbrk/ret=0,ks=126/126]
[1/1588:  5 open        ("/etc/inittab", 0, 438)][1:open/ret=3,ks=392/392]
[1/155a: 54 ioctl       (3, 21505, 5482)][1:ioctl/ret=-22,ks=126/392]
[1/156c: 69 sbrk        (0)][1:sbrk/ret=0,ks=126/392]
[1/156c: 69 sbrk        (2048)][1:sbrk/ret=0,ks=126/392]
[1/154c: 54 ioctl       (1, 21505, 5468)][1:ioctl/ret=0,ks=126/392]
[1/157c:  3 read        (3, 0x2EC, 1024)][1:read/ret=493,ks=250/392]
[1/13f8:  2 fork        ()][1:fork/ret=2,ks=126/392]
[1/1480:  7 wait4       (-1, &0, 0)][2/13f8: 68 setsid      ()][2:setsid/ret=2,ks=126/392]
[2/13f4:  5 open        ("/dev/console", 2, 0)][2:open/ret=4,ks=282/392]
[2/13f4: 45 dup2        (4, 0)][2:dup2/ret=0,ks=126/392]
[2/13f0: 45 dup2        (4, 1)][2:dup2/ret=1,ks=126/392]
[2/13ec: 45 dup2        (4, 2)][2:dup2/ret=2,ks=126/392]
[2/13f6:  6 close       (4)][2:close/ret=0,ks=126/392]
[2/13cc: 69 sbrk        (54)][2:sbrk/ret=0,ks=126/392]
[2/13d2: 11 execve      ("/bin/sh", 0xED0, 54)][2:execve/ret=0,ks=414/414]
[2/4ff8: 48 signal      (7, 0x1)][2:signal/ret=0,ks=126/414]
[2/5002: 20 getpid      ()][2:getpid/ret=2,ks=126/414]
[2/4ff4: 24 getuid      ()][2:getuid/ret=0,ks=126/414]
[2/4fcc: 69 sbrk        (0)][2:sbrk/ret=0,ks=126/414]
[2/4fcc: 69 sbrk        (1024)][2:sbrk/ret=0,ks=126/414]
[2/4fc8: 54 ioctl       (0, 21505, 20440)][2:ioctl/ret=0,ks=126/414]
[2/4fc8: 54 ioctl       (1, 21505, 20440)][2:ioctl/ret=0,ks=126/414]
[2/4f90:  2 fork        ()][2:fork/ret=3,ks=126/414]
[2/4f64:  7 wait4       (-1, &20370, 0)][3/4f72: 69 sbrk        (0)][3:sbrk/ret=0,ks=126/414]
[3/4f5e: 69 sbrk        (39)][3:sbrk/ret=0,ks=126/414]
[3/4f64: 11 execve      ("/etc/rc.sys", 0x2C30, 39)][3:execve/ret=-8,ks=304/414]
[3/4f58: 69 sbrk        (-39)][3:sbrk/ret=0,ks=126/414]
[3/4f70: 24 getuid      ()][3:getuid/ret=0,ks=126/414]
[3/4f70:  5 open        ("/etc/rc.sys", 0, 0)][3:open/ret=4,ks=282/414]
[3/4f66: 50 fcntl       (4, 0, 10)][3:fcntl/ret=10,ks=126/414]
[3/4f6e:  6 close       (4)][3:close/ret=0,ks=126/414]
[3/4f64: 50 fcntl       (10, 1, 20352)][3:fcntl/ret=0,ks=126/414]
[3/4f5e: 50 fcntl       (10, 2, 1)][3:fcntl/ret=0,ks=126/414]
[3/4f70:  3 read        (10, 0x1350, 1024)][3:read/ret=643,ks=214/414]
[3/5002: 20 getpid      ()][3:getpid/ret=3,ks=126/414]
[3/4f58: 69 sbrk        (0)][3:sbrk/ret=0,ks=126/414]
[3/4f58: 69 sbrk        (2048)][3:sbrk/ret=0,ks=126/414]
[3/4f7e:  4 write       (1, 0x28B4, 27)]Running /etc/rc.sys script
[3:write/ret=27,ks=126/414]
```
The first few lines are showing the execution of /bin/init, where it executes getpid and alarm, with a max stack of 126. However, (this is running on a FAT boot filesystem), after the execution of open("/etc/inittab"), the kernel stack used is 392. Shortly after that, after exec'ing /bin/sh to run the /etc/rc.sys script, the max stack of 414 is used. 

On my system, this max stack stays at 414 when I execute "cp /bin/* /mnt/bin/". (The ks=X/MAX display shows the kernel stack X used on the system call and maximum stack ever used as MAX).

Perhaps this PR will help reduce the stack requirement on PC-98 running FAT filesystem. I would need more information on when the stack overflow occurs in order to best debug this (preferably a full strace log) so we don't have to increase the KSTACK_BYTES for the whole system.

Thank you!