### PR TITLE
[ash] Decrease size of /bin/sh

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -99,7 +99,7 @@ sh_utils/echo			        :be-shutil              :1200k  :1440k
 #sh_utils/logname				:shutil					:1200k	:1440k
 #sh_utils/mesg					:shutil					:1200k	:1440k
 sh_utils/stty					:shutil					:1200k	:1440k
-sh_utils/printenv				:shutil					:1200k	:1440k
+sh_utils/printenv				:shutil		    :360k
 sh_utils/pwd					:shutil			:360k
 sh_utils/tr						:shutil				:720k
 #sh_utils/which					:shutil					:1200k	:1440k

--- a/elkscmd/ash/README.elks
+++ b/elkscmd/ash/README.elks
@@ -97,4 +97,5 @@ Removed Claudio's workarounds for bcc problems
 
 Activated test/expr builtin in build (was already being compiled in unused)
 
+Changed _SMALL_ to MAIL
 --------------------------------------------------------------

--- a/elkscmd/ash/autocomplete.c
+++ b/elkscmd/ash/autocomplete.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "linenoise.h"
+#include "output.h"
 
 void completion(const char *buf, linenoiseCompletions *lc)
 {
@@ -70,7 +71,7 @@ void completion(const char *buf, linenoiseCompletions *lc)
 		struct stat st;
 		char path[128];
 
-		sprintf(path, "%s/%s", dir, lastentry);
+		fmtstr(path, sizeof(path), "%s/%s", dir, lastentry);
 		if (!stat(path, &st)) {
 			if (S_ISDIR(st.st_mode))
 				strcat(result, "/");
@@ -96,20 +97,20 @@ void completion(const char *buf, linenoiseCompletions *lc)
 				linenoiseAddCompletion(lc, result);
 
 				strcpy(result, dp->d_name);
-				sprintf(path, "%s/%s", dir, dp->d_name);
+				fmtstr(path, sizeof(path), "%s/%s", dir, dp->d_name);
 				if (!stat(path, &st) && S_ISDIR(st.st_mode))
 					strcat(result, "/");
 
 				if ((count & 3) == 0)
-					printf("\r\n");
-				printf("%-16s", result);
+					out1str("\r\n");
+				outfmt(out1, "%-16s", result);
 				count++;
 			}
 		}
 	}
 	if (count)
-		printf("\r\n");
-	fflush(stdout);
+		out1str("\r\n");
+	flushout(out1);
 	closedir(fp);
 }
 

--- a/elkscmd/ash/builtins.table
+++ b/elkscmd/ash/builtins.table
@@ -64,7 +64,7 @@ exprcmd 	expr test [
 fgcmd -j	fg
 getoptscmd	getopts
 hashcmd 	hash
-jobidcmd	jobid
+jobidcmd -j	jobid
 jobscmd 	jobs
 #lccmd		lc
 #linecmd 	line

--- a/elkscmd/ash/jobs.c
+++ b/elkscmd/ash/jobs.c
@@ -372,6 +372,7 @@ waitcmd(argc, argv)  char **argv; {
 
 
 
+#if JOBS
 jobidcmd(argc, argv)  char **argv; {
 	register struct job *jp;
 	int i;
@@ -383,6 +384,7 @@ jobidcmd(argc, argv)  char **argv; {
 	}
 	return 0;
 }
+#endif
 
 
 

--- a/elkscmd/ash/mail.c
+++ b/elkscmd/ash/mail.c
@@ -53,6 +53,7 @@ static char sccsid[] = "@(#)mail.c	5.1 (Berkeley) 3/7/91";
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#if MAIL
 
 #define MAXMBOXES 10
 
@@ -113,3 +114,4 @@ void chkmail(int silent) {
 	nmboxes = i;
 	popstackmark(&smark);
 }
+#endif

--- a/elkscmd/ash/main.c
+++ b/elkscmd/ash/main.c
@@ -227,7 +227,7 @@ cmdloop(top) {
 		if (iflag && top) {
 			inter++;
 			showjobs(1);
-#ifndef _SMALL_
+#if MAIL
 			chkmail(0);
 #endif
 			flushout(&output);

--- a/elkscmd/ash/shell.h
+++ b/elkscmd/ash/shell.h
@@ -57,13 +57,6 @@
  * a quit signal will generate a core dump.
  */
 
-/* ELKS */
-/* Remove _SMALL_ to enable all bloating features:- */
-/* (1) Checking for new mail */
-#define _SMALL_
-
-/* END ELKS */
-
 #define JOBS	  0
 #define SYMLINKS  0
 #define DIRENT	  1
@@ -75,6 +68,7 @@
 #define LINENOISE 1
 /* #define BSD */
 #define POSIX	  1
+#define MAIL      0
 #define DEBUG	  0
 
 #ifdef __STDC__

--- a/elkscmd/ash/var.c
+++ b/elkscmd/ash/var.c
@@ -235,7 +235,7 @@ void setvareq(char *s, int flags)
 			vp->flags &=~ (VTEXTFIXED|VSTACK|VUNSET);
 			vp->flags |= flags;
 			vp->text = s;
-#ifndef _SMALL_
+#if MAIL
 			if (vp == &vmpath || (vp == &vmail && ! mpathset()))
 				chkmail(1);
 #endif

--- a/elkscmd/rootfs_template/etc/profile
+++ b/elkscmd/rootfs_template/etc/profile
@@ -1,5 +1,6 @@
 export PATH=/bin
-#export MANPATH=/root/man:/lib
 PS1="$HOSTNAME$PS1"
+umask 022
+#export MANPATH=/root/man:/lib
 #TZ=GMT0
 # if TZ= set in /bootopts or above it overrides CONFIG_TIME_TZ, so don't set TZ= below

--- a/elkscmd/rootfs_template/etc/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.sys
@@ -44,3 +44,5 @@ esac
 #uname -snrm
 
 date
+# display internal commands used
+#hash


### PR DESCRIPTION
Decreases size of /bin/sh by 1.6K by replacing stdio sprintf/printf/fflush with internal shell routines. Now 49296 bytes.

Adds printenv to 360k image.

Removed mail checking and jobid, size now 48848.