### PR TITLE
[libc] Enhance tiny printf, further decrease application sizes

### DIFF
--- a/elkscmd/file_utils/Makefile
+++ b/elkscmd/file_utils/Makefile
@@ -35,8 +35,8 @@ cmp: cmp.o
 cp: cp.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -maout-heap=0xffff -o cp cp.o $(TINYPRINTF) $(LDLIBS)
 
-df: df.o
-	$(LD) $(LDFLAGS) -o df df.o $(LDLIBS)
+df: df.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o df df.o $(TINYPRINTF) $(LDLIBS)
 
 dd: dd.o
 	$(LD) $(LDFLAGS) -maout-heap=12288 -o dd dd.o $(LDLIBS)
@@ -68,8 +68,8 @@ more: more.o
 mv: mv.o
 	$(LD) $(LDFLAGS) -o mv mv.o $(LDLIBS)
 
-rm: rm.o
-	$(LD) $(LDFLAGS) -maout-stack=12228 -o rm rm.o $(LDLIBS)
+rm: rm.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -maout-stack=12228 -o rm rm.o $(TINYPRINTF) $(LDLIBS)
 
 rmdir: rmdir.o
 	$(LD) $(LDFLAGS) -o rmdir rmdir.o $(LDLIBS)

--- a/elkscmd/file_utils/cp.c
+++ b/elkscmd/file_utils/cp.c
@@ -656,6 +656,6 @@ error_copy:
 	fprintf(stderr, "Failed to copy %s -> %s\n", srcname, destname);
 	return 1;
 usage:
-	fprintf(stderr, "Usage: cp [-R][-v] source [...] target_file_or_directory\n");
+	fprintf(stderr, "usage: cp [-R][-v] source [...] target_file_or_directory\n");
 	return 1;
 }

--- a/elkscmd/file_utils/dd.c
+++ b/elkscmd/file_utils/dd.c
@@ -39,7 +39,6 @@ static struct param params[] = {
 	{ NULL,		PAR_NONE }
 };
 
-
 /* Fixed buffer */
 static char localbuf[BUFSIZ];		/* use disk block size for efficiency*/
 
@@ -310,11 +309,6 @@ cleanup2:
 	return retval;
 
 usage:
-	errmsg("usage: dd if=<infile> of=<outfile> [optional_params ...]\n\n");
-	errmsg("If if= and/or of= are omitted, stdin/stdout will be used.\n");
-	errmsg("Optional parameters:\n");
-	errmsg("bs=<blocksize>  seek=<count>  skip=<count>  count=<count>\n");
-	errmsg("seek/skip skips <count> blocks in input/output files, respectively\n");
-	errmsg("count copies only <count> blocks (default is until end of file)\n\n");
+	errmsg("usage: dd [if=file][of=file][bs=N][count=N][seek=N][skip=N]\n");
 	return 1;
 }

--- a/elkscmd/file_utils/df.c
+++ b/elkscmd/file_utils/df.c
@@ -39,7 +39,7 @@ int istty;	/* isatty(1) */
 
 void usage(void)
 {
-	fprintf(stderr, "Usage: df [-ikP] [device]...\n");
+	fprintf(stderr, "usage: df [-ikP] [device_or_mount_point]\n");
 	exit(1);
 }
 
@@ -119,7 +119,7 @@ int df(char *device)
   lseek(fd, (off_t) BLOCK_SIZE * 2L, SEEK_SET);	/* skip rest of super block */
   sp = &super;
   if (sp->s_magic != MINIX_SUPER_MAGIC && sp->s_magic != MINIX_SUPER_MAGIC2) {
-	fprintf(stderr, "df: %s: Not a valid file system\n", device);
+	fprintf(stderr, "df: %s: Not a MINIX file system\n", device);
 	close(fd);
 	return(1);
   }

--- a/elkscmd/file_utils/df.c
+++ b/elkscmd/file_utils/df.c
@@ -154,8 +154,8 @@ int df(char *device)
   /* Print results. */
   printf("%s", device);
   n= strlen(device);
-  if (n > 15 && istty) { putchar('\n'); n= 0; }
-  while (n < 15) { putchar(' '); n++; }
+  if (n > 15 && istty) { printf("\n"); n= 0; }
+  while (n < 15) { printf(" "); n++; }
 
   if (!Pflag && !iflag) {
 	printf(" %7ld  %7ld  %7ld %3d%%   %3d%%\n",

--- a/elkscmd/file_utils/mv.c
+++ b/elkscmd/file_utils/mv.c
@@ -318,7 +318,6 @@ copy:
 	return 0;
 
 usage:
-	errmsg("usage: mv source_file dest_file\n");
-	errmsg("       mv file [...] dest_dir\n");
+	errmsg("usage: mv source [...] target_file_or_directory\n");
 	return 1;
 }

--- a/elkscmd/file_utils/rm.c
+++ b/elkscmd/file_utils/rm.c
@@ -8,7 +8,7 @@
 #include <fcntl.h>
 
 static 	int	errcode;
-static	int	usage(char *);
+static	int	usage(void);
 static	void	rm();
 static 	int	yes();
 static	int 	dotname();
@@ -19,7 +19,7 @@ main(int argc, char **argv) {
 	char *arg;
 
 	if (argc < 2)
-		return(usage(argv[0]));
+		return usage();
 	errcode = 0;
 
         while(argc>1 && argv[1][0]=='-') {
@@ -43,7 +43,7 @@ main(int argc, char **argv) {
                                 recurse++;
                                 break;
                         default:
-                                return(usage(*argv));
+                                return usage();
                         }
         }
         while(--argc > 0) {
@@ -56,9 +56,10 @@ main(int argc, char **argv) {
         return(errcode);
 }
 
-int usage(char * a) {
-	fprintf(stderr, "usage: %s [-rfi] file1 [file2] ...\n", a);
-	return(1);
+int usage(void)
+{
+	fprintf(stderr, "usage: rm [-rfi] file1 [file2] ...\n");
+	return 1;
 }
 
 void

--- a/elkscmd/file_utils/rm.c
+++ b/elkscmd/file_utils/rm.c
@@ -8,62 +8,36 @@
 #include <fcntl.h>
 
 static 	int	errcode;
-static	int	usage(void);
-static	void	rm();
-static 	int	yes();
-static	int 	dotname();
-
-int
-main(int argc, char **argv) {
-	int force=0, recurse = 0, interact =0 ;
-	char *arg;
-
-	if (argc < 2)
-		return usage();
-	errcode = 0;
-
-        while(argc>1 && argv[1][0]=='-') {
-                arg = *++argv;
-                argc--;
-
-                /*
-                 *  all files following a single '-' are considered file names
-                 */
-                if (*(arg+1) == '\0') break;
-
-                while(*++arg != '\0')
-                        switch(*arg) {
-                        case 'f':
-                                force++;
-                                break;
-                        case 'i':
-                                interact++;
-                                break;
-                        case 'r':
-                                recurse++;
-                                break;
-                        default:
-                                return usage();
-                        }
-        }
-        while(--argc > 0) {
-                if(!strcmp(*++argv, "..")) {
-                        fprintf(stderr, "rm: cannot remove `..'\n");
-                        continue;
-                }
-                rm(*argv, force, recurse, interact, 0);
-        }
-        return(errcode);
-}
 
 int usage(void)
 {
-	fprintf(stderr, "usage: rm [-rfi] file1 [file2] ...\n");
+	fprintf(stderr, "usage: rm [-rfi] file [...]\n");
 	return 1;
 }
 
-void
-rm(char *arg, int fflg, int rflg, int iflg, int level) {
+int yes(void) {
+        int i, b;
+
+        i = b = getchar();
+        while(b != '\n' && b != EOF)
+                b = getchar();
+        return(i == 'y');
+}
+
+int dotname(char *s) {
+        if ((s[0] == '.')) {
+                if (s[1] == '.')
+                        if (s[2] == '\0')
+                                return(1);
+                        else
+                                return(0);
+                else if(s[1] == '\0')
+                        return(1);
+        }
+	return(0);
+}
+
+void rm(char *arg, int fflg, int rflg, int iflg, int level) {
         struct stat buf;
         struct dirent *dp;
         DIR *dirp;
@@ -131,27 +105,45 @@ rm(char *arg, int fflg, int rflg, int iflg, int level) {
         }
 	return;
 }
-                                
 
-int
-dotname(char *s) {
-        if ((s[0] == '.')) {
-                if (s[1] == '.')
-                        if (s[2] == '\0')
-                                return(1);
-                        else
-                                return(0);
-                else if(s[1] == '\0')
-                        return(1);
+int main(int argc, char **argv) {
+	int force=0, recurse = 0, interact =0 ;
+	char *arg;
+
+	if (argc < 2)
+		return usage();
+	errcode = 0;
+
+        while(argc>1 && argv[1][0]=='-') {
+                arg = *++argv;
+                argc--;
+
+                /*
+                 *  all files following a single '-' are considered file names
+                 */
+                if (*(arg+1) == '\0') break;
+
+                while(*++arg != '\0')
+                        switch(*arg) {
+                        case 'f':
+                                force++;
+                                break;
+                        case 'i':
+                                interact++;
+                                break;
+                        case 'r':
+                                recurse++;
+                                break;
+                        default:
+                                return usage();
+                        }
         }
-	return(0);
-}
-
-int yes(void) {
-        int i, b;
-
-        i = b = getchar();
-        while(b != '\n' && b != EOF)
-                b = getchar();
-        return(i == 'y');
+        while(--argc > 0) {
+                if(!strcmp(*++argv, "..")) {
+                        fprintf(stderr, "rm: cannot remove `..'\n");
+                        continue;
+                }
+                rm(*argv, force, recurse, interact, 0);
+        }
+        return(errcode);
 }

--- a/elkscmd/inet/httpd/Makefile
+++ b/elkscmd/inet/httpd/Makefile
@@ -17,8 +17,8 @@ LDFLAGS += -maout-heap=1024 -maout-stack=1024
 
 all: $(PRG)
 
-$(PRG): httpd.o
-	$(LD) $(LDFLAGS) -o $(PRG) httpd.o $(LDLIBS)
+$(PRG): httpd.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o $(PRG) httpd.o $(TINYPRINTF) $(LDLIBS)
 
 install: $(PRG)
 	$(INSTALL) $(PRG) $(DESTDIR)/bin

--- a/elkscmd/inet/nettools/Makefile
+++ b/elkscmd/inet/nettools/Makefile
@@ -20,14 +20,14 @@ install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 #	$(INSTALL) resolv.cfg $(DESTDIR)/etc
 
-netstat: netstat.o
-	$(LD) $(LDFLAGS) netstat.o -o netstat $(LDLIBS)
+netstat: netstat.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) netstat.o $(TINYPRINTF) -o netstat $(LDLIBS)
 
 nslookup: nslookup.o
 	$(LD) $(LDFLAGS) nslookup.o -o nslookup $(LDLIBS)
 
-arp: arp.o
-	$(LD) $(LDFLAGS) arp.o -o arp $(LDLIBS)
+arp: arp.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) arp.o $(TINYPRINTF) -o arp $(LDLIBS)
 
 clean:
 	rm -f core *.o $(PRGS)

--- a/elkscmd/inet/telnet/Makefile
+++ b/elkscmd/inet/telnet/Makefile
@@ -17,8 +17,8 @@ OBJS = $(SRCS:.c=.o)
 
 all:	telnet
 
-telnet:	$(OBJS)
-	$(LD) $(LDFLAGS) -o $@ $(OBJS) $(LDLIBS)
+telnet:	$(OBJS) $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o $@ $(OBJS) $(TINYPRINTF) $(LDLIBS)
 
 install: telnet
 	$(INSTALL) telnet $(DESTDIR)/bin

--- a/elkscmd/inet/tinyirc/Makefile
+++ b/elkscmd/inet/tinyirc/Makefile
@@ -24,8 +24,8 @@ all: tinyirc
 
 LOCALDEFS = -DDEFAULTSERVER=\"$(SERVER)\" -DDEFAULTPORT=$(PORT)
 
-tinyirc: tinyirc.o
-	$(LD) $(LDFLAGS) -o tinyirc tinyirc.o $(LDLIBS)
+tinyirc: tinyirc.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o tinyirc tinyirc.o $(TINYPRINTF) $(LDLIBS)
 
 tinyircd: tinyircd.o
 	$(LD) $(LDFLAGS) -o tinyircd tinyircd.o $(LDLIBS)

--- a/elkscmd/inet/tinyirc/Makefile
+++ b/elkscmd/inet/tinyirc/Makefile
@@ -24,8 +24,8 @@ all: tinyirc
 
 LOCALDEFS = -DDEFAULTSERVER=\"$(SERVER)\" -DDEFAULTPORT=$(PORT)
 
-tinyirc: tinyirc.o $(TINYPRINTF)
-	$(LD) $(LDFLAGS) -o tinyirc tinyirc.o $(TINYPRINTF) $(LDLIBS)
+tinyirc: tinyirc.o
+	$(LD) $(LDFLAGS) -o tinyirc tinyirc.o $(LDLIBS)
 
 tinyircd: tinyircd.o
 	$(LD) $(LDFLAGS) -o tinyircd tinyircd.o $(LDLIBS)

--- a/elkscmd/inet/urlget/Makefile
+++ b/elkscmd/inet/urlget/Makefile
@@ -17,8 +17,8 @@ OBJS = $(SRCS:.c=.o)
 
 all:	urlget
 
-urlget:	$(OBJS)
-	$(LD) $(LDFLAGS) -o urlget $(OBJS) $(LDLIBS)
+urlget:	$(OBJS) $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o urlget $(OBJS) $(TINYPRINTF) $(LDLIBS)
 
 install: urlget
 	$(INSTALL) urlget $(DESTDIR)/bin

--- a/elkscmd/man/man1/meminfo.1
+++ b/elkscmd/man/man1/meminfo.1
@@ -3,6 +3,25 @@
 meminfo \- list system memory usage
 .SH SYNOPSIS
 .B meminfo
+.RB [ \-a ]
+.RB [ \-f ]
+.RB [ \-t ]
+.RB [ \-b ]
+.br
+.SS OPTIONS
+Defaults to showing all memory.
+.TP 5
+.B -a
+Show application memory
+.TP 5
+.B -f
+Show free memory
+.TP 5
+.B -t
+Show tty memory
+.TP 5
+.B -b
+Show buffer memory
 .SH DESCRIPTION
 .B meminfo
 traverses the kernel local heap and displays a line for each in-use or free entry. 

--- a/elkscmd/minix1/Makefile
+++ b/elkscmd/minix1/Makefile
@@ -31,8 +31,8 @@ decomp16: decomp16.o
 du: du.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -o du du.o $(TINYPRINTF) $(LDLIBS)
 
-fgrep: fgrep.o $(TINYPRINTF)
-	$(LD) $(LDFLAGS) -o fgrep fgrep.o $(TINYPRINTF) $(LDLIBS)
+fgrep: fgrep.o
+	$(LD) $(LDFLAGS) -o fgrep fgrep.o $(LDLIBS)
 
 grep: grep.o
 	$(LD) $(LDFLAGS) -o grep grep.o $(LDLIBS)

--- a/elkscmd/minix1/Makefile
+++ b/elkscmd/minix1/Makefile
@@ -19,8 +19,8 @@ all: $(PRGS)
 banner: banner.o
 	$(LD) $(LDFLAGS) -o banner banner.o $(LDLIBS)
 
-cksum: cksum.o
-	$(LD) $(LDFLAGS) -o cksum cksum.o $(LDLIBS)
+cksum: cksum.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o cksum cksum.o $(TINYPRINTF) $(LDLIBS)
 
 cut: cut.o
 	$(LD) $(LDFLAGS) -o cut cut.o $(LDLIBS)
@@ -28,11 +28,11 @@ cut: cut.o
 decomp16: decomp16.o
 	$(LD) $(LDFLAGS) -o decomp16 decomp16.o $(LDLIBS)
 
-du: du.o
-	$(LD) $(LDFLAGS) -o du du.o $(LDLIBS)
+du: du.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o du du.o $(TINYPRINTF) $(LDLIBS)
 
-fgrep: fgrep.o
-	$(LD) $(LDFLAGS) -o fgrep fgrep.o $(LDLIBS)
+fgrep: fgrep.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o fgrep fgrep.o $(TINYPRINTF) $(LDLIBS)
 
 grep: grep.o
 	$(LD) $(LDFLAGS) -o grep grep.o $(LDLIBS)
@@ -40,8 +40,8 @@ grep: grep.o
 proto: proto.o
 	$(LD) $(LDFLAGS) -o proto proto.o $(LDLIBS)
 
-sum: sum.o
-	$(LD) $(LDFLAGS) -o sum sum.o $(LDLIBS)
+sum: sum.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o sum sum.o $(TINYPRINTF) $(LDLIBS)
 
 uniq: uniq.o
 	$(LD) $(LDFLAGS) -o uniq uniq.o $(LDLIBS)

--- a/elkscmd/minix1/banner.c
+++ b/elkscmd/minix1/banner.c
@@ -21,7 +21,7 @@
  *****************************************************************/
 
 #include <string.h>
-#include <stdio.h>
+#include <unistd.h>
 
 char *glyphs[] = {
 	  "         @@@  @@   @@  @ @   @@@@@          @@     @@@  ",
@@ -143,9 +143,10 @@ char *argv[];
 			if (line[b] != ' ') break;
 			line[b] = '\0';
 		}
-		printf("%s\n", line);
+		write(STDOUT_FILENO, line, strlen(line));
+		write(STDOUT_FILENO, "\n", 1);
 	}
-	printf("\n");
+	write(STDOUT_FILENO, "\n", 1);
   }
   return(0);
 }

--- a/elkscmd/minix1/cksum.c
+++ b/elkscmd/minix1/cksum.c
@@ -130,7 +130,7 @@ static void crc(int fd, char *name)
   if (name)
 	printf(" %s\n", name);
   else
-	putchar('\n');
+	printf("\n");
 }
 
 /* Main module. No options switches allowed, none parsed. */

--- a/elkscmd/minix2/Makefile
+++ b/elkscmd/minix2/Makefile
@@ -30,11 +30,11 @@ man: man.o
 remsync: remsync.o
 	$(LD) $(LDFLAGS) -o remsync remsync.o $(LDLIBS)
 
-synctree: synctree.o $(TINYPRINTF)
-	$(LD) $(LDFLAGS) -o synctree synctree.o $(TINYPRINTF) $(LDLIBS)
+synctree: synctree.o
+	$(LD) $(LDFLAGS) -o synctree synctree.o $(LDLIBS)
 
-tget: tget.o $(TINYPRINTF)
-	$(LD) $(LDFLAGS) -o tget tget.o $(TINYPRINTF) $(LDLIBS)
+tget: tget.o
+	$(LD) $(LDFLAGS) -o tget tget.o $(LDLIBS)
 
 
 all: $(PRGS)

--- a/elkscmd/minix2/Makefile
+++ b/elkscmd/minix2/Makefile
@@ -15,14 +15,14 @@ include $(BASEDIR)/Make.rules
 # TODO: lpd man mt install	# Do not compile.
 PRGS=env lp pwdauth remsync synctree tget
 
-env: env.o
-	$(LD) $(LDFLAGS) -o env env.o $(LDLIBS)
+env: env.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o env env.o $(TINYPRINTF) $(LDLIBS)
 
 pwdauth: pwdauth.o
 	$(LD) $(LDFLAGS) -o pwdauth pwdauth.o $(LDLIBS)
 
-lp: lp.o
-	$(LD) $(LDFLAGS) -o lp lp.o $(LDLIBS)
+lp: lp.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o lp lp.o $(TINYPRINTF) $(LDLIBS)
 
 man: man.o
 	$(LD) $(LDFLAGS) -o man man.o $(LDLIBS)
@@ -30,11 +30,11 @@ man: man.o
 remsync: remsync.o
 	$(LD) $(LDFLAGS) -o remsync remsync.o $(LDLIBS)
 
-synctree: synctree.o
-	$(LD) $(LDFLAGS) -o synctree synctree.o $(LDLIBS)
+synctree: synctree.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o synctree synctree.o $(TINYPRINTF) $(LDLIBS)
 
-tget: tget.o
-	$(LD) $(LDFLAGS) -o tget tget.o $(LDLIBS)
+tget: tget.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o tget tget.o $(TINYPRINTF) $(LDLIBS)
 
 
 all: $(PRGS)

--- a/elkscmd/minix3/Makefile
+++ b/elkscmd/minix3/Makefile
@@ -27,8 +27,8 @@ diff: diff.o
 file: file.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -o file file.o $(TINYPRINTF) $(LDLIBS)
 
-find: find.o $(TINYPRINTF)
-	$(LD) $(LDFLAGS) -o find find.o $(TINYPRINTF) $(LDLIBS)
+find: find.o
+	$(LD) $(LDFLAGS) -o find find.o $(LDLIBS)
 
 head: head.o
 	$(LD) $(LDFLAGS) -o head head.o $(LDLIBS)

--- a/elkscmd/minix3/Makefile
+++ b/elkscmd/minix3/Makefile
@@ -18,17 +18,17 @@ PRGS = file head sed sort tail tee cal diff find
 # Rules
 #
 
-cal: cal.o
-	$(LD) $(LDFLAGS) -o cal cal.o $(LDLIBS)
+cal: cal.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o cal cal.o $(TINYPRINTF) $(LDLIBS)
 
 diff: diff.o
 	$(LD) $(LDFLAGS) -o diff diff.o $(LDLIBS)
 
-file: file.o
-	$(LD) $(LDFLAGS) -o file file.o $(LDLIBS)
+file: file.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o file file.o $(TINYPRINTF) $(LDLIBS)
 
-find: find.o
-	$(LD) $(LDFLAGS) -o find find.o $(LDLIBS)
+find: find.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o find find.o $(TINYPRINTF) $(LDLIBS)
 
 head: head.o
 	$(LD) $(LDFLAGS) -o head head.o $(LDLIBS)

--- a/elkscmd/minix3/tee.c
+++ b/elkscmd/minix3/tee.c
@@ -6,13 +6,13 @@
 #include <signal.h>
 #include <unistd.h>
 #include <stdlib.h>
-#if 0
-#include <minix/minlib.h>
-#endif
 #include "defs.h"
 
 #define	MAXFD	18
 #define CHUNK_SIZE	BUFSIZ		/* use disk block size for stack limit and efficiency*/
+
+#define errmsg(str) write(STDERR_FILENO, str, sizeof(str) - 1)
+#define errstr(str) write(STDERR_FILENO, str, strlen(str))
 
 int fd[MAXFD];
 
@@ -33,12 +33,11 @@ char **argv;
 	    case 'i':		/* Interrupt turned off. */
 		iflag++;
 		break;
-	    case 'a':		/* Append to outputfile(s), instead of
-			 * overwriting them. */
+	    case 'a':		/* Append to outputfile(s), instead of overwriting them. */
 		aflag++;
 		break;
 	    default:
-		fprintf(stderr,"Usage: tee [-i] [-a] [files].\n");
+		errmsg("usage: tee [-i][-a] [file ...]\n");
 		exit(1);
 	}
 	argv++;
@@ -52,9 +51,9 @@ char **argv;
 	} else {
 		if ((fd[s] = creat(*argv, 0666)) >= 0) continue;
 	}
-	fprintf(stderr,"Cannot open output file: ");
-	fprintf(stderr,*argv);
-	fprintf(stderr,"\n");
+	errmsg("Cannot open output file: ");
+	errmsg(*argv);
+	errmsg("\n");
 	exit(2);
   }
 

--- a/elkscmd/sh_utils/Makefile
+++ b/elkscmd/sh_utils/Makefile
@@ -57,8 +57,8 @@ yes: yes.o
 logname: logname.o
 	$(LD) $(LDFLAGS) -o logname logname.o $(LDLIBS)
 
-tr: tr.o $(TINYPRINTF)
-	$(LD) $(LDFLAGS) -o tr tr.o $(TINYPRINTF) $(LDLIBS)
+tr: tr.o
+	$(LD) $(LDFLAGS) -o tr tr.o $(LDLIBS)
 
 xargs: xargs.o
 	$(LD) $(LDFLAGS) -o xargs xargs.o $(LDLIBS)
@@ -66,8 +66,8 @@ xargs: xargs.o
 mesg: mesg.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -o mesg mesg.o $(TINYPRINTF) $(LDLIBS)
 
-stty: stty.o $(TINYPRINTF)
-	$(LD) $(LDFLAGS) -o stty stty.o $(TINYPRINTF) $(LDLIBS)
+stty: stty.o
+	$(LD) $(LDFLAGS) -o stty stty.o $(LDLIBS)
 
 test: test.o
 	$(LD) $(LDFLAGS) -o test test.o $(LDLIBS)

--- a/elkscmd/sh_utils/which.c
+++ b/elkscmd/sh_utils/which.c
@@ -3,13 +3,8 @@
 #include <string.h>
 #include <unistd.h>
 
-#define errmsg(str) write(STDERR_FILENO, str, sizeof(str) - 1)
-#define errstr(str) write(STDERR_FILENO, str, strlen(str))
-
 int
-main(argc,argv)
-int argc;
-char ** argv;
+main(int argc, char **argv)
 {
 	char *envpath;
 	char *path, *cp;
@@ -18,7 +13,7 @@ char ** argv;
 	int quit, found;
 
 	if (argc < 2) {
-		errmsg("Usage: which cmd [...]\n");
+		printf("Usage: which cmd [...]\n");
 		return 1;
 	}
 	if ((envpath = getenv("PATH")) == 0)

--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -51,8 +51,8 @@ login: login.o
 kill: kill.o
 	$(LD) $(LDFLAGS) -o kill kill.o $(LDLIBS)
 
-mount: mount.o
-	$(LD) $(LDFLAGS) -o mount mount.o $(LDLIBS)
+mount: mount.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o mount mount.o $(TINYPRINTF) $(LDLIBS)
 
 umount: umount.o
 	$(LD) $(LDFLAGS) -o umount umount.o $(LDLIBS)
@@ -66,11 +66,11 @@ reboot: reboot.o
 shutdown: shutdown.o
 	$(LD) $(LDFLAGS) -o shutdown shutdown.o $(LDLIBS)
 
-ps: ps.o
-	$(LD) $(LDFLAGS) -maout-heap=1024 -maout-stack=2048 -o ps ps.o $(LDLIBS)
+ps: ps.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -maout-heap=1024 -maout-stack=2048 -o ps ps.o $(TINYPRINTF) $(LDLIBS)
 
-meminfo: meminfo.o
-	$(LD) $(LDFLAGS) -maout-heap=1 -maout-stack=512 -o meminfo meminfo.o $(LDLIBS)
+meminfo: meminfo.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -maout-heap=1 -maout-stack=512 -o meminfo meminfo.o $(TINYPRINTF) $(LDLIBS)
 
 who: who.o
 	$(LD) $(LDFLAGS) -o who who.o $(LDLIBS)
@@ -90,8 +90,8 @@ man: man.o
 poweroff: poweroff.o
 	$(LD) $(LDFLAGS) -o poweroff poweroff.o $(LDLIBS)
 
-chmem: chmem.o
-	$(LD) $(LDFLAGS) -o chmem chmem.o $(LDLIBS)
+chmem: chmem.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o chmem chmem.o $(TINYPRINTF) $(LDLIBS)
 
 mouse: mouse.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -o mouse mouse.o $(TINYPRINTF) $(LDLIBS)

--- a/elkscmd/sys_utils/console.c
+++ b/elkscmd/sys_utils/console.c
@@ -8,13 +8,15 @@
 #include <sys/stat.h>
 #include <sys/ioctl.h>
 
+#define errmsg(str) write(STDERR_FILENO, str, sizeof(str) - 1)
+
 int main(int argc, char **argv)
 {
 	int fd;
 	struct stat statbuf;
 
 	if (argc != 2) {
-		printf("Usage: console </dev/ttyXX>\n");
+		errmsg("usage: console </dev/ttyXX>\n");
 		return 1;
 	}
 


### PR DESCRIPTION
Adds field width, precision and left justification to tiny printf.
Use tiny printf with more commands.

Enhance `meminfo` man page for (forgotten) options.