### PR TITLE
Increased KSTACK_BYTES for CONFIG_ARCH_PC98

### DIFF
--- a/elks/include/linuxmt/limits.h
+++ b/elks/include/linuxmt/limits.h
@@ -3,7 +3,11 @@
 
 #define MAX_TASKS	16	/* Max # processes */
 
+#ifdef CONFIG_ARCH_PC98
+#define KSTACK_BYTES	740	/* Size of kernel stacks */
+#else
 #define KSTACK_BYTES	640	/* Size of kernel stacks */
+#endif
 
 #define POLL_MAX	6	/* Maximum number of polled queues per process */
 


### PR DESCRIPTION
As I wrote at #1047 , increasing KSTACK_BYTES for CONFIG_ARCH_PC98 worked to avoid panic.

https://github.com/jbruchon/elks/issues/1047#issuecomment-1071165038

Thank you.