### PR TITLE
[cmds] Add math functions to BASIC, allow host compilation

### DIFF
--- a/elkscmd/basic/.gitignore
+++ b/elkscmd/basic/.gitignore
@@ -1,1 +1,2 @@
 basic
+hostbasic

--- a/elkscmd/basic/Makefile
+++ b/elkscmd/basic/Makefile
@@ -10,17 +10,26 @@ include $(BASEDIR)/Make.rules
 
 CFLAGS += -Wno-maybe-uninitialized
 
+HOSTCC = gcc
+HOST_CFLAGS = -O3
+
 ###############################################################################
 
 PRGS = basic
 
 all: $(PRGS)
 
-basic: basic.o host.o
+basic: basic.o host.o basic.h host.h
 	$(LD) $(LDFLAGS) -o basic basic.o host.o $(LDLIBS)
+
+HOSTSRC = basic.c host.c
+HOSTSRC += ../../libc/misc/ecvt.c
+HOSTSRC += ../../libc/stdio/__fp_print_func.c
+hostbasic: $(HOSTSRC) host.h basic.h
+	$(HOSTCC) $(HOST_CFLAGS) $(HOSTSRC) -o $@
 
 install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 clean:
-	rm -f $(PRGS) *.o
+	rm -f $(PRGS) *.o hostbasic

--- a/elkscmd/basic/basic.h
+++ b/elkscmd/basic/basic.h
@@ -15,6 +15,7 @@
 #define TOKEN_NUMBER	        3	// special case - number follows
 #define TOKEN_STRING	        4	// special case - string follows
 
+#define FIRST_NON_ALPHA_TOKEN   8
 #define TOKEN_LBRACKET	        8
 #define TOKEN_RBRACKET	        9
 #define TOKEN_PLUS	    	10
@@ -30,6 +31,8 @@
 #define TOKEN_CMD_SEP	        20
 #define TOKEN_SEMICOLON	        21
 #define TOKEN_COMMA		22
+#define LAST_NON_ALPHA_TOKEN    22
+#define FIRST_IDENT_TOKEN       23
 #define TOKEN_AND		23	// FIRST_IDENT_TOKEN
 #define TOKEN_OR		24
 #define TOKEN_NOT		25
@@ -73,12 +76,18 @@
 #define TOKEN_ANALOGRD          63
 #define TOKEN_DIR               64
 #define TOKEN_DELETE            65
-
-#define FIRST_IDENT_TOKEN 23
-#define LAST_IDENT_TOKEN 65
-
-#define FIRST_NON_ALPHA_TOKEN    8
-#define LAST_NON_ALPHA_TOKEN    22
+#define TOKEN_PI		66
+#define TOKEN_ABS		67
+#define TOKEN_COS		68
+#define TOKEN_SIN		69
+#define TOKEN_TAN		70
+#define TOKEN_ACS		71
+#define TOKEN_ASN		72
+#define TOKEN_ATN		73
+#define TOKEN_EXP		74
+#define TOKEN_LN		75
+#define TOKEN_POW		76
+#define LAST_IDENT_TOKEN	76
 
 #define ERROR_NONE				0
 // parse errors
@@ -109,6 +118,8 @@
 #define ERROR_BAD_PARAMETER                     24
 #define ERROR_EOF				25
 #define ERROR_FILE_ERROR			26
+#define ERROR_FUNCTION_NOT_BUILTIN		27
+#define ERROR_WRONG_NUM_FUNCTION_ARGS		28
 
 extern unsigned char mem[];
 extern int sysPROGEND;

--- a/elkscmd/basic/host.h
+++ b/elkscmd/basic/host.h
@@ -1,8 +1,37 @@
-#define PROGMEM
-#define pgm_read_word(x)		(x)
-#define pgm_read_byte_near(x)	(x)
+/* host dependent definitions */
 
-#define FS_ACCESS_ALLOWED		/* allow DELETE/DIR/LIST/SAVE */
+#define DISK_FUNCTIONS			1	/* compile in DELETE/DIR/LIST/SAVE */
+#define MATH_FUNCTIONS			1	/* compile in COS, SIN, TAN, etc */
+#define MATH_DBL_PRECISION		0	/* 0=use 4-byte floats vs 8-byte double */
+
+#if MATH_DBL_PRECISION
+#define MATH_PRECISION	14
+#define float double
+#define COS(x)		cos(x)
+#define SIN(x)		sin(x)
+#define TAN(x)		tan(x)
+#define ACOS(x)		acos(x)
+#define ASIN(x)		asin(x)
+#define ATAN(x)		atan(x)
+#define EXP(x)		exp(x)
+#define LOG(x)		log(x)
+#define POW(x,y)	pow(x,y)
+#else
+#define MATH_PRECISION	6
+#define COS(x)		cosf(x)
+#define SIN(x)		sinf(x)
+#define TAN(x)		tanf(x)
+#define ACOS(x)		acosf(x)
+#define ASIN(x)		asinf(x)
+#define ATAN(x)		atanf(x)
+#define EXP(x)		expf(x)
+#define LOG(x)		logf(x)
+#define POW(x,y)	powf(x,y)
+#endif
+
+#define PROGMEM
+#define pgm_read_word(x)        (x)
+#define pgm_read_byte_near(x)	(x)
 
 void host_cls();
 void host_showBuffer();
@@ -24,7 +53,7 @@ int host_analogRead(int pin);
 void host_pinMode(int pin, int mode);
 float host_floor(float x);
 
-#ifdef FS_ACCESS_ALLOWED
+#if DISK_FUNCTIONS
 int host_directoryListing();
 int host_saveProgramToFile(char *fileName, int autoexec);
 int host_loadProgramFromFile(char *fileName);

--- a/elkscmd/basic/test.bas
+++ b/elkscmd/basic/test.bas
@@ -1,0 +1,17 @@
+10 i = pi
+20 print i
+30 i = rnd
+40 print i
+50 i = 1
+60 print abs(i)
+70 i = -1
+80 print abs(i)
+90 i = 0
+100 print abs(i)
+110 print
+200 pio2 = PI/2
+300 for i = 0 to 2*PI step pio2
+400 print "cos(";i;") = ";cos(i)
+500 next i
+600 print "pow(3,4) = ";pow(3,4)
+700 print "exp(1) = ";exp(1)

--- a/libc/include/math.h
+++ b/libc/include/math.h
@@ -1,3 +1,5 @@
+#ifndef __MATH_H
+#define __MATH_H
 /*
  * ELKS libc math header file
  *
@@ -18,47 +20,48 @@
 #define M_SQRT2     1.41421356237309504880  /* sqrt(2) */
 #define M_SQRT1_2   0.70710678118654752440  /* 1/sqrt(2) */
 
-double floor(double x);
+double floor(double x);		/* round to largest integral value not greater than x */
 float floorf(float x);
 
-double sqrt(double x);
+double sqrt(double x);		/* square root function */
 float sqrtf(float x);
 
-double fabs(double x);
+double fabs(double x);		/* absolute value function */
 float fabsf(float x);
 
-double exp(double x);
+double exp(double x);		/* e**x, base-e exponential */
 float expf(float x);
 
-double exp2(double x);
+double exp2(double x);		/* 2**x, base-2 exponential */
 float exp2f(float x);
 
-double pow(double x, double y);
+double pow(double x, double y);	/* x**y, x raised to the power of y */
 float powf(float x, float y);
 
-double log(double x);
+double log(double x);		/* natural logarithm */
 float logf(float x);
 
-double log2(double x);
+double log2(double x);		/* base 2 logarithm */
 float log2f(float x);
 
-double log10(double x);
+double log10(double x);		/* base 10 logarithm */
 float log10f(float x);
 
-double sin(double x);
-float sinf(float x);
-
-double cos(double x);
+double cos(double x);		/* cosine function */
 float cosf(float x);
 
-double tan(double x);
+double sin(double x);		/* sine function */
+float sinf(float x);
+
+double tan(double x);		/* tangent function */
 float tanf(float x);
 
-double acos(double x);
+double acos(double x);		/* arc cosine function */
 float acosf(float x);
 
-double asin(double x);
+double asin(double x);		/* arc sine function */
 float asinf(float x);
 
-double atan(double x);
+double atan(double x);		/* arc tangent of one variable */
 float atanf(float x);
+#endif


### PR DESCRIPTION
Adds COS, SIN, TAN, ACS, ASN, ATN, EXP, LN and POW functions to BASIC.
For now, use POW(x,y) instead of the original Sinclair BASIC x^y.
Adds PI constant.
Uses new ELKS math library.

A host version of BASIC (`hostbasic`) for easier testing and development can be compiled by "make hostbasic" in elkscmd/basic.

BASIC now supports single or double precision calculations (about 6 vs 14 digit precision), selectable at compile time.
Or, math functions can be removed, resulting in a smaller binary (~50k vs ~30k).

We still have some floating point formatting/display issues, especially with regards to values extremely close to an integer. Some trig functions display -0 or 0.00001 instead of 0. I'm still working on this. There are also compatibility issues when running on ELKS vs a host platform with regards to very accurate float point text-to-translation and display.