### PR TITLE
[ash] Add internal test, [ commands to shell

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -51,9 +51,6 @@ sys_utils/mount			:boot	:sysutil
 sys_utils/umount		:boot	:sysutil
 sys_utils/clock			:boot	:sysutil
 sys_utils/shutdown		:boot	:sysutil
-sh_utils/test			:boot	:shutil
-sh_utils/true			:boot	:be-shutil
-sh_utils/echo			:boot	:be-shutil
 sh_utils/uname			:boot	:be-shutil
 file_utils/cat			:boot	:be-fileutil
 file_utils/chgrp				:be-fileutil			:1200k	:1440k
@@ -61,7 +58,7 @@ file_utils/chmod				:be-fileutil			:1200k	:1440k
 file_utils/chown				:be-fileutil			:1200k	:1440k
 file_utils/cmp					:be-fileutil			:1200k	:1440k
 file_utils/cp					:be-fileutil	:360k
-file_utils/df					:be-fileutil			:1200k	:1440k
+file_utils/df					:be-fileutil    :360k
 file_utils/dd					:be-fileutil			:1200k	:1440k
 file_utils/mkdir				:fileutil		:360k
 file_utils/mknod				:fileutil		:360k
@@ -95,7 +92,10 @@ sh_utils/basename				:be-shutil			:720k
 sh_utils/clear					:shutil					:1200k	:1440k
 sh_utils/date					:be-shutil		:360k
 sh_utils/dirname				:be-shutil			:720k
-sh_utils/false					:be-shutil				:1200k	:1440k
+sh_utils/echo			        :be-shutil              :1200k  :1440k
+#sh_utils/test			        :shutil                 :1200k  :1440k
+#sh_utils/false					:be-shutil				:1200k	:1440k
+#sh_utils/true					:be-shutil				:1200k	:1440k
 #sh_utils/logname				:shutil					:1200k	:1440k
 #sh_utils/mesg					:shutil					:1200k	:1440k
 sh_utils/stty					:shutil					:1200k	:1440k

--- a/elkscmd/Make.install
+++ b/elkscmd/Make.install
@@ -140,7 +140,7 @@ ifdef CONFIG_APPS_1232K
 endif
 
 ifdef CONFIG_APPS_1440K
-	TAGS = :boot|:360k|:net|:720k|:1440k|:man|
+	TAGS = :boot|:360k|:net|:720k|:1200k|:1440k|:man|
 endif
 
 ifdef CONFIG_APPS_2880K

--- a/elkscmd/ash/Makefile
+++ b/elkscmd/ash/Makefile
@@ -27,10 +27,13 @@ OBJS=	builtins.o cd.o dirent.o error.o eval.o exec.o expand.o input.o \
 	jobs.o mail.o main.o memalloc.o miscbltin.o mystring.o nodes.o \
 	options.o parser.o redir.o show.o signames.o syntax.o trap.o \
 	output.o var.o init.o \
-	bltin/echo.o bltin/expr.o bltin/regexp.o bltin/operators.o \
 	linenoise_elks.o autocomplete.o
 
-LDFLAGS += -maout-heap=8192 -maout-stack=2048
+# builtins must be manually added
+OBJS += bltin/echo.o
+OBJS += bltin/expr.o bltin/regexp.o bltin/operators.o
+
+LDFLAGS += -maout-heap=8192 -maout-stack=2304
 
 #
 # Set READLINE in shell.h and add -ledit to LIBS if you want to use the

--- a/elkscmd/ash/README.elks
+++ b/elkscmd/ash/README.elks
@@ -91,3 +91,10 @@ TODO:
 (*) Added #define _SMALL_ in shell.h, which when defined removes some
     features that are no use to elks, such as checking for new mail.
 --------------------------------------------------------------
+20220504 Greg Haerr <greg@censoft.com>
+
+Removed Claudio's workarounds for bcc problems
+
+Activated test/expr builtin in build (was already being compiled in unused)
+
+--------------------------------------------------------------

--- a/elkscmd/ash/bltin/expr.c
+++ b/elkscmd/ash/bltin/expr.c
@@ -172,21 +172,8 @@ overflow:		error("Expression too complex");
 	    while (opsp < &opstack[STACKSIZE] && opsp->pri >= pri) {
 		  binary = opsp->op;
 		  for (;;) {
-			/*
-			 * 19980218 Claudio Matsuoka <claudio@conectiva.com>
-			 * Oh my, this is a nasty one! Once again, bcc
-			 * complains about invalid indirect to indirect
-			 * (mov byte ptr -9[bp],#_op_argflag[bx]).
-			 */
-#if 0
 			valsp--;
 			c = op_argflag[opsp->op];
-#else
-			char *kludge;
-			kludge = op_argflag;
-			kludge += opsp->op;
-			c = *kludge;
-#endif
 			if (c == OP_INT) {
 			      if (valsp->type == STRING)
 				    valsp->u.num = atol(valsp->u.string);
@@ -279,17 +266,6 @@ expr_is_false(val)
  * to stat, to avoid repeated stat calls on the same file.
  */
 
-/*
- * 19980218 Claudio Matsuoka <claudio@conectiva.com>
- * So, here's one more workaround for a bcc problem. This time bcc
- * complains about an illegal label when using `goto filetype'.
- */
-
-#define GOTO_FILETYPE_WORKAROUND { \
-	sp->u.num = ((fs->stat.st_mode & S_IFMT) == i && fs->rcode >= 0); \
-	sp->type = BOOLEAN; \
-	break; }
-
 void
 expr_operator(op, sp, fs)
       int op;
@@ -323,17 +299,17 @@ permission:
 	    goto filetype;
       case ISDIR:
 	    i = S_IFDIR;
-	    GOTO_FILETYPE_WORKAROUND;
+		goto filetype;
       case ISCHAR:
 	    i = S_IFCHR;
-	    GOTO_FILETYPE_WORKAROUND;
+		goto filetype;
       case ISBLOCK:
 	    i = S_IFBLK;
-	    GOTO_FILETYPE_WORKAROUND;
+		goto filetype;
       case ISFIFO:
 #ifdef S_IFIFO
 	    i = S_IFIFO;
-	    GOTO_FILETYPE_WORKAROUND;
+		goto filetype;
 #else
 	    goto false;
 #endif

--- a/elkscmd/ash/bltin/regexp.c
+++ b/elkscmd/ash/bltin/regexp.c
@@ -8,6 +8,7 @@
  */
 
 #include "bltin.h"
+#include <stdlib.h>
 
 
 #define RE_END 0		/* end of regular expression */
@@ -46,7 +47,6 @@ char *re_compile(char *pattern)
 	char stack[10];
 	int paren_num;
 	int i;
-	char *malloc();
 
 	p = pattern;
 	if (*p == '^')
@@ -203,8 +203,6 @@ match(pattern, string)
 	char *r;
 	int len;
 	char c;
-	short *kludge;
-	char **kludge2;
 
 	p = pattern;
 	q = string;
@@ -257,25 +255,8 @@ ccl:
 			p++;
 			break;
 		case RE_MATCHED:
-			/*
-			 * 19980218 Claudio Matsuoka <claudio@conectiva.com>
-			 * Workaround for bcc compilation problem
-			 */
-			
-#if 0
 			r = match_begin[*p];
 			len = match_length[*p++];
-#else
-			kludge2 = match_begin;
-			kludge2 += *p;
-			r = *kludge2;
-
-			kludge = match_length;
-			kludge += *p;
-			len = *kludge;
-			p++;
-#endif
-
 			while (--len >= 0) {
 				if (*q++ != *r++)
 					goto bad;
@@ -307,17 +288,7 @@ bad:
 		return 0;
 	len = 1;
 	if (*curpat == RE_MATCHED) {
-		/*
-		 * 19980218 Claudio Matsuoka <claudio@conectiva.com>
-		 * Yet another workaround for a bcc problem.
-		 */
-#if 0
 		len = match_length[curpat[1]];
-#else
-		kludge = match_length;
-		kludge += curpat[1];
-		len = *kludge;
-#endif
 	}
 	while (--count >= low) {
 		if (match(p, start_count + count * len))

--- a/elkscmd/ash/builtins.table
+++ b/elkscmd/ash/builtins.table
@@ -60,7 +60,7 @@ evalcmd 	eval
 execcmd 	exec
 exitcmd 	exit
 exportcmd	export readonly
-#exprcmd 	expr test [
+exprcmd 	expr test [
 fgcmd -j	fg
 getoptscmd	getopts
 hashcmd 	hash

--- a/elkscmd/ash/main.c
+++ b/elkscmd/ash/main.c
@@ -332,6 +332,7 @@ void exitcmd(int argc, char **argv)
 }
 
 
+#if NOT_YET
 int lccmd(int argc, char **argv)
 {
 	if (argc > 1) {
@@ -347,7 +348,7 @@ int lccmd(int argc, char **argv)
 		return exitstatus;
 	}
 }
-
+#endif
 
 
 #ifdef notdef

--- a/elkscmd/ash/parser.c
+++ b/elkscmd/ash/parser.c
@@ -679,11 +679,7 @@ STATIC int readtoken(void) {
  *  have parseword (readtoken1?) handle both words and redirection.]
  */
 
-/*
- * 19980209 Claudio Matsuoka <claudio@conectiva.com>
- * bcc fails with `return lasttoken = token', returning an invalid value.
- */
-#define RETURN(token)	{ lasttoken = token; return token; }
+#define RETURN(token)	return lasttoken = token
 
 STATIC int xxreadtoken(void) {
 	register c;

--- a/elkscmd/ash/trap.c
+++ b/elkscmd/ash/trap.c
@@ -197,7 +197,7 @@ setsignal(signo) {
 		 * ELKS does not implement signal()
 		 * If signals not supported, set old value to S_HARD_IGN
 		 */
-		if ((int)(sigact = signal(signo, SIG_IGN)) == SIG_ERR)
+		if ((sigact = signal(signo, SIG_IGN)) == SIG_ERR)
 			if (errno==ENOSYS)	/* HACK: man signal(2) does not mention errno */
 				*t = S_HARD_IGN;
 			else


### PR DESCRIPTION
Adds `test` (and `[`) command as `ash` shell builtin. This should improve boot and shell script speed on floppy systems (running /etc/rc.sys, etc).

Turns out `test` was already compiled in, just never activated. Was able to actually shrink shell size removing unused builtins and bcc workarounds from 1998.

Removes /bin/true, false and test, as these external commands now not needed.
Adds `df` to 360k floppy package manager image build.