### PR TITLE
[kernel] Fix signals on systems not running /bin/init

### DIFF
--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -133,6 +133,11 @@ static void init_task(void)
 
     mount_root();
 
+#if defined(CONFIG_APP_SASH) && !defined(CONFIG_APP_ASH)
+    /* when no /bin/init, force initial process group on console to make signals work*/
+    current->session = current->pgrp = 1;
+#endif
+
     /* Don't open /dev/console for /bin/init, 0-2 closed immediately and fragments heap*/
     //if (strcmp(init_command, bininit) != 0) {
 	/* Set stdin/stdout/stderr to /dev/console if not running /bin/init*/
@@ -154,7 +159,7 @@ static void init_task(void)
 	run_init_process_sptr(init_command, (char *)argv_init, argv_slen);
     } else
 #endif
-	run_init_process(bininit);
+    run_init_process(bininit);
 
     printk("No init - running /bin/sh\n");
     current->ppid = 1;			/* turns off auto-child reaping*/


### PR DESCRIPTION
Allows proper ^C/SIGINT signal generation for systems not running /bin/init, discussed in https://github.com/jbruchon/elks/issues/1017#issuecomment-1087063918.

For these systems, CONFIG_APP_SASH will be defined, and CONFIG_APP_ASH won't be, and a controlling tty process group is forced, emulating the behavior of `setsid` executed by /bin/init normally.

A fully proper fix is complicated by both shells expecting stdin/stdout/stderr to be fully setup prior to their execution, but in this case, /bin/init may not execute, and the kernel has to essentially work around this.

Thus, for now, the above CONFIG_APP_ configuration of sash only, which isn't defined for non-ROMFS builds, is checked.