### PR TITLE
[cmds] Update BASIC documentation, add arch-specific host*.c files

### DIFF
--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -93,11 +93,7 @@ static void INITPROC add_partition(struct gendisk *hd, unsigned short int minor,
      * If the root device is already fully known, i.e. ROOT_DEV is already
      * a device number, then we do not really need boot_partition.
      */
-#ifdef CONFIG_ARCH_PC98
     if (ROOT_DEV == hd_drive_map[minor >> hd->minor_shift]) {
-#else
-    if (ROOT_DEV == (0x80 | minor >> hd->minor_shift)) {
-#endif
 	sector_t boot_start = SETUP_PART_OFFSETLO | (sector_t) SETUP_PART_OFFSETHI << 16;
 	if (start == boot_start)
 	    boot_partition = minor & 0x7;

--- a/elkscmd/basic/Makefile
+++ b/elkscmd/basic/Makefile
@@ -16,13 +16,20 @@ HOST_CFLAGS = -O3
 ###############################################################################
 
 PRGS = basic
+OBJS = basic.o host.o
+
+ifeq ($(CONFIG_ARCH_8018X), y)
+OBJS += host-8018x.o
+else
+OBJS += host-stubs.o
+endif
 
 all: $(PRGS)
 
-basic: basic.o host.o basic.h host.h
-	$(LD) $(LDFLAGS) -o basic basic.o host.o $(LDLIBS)
+basic: $(OBJS) basic.h host.h
+	$(LD) $(LDFLAGS) -o basic $(OBJS) $(LDLIBS)
 
-HOSTSRC = basic.c host.c
+HOSTSRC = basic.c host.c host-stubs.c
 HOSTSRC += ../../libc/misc/ecvt.c
 HOSTSRC += ../../libc/stdio/__fp_print_func.c
 hostbasic: $(HOSTSRC) host.h basic.h

--- a/elkscmd/basic/README.md
+++ b/elkscmd/basic/README.md
@@ -1,10 +1,8 @@
-Arduino/Sinclair Basic
+ELKS Sinclair Basic
 ======================
 From Robin Edwards' ArduinoBASIC (https://github.com/robinhedwards/ArduinoBASIC).
 
 A complete BASIC interpreter for your 80's home computer! The BASIC supports almost all the usual features, with float and string variables, multi-dimensional arrays, FOR-NEXT, GOSUB-RETURN, etc.
-
-[![Demo](http://img.youtube.com/vi/JB5RXoO1IwQ/0.jpg)](http://www.youtube.com/watch?v=JB5RXoO1IwQ)
 
 BASIC Language
 --------------
@@ -31,10 +29,8 @@ Only the addition operator is supported on strings (plus the functions below).
 Commands
 ```
 PRINT <expr>;<expr>... e.g. PRINT "A=";a
-LET variable = <expr> e.g. LET A$="Hello".
+LET variable = <expr> e.g. LET A$="Hello"
 variable = <expr> e.g. A=5
-LIST [start],[end] e.g. LIST or LIST 10,100
-RUN [lineNumber]
 GOTO lineNumber
 REM <comment> e.g. REM ** My Program ***
 STOP
@@ -43,24 +39,46 @@ INPUT variable e.g. INPUT a$ or INPUT a(5,3)
 IF <expr> THEN cmd e.g. IF a>10 THEN a = 0: GOTO 20
 FOR variable = start TO end STEP step
 NEXT variable
-NEW
 GOSUB lineNumber
 RETURN
 DIM variable(n1,n2...)
 CLS
 PAUSE milliseconds
 POSITION x,y sets the cursor
+NEW
+LIST [start],[end] e.g. LIST or LIST 10,100
+RUN [lineNumber]
+LOAD "filename" from filesystem
+SAVE "filename" to filesystem
+SAVE+ "filename" to filesystem, set auto-run on load
+DELETE "filename" from filesystem
+DIR
+
+Architecture-specific
 PIN pinNum, value (0 = low, non-zero = high)
-PINMODE pinNum, mode ( 0 = input, 1 = output)
-LOAD (from internal EEPROM)
-SAVE (to internal EEPROM) e.g. use SAVE + to set auto-run on boot flag
-LOAD "filename", SAVE "filename, DIR, DELETE "filename" if using with external EEPROM.
+PINMODE pinNum, mode - not implemented
+
+Not yet implemented
+POKE offset,segment,value
+OUT port,value
+RANDOMIZE [nmber]
+READ var
+DATA
+RESTORE [line]
+INPUT [prompt,] variable
+PRINT <expr>,<expr> (tab separated output)
+MODE number (set graphics mode)
+COLOR fg[,bg]
+PLOT x,y
+DRAW x,y[,a]
+CIRCLE x,y[,r]
 ```
 
 "Pseudo-identifiers"
 ```
 INKEY$ - returns (and eats) the last key pressed buffer (non-blocking). e.g. PRINT INKEY$
 RND - random number betweeen 0 and 1. e.g. LET a = RND
+PI - 3.1415926
 ```
 
 Functions
@@ -68,10 +86,32 @@ Functions
 LEN(string) e.g. PRINT LEN("Hello") -> 5
 VAL(string) e.g. PRINT VAL("1+2")
 INT(number) e.g. INT(1.5)-> 1
+ABS(number) e.g. ABS(-1)-> 1
 STR$(number) e.g. STR$(2) -> "2"
 LEFT$(string,n)
 RIGHT$(string,n)
 MID$(string,start,n)
-PINREAD(pin) - see Arduino digitalRead()
-ANALOGRD(pin) - see Arduino analogRead()
+COS(x)
+SIN(x)
+TAN(x)
+ACS(x)
+ASN(x)
+ATN(x)
+EXP(x)
+LN(x)
+POW(x,y) e.g. POW(2,0.5) -> 1.414 square root of 2
+
+Architecture-specific
+PINREAD(pin)
+ANALOGRD(pin) - not implemented
+
+Not yet implemented
+SGN(number) e.g. SGN(-1) -> -1
+CHR$(number) e.g. CHR$(32) -> " "
+CODE(string) e.g. CODE(" ") -> 32
+PEEK(offset,segment) - not yet i
+IN(port)
+SCREEN$(line,col)
+ATTR(line,col)
+POINT(x,y)
 ```

--- a/elkscmd/basic/host-8018x.c
+++ b/elkscmd/basic/host-8018x.c
@@ -1,0 +1,49 @@
+/*
+ * Architecture Specific routines for 8018x
+ */
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "host.h"
+#include "basic.h"
+#include "arch/io.h"
+
+/**
+ * NOTE: This only works on MY 80C188EB board, needs to be more
+ * generalized using the 8018x's GPIOs instead!
+ */
+
+static uint8_t the_leds = 0xfe;
+void host_digitalWrite(int pin,int state) {
+    if (pin > 7) {
+        return;
+    }
+
+    uint8_t new_state = 1 << pin;
+    if (state == 0) {
+        the_leds |= new_state;
+    } else {
+        the_leds &= ~new_state;
+    }
+    /* there's a latch on port 0x2002 where 8 leds are connected to */
+    outb(the_leds, 0x2002);
+}
+
+int host_digitalRead(int pin) {
+    if (pin > 7) {
+        if (pin == 69) {
+            /* buffer on port 0x2003, bit #3 is the switch */
+            return inb(0x2003) & (1 << 3) ? 1 : 0;
+        }
+        return 0;
+    }
+
+    /* there's a buffer on port 0x2001 where an 8 switches dip switch is conncted to */
+    uint8_t b = inb(0x2001);
+    uint8_t bit = 1 << pin;
+
+    if (b & bit) {
+        return 1;
+    }
+	return 0;
+}

--- a/elkscmd/basic/host-stubs.c
+++ b/elkscmd/basic/host-stubs.c
@@ -1,0 +1,22 @@
+/*
+ * Architecture Specific stubs
+ */
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "host.h"
+#include "basic.h"
+
+void host_digitalWrite(int pin,int state) {
+}
+
+int host_digitalRead(int pin) {
+    return 0;
+}
+
+int host_analogRead(int pin) {
+	return 0;
+}
+
+void host_pinMode(int pin,int mode) {
+}

--- a/elkscmd/basic/host.c
+++ b/elkscmd/basic/host.c
@@ -128,69 +128,6 @@ void host_sleep(long ms) {
     usleep(ms * 1000);
 }
 
-#ifdef __ia16__
-#include <linuxmt/config.h>
-#endif
-#ifdef CONFIG_ARCH_8018X
-/**
- * NOTE: This only works on MY 80C188EB board, needs to be more
- * generalized using the 8018x's GPIOs instead!
- */
-#include "arch/io.h"
-
-static uint8_t the_leds = 0xfe;
-void host_digitalWrite(int pin,int state) {
-    if (pin > 7) {
-        return;
-    }
-
-    uint8_t new_state = 1 << pin;
-    if (state == 0) {
-        the_leds |= new_state;
-    } else {
-        the_leds &= ~new_state;
-    }
-    /* there's a latch on port 0x2002 where 8 leds are connected to */
-    outb(the_leds, 0x2002);
-}
-
-int host_digitalRead(int pin) {
-    if (pin > 7) {
-        if (pin == 69) {
-            /* buffer on port 0x2003, bit #3 is the switch */
-            return inb(0x2003) & (1 << 3) ? 1 : 0;
-        }
-        return 0;
-    }
-
-    /* there's a buffer on port 0x2001 where an 8 switches dip switch is conncted to */
-    uint8_t b = inb(0x2001);
-    uint8_t bit = 1 << pin;
-
-    if (b & bit) {
-        return 1;
-    }
-	return 0;
-}
-#else
-
-void host_digitalWrite(int pin,int state) {
-}
-
-int host_digitalRead(int pin) {
-    return 0;
-}
-#endif
-
-int host_analogRead(int pin) {
-    //return analogRead(pin);
-	return 0;
-}
-
-void host_pinMode(int pin,int mode) {
-    //pinMode(pin, mode);
-}
-
 #if DISK_FUNCTIONS
 
 #include <dirent.h>

--- a/elkscmd/basic/host.h
+++ b/elkscmd/basic/host.h
@@ -41,17 +41,13 @@ void host_outputChar(char c);
 void host_outputLong(long num);
 void host_outputFloat(float f);
 char *host_floatToStr(float f, char *buf);
+float host_floor(float x);
 void host_newLine();
 char *host_readLine();
 char host_getKey();
 int host_ESCPressed();
 void host_outputFreeMem(unsigned int val);
 void host_sleep(long ms);
-void host_digitalWrite(int pin,int state);
-int host_digitalRead(int pin);
-int host_analogRead(int pin);
-void host_pinMode(int pin, int mode);
-float host_floor(float x);
 
 #if DISK_FUNCTIONS
 int host_directoryListing();
@@ -59,3 +55,9 @@ int host_saveProgramToFile(char *fileName, int autoexec);
 int host_loadProgramFromFile(char *fileName);
 int host_removeFile(char *fileName);
 #endif
+
+/* architecture specific */
+void host_digitalWrite(int pin,int state);
+int host_digitalRead(int pin);
+int host_analogRead(int pin);
+void host_pinMode(int pin, int mode);


### PR DESCRIPTION
Updates our [BASIC documentation](https://github.com/jbruchon/elks/blob/master/elkscmd/basic/README.md) on existing and not-yet-implemented commands and functions.

Splits out architecture-specific routines into separate host-xxx.c files.

This should allow unimplemented functions and commands to be more easily contributed with an agreed-on syntax, as well as having a place for architecture-specific routines in the host-xxx.c files.

@cocus, I moved routines specific to your 8081x project to host-8018x.c. I didn't test this, hopefully it works fine and will automatically compile and run for you.

Unrelated - removes small ifdef in genhd.c code for IBM PC.