### PR TITLE
[config] Fix string entry in make menuconfig

### DIFF
--- a/8018x.config
+++ b/8018x.config
@@ -161,7 +161,7 @@ CONFIG_APP_BASIC=y
 # CONFIG_APP_TEST is not set
 CONFIG_APP_KTCP=y
 # CONFIG_APP_MAN_PAGES is not set
-CONFIG_APP_ROM_TAGS=":ash|:128k|:192k|"
+CONFIG_APP_TAGS=":ash|:128k|:192k|"
 
 #
 # Target image

--- a/config/Configure
+++ b/config/Configure
@@ -533,8 +533,13 @@ function hex () {
 #	define_string define value
 
 function define_string () {
-    echo "$1=\"$2\"" >>$CONFIG
-    echo "#define $1 \"$2\"" >>$CFG_H
+    if [ "$2" != "" ]; then
+        echo "$1=\"$2\"" >>$CONFIG
+        echo "#define $1 \"$2\"" >>$CFG_H
+    else
+        #echo "# $1 is not set" >>$CONFIG
+        echo "#undef  $1" >>$CFG_H
+    fi
     eval "$1=\"$2\""
 }
 

--- a/config/Menuconfig
+++ b/config/Menuconfig
@@ -20,7 +20,7 @@
 # script.
 #
 # William Roadcap was the original author of Menuconfig.
-# Jody Bruchon (jody@jodybruchon.com) is the current maintainer.
+# Michael Elizabeth Chastain (mec@shout.net) is the current maintainer.
 #
 # 07 Apr 1997 Bernhard Kaindl <bkaindl@netway.at>
 #	- get default values for new bool, tristate and dep_tristate
@@ -305,6 +305,12 @@ function hex () {
 # Add a menu item which will call our local string function.
 
 function string () {
+    set_x_info "$2" "$3"
+    echo -ne "'$2' '[$x] $1$info' " >>MCmenu
+    echo -e "function $2 () { l_string '$1' '$2' '$3' '$x' ;}" >>MCradiolists
+}
+
+function string_broken () {
     set_x_info "$2" "$3"
     echo -ne "'$2' '     $1: \"$x\"$info' " >>MCmenu
     echo -e "function $2 () { l_string '$1' '$2' '$3' '$x' ;}" >>MCradiolists
@@ -641,6 +647,21 @@ function l_hex_broken () {
 # Create a dialog for entering a string into a kernel option.
 
 function l_string () {
+    while true ; do
+	if $DIALOG --title "$1" --backtitle "$backtitle" \
+		--inputbox "$inputbox_instructions_string" \
+		10 75 "$4" 2>MCdialog.out
+	then
+	    answer="`cat MCdialog.out`"
+	    answer="${answer:-$3}"
+	    eval $2='${answer}'
+	    break
+	fi
+	help "$2" "$1"
+    done
+}
+
+function l_string_broken () {
     while true ; do
 	if $DIALOG --title "$1" --inputbox "$inputbox_instructions_string" \
 		   --backtitle "$backtitle" 10 75 "$4" 2>MCdialog.out
@@ -1108,8 +1129,13 @@ save_configuration () {
 
     function string () {
 	set_x_info "$2" "$3"
-	echo "$2=\"$x\""			>> $CONFIG
-	echo "#define $2 \"$x\""		>> $CFG_H
+	if [ "$x" != "" ]; then
+	    echo "$2=\"$x\""			>> $CONFIG
+	    echo "#define $2 \"$x\""		>> $CFG_H
+	else
+		#echo "# $2 is not set" >>$CONFIG
+		echo "#undef $2" >>$CFG_H
+	fi
     }
 
     function define_hex () {

--- a/elks/config.in
+++ b/elks/config.in
@@ -62,9 +62,7 @@ mainmenu_option next_comment
 	bool 'Boot Options in /bootopts'          CONFIG_BOOTOPTS     y
 	bool 'Calculate process CPU usage'        CONFIG_CPU_USAGE    y
 	bool 'Real time clock in localtime'       CONFIG_TIME_RTC_LOCALTIME n
-	if [ "$CONFIG_TIME_TZ" != "" ]; then
-		string 'Compiled-in TZ= timezone string'  CONFIG_TIME_TZ      "$CONFIG_TIME_TZ"
-	fi
+	string 'Compiled-in TZ= timezone string'  CONFIG_TIME_TZ      ''
 	bool 'System Trace'                       CONFIG_STRACE       n
 	bool 'Halt on Idle'                       CONFIG_IDLE_HALT    n
 

--- a/elkscmd/Make.install
+++ b/elkscmd/Make.install
@@ -19,8 +19,8 @@ TAGS=
 # Old-style installation
 INSTDIRS=
 
-ifdef CONFIG_APP_ROM_TAGS
-	TAGS += "$(CONFIG_APP_ROM_TAGS)"
+ifdef CONFIG_APP_TAGS
+	TAGS += "$(CONFIG_APP_TAGS)"
 endif
 
 #

--- a/elkscmd/config.in
+++ b/elkscmd/config.in
@@ -32,6 +32,7 @@ mainmenu_option next_comment
 		bool 'nano-X'			CONFIG_APP_NANOX		y
 		bool 'BASIC'			CONFIG_APP_BASIC		y
 		bool 'other'         	CONFIG_APP_OTHER        y
+		string 'Additional TAG string for app selection'  CONFIG_APP_TAGS      ''
 
 		comment 'Commands not compiling'
 
@@ -68,10 +69,6 @@ mainmenu_option next_comment
 		comment 'Man pages'
 
 		bool 'Man Pages'      		CONFIG_APP_MAN_PAGES  n
-
-		if [ "$CONFIG_ROMCODE" = "y" ]; then
-			string 'TAG string for ROM apps'  CONFIG_APP_ROM_TAGS      ""
-		fi
 	else
 		comment "Select Applications by Image Size"
 

--- a/emu86-rom-full.config
+++ b/emu86-rom-full.config
@@ -160,7 +160,7 @@ CONFIG_PSEUDO_TTY=y
 # CONFIG_APP_M4 is not set
 # CONFIG_APP_TEST is not set
 # CONFIG_APP_KTCP is not set
-CONFIG_APP_ROM_TAGS=":ash|:128k|"
+CONFIG_APP_TAGS=":ash|:128k|"
 
 #
 # Target image

--- a/emu86-rom.config
+++ b/emu86-rom.config
@@ -155,7 +155,7 @@ CONFIG_PSEUDO_TTY=y
 # CONFIG_APP_M4 is not set
 # CONFIG_APP_TEST is not set
 # CONFIG_APP_KTCP is not set
-CONFIG_APP_ROM_TAGS=":ash|:128k|"
+CONFIG_APP_TAGS=":ash|:128k|"
 
 #
 # Target image


### PR DESCRIPTION
Fixes `string` type in configuration managers `make config` and `make menuconfig`.

Allows entry of previously broken CONFIG_TIME_TZ time zone string and new CONFIG_APP_TAGS additional application tag string in `make menuconfig`.

Renames CONFIG_APP_ROM_TAGS to CONFIG_APP_TAGS, as tag string is now made available for finer grained addition of apps for all platforms.
