### PR TITLE
[net] Add setup command to quickly configure hostname and IP address

### DIFF
--- a/elkscmd/rootfs_template/bin/setup
+++ b/elkscmd/rootfs_template/bin/setup
@@ -1,8 +1,9 @@
 #
-# ELKS image network name/address setup script
+# Quick configure /bootopts and /etc/hosts files
 #
-# Usage: setup node_number
-#   node_number will be used as last digits in IP address and elks hostname
+# Usage: setup node_number [bootopts_enable_string]
+#	sets last digits of LOCALIP and HOSTNAME to node_number
+#	uncomment matching /bootopts lines
 #
 
 # defaults
@@ -10,25 +11,28 @@ network=10.0.2
 bootopts=/bootopts
 hosts=/etc/hosts
 
-# check for argument, use as id
+# 1st arg is node number
 if test "$#" -lt 1; then
-  echo "Usage: setup node_number"
+  echo "Usage: setup node_number [bootops_enable_string]"
   echo
   cat $bootopts
   cat $hosts
   exit 0
 fi
-
-# node_number used as last digits in IP address and hostname
 id=$1
 
-# template code follows
+# 2nd arg matchstr
+match_str=SEDNOMATCH
+if test "$#" -ge 2; then match_str=$2; fi
+
+# template strings
 hostname=elks$id
 localip=$network.$id
 gateway=$network.2
 
 # rewrite /bootopts
-sed -e "s/.*LOCALIP=.*/LOCALIP=$localip/" -e "s/.*HOSTNAME=.*/HOSTNAME=$hostname/" < $bootopts > /tmp/bootopts
+sed -e "s/.*LOCALIP=.*/LOCALIP=$localip/" -e "s/.*HOSTNAME=.*/HOSTNAME=$hostname/" \
+	-e "s/#\(.*$match_str.*\)/\1/" < $bootopts > /tmp/bootopts
 mv /tmp/bootopts $bootopts
 
 # rewrite /etc/hosts

--- a/elkscmd/rootfs_template/bin/setup
+++ b/elkscmd/rootfs_template/bin/setup
@@ -1,0 +1,47 @@
+#
+# ELKS image network name/address setup script
+#
+# Usage: setup node_number
+#   node_number will be used as last digits in IP address and elks hostname
+#
+
+# defaults
+network=10.0.2
+bootopts=/bootopts
+hosts=/etc/hosts
+
+# check for argument, use as id
+if test "$#" -lt 1; then
+  echo "Usage: setup node_number"
+  echo
+  cat $bootopts
+  cat $hosts
+  exit 0
+fi
+
+# node_number used as last digits in IP address and hostname
+id=$1
+
+# template code follows
+hostname=elks$id
+localip=$network.$id
+gateway=$network.2
+
+# rewrite /bootopts
+sed -e "s/.*LOCALIP=.*/LOCALIP=$localip/" -e "s/.*HOSTNAME=.*/HOSTNAME=$hostname/" < $bootopts > /tmp/bootopts
+mv /tmp/bootopts $bootopts
+
+# rewrite /etc/hosts
+cat << EOF > $hosts
+#127.0.0.1	localhost
+$network.$id	elks$id
+$network.15	elks15
+$network.16	elks16
+$network.17	elks17
+$gateway	gateway
+EOF
+
+# display results
+cat $bootopts
+cat $hosts
+sync

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -3,6 +3,7 @@
 #QEMU=1			# to use ftp/ftpd in qemu
 #TZ=MDT7
 #LOCALIP=10.0.2.16
+#HOSTNAME=elks16
 #netirq=9 netport=0x300 # NIC
 #bufs=2500		# system buffers
 #sync=30		# autosync secs

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,5 +1,5 @@
 ## boot options max size 511 bytes
-#console=ttyS0,57600 debug net=eth 3 # serial console, multiuser, networking
+#console=ttyS0,57600 debug net=eth 3 # sercons, multiuser, networking
 #QEMU=1			# to use ftp/ftpd in qemu
 #TZ=MDT7
 #LOCALIP=10.0.2.16

--- a/elkscmd/rootfs_template/etc/hosts
+++ b/elkscmd/rootfs_template/etc/hosts
@@ -1,5 +1,5 @@
 #127.0.0.1	localhost
-10.0.2.15	elks1 elks
-10.0.2.16	elks2
-10.0.2.17	elks3
+10.0.2.15	elks15
+10.0.2.16	elks16
+10.0.2.17	elks17
 10.0.2.2	gateway

--- a/elkscmd/rootfs_template/etc/profile
+++ b/elkscmd/rootfs_template/etc/profile
@@ -2,3 +2,4 @@ export PATH=/bin
 # timezone can be set in either /bootopts or here
 #export TZ=GMT0
 #export MANPATH=/root/man:/lib
+PS1="$HOSTNAME$PS1"


### PR DESCRIPTION
Adds `setup` command to allow quickly configuring the last digits of the system hostname and IP address.

Usage: `setup 16` will edit the /bootopts and /etc/hosts files to arrange for the system to have IP address 10.0.2.16 and hostname elks16 after the next boot. After execution, or with no argument, it displays the current settings of the /bootopts and /etc/hosts files.

@Mellvik, I this should ease your configuration duties after any ELKS update by allowing each of your systems to be network configured by only executing setup, followed by reboot. The setup command can be re-executed at any time, but since it uses /bootopts, it is necessary to reboot the system, rather than using net start/stop.

Let me know what you think, and what other changes should be made. You may notice that when using numbers 15, 16 or 17, there is as duplicate line in /etc/hosts, but this was necessary to allow selecting any other node number (3 ... 254) without making /etc/hosts too large or setup too complex.
<img width="832" alt="Screen Shot 2022-04-29 at 3 53 51 PM" src="https://user-images.githubusercontent.com/11985637/166074818-f1d37654-49e8-41a8-a226-ff1645f77781.png">

