### PR TITLE
[8018x] interrupt pin mapping to logical IRQs

### DIFF
--- a/8018x.config
+++ b/8018x.config
@@ -9,11 +9,18 @@
 
 
 #
-# Hardware
+# System
 #
 
 # CONFIG_ARCH_IBMPC is not set
 CONFIG_ARCH_8018X=y
+# CONFIG_ARCH_PC98 is not set
+CONFIG_CPU_8086=y
+CONFIG_8018X_INT0=0
+CONFIG_8018X_INT1=12
+CONFIG_8018X_INT2=0
+CONFIG_8018X_INT3=0
+CONFIG_8018X_INT4=0
 
 #
 # Kernel settings
@@ -50,7 +57,10 @@ CONFIG_ROM_CHECKSUM_SIZE=64
 # Networking Support
 #
 
-# CONFIG_SOCKET is not set
+CONFIG_SOCKET=y
+# CONFIG_NANO is not set
+CONFIG_INET=y
+# CONFIG_UNIX is not set
 
 #
 # Filesystem Support
@@ -59,7 +69,8 @@ CONFIG_ROM_CHECKSUM_SIZE=64
 # CONFIG_MINIX_FS is not set
 CONFIG_ROMFS_FS=y
 CONFIG_ROMFS_BASE=0x8000
-# CONFIG_FS_FAT is not set
+CONFIG_FS_FAT=y
+CONFIG_FS_DEV=y
 # CONFIG_ROOT_READONLY is not set
 # CONFIG_FS_RO is not set
 CONFIG_FULL_VFS=y
@@ -84,8 +95,10 @@ CONFIG_PIPE=y
 # CONFIG_BLK_DEV_HD is not set
 # CONFIG_DMA is not set
 # CONFIG_BLK_DEV_RAM is not set
-# CONFIG_BLK_DEV_CHAR is not set
+# CONFIG_BLK_DEV_SSD_NONE is not set
+# CONFIG_BLK_DEV_SSD_TEST is not set
 CONFIG_BLK_DEV_SSD_SD8018X=y
+# CONFIG_BLK_DEV_CHAR is not set
 
 #
 # Character device drivers
@@ -93,22 +106,27 @@ CONFIG_BLK_DEV_SSD_SD8018X=y
 
 # CONFIG_CONSOLE_DIRECT is not set
 # CONFIG_CONSOLE_BIOS is not set
-# CONFIG_CONSOLE_HEADLESS is not set
 CONFIG_CONSOLE_8018X=y
+# CONFIG_CONSOLE_HEADLESS is not set
 # CONFIG_KEYBOARD_SCANCODE is not set
 # CONFIG_CONSOLE_SERIAL is not set
 # CONFIG_CHAR_DEV_RS is not set
 # CONFIG_CHAR_DEV_LP is not set
 # CONFIG_CHAR_DEV_CGATEXT is not set
 CONFIG_CHAR_DEV_MEM=y
-# CONFIG_PSEUDO_TTY is not set
+# CONFIG_CHAR_DEV_MEM_PORT_READ is not set
+# CONFIG_CHAR_DEV_MEM_PORT_WRITE is not set
+CONFIG_PSEUDO_TTY=y
 # CONFIG_DEV_META is not set
 
 #
 # Network device drivers
 #
 
-# CONFIG_ETH is not set
+CONFIG_ETH=y
+CONFIG_ETH_NE2K=y
+# CONFIG_ETH_WD is not set
+CONFIG_ETH_BYTE_ACCESS=y
 
 #
 # Userland
@@ -119,11 +137,13 @@ CONFIG_CHAR_DEV_MEM=y
 CONFIG_APP_SASH=y
 # CONFIG_APP_BUSYELKS is not set
 # CONFIG_APP_CGATEXT is not set
+# CONFIG_APP_OR566LEDS is not set
+# CONFIG_APP_LL_UTILS is not set
 # CONFIG_APP_SCREEN is not set
 # CONFIG_APP_CRON is not set
-# CONFIG_APP_DISK_UTILS is not set
+CONFIG_APP_DISK_UTILS=y
 # CONFIG_APP_FILE_UTILS is not set
-# CONFIG_APP_SH_UTILS is not set
+CONFIG_APP_SH_UTILS=y
 # CONFIG_APP_SYS_UTILS is not set
 # CONFIG_APP_ELVIS is not set
 # CONFIG_APP_MINIX1 is not set
@@ -136,6 +156,8 @@ CONFIG_APP_SASH=y
 # CONFIG_APP_BYACC is not set
 # CONFIG_APP_M4 is not set
 # CONFIG_APP_TEST is not set
+CONFIG_APP_KTCP=y
+# CONFIG_APP_MAN_PAGES is not set
 
 #
 # Target image

--- a/elks/arch/i86/kernel/irq-8018x.c
+++ b/elks/arch/i86/kernel/irq-8018x.c
@@ -27,18 +27,58 @@ void init_irq(void)
     outw(0xfd, PCB_IMASK);
 }
 
+struct irq_logical_map {
+    unsigned int irq;           /* logical IRQ from ELKS */
+    unsigned int config_word;   /* config word for the Interrupt control register */
+    unsigned int pcb_register;  /* interrupt control register on the PCB */
+    int irq_vector;             /* CPU IRQ Vector number */
+} logical_map[] = {
+    /* 8018x: Timer Interrupt unmasked, priority 7, Interrupt type (vector) 18. */
+    { TIMER_IRQ, 0x7, PCB_TCUCON, CPU_VEC_TIMER1 },
+    /**
+     * 8018x: Enabling Serial Interrupts will enable the RX and TX IRQs
+     * at the same time, this is a CPU limitation.
+     * Serial Interrupts unmasked, priority 1, Interrupt type (vector) 20 and 21.
+     */
+    { UART0_IRQ_RX, 0x1, PCB_SCUCON, CPU_VEC_S0_RX },
+    { UART0_IRQ_TX, 0x1, PCB_SCUCON, CPU_VEC_S0_TX },
+#if CONFIG_8018X_INT0 + 0 > 0
+    { CONFIG_8018X_INT0, 0x6, PCB_I0CON, CPU_VEC_INT0 },
+#endif
+#if CONFIG_8018X_INT1 + 0 > 0
+    { CONFIG_8018X_INT1, 0x6, PCB_I1CON, CPU_VEC_INT1 },
+#endif
+#if CONFIG_8018X_INT2 + 0 > 0
+    { CONFIG_8018X_INT2, 0x6, PCB_I2CON, CPU_VEC_INT2 },
+#endif
+#if CONFIG_8018X_INT3 + 0 > 0 
+    { CONFIG_8018X_INT3, 0x6, PCB_I3CON, CPU_VEC_INT3 },
+#endif
+#if CONFIG_8018X_INT4 + 0 > 0
+    { CONFIG_8018X_INT4, 0x6, PCB_I4CON, CPU_VEC_INT4 },
+#endif
+};
+
+struct irq_logical_map* get_from_logical_irq(unsigned int irq)
+{
+    size_t i;
+    for (i = 0; i < (sizeof(logical_map)/sizeof(logical_map[0])); ++i)
+    {
+        if (logical_map[i].irq == irq)
+        {
+            return &logical_map[i];
+        }
+    }
+
+    return NULL;
+}
+
 void enable_irq(unsigned int irq)
 {
-    if (irq == TIMER_IRQ) {
-        /* 8018x: Timer Interrupt unmasked, priority 7. */
-        outw(7, PCB_TCUCON);
-    } else if ((irq == UART0_IRQ_RX) || (irq == UART0_IRQ_TX)) {
-        /**
-         * 8018x: Enabling Serial Interrupts will enable the RX and TX IRQs
-         * at the same time, this is a CPU limitation.
-         * Serial Interrupts unmasked, priority 1.
-         */
-        outw(1, PCB_SCUCON);
+    struct irq_logical_map* map;
+    map = get_from_logical_irq(irq);
+    if (map) {
+        outw(map->config_word, map->pcb_register);
     }
 }
 
@@ -51,15 +91,12 @@ int remap_irq(int irq)
 // Get interrupt vector from IRQ
 int irq_vector(int irq)
 {
-    if (irq == TIMER_IRQ) {
-        /* 8018x: Timer 1 Interrupt => Interrupt type (vector) 18 */
-        return CPU_VEC_TIMER1;
-    } else if (irq == UART0_IRQ_RX) {
-        /* 8018x: Serial 0 RX Interrupt => Interrupt type (vector) 20 */
-        return CPU_VEC_S0_RX;
-    } else if (irq == UART0_IRQ_TX) {
-        /* 8018x: Serial 0 TX Interrupt => Interrupt type (vector) 21 */
-        return CPU_VEC_S0_TX;
+    struct irq_logical_map* map;
+
+    map = get_from_logical_irq(irq);
+    if (map) {
+        return map->irq_vector;
     }
+
     return -EINVAL;
 }

--- a/elks/config.in
+++ b/elks/config.in
@@ -38,6 +38,13 @@ mainmenu_option next_comment
 
 		comment 'Devices'
 
+		comment 'INTx pins (0=disabled)'
+		int 'INT0 Logical IRQ' CONFIG_8018X_INT0 0
+		int 'INT1 Logical IRQ' CONFIG_8018X_INT1 12
+		int 'INT0 Logical IRQ' CONFIG_8018X_INT2 0
+		int 'INT0 Logical IRQ' CONFIG_8018X_INT3 0
+		int 'INT0 Logical IRQ' CONFIG_8018X_INT4 0
+
 	elif [ "$CONFIG_ARCH_PC98" = "y" ]; then
 
 		comment 'Devices'


### PR DESCRIPTION
Adds appropriate configurations for the 8018x processors to support
the INTx pins, mapping their interrupts to logical IRQs. This is
quite different than x86 PCs since there's no standard for the
devices using an 8018x.