### PR TITLE
[cmds] Correct trig function near zero display errors in BASIC

### DIFF
--- a/elkscmd/basic/TODO
+++ b/elkscmd/basic/TODO
@@ -1,11 +1,15 @@
 Sinclair basic examples and compatibility
 	randomize, data, read
 	inkey$
-	go to -> goto
 ^C stop
 parse 1e4 numbers
 strtol must return LONG_MAX or MIN on over/underflow
-%.12f variable precision output
+double precision too large w/POW for ELKS, need medium model
+	why is double math lib so much larger?
+	possibly add SQRT if no POW for space
+check what other math functions require adjust()
+check host_floor works ok with double precision using 32 bit ints
+%.14f variable precision output in __fp_print_func
 print Nan
 TOKEN_INTEGER - size 4 or 2, line number only?
 	don't convert to integer then float each time

--- a/elkscmd/basic/basic.c
+++ b/elkscmd/basic/basic.c
@@ -1186,7 +1186,7 @@ int parseFnCallExpr() {
             if (!stackPushNum(host_analogRead(tmp))) return ERROR_OUT_OF_MEMORY;
             break;
         case TOKEN_POW:
-#if MATH_FUNCTIONS
+#if MATH_FUNCTIONS && MATH_INCLUDE_POW
 			{
 				float y = stackPopNum();
 				stackPushNum(POW(stackPopNum(), y));

--- a/elkscmd/basic/host.c
+++ b/elkscmd/basic/host.c
@@ -38,9 +38,22 @@ void host_outputLong(long num) {
 	fprintf(outfile, "%ld", num);
 }
 
+#if MATH_CORRECT_NEAR_ZERO
+// experimental function to correct trig functions returning near zero values
+// some hosts return -0 or +/-0.00000000000001
+float adjust(float f) {
+	if (FABS(f) < (float)EPSILON) {
+		//printf("[%f,%f]", f, FABS(f));
+		return 0;
+	}
+	return f;
+}
+#endif
+
 // for float testing compatibility, use same FP formatting routines on host for now
 // floats have approx 7 sig figs, 15 for double
-#ifdef __ia6__
+
+#ifdef __ia16__
 __STDIO_PRINT_FLOATS;		// link in libc printf float support
 
 char *host_floatToStr(float f, char *buf) {
@@ -53,6 +66,7 @@ char *ecvt(double val, int ndig, int *pdecpt, int *psign);
 char *fcvt(double val, int ndig, int *pdecpt, int *psign);
 
 char *host_floatToStr(float f, char *buf) {
+
 	__fp_print_func(f, 'g', MATH_PRECISION, buf);
     return buf;
 }
@@ -106,15 +120,15 @@ void host_outputFreeMem(unsigned int val)
 /* LONG_MAX is not exact as a double, yet LONG_MAX + 1 is */
 #define LONG_MAX_P1 ((LONG_MAX/2 + 1) * 2.0)
 
-/* small ELKS floor function using 32-bit longs */
+/* small ELKS floor function using 32-bit longs, required for INT() fn */
 float host_floor(float x)
 {
-  if (x >= 0.0) {
+  if (x >= (float)0.0) {
     if (x < LONG_MAX_P1) {
       return (float)(long)x;
     }
     return x;
-  } else if (x < 0.0) {
+  } else if (x < (float)0.0) {
     if (x >= LONG_MIN) {
       long ix = (long) x;
       return (ix == x) ? x : (float)(ix-1);

--- a/elkscmd/basic/host.h
+++ b/elkscmd/basic/host.h
@@ -2,13 +2,17 @@
 
 #define DISK_FUNCTIONS			1	/* compile in DELETE/DIR/LIST/SAVE */
 #define MATH_FUNCTIONS			1	/* compile in COS, SIN, TAN, etc */
+#define MATH_INCLUDE_POW		1	/* compile in large POW function */
 #define MATH_DBL_PRECISION		0	/* 0=use 4-byte floats vs 8-byte double */
+#define MATH_CORRECT_NEAR_ZERO	1	/* adjust trig routines returning -0, +/-EPSILON */
 
 #if MATH_DBL_PRECISION
 #define MATH_PRECISION	14
+#define EPSILON         0.00000000000001
 #define float double
-#define COS(x)		cos(x)
-#define SIN(x)		sin(x)
+#define FABS(x)		fabs(x)
+#define COS(x)		adjust(cos(x))
+#define SIN(x)		adjust(sin(x))
 #define TAN(x)		tan(x)
 #define ACOS(x)		acos(x)
 #define ASIN(x)		asin(x)
@@ -18,8 +22,10 @@
 #define POW(x,y)	pow(x,y)
 #else
 #define MATH_PRECISION	6
-#define COS(x)		cosf(x)
-#define SIN(x)		sinf(x)
+#define EPSILON         0.000001
+#define FABS(x)		fabsf(x)
+#define COS(x)		adjust(cosf(x))
+#define SIN(x)		adjust(sinf(x))
 #define TAN(x)		tanf(x)
 #define ACOS(x)		acosf(x)
 #define ASIN(x)		asinf(x)
@@ -27,6 +33,12 @@
 #define EXP(x)		expf(x)
 #define LOG(x)		logf(x)
 #define POW(x,y)	powf(x,y)
+#endif
+
+#if MATH_CORRECT_NEAR_ZERO
+float adjust(float f);
+#else
+#define adjust(f)	(f)
 #endif
 
 #define PROGMEM

--- a/elkscmd/basic/test.bas
+++ b/elkscmd/basic/test.bas
@@ -9,13 +9,15 @@
 90 i = 0
 100 print abs(i)
 110 print
+120 print "INT(1.000000001) = ";int(1.000000001)
 200 pio2 = PI/2
 300 for i = 0 to 2*PI step pio2
 400 print "cos(";i;") = ";cos(i)
 500 next i
-600 print "pow(3,4) = ";pow(3,4)
+600 rem print "pow(3,4) = ";pow(3,4)
 700 print "exp(1) = ";exp(1)
 710 print chr$(65);"=A"
 720 print code(" ");"=32"
-800 input "Enter a string:",a$
-900 print a$
+780 rem test negative 0 return on macOS
+800 j = cos(pio2)
+900 if j < 0 then print "ERROR: cos(pi/2) < 0",j


### PR DESCRIPTION
Corrects returns values of COS/SIN functions very close to 0, previously displayed as -0 and +/-0.000001 (single precision) and +/-0.00000000000001 (double precision), instead of just 0.

The floating point math libraries are unbelievably complicated, so much so that the double precision version used in BASIC runs out of 64k code space when all functions including `pow(x,y)` (x to the power of y double precision) is linked in. An option to exclude just `pow` saves 15k in the final executable. The single precision float versions are quite a bit smaller, which is the current default for BASIC.

Additionally, there are differences between the displayed output (float or double conversion to ASCII and vice versa) between macOS and ELKS versions of BASIC, due to differences in conversion routines as well as the ELKS printf formatter. For compatibility, BASIC now includes the ELKS floating point formatting routines even for host BASIC complications, but the math routines are still different, and produce slightly different results near zero, requiring adjustment for accurate SIN(PI) or COS(PI/2), which should equal exactly 0.

At this point, we're probably just fine given the precision of things required from the BASIC language, but this project is helping to test our new recently added libc math functions, as well as gain a better understanding of floating point calculations and conversions in general.