### PR TITLE
[cmds] BASIC interpreter fixes and enhancements

### DIFF
--- a/elkscmd/basic/TODO
+++ b/elkscmd/basic/TODO
@@ -2,9 +2,10 @@ Sinclair basic examples and compatibility
 	randomize, data, read
 	inkey$
 	go to -> goto
-parse 1e4 etc
+^C stop
+parse 1e4 numbers
 strtol must return LONG_MAX or MIN on over/underflow
 %.12f variable precision output
 print Nan
-^C stop
 TOKEN_INTEGER - size 4 or 2, line number only?
+	don't convert to integer then float each time

--- a/elkscmd/basic/TODO
+++ b/elkscmd/basic/TODO
@@ -1,12 +1,9 @@
 Sinclair basic examples and compatibility
 	randomize, data, read
 	inkey$
-	SAVE
 	go to -> goto
-float -> double
 parse 1e4 etc
 strtol must return LONG_MAX or MIN on over/underflow
-cleanup floor statements at start
 %.12f variable precision output
 print Nan
 ^C stop

--- a/elkscmd/basic/basic.h
+++ b/elkscmd/basic/basic.h
@@ -6,6 +6,7 @@
 #define MEMORY_SIZE	10240		// max tokenized memory bytes for program
 #define MAX_IDENT_LEN	8
 #define MAX_NUMBER_LEN	30
+#define MAX_PATH_LEN	64		// for LOAD/SAVE filename strings
 
 #define false		0
 #define true		1
@@ -109,6 +110,7 @@
 #define ERROR_IN_VAL_INPUT			23
 #define ERROR_BAD_PARAMETER                     24
 #define ERROR_EOF				25
+#define ERROR_FILE_ERROR			26
 
 extern unsigned char mem[];
 extern int sysPROGEND;
@@ -141,6 +143,7 @@ extern const char* const errorTable[];
 void reset();
 int tokenize(unsigned char *input, unsigned char *output, int outputSize);
 int processInput(unsigned char *tokenBuf);
+void listProg(uint16_t first, uint16_t last);
 
 #endif
 

--- a/elkscmd/basic/basic.h
+++ b/elkscmd/basic/basic.h
@@ -1,9 +1,7 @@
-#ifndef _BASIC_H
-#define _BASIC_H
-
 #include <stdint.h>
 
 #define MEMORY_SIZE	10240		// max tokenized memory bytes for program
+#define TOKEN_BUF_SIZE  64      // max tokenized bytes per line
 #define MAX_IDENT_LEN	8
 #define MAX_NUMBER_LEN	30
 #define MAX_PATH_LEN	64		// for LOAD/SAVE filename strings
@@ -144,6 +142,3 @@ void reset();
 int tokenize(unsigned char *input, unsigned char *output, int outputSize);
 int processInput(unsigned char *tokenBuf);
 void listProg(uint16_t first, uint16_t last);
-
-#endif
-

--- a/elkscmd/basic/host.c
+++ b/elkscmd/basic/host.c
@@ -11,7 +11,6 @@
 __STDIO_PRINT_FLOATS;		// link in libc printf float support
 
 unsigned char mem[MEMORY_SIZE];
-#define TOKEN_BUF_SIZE    64
 static unsigned char tokenBuf[TOKEN_BUF_SIZE];
 
 static FILE *infile;
@@ -66,15 +65,13 @@ char *host_readLine() {
 }
 
 char host_getKey() {
-#if 1
-	return 0;
-#else
+#if 0
     char c = inkeyChar;
     inkeyChar = 0;
     if (c >= 32 && c <= 126)
         return c;
-    else return 0;
 #endif
+    return 0;
 }
 
 int host_ESCPressed() {
@@ -205,7 +202,13 @@ int host_directoryListing() {
 }
 
 int host_removeFile(char *fileName) {
-    if (unlink(fileName) < 0)
+	char file[MAX_PATH_LEN+5];
+
+	strcpy(file, fileName);
+	if (!strstr(file, ".bas"))
+		strcat(file, ".bas");
+
+    if (unlink(file) < 0)
 		return ERROR_FILE_ERROR;
     return ERROR_NONE;
 }

--- a/elkscmd/basic/host.h
+++ b/elkscmd/basic/host.h
@@ -1,8 +1,8 @@
 #define PROGMEM
 #define pgm_read_word(x)		(x)
 #define pgm_read_byte_near(x)	(x)
-#define float double			/* ELKS gcc 'double' use gen much less code */
-#define FS_ACCESS_ALLOWED
+
+#define FS_ACCESS_ALLOWED		/* allow DELETE/DIR/LIST/SAVE */
 
 void host_cls();
 void host_showBuffer();
@@ -22,11 +22,11 @@ void host_digitalWrite(int pin,int state);
 int host_digitalRead(int pin);
 int host_analogRead(int pin);
 void host_pinMode(int pin, int mode);
-double host_floor(double x);
+float host_floor(float x);
 
 #ifdef FS_ACCESS_ALLOWED
-void host_directoryListing();
-int host_saveProgramToFile(char *fileName);
+int host_directoryListing();
+int host_saveProgramToFile(char *fileName, int autoexec);
 int host_loadProgramFromFile(char *fileName);
 int host_removeFile(char *fileName);
 #endif

--- a/elkscmd/misc_utils/Makefile
+++ b/elkscmd/misc_utils/Makefile
@@ -22,10 +22,8 @@ PRGS += float
 
 all: $(PRGS) $(PRGS_HOST)
 
-# FIXME work around undefined 'memcpy' in libgcc.a
-ECVT=../../libc/build-ml/elkslibc/misc/ecvt.o
 float: float.o
-	$(LD) $(LDFLAGS) -o float float.o $(ECVT) $(LDLIBS)
+	$(LD) $(LDFLAGS) -o float float.o $(ECVT) $(LDLIBS) -lc
 
 ed: ed.o
 	$(LD) $(LDFLAGS) -o ed ed.o $(LDLIBS)

--- a/elkscmd/misc_utils/float.c
+++ b/elkscmd/misc_utils/float.c
@@ -88,6 +88,8 @@ int main(int argc, char **argv) {
 	printf("floor(3.1415926) = %f\n", host_floor(3.1415926));
 	printf("floor(-3.1415926) = %f\n", host_floor(-3.1415926));
 
+	// beware: floating point literals are double
+	// (float) cast doesn't stop promotion to double on varargs routines
 	//f = (float)3.1415926;
 	f = 3.1515926;
 	g = f * g;

--- a/elkscmd/misc_utils/float.c
+++ b/elkscmd/misc_utils/float.c
@@ -1,17 +1,98 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <limits.h>
 
 __STDIO_PRINT_FLOATS;	/* force float libc printf/sprintf support */
 
-double g = 2.0;
+#define FLOAT	float
+#define VOLATILE volatile
+VOLATILE FLOAT f = 1;
+VOLATILE FLOAT g = 2.0;
+
+extern void z(float);
+//extern xprintf(char *, ...);
+extern xprintf(char *, float, float);
+void x(float f)
+{
+	//z(f);
+}
+
+char *host_floatToStr(float f, char *buf) {
+#if 1
+    sprintf(buf, "%g", (double)f);
+    return buf;
+#else
+    // floats have approx 7 sig figs
+    float a = fabs(f);
+    if (f == 0.0f) {
+        buf[0] = '0';
+        buf[1] = 0;
+    }
+    else if (a<0.0001 || a>1000000) {
+        // this will output -1.123456E99 = 13 characters max including trailing nul
+        dtostre(f, buf, 6, 0);
+    }
+    else {
+        int decPos = 7 - (int)(floor(log10(a))+1.0f);
+        dtostrf(f, 1, decPos, buf);
+        if (decPos) {
+            // remove trailing 0s
+            char *p = buf;
+            while (*p) p++;
+            p--;
+            while (*p == '0') {
+                *p-- = 0;
+            }
+            if (*p == '.') *p = 0;
+        }
+    }
+    return buf;
+#endif
+}
+
+/* LONG_MAX is not exact as a double, yet LONG_MAX + 1 is */
+#define LONG_MAX_P1 ((LONG_MAX/2 + 1) * 2.0)
+
+/* small ELKS floor function using 32-bit longs */
+float host_floor(float x)
+{
+  if (x >= 0.0) {
+    if (x < LONG_MAX_P1) {
+      return (float)(long)x;
+    }
+    return x;
+  } else if (x < 0.0) {
+    if (x >= LONG_MIN) {
+      long ix = (long) x;
+      return (ix == x) ? x : (float)(ix-1);
+    }
+    return x;
+  }
+  return x; // NAN
+}
 
 int main(int argc, char **argv) {
-	double f = 3.00 * g;
-	//int decpt, neg;
-	//char *s = fcvt(f, 12, &decpt, &neg);
+	FLOAT f = 3.00 * g;
+	int decpt, neg;
+	printf("%s\n", fcvt(f, 12, &decpt, &neg));
+
 	char buf[32];
 	__fp_print_func(f, 'g', -1, buf);
 	printf("%s, %g, %f, %e\n", buf, f, f, f);
+
+	printf("float = %d\n", sizeof(float));
+	printf("LONG_MAX = %ld,%ld\n", LONG_MAX, LONG_MIN);
+	printf("3.1415926 = %f\n", strtod("3.1415926", 0));
+	printf("3.1415926 = %f\n", (FLOAT)3.1415926);
+	printf("2e5 = %g\n", strtod("2e5", 0));
+	printf("floor(3.1415926) = %f\n", host_floor(3.1415926));
+	printf("floor(-3.1415926) = %f\n", host_floor(-3.1415926));
+
+	//f = (float)3.1415926;
+	f = 3.1515926;
+	g = f * g;
+	printf("2 x %g = %g\n", (float)f, (float)g);
+	x(f);
 
 	return 0;
 }


### PR DESCRIPTION
SAVE and LOAD now work with human-readable .bas files.
SAVE+ "file" sets autorun so that the file is run when loaded with LOAD or as a command line argument.
Filenames enclosed in quotes need not contain ".bas", this will be added automatically, also in command line.
Fixed problem with large code generated for doubles, all calculations now use smaller 4-byte float format and 6 digits precision.
Add "Ok" output after each successful command, otherwise error message.
All error messages moved to internal error string array.
Moved experimental float testing to elkscmd/misc_util/float.c

Thanks to @cocus for initially getting LOAD/SAVE/DIR/DELETE working. 
