### PR TITLE
[cmds] Various updates to mkdir, mount and reboot

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -101,7 +101,7 @@ sh_utils/stty					:shutil					:1200k	:1440k
 sh_utils/printenv				:shutil					:1200k	:1440k
 sh_utils/pwd					:shutil			:360k
 sh_utils/tr						:shutil				:720k
-sh_utils/which					:shutil					:1200k	:1440k
+#sh_utils/which					:shutil					:1200k	:1440k
 #sh_utils/whoami				:shutil					:1200k	:1440k
 sh_utils/xargs					:shutil					:1200k	:1440k
 sh_utils/yes					:shutil				:720k

--- a/elkscmd/file_utils/mkdir.c
+++ b/elkscmd/file_utils/mkdir.c
@@ -10,14 +10,15 @@ static unsigned short newmode;
 static int make_dir(char *name, int f)
 {
 	char *line;
-	char iname[256];
+	char iname[80];
 	
 	strcpy(iname, name);
 	if (((line = rindex(iname,'/')) != NULL) && f) {
 		while ((line > iname) && (*line == '/'))
 			--line;
 		line[1] = 0;
-		make_dir(iname,1);
+		if (*line != '/')
+			make_dir(iname,1);
 	}
 	if (mkdir(name, newmode) < 0 && !f)
 		return 1;

--- a/elkscmd/man/man8/reboot.8
+++ b/elkscmd/man/man8/reboot.8
@@ -3,12 +3,17 @@
 reboot \- reboot the system immediately
 .SH SYNOPSIS
 .B reboot
+.RB [ -f ]
+.SS OPTIONS
+.TP 5
+.B \-f
+Force reboot even if root volume cannot be remounted read-only.
 .SH DESCRIPTION
 .B Reboot
-is a program that allows the superuser to shut down and reboot the system immediately,
+is a program that allows the superuser to shut down and reboot the system immediately.
 A
 .B sync
-and unmount of the root filesystem are performed, and after 3 seconds
+and unmount of the root filesystem are performed, and if successful, after 3 seconds
 have elapsed, the system is rebooted.
 .SH "SEE ALSO"
 .BR sync (1),

--- a/elkscmd/rootfs_template/etc/mount.cfg
+++ b/elkscmd/rootfs_template/etc/mount.cfg
@@ -43,17 +43,17 @@ fstype()
 
 # mount floppy B (MINIX or FAT)
 #check_filesystem /dev/fd1
-#mount -a /dev/fd1 /mnt || true
+#mount /dev/fd1 /mnt || true
 
 # various HD mounts
 #check_filesystem /dev/hda
-#mount -a /dev/hda /mnt
+#mount /dev/hda /mnt
 
-#mount -a /dev/hda1 /mnt
+#mount /dev/hda1 /mnt
 
-#mkdir /mnt2 || true
-#mount -a /dev/hda2 /mnt2
-#mkdir /mnt3 || true
-#mount -a /dev/hda3 /mnt3
-#mkdir /mnt4 || true
-#mount -a /dev/hda4 /mnt4
+#mkdir -p /mnt2 || true
+#mount /dev/hda2 /mnt2
+#mkdir -p /mnt3 || true
+#mount /dev/hda3 /mnt3
+#mkdir -p /mnt4 || true
+#mount /dev/hda4 /mnt4

--- a/elkscmd/sys_utils/mount.c
+++ b/elkscmd/sys_utils/mount.c
@@ -161,6 +161,8 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
+	if (flags == 0 && type == 0)
+		flags = MS_AUTOMOUNT;
 	if (mount(argv[0], argv[1], type, flags) < 0) {
 		if (flags & MS_AUTOMOUNT) {
 			type = (!type || type == FST_MINIX)? FST_MSDOS: FST_MINIX;

--- a/elkscmd/sys_utils/reboot.c
+++ b/elkscmd/sys_utils/reboot.c
@@ -8,10 +8,6 @@
  * License v2, or at your option any later version.
  */
 
-/*
- * This is a small version of reboot for use in the ELKS project.
- */
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -23,9 +19,12 @@
 int main(int argc, char **argv)
 {
 	sync();
-	if (umount("/")) {
-		perror("reboot umount");
-		return 1;
+	if (umount("/") < 0) {
+		/* -f forces reboot even if mount fails */
+		if (argc < 2 || argv[1][0] != '-' || argv[1][1] != 'f')	 {
+			perror("reboot umount");
+			return 1;
+		}
 	}
 	sleep(3);
 	if (reboot(0x1D1E,0xC0DE,0x0123)) {


### PR DESCRIPTION
Enhancements and bug fixes requested in #1155.

Fixes mkdir -p.
Changes mount -a (automount) to be default if no other options given.
Adds reboot -f option to force reboot even if root filesystem can't be remounted read-only.