### PR TITLE
[libc] Add floating point support to C library

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -105,6 +105,7 @@ sh_utils/which					:shutil					:1200k	:1440k
 #sh_utils/whoami				:shutil					:1200k	:1440k
 sh_utils/xargs					:shutil					:1200k	:1440k
 sh_utils/yes					:shutil				:720k
+misc_utils/float				:miscutil						:1440k
 misc_utils/compress				:miscutil						:1440k
 misc_utils/miniterm				:miscutil			:720k
 misc_utils/fdtest				:miscutil				:1200k	:1440k

--- a/elkscmd/misc_utils/.gitignore
+++ b/elkscmd/misc_utils/.gitignore
@@ -3,6 +3,7 @@ compress
 compress.host
 ed
 fdtest
+float
 tar
 od
 hd

--- a/elkscmd/misc_utils/Makefile
+++ b/elkscmd/misc_utils/Makefile
@@ -16,10 +16,16 @@ KERNEL_LIBS = $(TOPDIR)/elks/arch/i86/lib/lib86.a
 
 #TODO: fix uncompress zcat lpfilter disabled
 PRGS = tar miniterm ed fdtest od hd time kilo mined sleep tty uuencode uudecode compress
+PRGS += float
 
 #PRGS_HOST=compress.host
 
 all: $(PRGS) $(PRGS_HOST)
+
+# FIXME work around undefined 'memcpy' in libgcc.a
+ECVT=../../libc/build-ml/elkslibc/misc/ecvt.o
+float: float.o
+	$(LD) $(LDFLAGS) -o float float.o $(ECVT) $(LDLIBS)
 
 ed: ed.o
 	$(LD) $(LDFLAGS) -o ed ed.o $(LDLIBS)

--- a/elkscmd/misc_utils/float.c
+++ b/elkscmd/misc_utils/float.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+__STDIO_PRINT_FLOATS;	/* force float libc printf/sprintf support */
+
+double g = 2.0;
+
+int main(int argc, char **argv) {
+	double f = 3.00 * g;
+	//int decpt, neg;
+	//char *s = fcvt(f, 12, &decpt, &neg);
+	char buf[32];
+	__fp_print_func(f, 'g', -1, buf);
+	printf("%s, %g, %f, %e\n", buf, f, f, f);
+
+	return 0;
+}

--- a/libc/Makefile.inc
+++ b/libc/Makefile.inc
@@ -2,7 +2,7 @@
 VERSION=elks-0.5.0
 
 INCLUDES=-I$(TOPDIR)/include -I$(TOPDIR)/libc/include -I$(TOPDIR)/elks/include
-DEFINES=-D__LIBC__ -D__LIBC_VER__='"$(VERSION)"' -D__HAS_NO_FLOATS__
+DEFINES=-D__LIBC__ -D__LIBC_VER__='"$(VERSION)"'
 
 INCS=$(INCLUDES)
 SDEFS=$(DEFINES)

--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -142,6 +142,13 @@ int vfprintf (FILE * stream, const char * format, va_list ap);
 int vsprintf (char * sp, const char * format, va_list ap);
 int vsnprintf (char * sp, size_t, const char * format, va_list ap);
 
+#ifndef __HAS_NO_FLOATS__
+void __fp_print_func(double val, int style, int preci, char *ptmp);
+extern void  (*__fp_print)();
+/* use this macro to link in libc %e,%f,%g printf/sprintf support into user program */
+#define __STDIO_PRINT_FLOATS	void (*__fp_print)() = __fp_print_func
+#endif
+
 #define stdio_pending(fp) ((fp)->bufread>(fp)->bufpos)
 
 void perror (const char * s);

--- a/libc/include/stdlib.h
+++ b/libc/include/stdlib.h
@@ -16,8 +16,9 @@
 #define EXIT_FAILURE 1
 #define EXIT_SUCCESS 0
 
-extern int rand __P ((void));
-extern void srand __P ((unsigned int seed));
+#define RAND_MAX	0x7fff
+int rand(void);
+void srand(unsigned int seed);
 
 long strtol(const char * nptr, char ** endptr, int base);
 unsigned long strtoul(const char * nptr, char ** endptr, int base);

--- a/libc/include/stdlib.h
+++ b/libc/include/stdlib.h
@@ -19,16 +19,18 @@
 extern int rand __P ((void));
 extern void srand __P ((unsigned int seed));
 
-extern long strtol __P ((const char * nptr, char ** endptr, int base));
-extern unsigned long strtoul __P ((const char * nptr,
-				   char ** endptr, int base));
+long strtol(const char * nptr, char ** endptr, int base);
+unsigned long strtoul(const char * nptr, char ** endptr, int base);
+
 #ifndef __HAS_NO_FLOATS__
-extern double strtod __P ((const char * nptr, char ** endptr));
-extern double atof __P ((__const char *__nptr));
+double strtod(const char *nptr, char ** endptr);
+double atof(const char *str);
+char *ecvt(double val, int ndig, int *pdecpt, int *psign);
+char *fcvt(double val, int nfrac, int *pdecpt, int *psign);
 #endif
 
-extern long int atol __P ((__const char *__nptr));
-extern int atoi __P ((__const char *__nptr));
+long atol(const char *str);
+int atoi(const char *str);
 
 /* Returned by `div'.  */
 typedef struct

--- a/libc/misc/Makefile
+++ b/libc/misc/Makefile
@@ -9,12 +9,14 @@ LIB = out.a
 OBJS = \
 	aliases.o \
 	atexit.o \
+	atof.o \
 	atoi.o \
 	atol.o \
 	basename.o \
 	crypt.o \
 	ctype.o \
 	dirname.o \
+	ecvt.o \
 	getcwd.o \
 	getenv.o \
 	getpass.o \
@@ -27,6 +29,7 @@ OBJS = \
 	putenv.o \
 	qsort-bsd.o \
 	rand.o \
+	strtod.o \
 	strtol.o \
 	system.o \
 	tmpnam.o \

--- a/libc/misc/atof.c
+++ b/libc/misc/atof.c
@@ -1,16 +1,14 @@
+#ifndef __HAS_NO_FLOATS__
+
 /* Copyright (C) Robert de Bath <robert@debath.co.uk>
  * This file is part of the Linux-8086 C library and is distributed
  * under the GNU Library General Public License.
  */
+#include <stdlib.h>
 
 double 
-#ifdef __STDC__
-atof(const char *p)
-#else
-atof(p)
-char *p;
-#endif
+atof(const char *str)
 {
-   return strtod(p, (char**)0);
+   return strtod(str, (char **)NULL);
 }
-
+#endif

--- a/libc/misc/atoi.c
+++ b/libc/misc/atoi.c
@@ -6,7 +6,7 @@
 #include <stdlib.h>
 
 int
-atoi(register const char *number)
+atoi(const char *number)
 {
 #ifdef USE_ATOL_AS_ATOI
 	return atol(number);

--- a/libc/misc/atol.c
+++ b/libc/misc/atol.c
@@ -4,10 +4,9 @@
  */
 
 long
-atol(number)
-register char  *number;
+atol(const char *number)
 {
-   register long   n = 0, neg = 0;
+   long   n = 0, neg = 0;
 
    while (*number <= ' ' && *number > 0)
       ++number;

--- a/libc/misc/ecvt.c
+++ b/libc/misc/ecvt.c
@@ -1,0 +1,115 @@
+#ifndef __HAS_NO_FLOATS__
+
+/* from dev86 libc */
+#include <stdlib.h>
+
+#define DIGMAX	30		/* max # of digits in string */
+#define DIGPREC	17		/* max # of significant digits */
+#define ECVT	0
+#define FCVT	1
+static char digstr[DIGMAX + 1 + 1];    /* +1 for end of string         */
+
+    /* +1 in case rounding adds     */
+    /* another digit                */
+static double negtab[] =
+    { 1e-256, 1e-128, 1e-64, 1e-32, 1e-16, 1e-8, 1e-4, 1e-2, 1e-1, 1.0 };
+static double postab[] =
+    { 1e+256, 1e+128, 1e+64, 1e+32, 1e+16, 1e+8, 1e+4, 1e+2, 1e+1 };
+
+static char *
+_cvt(int cnvflag, double val, int ndig, int *pdecpt, int *psign)
+{
+   int   decpt, pow, i;
+   char *p;
+   *psign = (val < 0) ? ((val = -val), 1) : 0;
+   ndig = (ndig < 0) ? 0 : (ndig < DIGMAX) ? ndig : DIGMAX;
+   if (val == 0) {
+      for (p = &digstr[0]; p < &digstr[ndig]; p++)
+	 *p = '0';
+      decpt = 0;
+   } else {
+      /* Adjust things so that 1 <= val < 10  */
+      /* in these loops if val == MAXDOUBLE)  */
+      decpt = 1;
+      pow = 256;
+      i = 0;
+      while (val < 1) {
+	 while (val < negtab[i + 1]) {
+	    val /= negtab[i];
+	    decpt -= pow;
+	 }
+	 pow >>= 1;
+	 i++;
+      }
+      pow = 256;
+      i = 0;
+      while (val >= 10) {
+	 while (val >= postab[i]) {
+	    val /= postab[i];
+	    decpt += pow;
+	 }
+	 pow >>= 1;
+	 i++;
+      }
+      if (cnvflag == FCVT) {
+	 ndig += decpt;
+	 ndig = (ndig < 0) ? 0 : (ndig < DIGMAX) ? ndig : DIGMAX;
+      }
+
+      /* Pick off digits 1 by 1 and stuff into digstr[]       */
+      /* Do 1 extra digit for rounding purposes               */
+      for (p = &digstr[0]; p <= &digstr[ndig]; p++) {
+	 int   n;
+
+	 /* 'twould be silly to have zillions of digits  */
+	 /* when only DIGPREC are significant            */
+	 if (p >= &digstr[DIGPREC])
+	    *p = '0';
+
+	 else {
+	    n = val;
+	    *p = n + '0';
+	    val = (val - n) * 10;	/* get next digit */
+	 }
+      }
+      if (*--p >= '5') {	/* if we need to round              */
+	 while (1) {
+	    if (p == &digstr[0]) {	/* if at start      */
+	       ndig += cnvflag;
+	       decpt++;		/* shift dec pnt */
+	       digstr[0] = '1';	/* "100000..." */
+	       break;
+	    }
+	    *p = '0';
+	    --p;
+	    if (*p != '9') {
+	       (*p)++;
+	       break;
+	    }
+	 }			/* while */
+      }				/* if */
+   }				/* else */
+   *pdecpt = decpt;
+   digstr[ndig] = 0;		/* terminate string             */
+   return &digstr[0];
+}
+
+/*
+ * Convert double val to a string of decimal digits.
+ *	ndig = # of digits in resulting string
+ * Returns:
+ *	*pdecpt = position of decimal point from left of first digit
+ *	*psign  = nonzero if value was negative
+ */
+char *
+ecvt(double val, int ndig, int *pdecpt, int *psign)
+{
+   return _cvt(ECVT, val, ndig, pdecpt, psign);
+}
+
+char *
+fcvt(double val, int nfrac, int *pdecpt, int *psign)
+{
+   return _cvt(FCVT, val, nfrac, pdecpt, psign);
+}
+#endif

--- a/libc/misc/strtod.c
+++ b/libc/misc/strtod.c
@@ -1,0 +1,99 @@
+#ifndef __HAS_NO_FLOATS__
+
+/*
+ * strtod.c - This file is part of the libc-8086 package for ELKS,
+ * Copyright (C) 1995, 1996 Nat Friedman <ndf@linux.mit.edu>.
+ * 
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Library General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Library General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Library General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
+#include <stdlib.h>
+#include <ctype.h>
+
+double
+strtod(const char *nptr, char ** endptr)
+{
+  unsigned short negative;
+  double number;
+  double fp_part;
+  int exponent = 0;
+  unsigned short exp_negative = 0;
+
+  /* advance beyond any leading whitespace */
+  while (isspace(*nptr))
+    nptr++;
+
+  /* check for optional '+' or '-' */
+  negative=0;
+  if (*nptr=='-')
+    {
+      negative=1;
+      nptr++;
+    }
+  else
+    if (*nptr=='+')
+      nptr++;
+
+  number=0;
+  while (isdigit(*nptr))
+    {
+      number=number*10+(*nptr-'0');
+      nptr++;
+    }
+
+  if (*nptr=='.')
+    {
+      nptr++;
+      fp_part=0;
+      while (isdigit(*nptr))
+	{
+	  fp_part=fp_part/10.0 + (*nptr-'0')/10.0;
+	  nptr++;
+	}
+      number+=fp_part;
+    }
+
+  if (*nptr=='e' || *nptr=='E')
+    {
+      nptr++;
+      exp_negative=0;
+      if (*nptr=='-')
+	{
+	  exp_negative=1;
+	  nptr++;
+	}
+      else
+	if (*nptr=='+')
+	  nptr++;
+
+      exponent=0;
+      while (isdigit(*nptr))
+	{
+	  exponent=exponent*10+(*nptr-'0');
+	  exponent++;
+	}
+    }
+
+  while (exponent)
+    {
+      if (exp_negative)
+	number/=10;
+      else
+	number*=10;
+      exponent--;
+    }
+  return (negative ? -number:number);
+}
+#endif

--- a/libc/misc/strtod.c
+++ b/libc/misc/strtod.c
@@ -18,29 +18,27 @@
  *  License along with this library; if not, write to the Free
  *  Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  *
+ * Apr 2022 made working by Greg Haerr
  */
 #include <stdlib.h>
 #include <ctype.h>
 
 double
-strtod(const char *nptr, char ** endptr)
+strtod(const char *nptr, char **endptr)
 {
-  unsigned short negative;
   double number;
-  double fp_part;
-  int exponent = 0;
-  unsigned short exp_negative = 0;
+  double fp_part, fp_divisor;
+  int negative = 0;
 
   /* advance beyond any leading whitespace */
   while (isspace(*nptr))
     nptr++;
 
   /* check for optional '+' or '-' */
-  negative=0;
   if (*nptr=='-')
     {
-      negative=1;
       nptr++;
+      negative=1;
     }
   else
     if (*nptr=='+')
@@ -56,44 +54,48 @@ strtod(const char *nptr, char ** endptr)
   if (*nptr=='.')
     {
       nptr++;
-      fp_part=0;
+      fp_part = 0;
+      fp_divisor = 10.0;
       while (isdigit(*nptr))
 	{
-	  fp_part=fp_part/10.0 + (*nptr-'0')/10.0;
-	  nptr++;
+	  fp_part += (*nptr++ - '0') / fp_divisor;
+	  fp_divisor *= 10.0;
 	}
       number+=fp_part;
     }
 
   if (*nptr=='e' || *nptr=='E')
     {
+      int exponent = 0;
+      int exp_negative = 0;
+
       nptr++;
-      exp_negative=0;
       if (*nptr=='-')
 	{
-	  exp_negative=1;
 	  nptr++;
+	  exp_negative=1;
 	}
       else
 	if (*nptr=='+')
 	  nptr++;
 
-      exponent=0;
       while (isdigit(*nptr))
 	{
-	  exponent=exponent*10+(*nptr-'0');
-	  exponent++;
+	  exponent = exponent * 10 + (*nptr++ - '0');
 	}
+      while (exponent)
+        {
+          if (exp_negative)
+	    number/=10;
+          else
+	    number*=10;
+          exponent--;
+        }
     }
 
-  while (exponent)
-    {
-      if (exp_negative)
-	number/=10;
-      else
-	number*=10;
-      exponent--;
-    }
+  if (endptr)
+	*endptr = (char *)nptr;
+
   return (negative ? -number:number);
 }
 #endif

--- a/libc/misc/strtol.c
+++ b/libc/misc/strtol.c
@@ -23,12 +23,12 @@
 #include <ctype.h>
 #include <stdlib.h>
 
-long int
+long
 strtol(const char *nptr, char **endptr, int base)
 {
   const char * ptr;
   unsigned short negative;
-  long int number;
+  long number;
 
   ptr=nptr;
 
@@ -39,15 +39,15 @@ strtol(const char *nptr, char **endptr, int base)
   if (*ptr=='-')
     negative=1;
 
-  number=(long int)strtoul(nptr, endptr, base);
+  number=(long)strtoul(nptr, endptr, base);
 
   return (negative ? -number:number);
 }
 
-unsigned long int
+unsigned long
 strtoul(const char *nptr, char **endptr, int base)
 {
-  unsigned long int number;
+  unsigned long number;
 
   /* Sanity check the arguments */
   if (base==1 || base>36 || base<0)

--- a/libc/stdio/Makefile
+++ b/libc/stdio/Makefile
@@ -7,7 +7,6 @@ CFLAGS	+= -DL_ftell
 OBJS = \
 	stdio.o \
 	__fopen.o \
-	__fp_print.o \
 	__fp_print_func.o \
 	__io_init.o \
 	__io_list.o \

--- a/libc/stdio/__fp_print.c
+++ b/libc/stdio/__fp_print.c
@@ -1,5 +1,0 @@
-#ifndef __HAS_NO_FLOATS__
-#include "_stdio.h"
-
-int (*__fp_print)() = 0;
-#endif

--- a/libc/stdio/__fp_print_func.c
+++ b/libc/stdio/__fp_print_func.c
@@ -1,7 +1,66 @@
-#ifdef L_fp_print
-#include "_stdio.h"
-
 #ifndef __HAS_NO_FLOATS__
+
+/*
+ * floating point output
+ *
+ * Added 'g' output format
+ * Apr 2022 Greg Haerr
+ */
+#include <stdio.h>
+#include <stdlib.h>
+
+void
+__fp_print_func(double val, int style, int preci, char * ptmp)
+{
+   int decpt, negative, diddecpt = 0;
+   char * cvt;
+
+   if (preci < 0) preci = 6;
+
+   if (style == 'e')
+	cvt = ecvt(val, preci, &decpt, &negative);	/* preci = ndigits */
+   else cvt = fcvt(val, preci, &decpt, &negative);
+   if(negative)
+      *ptmp++ = '-';
+
+   if (decpt<0) {
+      *ptmp++ = '0';
+      *ptmp++ = '.';
+      while(decpt<0) {
+	 *ptmp++ = '0'; decpt++;
+      }
+   }
+
+   while(*cvt) {
+      *ptmp++ = *cvt++;
+      if (decpt == 1) {
+	 *ptmp++ = '.';
+	 diddecpt = 1;
+      }
+      decpt--;
+   }
+
+   while(decpt > 0) {
+      *ptmp++ = '0';
+      decpt--;
+   }
+   if (style == 'g' && diddecpt) {
+	for (;;) {
+	   int c = *--ptmp;
+	   if (c == '0' || c == '.')
+          *ptmp = 0;
+	   if (c != '0') break;
+	}
+   }
+}
+
+#if 0
+static void
+__xfpcvt()
+{
+   extern int (*__fp_print)();
+   __fp_print = __fp_print_func;
+}
 
 #ifdef __AS386_16__
 #asm
@@ -20,46 +79,6 @@ auto_func:        ! Label for bcc -M to work.
   .text           ! So the function after is also in the correct seg.
 #endasm
 #endif
+#endif /* #if 0 */
 
-void
-__fp_print_func(double * pval, int style, int preci, char * ptmp)
-{
-   int decpt, negative;
-   char * cvt;
-   double val = *pval;
-
-   if (preci < 0) preci = 6;
-
-   cvt = fcvt(val, preci, &decpt, &negative);
-   if(negative)
-      *ptmp++ = '-';
-
-   if (decpt<0) {
-      *ptmp++ = '0';
-      *ptmp++ = '.';
-      while(decpt<0) {
-	 *ptmp++ = '0'; decpt++;
-      }
-   }
-
-   while(*cvt) {
-      *ptmp++ = *cvt++;
-      if (decpt == 1)
-	 *ptmp++ = '.';
-      decpt--;
-   }
-
-   while(decpt > 0) {
-      *ptmp++ = '0';
-      decpt--;
-   }
-}
-
-static void
-__xfpcvt()
-{
-   extern int (*__fp_print)();
-   __fp_print = __fp_print_func;
-}
-#endif
-#endif
+#endif /* __HAS_NO_FLOATS__ */

--- a/libc/stdio/__fp_print_func.c
+++ b/libc/stdio/__fp_print_func.c
@@ -44,6 +44,7 @@ __fp_print_func(double val, int style, int preci, char * ptmp)
       *ptmp++ = '0';
       decpt--;
    }
+   *ptmp = 0;
    if (style == 'g' && diddecpt) {
 	for (;;) {
 	   int c = *--ptmp;
@@ -52,6 +53,7 @@ __fp_print_func(double val, int style, int preci, char * ptmp)
 	   if (c != '0') break;
 	}
    }
+
 }
 
 #if 0

--- a/libc/stdio/_stdio.h
+++ b/libc/stdio/_stdio.h
@@ -24,14 +24,12 @@
 #endif
 
 extern FILE *__IO_list;		/* For fflush at exit */
-extern int (*__fp_print)();
 
 #if defined(__cplusplus)
 extern "C" {
 #endif
 
 void __io_init_vars(void);
-void __fp_print_func(double * pval, int style, int preci, char * ptmp);
 
 #if defined(__cplusplus)
 }

--- a/libc/stdio/vfprintf.c
+++ b/libc/stdio/vfprintf.c
@@ -22,14 +22,18 @@
  */
 
 #include <sys/types.h>
-
 #include <fcntl.h>
 #include <string.h>
-
+#include <stdlib.h>
 #include "_stdio.h"
 
-extern char * ltostr (long val, int radix);
-extern char * ultostr (unsigned long val, int radix);
+#ifndef __HAS_NO_FLOATS__
+/*
+ * Use '__STDIO_PRINT_FLOATS;' in user program to link in libc %e,%f,%g
+ * printf/sprintf support (see stdio.h).
+ */
+void (*__fp_print)();	/* =0 by default by linker which disables float support */
+#endif
 
 static int
 prtfld(FILE *op, unsigned char *buf,
@@ -241,7 +245,7 @@ vfprintf(FILE *op, const char *fmt, va_list ap)
 	 case 'G':
 	    if ( __fp_print )
 	    {
-	       (*__fp_print)(&va_arg(ap, double), *fmt, preci, ptmp);
+	       (*__fp_print)(va_arg(ap, double), *fmt, preci, ptmp);
 	       preci = -1;
 	       goto printit;
 	    }
@@ -267,9 +271,7 @@ vfprintf(FILE *op, const char *fmt, va_list ap)
    return (cnt);
 }
 
-#ifdef L_fp_print
-#ifndef __HAS_NO_FLOATS__
-
+#if 0
 #ifdef __AS386_16__
 #asm
   loc   1         ! Make sure the pointer is in the correct segment
@@ -294,5 +296,4 @@ __xfpcvt(void)
    extern int (*__fp_print)();
    __fp_print = __fp_print_func;
 }
-#endif
 #endif


### PR DESCRIPTION
Add %e,%f,%g floating point output support to printf, sprintf etc.
Add ecvt, fcvt, strtod, atof libc functions.

Temporarily add elkscmd/misc_util/float.c example program showing use of floats. Currently, __STDIO_PRINT_FLOATS is required in main program to enable linking in extended float format support in printf, in order to keep size down. This may change to instead use weak linker symbols. 

Libc float support is being added as a precursor to ongoing work porting a Sinclair/Arduino BASIC interpreter to ELKS, which performs all math in floating point.