### PR TITLE
[cmds] Add uname application and system call

### DIFF
--- a/elks/Makefile
+++ b/elks/Makefile
@@ -124,14 +124,17 @@ net/net.a:
 
 tools:
 	${MAKE} -C tools all
+	-rm include/linuxmt/compiler-generated.h
+	-rm kernel/version.o
 
 #########################################################################
 # Compiler-generated definitions not given as command arguments.
 
 include/linuxmt/compiler-generated.h:
 	printf > include/linuxmt/compiler-generated.h		\
-		'#define %s %s\n'				\
-		UTS_VERSION "\"#$(DIST) $(shell date +%Y-%m-%d)\""
+		'#define UTS_RELEASE %s\n' "\"$(DIST)\""
+	printf >> include/linuxmt/compiler-generated.h		\
+		'#define UTS_VERSION %s\n' "\"$(shell git log --abbrev-commit | head -1 | sed 's/commit/commit/') $(shell date '+%d %b %Y %T %z')\""
 
 #########################################################################
 # lint rule

--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -108,8 +108,7 @@ DISTDIR 	= $(shell $(BASEDIR)/scripts/setdir $(TOPDIR)/elks-$(DIST)/$(MYDIR))
 #########################################################################
 # Specify the standard definitions to be given to system programs.
 
-CCDEFS = -DUTS_RELEASE=\"$(DIST)\"			\
-		  -D__KERNEL__
+CCDEFS = -D__KERNEL__
 
 #########################################################################
 # Set the target environment and the compiler to use.

--- a/elks/arch/i86/kernel/strace.h
+++ b/elks/arch/i86/kernel/strace.h
@@ -118,7 +118,7 @@ struct syscall_info elks_table[] = {
     { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
     { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
     { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "knlvsn",		packinfo(1, P_PSTR,   P_NONE,    P_NONE   ) },
+    { "uname",		packinfo(1, P_PDATA,  P_NONE,    P_NONE   ) },
     { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
     { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
     { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },

--- a/elks/arch/i86/kernel/syscall.dat
+++ b/elks/arch/i86/kernel/syscall.dat
@@ -91,7 +91,7 @@ dlload		+67	2	- Removed support for dynamic libraries
 setsid		+68	0
 sbrk		+69	2	* Legacy number from Linux
 ustatfs		+70	2
-knlvsn		+74	1
+uname		+74	1	. was knlvsn
 #
 # From /usr/include/asm-generic/unistd.h
 #

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -34,6 +34,7 @@
 #ifdef CONFIG_ROMCODE
 #define SYS_CAPS	(CAP_PC_AT|CAP_DRIVE_PARMS)
 #endif
+#define UTS_MACHINE		"ibmpc i8086"
 #endif
 
 #ifdef CONFIG_ARCH_PC98
@@ -47,6 +48,7 @@
 #define SETUP_PART_OFFSETLO	setupw(0x1e2)	/* partition offset low word */
 #define SETUP_PART_OFFSETHI	setupw(0x1e4)	/* partition offset high word */
 #define SYS_CAPS		0	/* no XT/AT capabilities */
+#define UTS_MACHINE		"pc-98 i8086"
 #endif
 
 #ifdef CONFIG_ARCH_8018X
@@ -60,7 +62,7 @@
 #define SETUP_PART_OFFSETLO	0	/* partition offset low word */
 #define SETUP_PART_OFFSETHI	0	/* partition offset high word */
 #define SYS_CAPS		0	/* no XT/AT capabilities */
-
+#define UTS_MACHINE		"8018X"
 
 #define CONFIG_8018X_FCPU	16
 #define CONFIG_8018X_EB
@@ -145,10 +147,9 @@
 /*
  * Defines for what uname() should return.
  * The definitions for UTS_RELEASE and UTS_VERSION are now passed as
- * kernel compilation parameters, and should only be used by linux/version.c
+ * kernel compilation parameters, and should only be used by elks/kernel/version.c
  */
 #define UTS_SYSNAME "ELKS"
-#define UTS_MACHINE "i8086"
-#define UTS_NODENAME "(none)"		/* set by sethostname() */
+#define UTS_NODENAME "elks"		/* someday set by sethostname() */
 
 #endif

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -62,7 +62,7 @@
 #define SETUP_PART_OFFSETLO	0	/* partition offset low word */
 #define SETUP_PART_OFFSETHI	0	/* partition offset high word */
 #define SYS_CAPS		0	/* no XT/AT capabilities */
-#define UTS_MACHINE		"8018X"
+#define UTS_MACHINE		"8018x"
 
 #define CONFIG_8018X_FCPU	16
 #define CONFIG_8018X_EB

--- a/elks/include/linuxmt/utsname.h
+++ b/elks/include/linuxmt/utsname.h
@@ -2,13 +2,15 @@
 #define __LINUXMT_UTSNAME_H
 
 struct utsname {
-    char sysname[16];
-    char nodename[80];
-    char release[16];
+    char sysname[8];
+    char nodename[16];
+    char release[12];
     char version[48];
     char machine[16];
 };
 
+#ifdef __KERNEL__
 extern struct utsname system_utsname;
+#endif
 
 #endif

--- a/elks/kernel/sys.c
+++ b/elks/kernel/sys.c
@@ -85,11 +85,9 @@ void ctrl_alt_del(void)
  * This function returns the version number associated with this kernel.
  */
 
-int sys_knlvsn(char *vsn)
+int sys_uname(struct utsname *utsname)
 {
-    register char *p = system_utsname.release;
-
-    return verified_memcpy_tofs(vsn, p, strlen(p) + 1);
+    return verified_memcpy_tofs(utsname, &system_utsname, sizeof(struct utsname));
 }
 
 /*

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -54,6 +54,7 @@ sys_utils/shutdown		:boot	:sysutil
 sh_utils/test			:boot	:shutil
 sh_utils/true			:boot	:be-shutil
 sh_utils/echo			:boot	:be-shutil
+sh_utils/uname			:boot	:be-shutil
 file_utils/cat			:boot	:be-fileutil
 file_utils/chgrp				:be-fileutil			:1200k	:1440k
 file_utils/chmod				:be-fileutil			:1200k	:1440k

--- a/elkscmd/man/man1/uname.1
+++ b/elkscmd/man/man1/uname.1
@@ -1,0 +1,38 @@
+.TH uname 1
+.SH NAME
+uname \- Display operating system name and system information
+.SH SYNOPSIS
+.B uname
+.RB [ \-asnrvm ]
+.SH DESCRIPTION
+The
+.B uname
+utility writes various operating system and system characteristics
+to the standard output.
+.SS OPTIONS
+Defaults to showing system name.
+.TP 5
+.B -a
+Behave as though all the options
+.B -snrvm
+were specified.
+.TP 5
+.B -s
+Show operating system name (ELKS).
+.TP 5
+.B -n
+Show nodename (name the system is known on TCP/IP).
+.TP 5
+.B -r
+Show the operating system release number.
+.TP 5
+.B -v
+Show the operating system version (commit number and date).
+.TP 5
+.B -m
+Show the machine hardware name.
+.SH BUGS
+The nodename is currently fixed as
+.IR elks .
+.SH AUTHOR
+Greg Haerr (greg@censoft.com)

--- a/elkscmd/man/man2/uname.2
+++ b/elkscmd/man/man2/uname.2
@@ -17,18 +17,16 @@ in <sys/utsname.h> as follows:
 .nf
 .ta +4n +6n +25n
 struct utsname {
-	char	sysname[15+1];		/* System name */
-	char	nodename[255+1];	/* Node/Network name */
+	char	sysname[7+1];		/* System name */
+	char	nodename[15+1];		/* Node/Network name */
 	char	release[11+1];		/* O.S. release */
-	char	version[7+1];		/* O.S. version */
-	char	machine[11+1];		/* Machine hardware */
-	char	arch[11+1];		/* Architecture */
+	char	version[47+1];		/* O.S. version */
+	char	machine[15+1];		/* Machine hardware */
 };
 .fi
 .PP
-The strings are always null terminated, and may be of a different length then
-shown here.  The first five are required by \s-2POSIX\s+2, the last is
-MINIX 3 specific.
+The strings are always null terminated, and may be of a different length than
+shown here.  The first five are required by \s-2POSIX\s+2.
 .SH "SEE ALSO"
 .BR uname (1).
 .SH AUTHOR

--- a/elkscmd/rootfs_template/etc/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.sys
@@ -38,8 +38,9 @@ cslip)
 esac
 
 # View message of day
-if test -f /etc/motd; then
-    cat /etc/motd
-fi
+uname -snrm
+#if test -f /etc/motd; then
+#	cat /etc/motd
+#fi
 
 date

--- a/elkscmd/rootfs_template/etc/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.sys
@@ -38,9 +38,10 @@ cslip)
 esac
 
 # View message of day
-uname -snrm
 #if test -f /etc/motd; then
 #	cat /etc/motd
 #fi
+
+#uname -snrm
 
 date

--- a/elkscmd/sh_utils/Makefile
+++ b/elkscmd/sh_utils/Makefile
@@ -10,9 +10,9 @@ include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
-# TODO: uname write	# Do not compile
+# TODO: write	# Do not compile
 PRGS=basename clear date dirname echo false printenv pwd true which whoami \
-	yes logname tr xargs mesg stty test
+	yes logname tr xargs mesg stty test uname
 
 write: write.o ../sys_utils/utent.o
 
@@ -72,6 +72,8 @@ stty: stty.o
 test: test.o
 	$(LD) $(LDFLAGS) -o test test.o $(LDLIBS)
 
+uname: uname.o
+	$(LD) $(LDFLAGS) -o uname uname.o $(LDLIBS)
 
 install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin

--- a/elkscmd/sh_utils/uname.c
+++ b/elkscmd/sh_utils/uname.c
@@ -2,31 +2,27 @@
 #include <string.h>
 #include <sys/utsname.h>
 
-static void print_element ();
-
 /* Values that are bitwise or'd into toprint'. */
-/* Operating system name. */
-#define PRINT_SYSNAME 1
-
-/* Node name on a communications network. */
-#define PRINT_NODENAME 2
-
-/* Operating system release. */
-#define PRINT_RELEASE 4
-
-/* Operating system version. */
-#define PRINT_VERSION 8
-
-/* Machine hardware name. */
-#define PRINT_MACHINE 16
+#define PRINT_SYSNAME	1		/* Operating system name. */
+#define PRINT_NODENAME	2		/* Node name on a communications network. */
+#define PRINT_RELEASE	4		/* Operating system release. */
+#define PRINT_VERSION	8		/* Operating system version. */
+#define PRINT_MACHINE	16		/* Machine hardware name. */
 
 /* Mask indicating which elements of the name to print. */
 static unsigned char toprint;
 
-void
-main (argc, argv)
-	int argc;
-	char **argv;
+static void print_element(unsigned char mask, char *element)
+{
+	if (toprint & mask)
+	{
+		toprint &= ~mask;
+		write(STDOUT_FILENO,element,strlen(element));
+		write(STDOUT_FILENO,toprint ? " " : "\n",1);
+	}
+}
+
+int main(int argc, char **argv)
 {
 	int	i;
 	struct utsname name;
@@ -35,7 +31,8 @@ main (argc, argv)
 
 	for (i=1;i<argc;i++)
 	{
-		switch(argv[i][1])
+		char *p = &argv[i][1];
+		while (*p) switch(*p++)
 		{
 	        case 's':
         		toprint |= PRINT_SYSNAME;
@@ -77,19 +74,5 @@ main (argc, argv)
 		print_element (PRINT_MACHINE, name.machine);
 	}
 
-	exit(0);
+	return 0;
 }
-
-static void
-print_element (mask, element)
-	unsigned char mask;
-	char *element;
-{
-	if (toprint & mask)
-	{
-		toprint &= ~mask;
-		write(STDOUT_FILENO,element,strlen(element));
-		write(STDOUT_FILENO,toprint ? " " : "\n",1);
-	}
-}
-

--- a/image/Make.image
+++ b/image/Make.image
@@ -52,7 +52,7 @@ ifdef CONFIG_APPS_COMPRESS
 endif
 	$(MAKE) -C $(BOOTBLOCKS_DIR)
 	bash -c "./ver.pl $(ELKS_DIR)/Makefile-rules > $(DESTDIR)/etc/issue"
-	git log --abbrev-commit | head -1 | sed 's/commit/ELKS built from commit/' > $(DESTDIR)/etc/motd
+	#git log --abbrev-commit | head -1 | sed 's/commit/ELKS built from commit/' > $(DESTDIR)/etc/motd
 ifdef CONFIG_IMG_BOOT
 	install $(ELKS_DIR)/arch/i86/boot/Image $(DESTDIR)/linux
 endif

--- a/libc/include/sys/utsname.h
+++ b/libc/include/sys/utsname.h
@@ -1,0 +1,10 @@
+#ifndef _SYS_UTSNAME_H
+#define _SYS_UTSNAME_H
+
+#include <features.h>
+#include <sys/types.h>
+#include __SYSINC__(utsname.h)
+
+int uname(struct utsname *name);
+
+#endif


### PR DESCRIPTION
Adds `uname` command to display operating system release number, version, machine name, etc.

The version number includes commit number and date compiled, and the machine name includes the processor type and machine (ibmpc, pc-98, etc).

All this information is now available programmatically through the new `uname` system call, and most information is displayed when running /etc/rc.sys at boot. This should help solve @cocus's earlier request for discrete build version numbers, as it is changed on every compile.
<img width="832" alt="Screen Shot 2022-03-22 at 8 48 37 PM" src="https://user-images.githubusercontent.com/11985637/159615538-310e3996-61ef-4cc6-81af-87ee5cfaf1d3.png">
<img width="752" alt="Screen Shot 2022-03-22 at 8 43 12 PM" src="https://user-images.githubusercontent.com/11985637/159615550-49b7fd0a-1f9d-49d5-a479-378ff47d34cb.png">

