### PR TITLE
[cmds] Fix tar error reading from pipe

### DIFF
--- a/elkscmd/file_utils/cat.c
+++ b/elkscmd/file_utils/cat.c
@@ -3,53 +3,47 @@
  *
  * 1997 MTK, other insignificant people
  */
-
 #include <stdio.h>
-#include <stdlib.h>
 #include <unistd.h>
-#include <string.h>
-#include <sys/types.h>
 #include <fcntl.h>
 #include <errno.h>
 
-#define CAT_BUF_SIZE	BUFSIZ		/* use disk block size for stack limit and efficiency*/
+static char readbuf[BUFSIZ];    /* use disk block size for stack limit and efficiency*/
 
-static char readbuf[CAT_BUF_SIZE];
-
-static int dumpfile(int fd)
+static int copyfd(int fd)
 {
-	int nred;
+	int n;
 
-	while ((nred = read(fd, readbuf, CAT_BUF_SIZE)) > 0) {
-		write(STDOUT_FILENO, readbuf, nred);
-	}
-	if (nred < 0) return -1;
-	return 0;
+	while ((n = read(fd, readbuf, sizeof(readbuf))) > 0)
+		write(STDOUT_FILENO, readbuf, n);
+	return n < 0? 1: 0;
 }
 
 int main(int argc, char **argv)
 {
-	int i, fd = -1;
+	int i, fd;
 
 	if (argc <= 1) {
-		if (dumpfile(STDIN_FILENO)) {
+		if (copyfd(STDIN_FILENO)) {
 			perror("stdin");
 			return 1;
 		}
 	} else {
 		for (i = 1; i < argc; i++) {
 			errno = 0;
-			if ((fd = open(argv[i], O_RDONLY)) < 0) {
+			if (argv[i][0] == '-' && argv[i][1] == '\0')
+				fd = STDIN_FILENO;
+			else if ((fd = open(argv[i], O_RDONLY)) < 0) {
 				perror(argv[i]);
 				return 1;
-			} else {
-				if (dumpfile(fd)) {
-					perror(argv[i]);
-					close(fd);
-					return 1;
-				}
-				close(fd);
 			}
+			if (copyfd(fd)) {
+				perror(argv[i]);
+				close(fd);
+				return 1;
+			}
+			if (fd != STDIN_FILENO)
+				close(fd);
 		}
 	}
 	return 0;


### PR DESCRIPTION
Fixes issues found with `tar` in https://github.com/jbruchon/elks/issues/1155#issuecomment-1118293983.

Read/write from/to pipes now work correctly.
Removes 'tape' from most messages.
Shows errno on read/write errors.

Allow '-' argument to `cat` for stdin.
