### PR TITLE
[net,ne2k] Major driver update adds full support for 8bit interfaces

### DIFF
--- a/elks/arch/i86/drivers/net/ne2k-asm.S
+++ b/elks/arch/i86/drivers/net/ne2k-asm.S
@@ -1,14 +1,32 @@
 //-----------------------------------------------------------------------------
 // NE2K driver - low part - MAC routines
 //
-// Updated by Santiago Hormazabal on Dec 2021:
-//  . 8 bit access if CONFIG_ETH_BYTE_ACCESS is set, using a ne1k patch from
-//    NCommander.
-// Updated by Helge Skrivervik July 2020:
+// Updated by Helge Skrivervik (HS) July 2020:
 //	. pick up MAC address from prom
 //	. fixed read ring buffer wrap around errors
 //	. added ring buffer overflow handling
+//	. use word I/O
 // oct-2021: Pick up I/O port # from init/bootopts (HS)
+// Updated by Santiago Hormazabal on Dec 2021:
+//  . 8 bit access if CONFIG_ETH_BYTE_ACCESS is set, using a ne1k patch from
+//    NCommander.
+// apr-2022 (HS) : Support auto detection of 8bit mode, set 4k buffer size when in 8bit mode
+//	     assuming RTL8019 buffer restrictions.
+//	     Rewrote overflow handler, added direct access to many registers from C code
+//	     Cleaned up initialization code, optimized 8bit I/O
+//
+//-----------------------------------------------------------------------------
+// Terminology
+// The ring buffer pointer terminology used in the DP8390C/NS3249C document is confusing.
+// 'CURRENT' points to the next block to be filled by an incoming packet
+// 'BOUNDARY' points to the next block to be read from the NIC
+// The two must not be equal. If the ring buffer is empty, BOUNDARY = CURRENT -1
+// So the next block to read is not BOUNDARY but BOUNDARY + 1. Easy - except at
+// the wrap-around point: BOUNDARY may be 80 or 50, while the next block to read is 46.
+// For simplicity (to avoid the ring wraparound logic on every read)
+// the driver uses a variable to hold the next block to read - _ne2k_next_pk.
+// For debugging, this variable is also available to the C part of the driver.
+//
 //-----------------------------------------------------------------------------
 
 #include <linuxmt/config.h>
@@ -60,30 +78,35 @@ io_ne2k_reset      = 0x1F	// Really a port, not a register, force HW reset of th
 
 tx_first           = 0x40
 rx_first           = 0x46
-rx_last            = 0x80
+rx_last_16	   = 0x80
+rx_last_8	   = 0x50	// Use only 4k in 8 bit mode 
 
 //-----------------------------------------------------------------------------
 	.data
 	.extern current
 	.extern	net_port	// io-port base
 
+	.global _ne2k_next_pk
 _ne2k_next_pk:
 	.word 0	// being used as byte ...
-
-	.global _ne2k_skip_cnt
-_ne2k_skip_cnt:
-	.word 0	// # of packets to skip if buffer overrun, default is all (0)
 
 	.global _ne2k_has_data
 _ne2k_has_data:
 	.word 0 
+
+	.global _ne2k_is_8bit	// set if this is an 8bit card
+_ne2k_is_8bit:
+	.word 0
+
+_ne2k_rx_last:
+	.byte rx_last_16	// default to the 16 bit value
+
 
 	.text
 
 //-----------------------------------------------------------------------------
 // Set unicast address (aka MAC address)
 //-----------------------------------------------------------------------------
-
 // arg1 : pointer to unicast address (6 bytes)
 
 	.global ne2k_addr_set
@@ -92,7 +115,7 @@ ne2k_addr_set:
 
 	push    %bp
 	mov     %sp,%bp
-	push    %si  // used by compiler
+	push    %si  // used by compiler (???)
 
 	mov     4(%bp),%si
 
@@ -174,8 +197,6 @@ dma_write:
 	inc     %cx     // make byte count even
 	and     $0xfffe,%cx
 	call    dma_init
-	shr     %cx     // half -> word size transf
-
 
 	// start DMA write
 
@@ -185,41 +206,45 @@ dma_write:
 
 	// I/O write loop
 
-	mov	net_port,%dx	// Do this before changing the data segment
-	push	%dx		// Command register
+	//mov	net_port,%dx	// Do this before changing the data segment
 	add	$io_ne2k_data_io,%dx
+	mov	_ne2k_is_8bit,%ax
 	mov	current,%bx		// setup for far memory xfer
 	mov	TASK_USER_DS(%bx),%ds
 	cld
+	test	%ax,%ax		// checking _ne2k_is_8bit
+	jz	1f
 
-emw_loop:
+	// Byte loop
+4:	lodsb
+	outb     %al,%dx
+	loop    4b
+	jmp	2f
 
-#ifdef CONFIG_ETH_BYTE_ACCESS
-    lodsb
-    outb     %al,%dx
-    lodsb
-    outb     %al,%dx
-#else
-	lodsw
+	// word loop
+1:	shr	%cx
+3:	lodsw
 	out     %ax,%dx
-#endif
-
-	loop    emw_loop
-
+	loop	3b
+2:
 	// wait for DMA completed
 
-	pop	%dx	// instead of: mov	net_port,%dx
+	mov	net_port,%dx
 	add	$io_ne2k_int_stat,%dx
+
 check_dma_w:
 	in      %dx,%al
 	test    $0x40,%al       // dma done?
-	jz      check_dma_w     // loop if not
+	jnz	end_dma_w
 
-	mov     $0x40,%al       //clear DMA intr bit in ISR
+end_dma_w:
+	mov     $0x40,%al       // clear DMA intr bit in ISR
 	out     %al,%dx
+	sti			// Experimental
 
 
-	sti		// Experimental
+	mov	%cl,%al		// Error (debug) return
+	xor	%ah,%ah		// if AL is 0xff, we had a timeout, the dma never completed
 	pop     %si
 	pop	%ds
 	pop	%bx
@@ -228,10 +253,9 @@ check_dma_w:
 
 #if 0
 //-------------------------------------------------------------------------
-// This is an (untested) skeleton routine for DMA-assiste paket transfer
+// This is an (untested) skeleton routine for DMA-assisted packet transfer
 // from the NIC to host memory.
-// TODO: Add DMA channel setup and teardown. Makes sens to do that outiside of this
-// routine.
+// TODO: Add DMA channel setup and teardown. 
 //
 dma_r:	// Use the send data command to read exactly one backet, 
 	// the nic does everything on its own, needs only ES:DI
@@ -279,7 +303,7 @@ rlp_ret:
 // BX    : chip memory to read from
 // CX    : byte count
 // ES:DI : host memory to write to
-// AL:	 : 0: buffer is local, <>0: buffer is far
+// AL:	 : 0: buffer is local (kernel), <>0: buffer is far (process)
 
 dma_read:
 
@@ -288,11 +312,11 @@ dma_read:
 	push	%bx
 	push	%ax
 
-	cli		// Experimental - disable INTR
 	inc     %cx     // make byte count even
 	and     $0xfffe,%cx
+
+	cli		// Experimental - disable INTR
 	call    dma_init
-	shr     %cx     // half -> word size transf
 
 	mov     %ds,%bx
 	mov     %bx,%es
@@ -302,33 +326,35 @@ dma_read:
 	mov	current,%bx	// Normal: read directly into the (far) buffer
 	mov	TASK_USER_DS(%bx),%es
 
-buf_local:
 	pop	%bx
 	push	%bx
 
-	// start DMA read
-
+buf_local:
 	mov	net_port,%dx	// command register
-	mov	$0x0a,%al	// RD0 & STA
-	out     %al,%dx
-
-	// I/O read loop
+	mov	$0x0a,%al	// set RD0 & STA
+	out     %al,%dx		// start DMA read
 
 	mov	net_port,%dx
 	add	$io_ne2k_data_io,%dx
-	cld
-emr_loop:
-#ifdef CONFIG_ETH_BYTE_ACCESS
-    inb      %dx,%al
-    stosb
-    inb      %dx,%al
-    stosb
-#else
+	cld			// clear direction flag
+	cmpw	$0,_ne2k_is_8bit
+	jz	1f
+
+// Byte transfer
+byte_loop:
+	inb      %dx,%al
+	stosb
+	loop    byte_loop
+	jmp	3f
+
+// Word transfer
+1:
+	shr     %cx     // half -> word size transf
+word_loop:
 	in      %dx,%ax
 	stosw
-#endif
-	loop    emr_loop
-
+	loop	word_loop
+3:
 	// wait for DMA to complete
 
 	mov	net_port,%dx
@@ -358,12 +384,13 @@ check_dma_r:
 // 	read point is in the variable _NE2K_NEXT_PK. This trick is necessary
 //	because the internal logic in the NIC will trigger an overrun interrupt
 //	if the BOUNDARY pointer matches or exceeds the CURRENT pointer.
+//---------------
 // Used internally, exposed externally for debugging purposes.
 //
 	.global ne2k_getpage
 
 ne2k_getpage:
-	mov	$0x42,%al		// page 1
+	mov	$0x42,%al	// page 1
 	mov	net_port,%dx	// command register
 	out	%al,%dx
 
@@ -372,11 +399,11 @@ ne2k_getpage:
 	in      %dx,%al
 	mov     %al,%ah
 
-	mov	$0x02,%al		// page 0
+	mov	$0x02,%al	// page 0
 	mov	net_port,%dx	// command register
 	out	%al,%dx
 
-	mov	net_port,%dx
+	//mov	net_port,%dx
 	add	$io_ne2k_rx_get,%dx     // BOUNDARY
 	in      %dx,%al
 
@@ -427,15 +454,15 @@ nrs_exit:
 #else
 	// sep2020: keep ring buffer status in a variable
 	// instead of accessing the NIC registers continuously.
-	movw	_ne2k_has_data,%ax	// TEST !!!!!
+	call	ne2k_clr_int_reg // EXPERIMENTAL, should clear just the read.
+	movw	_ne2k_has_data,%ax
 #endif
 	ret
 
 //-----------------------------------------------------------------------------
 // Get received packet
 //-----------------------------------------------------------------------------
-// arg1 : packet buffer to receive the data. The buffer must be 4 bytes to hold 
-//	the NIC header plus the mac Ethernet frame size.
+// arg1: buffer to receive the data
 // arg2: int - requested read size (max buffer)
 // arg3: int array [2] (return) containing the NIC packet header.
 //
@@ -453,21 +480,22 @@ ne2k_pack_get:
 
 	//sub 	$4,%sp		// temp space
 	//mov	%sp,%di
-	mov	8(%bp),%di	// get the hdr into arg3
 
-	// get RX_put pointer
-
+	// get the 4 byte header first -> arg3
+	mov	8(%bp),%di	
 	mov	_ne2k_next_pk,%bh
 	xor	%bl,%bl		// Next pkt to read in BX
 
-	mov	$4,%cx
+	mov	$4,%cx		// Bytes to read
 	//mov     %ds,%ax
 	//mov     %ax,%es		// local address space
-	xor	%al,%al		// local address space
+	xor	%al,%al		// indicate local address space
 	call	dma_read
 
 	mov	0(%di),%ax	// AH : next record, AL : status
 	mov	2(%di),%cx	// packet size (without CRC)
+
+	// get the actual data
 
 	//add	$4,%sp
 	mov	4(%bp),%di	// Buffer address to receive data.
@@ -478,9 +506,12 @@ ne2k_pack_get:
 
 #if 0
 	// -------------------------------------------------------------
-	// Check packet size - not required since the NIC will not
+	// Packet size check not required since the NIC will not
 	// accept such packets per our initialization. Note, in order to handle
-	// erroneous packets, rx_get (BOUNDARY) pointer must be updated.
+	// erroneous packets, rx_get (BOUNDARY) pointer must be updated
+	// to point to the next packet.
+	// If oversized packets still occur, it's a driver problem (most likely
+	// reading the wrong buffer page).
 	// -------------------------------------------------------------
 	or      %cx,%cx		// zero length
 	jz      npg_err2
@@ -488,6 +519,17 @@ ne2k_pack_get:
 	cmp     $1528,%cx	// max - head - crc
 	jnc     npg_err
 #endif
+	// -------------------------------------------------------------
+	// This section did the smart thing when reading the NIC packet header:
+	// Got the entire block (256b) instead of the 4 first bytes. Which was great 
+	// for small packets (telnet, command packets etc.): One read instead of 2.
+	//
+	// Removed when changing to read directly into the process was introduced,
+	// there is no longer anywhere to put the first 4 bytes.
+	// It may be an idea to reintroduce a 256b buffer to take advantage 
+	// of this 'optimization' and at the same time help strangled 8bit 
+	// interfaces.
+
 	//sub	$252,%cx	// Got entire packet?
 	//jle	npg_cont
 				// If not, get rest.
@@ -500,7 +542,7 @@ npg_cont0:
 				// (keep the 4 byte NIC header)
 	push	%cx		// save length
 	push	%ax
-	add	$4,%bx
+	add	$4,%bx		// Skip the 4 bytes already read
 
 	mov	$1,%al		// use far transfer
 	call    dma_read
@@ -515,7 +557,8 @@ npg_cont:
 	dec	%al
 	cmp	$rx_first,%al
 	jnb	npg_next	// if the decrement sent us outside the ring..
-	mov	$rx_last-1,%al	// make it right ...
+	mov	_ne2k_rx_last,%al
+	dec	%al
 
 npg_next:
 
@@ -523,52 +566,21 @@ npg_next:
 	add	$io_ne2k_rx_get,%dx	// update RX_get (BOUNDARY)
 	out     %al,%dx
 
-#if 0	/* error processing - not used */
-	xor     %ax,%ax
-	jmp     npg_exit
-npg_err:
-	mov     $-1,%ax		// Packet too big
-	jmp	npg_exit
-
-npg_err2:
-	mov	$-2,%ax		// zero length packet
-#endif  /* ---------------------------- */
-
 npg_exit:
-#if 0	/* Handle ring buffer overflow - not used */
-        /* OFLOW handled by its interrupt handler */
-
-	mov	net_port,%dx  
-	add	$io_ne2k_int_stat,%dx  
-	in	%dx,%al			// get the status bits
-	test	$0x10,%al
-	jz	npg_no_oflw
-	push	%bx
-	call	ne2k_clr_oflow
-	pop	%bx
-
-npg_no_oflw:
-#endif
-	// The is effectively the replacement for the rx_stat routine,
+	// This is effectively the replacement for the rx_stat routine,
 	// clear the has_data flag if ring buffer is empty.
-	cli	// Interrupts off (experimental)
-	//mov	_ne2k_has_data,%ax
-	//dec	%ax	// TESTING
-	//cmp	$0,%ax
-	//jz	npg_zero	// don't set to zero unless sure (TESTING)
-	//mov	%ax,_ne2k_has_data
-npg_zero:
+	cli			// Interrupts off (experimental)
 	call	ne2k_getpage
 	cmp	%ah,%bl		// ring buffer empty?
 	jnz	npg_more_data
 	movw	$0,_ne2k_has_data
-npg_more_data:
 
+npg_more_data:
 	sti		// Enable interrupts
 	pop	%ax	// return byte count (from %cx)
 	//pop	%es
 	pop     %di
-	mov	%bp,%sp	// restore stack pointer
+	//mov	%bp,%sp	// restore stack pointer
 	pop     %bp
 	ret
 
@@ -594,24 +606,19 @@ ne2k_tx_stat:
 	jmp     nts_exit
 
 nts_ready:
-
 	mov     $2,%ax
 
 nts_exit:
-
 	ret
 
 //-----------------------------------------------------------------------------
 // Send packet: First transfer packet data to NIC memory, then kick off
 // the actual transmit and return.
 //-----------------------------------------------------------------------------
-
-// arg1 : packet buffer to read from
+// arg1 : packet buffer to transfer
 // arg2 : size in bytes
-
 // returns:
-
-// AX : error code
+//	AX : error code
 
 	.global ne2k_pack_put
 
@@ -632,11 +639,12 @@ ne2k_pack_put:
 	// set TX pointer and length
 
 	mov	net_port,%dx
-	add	$io_ne2k_tx_start,%dx	// FIXME: This may not be required, done
+	add	$io_ne2k_tx_start,%dx	// FIXME: This is probably superfluous, done
 					// at initialization time, never changes.
-	mov     $tx_first,%al
-	out     %al,%dx
+	//mov     $tx_first,%al
+	//out     %al,%dx
 
+	//add	$io_ne2k_tx_len1,%dx	// use inc instead
 	inc     %dx		// io_ne2k_tx_len1
 	mov     %cl,%al
 	out     %al,%dx
@@ -649,15 +657,11 @@ ne2k_pack_put:
 tx_rdy_wait:
 	mov	net_port,%dx	// command register
 	in	%dx,%al
-	test	$0x4,%al	// Check that previous transmit competed.
+	test	$0x4,%al	// Check that previous transmit completed.
 	jnz	tx_rdy_wait
-	mov	$6,%al		// Set TX bit, starts transfer...
+	and	$0x18,%al
+	or	$6,%al		// set TX + STA; keep the others
 	out	%al,%dx
-
-	//mov	net_port,%dx
-	//add	$io_ne2k_int_stat,%dx	// reset tx intr bit
-	//mov	$2,%al		// Test, should not make any difference
-	//out	%al,%dx
 
 1:	mov	net_port,%dx	// command register
 	in      %dx,%al
@@ -674,7 +678,7 @@ tx_rdy_wait:
 // Get NE2K interrupt status
 //-----------------------------------------------------------------------------
 
-// returns:
+// returns interrupt status reg unmodified
 
 // AX : status
 //   01h = packet received
@@ -686,24 +690,17 @@ tx_rdy_wait:
 
 ne2k_int_stat:
 
-	// get interrupt status
-
 	mov	net_port,%dx
 	add	$io_ne2k_int_stat,%dx
 	in      %dx,%al
-	test    $0x13,%al	// ring buffer overflow, tx, rx
-	jz      nis_next
-
-	mov	%al,%bl		// save return value
-	and	$3,%al		// Reset TX & RX bits here, otherwise traffic 
-				// will stop. DO NOT reset the RDC & OFLOW 
-				// interrupts, it will disturb dma rd/wr.
-	out     %al,%dx
-	xor	%ax,%ax
-	mov	%bl,%al		// unsave
-
-nis_next:
-
+#if 0
+	mov	%al,%ah
+	and	$3,%al
+	jz	1f
+	out	%al,%dx
+1:	mov	%ah,%al
+#endif
+	xor	%ah,%ah
 	ret
 
 //--------------------------------------------------------------
@@ -713,19 +710,21 @@ nis_next:
 ne2k_base_init:
 
 	mov	net_port,%dx	// command register
-
 	mov	$0x21,%al	// page 0 + Abort DMA; STOP
 	out     %al,%dx
 
-	// data I/O in words for PC/AT and higher
+	// Set data size, 16 or 8 bits
+	// Some machines are 8 bit only,
+	// some interfaces are 8 bits only
 
 	mov	net_port,%dx
 	add	$io_ne2k_data_conf,%dx
-#ifdef CONFIG_ETH_BYTE_ACCESS
-	mov     $0x48,%al	// set byte access
-#else
 	mov     $0x49,%al	// set word access
-#endif
+	cmpw	$0,_ne2k_is_8bit
+	jz	1f
+	dec     %al	// if in 8bit mode, 
+			// set byte access, data_conf reg = 0x48
+1:	
 	out     %al,%dx
 
 	// clear DMA length 
@@ -736,10 +735,12 @@ ne2k_base_init:
 	out     %al,%dx
 	inc     %dx  		// = io_ne2k_dma_len2
 	out     %al,%dx
+
 	ret
 
 //-----------------------------------------------------------------------------
 // NE2K initialization
+// Called from device open
 //-----------------------------------------------------------------------------
 
 	.global ne2k_init
@@ -763,70 +764,114 @@ ne2k_init:
 	mov     $2,%al  // 2 for loopback
 	out     %al,%dx
 
-	// set RX ring limits
-	// all 16KB on-chip memory
+	// set RX ring limits - all 16KB on-chip memory
 	// except one TX frame at beginning (6 x 256B)
+	// (unless it's an 8 bit card, then only 4KB for send&receive)
 
 	mov	net_port,%dx
 	add	$io_ne2k_rx_first,%dx
-	mov     $rx_first,%al
+	mov     $rx_first,%al	// start of ring, usually 0x46
 	out     %al,%dx
 
-	// set RX_get pointer [BOUNDARY]
-
-	mov	net_port,%dx
-	add	$io_ne2k_rx_get,%dx
-	out     %al,%dx
+	// set page at which the ring buffer ends,
+	// defaults to the 16 bit value (0x80) 
+	movb	$rx_last_16,%al
+	testw	$1,_ne2k_is_8bit
+	jz	1f
+	testw	$2,_ne2k_is_8bit
+	jnz	1f	// 16k override for 8 bit interface
+	movb	$rx_last_8,%al
+1:	movb	%al,_ne2k_rx_last
 
 	mov	net_port,%dx
 	add	$io_ne2k_rx_last,%dx
-	mov     $rx_last,%al
 	out     %al,%dx
 
+	call	ne2k_rx_init	// initialize receive buffer
+#if 0	
+	// this code is moved to ne2k_rx_init - TO BE DELETED
+	// set RX_get pointer [BOUNDARY] accordingly
+
+	mov     $rx_first,%al
+	mov	%al,%ah		// save copy
 	mov	net_port,%dx
-	add	$io_ne2k_tx_start,%dx
-	mov     $tx_first,%al
-	out     %al,%dx
-
-	// clear all interrupt flags
-
-	mov	net_port,%dx
-	add	$io_ne2k_int_stat,%dx
-	mov     $0x7F,%al
-	out     %al,%dx
-
-	// set interrupt mask
-	// TX & RX & OFLW, no error interrupts
-
-	mov	net_port,%dx
-	add	$io_ne2k_int_mask,%dx
-	mov     $0x13,%al	// 0x53 = RDC, Overflow, RX, TX 
-				// 0x13 = Overflow, RX, TX
+	add	$io_ne2k_rx_get,%dx
 	out     %al,%dx
 
 	mov	$0x42,%al	// page 1
 	mov	net_port,%dx	// command register
 	out	%al,%dx
 
-	// set RX put pointer  = RX get
+	// set RX_put pointer  [CURRENT] = RX_get [BOUNDARY]
 
 	mov	net_port,%dx
 	add	$io_ne2k_rx_put,%dx
-	mov     $rx_first,%al
-	inc     %al		// CURRENT = always one ahead
+	mov	%ah,%al		// restore
+	//inc	%al
 	out     %al,%dx
-	mov	%al,_ne2k_next_pk
+	mov	%al,_ne2k_next_pk // at initialization, CURRENT and BOUNDARY are equal
 
-	mov	$0x02,%al	// page 0
+	mov	$0x22,%al	// back to page 0, 
+	mov	net_port,%dx	// command register
+	out	%al,%dx
+#endif
+	// initialize start of TX buffer
+	mov	net_port,%dx
+	add	$io_ne2k_tx_start,%dx
+	mov     $tx_first,%al
+	out     %al,%dx
+
+
+	// FIXME _ wait till open (start) before enabling intr
+	// set interrupt mask
+	mov	net_port,%dx
+	add	$io_ne2k_int_mask,%dx
+	mov     $0x17,%al	// 0x53 = RDC, Overflow, RX, TX 
+				// 0x13 = Overflow, RX, TX
+				// 0x17 = Overflow, RXE, RX, TX
+	out     %al,%dx
+
+	// NOTE: Transmitter not yet enabled, done in the _start routine
+	// FIXME: Should move the int mask and status reg clearing to 
+	// the _start routine too to avoid interrupts from a closed device.
+
+	ret
+
+//------------------------------------------------------------------------
+// rx_init
+// reset the ring buffer front and end pointers to initial values
+// Remember to clear _ne2k_has_data !!
+//------------------------------------------------------------------------
+
+	.global ne2k_rx_init
+
+ne2k_rx_init:
+
+	// set RX_get pointer [BOUNDARY] 
+
+	mov     $rx_first,%al
+	mov	%al,%ah		// save copy
+	mov	net_port,%dx
+	add	$io_ne2k_rx_get,%dx
+	out     %al,%dx
+
+	mov	$0x40,%al	// page 1
 	mov	net_port,%dx	// command register
 	out	%al,%dx
 
-	// now enable transmitter
-	mov	net_port,%dx
-	add	$io_ne2k_tx_conf,%dx
-	mov     $0,%al		// 2 for loopback
-	out     %al,%dx
+	// set RX_put pointer  [CURRENT] = RX_get [BOUNDARY]
 
+	//mov	net_port,%dx
+	add	$io_ne2k_rx_put,%dx
+	mov	%ah,%al		// restore
+	inc	%al		// works w/o this one,
+				// but this is safer
+	out     %al,%dx
+	mov	%al,_ne2k_next_pk // at initialization, CURRENT and BOUNDARY are equal
+
+	mov	$0x0,%al	// back to page 0, don't touch the other bits
+	mov	net_port,%dx	// command register
+	out	%al,%dx
 	ret
 
 //-----------------------------------------------------------------------------
@@ -840,7 +885,7 @@ ne2k_start:
 	// start the transceiver
 
 	mov	net_port,%dx	// command register
-	mov	$0x02,%al
+	mov	$0x22,%al	// ensure page 0
 	out	%al,%dx
 
 	// move out of internal loopback
@@ -849,6 +894,8 @@ ne2k_start:
 	add	$io_ne2k_tx_conf,%dx
 	xor	%al,%al
 	out	%al,%dx
+
+	// FIXME: Move setting the int mask here (from init)
 
 	ret
 
@@ -864,6 +911,12 @@ ne2k_stop:
 
 	mov	net_port,%dx	// command register
 	mov	$0x21,%al	// page 0 + stop
+	out     %al,%dx
+
+	// mask all interrrupts
+
+	add	$io_ne2k_int_mask,%dx
+	xor     %al,%al
 	out     %al,%dx
 
 	// half-duplex and internal loopback
@@ -884,26 +937,7 @@ ne2k_stop:
 	inc     %dx  // = io_ne2k_dma_len2
 	out     %al,%dx
 
-	// TODO: wait for the chip to get stable
-
-	ret
-
-//-----------------------------------------------------------------------------
-// NE2K termination
-//-----------------------------------------------------------------------------
-
-// call ne2k_stop() before
-
-	.global ne2k_term
-
-ne2k_term:
-
-	// mask all interrrupts
-
-	mov	net_port,%dx
-	add	$io_ne2k_int_mask,%dx
-	xor     %al,%al
-	out     %al,%dx
+	// TODO: wait for the chip to get stable????
 
 	ret
 
@@ -999,10 +1033,13 @@ ne2k_get_hw_addr:
 	mov     4(%bp),%di
 
 	// Effectively a soft reset of the NIC, required in order to get access to the
-	// Address PROM - 32 bytes of which only the first 6 bytes are of interest.
-	// NOTE: Since we're reading the entire PROM, we also have the opportunity to
-	// detect the type of card. The caller can do this since the entire dataset 
-	// is being returned.
+	// address PROM. The PROM is 16 bytes, we get 32 back if reading in word mode,
+	// the upper byte of each word is garbage. The MAC address is in the first 6 bytes.
+	// The remaining 10 bytes sometimes identify the card type. The PROM content from 
+	// an 8 bit Weird Electronics (RTL8019AS) card looks like this:
+	// 001f1102602d49534138455448204242, the last 10 bytes being 'ISA8ETH BB'.
+	// Many 16 bit cards have 0x57 in the last 2 bytes, supposedly indicating
+	// 'true ne2k clones'.
 
 w_reset:
 	call	ne2k_base_init	// basic initialization
@@ -1010,11 +1047,8 @@ w_reset:
 	xor	%al,%al
 	mov	net_port,%dx
 	add	$io_ne2k_int_mask,%dx
-	out	%al,%dx         // mask completion irq
-	mov	net_port,%dx
-	add	$io_ne2k_int_stat,%dx
-	mov	$0x7f,%al
-	out	%al,%dx		// clear interrupt status reg, required
+	out	%al,%dx         // mask all interrupts
+	call	ne2k_clr_int_reg// required
 
 	mov	net_port,%dx
 	add	$io_ne2k_rx_conf,%dx
@@ -1030,7 +1064,7 @@ w_reset:
 	xor	%al,%al		// AL = 0 : local xfer
 	call	dma_read
 
-	mov	net_port,%dx	// set tx back to normal
+	mov	net_port,%dx
 	add	$io_ne2k_tx_conf,%dx	// set tx back to normal
 	xor	%al,%al
 	out	%al,%dx
@@ -1041,10 +1075,16 @@ w_reset:
 
 //-----------------------------------------------------------------------------
 // NE2K clear overflow --- respond to an input ring buffer overflow interrupt
-// The recovery reads the last compete pcket into the provided (arg1) buffer.
 //-----------------------------------------------------------------------------
-//      
-//      Returns: AL = new BOUNDARY ptr, AH = CURRENT ptr
+//      input: arg1 = buffer recovery strategy
+//		0 -> clear input buffer	and reset the NIC
+//		1 -> keep the oldest (next-to-read) packet, always safe
+//		2 and higher: delete this # of packets from the end (BOUNDARY)
+//		towards the head. In 8bit/4k mode, >1 doesn't make much sense.
+//	[May want to automatically set reasonable values, such as 1 for 8bit,
+//	  4 for 16bit.]
+//
+//      Returns: AL = BOUNDARY ptr, AH = CURRENT ptr for debugging
 //
 
 	.global ne2k_clr_oflow
@@ -1055,107 +1095,148 @@ ne2k_clr_oflow:
 	push	%bp
 	mov	%sp,%bp
 
+of_cont_1:
 	sub	$4,%sp		// get temp space on the stack
-	mov	%sp,%di
+	mov	%sp,%di		//   for the dma_read call
+	mov     6(%bp),%bx	// arg1, # of packets to kill
 
+	// We have not cleared the OFLW INT bit yet, so NIC interrupts are not enabled 
+	//cli
 	mov	net_port,%dx	// command register
-of_chk_tx:	// Ensure no transmit is in progress
-	in	%dx,%al
-	test	4,%al
-	//jnz	of_chk_tx
+1:	in	%dx,%al
+	test	$0x4,%al	// must wait for transmit to complete
+	jnz	1b
 
-	call	ne2k_base_init	// stop & soft reset
+	mov	$0x21,%al	// page 0 + Abort DMA; STOP
+	out     %al,%dx
+
+	// clear dma counters, required
+	add	io_ne2k_dma_len1,%dx  // io_ne2k_dma_len1
+	xor	%al,%al
+	out     %al,%dx
+	inc     %dx		// io_ne2k_dma_len2
+	out     %al,%dx
 
 	mov	net_port,%dx
 	add	$io_ne2k_int_stat,%dx
 
-of_reset:
+of_reset_wait:
 	in	%dx,%al		// wait for reset to complete
 	test	$0x80,%al
-	jz	of_reset
+	jz	of_reset_wait
 
 	mov	net_port,%dx
 	add	$io_ne2k_tx_conf,%dx	// must set tx to loopback
 	mov	$2,%al
 	out	%al,%dx
+
 	mov	net_port,%dx	// Command register
 	mov	$0x22,%al	// Restart NIC
 	out	%al,%dx
 	
-	// NIC has stopped, now clear out the ring buffer
-
-	call	ne2k_getpage    // get BOUNDARY (AL) and CURRENT (AH) pointers
+	// NIC is running but offline, start deleting
+1:
+	//call	ne2k_getpage    // get BOUNDARY (AL) and CURRENT (AH) pointers
 
 of_drop_packets:
-	// loop through the number of packets given by %bx
-	// terminate if we reach the head of the buffer before the # of packets
-	// if cnt = 0, just keep the oldest packet in the ring.
-	mov	%ax,%cx		// save BOUNDARY & CURRENT
-	mov	_ne2k_next_pk,%ah
-	mov	_ne2k_skip_cnt,%bx	// get # of packets to discard
+
+	// initial housekeeping
+	mov	_ne2k_next_pk,%ah	// The 'real' BOUNDARY ptr
+	and	$0x7,%bx		// limit the packet counter value and check for ZERO
+	jnz	of_drop_loop1
+	call	ne2k_rx_init	// purge everything
+	call	ne2k_getpage	// update return values
+	push	%ax
+	jmp	of_exit0
+
 of_drop_loop1:
-	push	%cx
 	push	%bx
 	xor	%bl,%bl
 	mov	%ah,%bh         // Start of next pkt
 
-	// get header
+	// get header of next packet from ring buffer
 	mov	$4,%cx		// 4 bytes only
-	mov	$0,%al		// local xfer
-	call	dma_read
+	xor	%al,%al		// use local memory
+	call	dma_read	// remember: interrupts are disabled in dma_read!!
 
 	mov	0(%di),%ax	// AH : next record, AL : status
-	pop	%bx		// packet counter
-	pop	%cx		// need CURRENT (front of queue)
-	cmp	$0,%bx		// Zero = keep the oldest packet, skip the rest.
-	jnz	of_drop_loop2
 
-	mov	%cl,%al		// save BOUNDARY for return
-	push	%ax
-	mov	$0x42,%al	// page 1
+	pop	%bx		// packet counter
+	dec	%bx		// packet counter
+	jnz	of_drop_loop1	// BX = 1-7
+
+of_drop_1:
+	/// Move the front of the ring (CURRENT) to the block # in AH
+	///   effectively deleting the rest of the ring.
 	mov	net_port,%dx	// Command register
+	mov	$0x42,%al	// set page 1
 	out	%al,%dx
 
-	mov	net_port,%dx
+	//mov	net_port,%dx
 	add	$io_ne2k_rx_put,%dx
 	mov	%ah,%al		// set CURRENT to the beginning of the next pkt,
 	out	%al,%dx		// effectively clearing everything but the 
 				// first pkt in the buffer.
 	mov	net_port,%dx	// Command register
-	mov	$2,%al
-	out	%al,%dx		// page 0
-	pop	%ax
+	mov	$22,%al
+	out	%al,%dx		// set page 0
 	jmp	of_drop_ok
-of_drop_loop2:
-	cmp	%ch,%ah		// Has the tail caught up with the head yet?
-	jz	of_wraparound
-	dec	%bx	
-	jnz	of_drop_loop1
-	// discard completed, get %ax in order for return
 
-of_wraparound:
-	mov	%ah,%al
-	dec	%al	// don't care about wraparound, this is debug info
+of_drop_2:
+#if 0
+	// ALT 2 (BX = 2), delete this packet, keep the rest -
+	// by moving the BOUNDARY pointer to the beginning of the next packet
+	// May not be safe for 8bit interfaces, the 'next' (last) packet
+	// may be garbage. Experimental	- KEPT FOR REFERENCE
+	// Verdict: Does not work well for any setting.
+
+	//mov	%cl,%al		// save BOUNDARY for return
+	//push	%ax
+	mov	net_port,%dx
+	add	$io_ne2k_rx_get,%dx
+	mov	%ah,%al		// set BOUNDARY to the beginning of the next pkt,
+				// don't touch CURRENT
+	mov	%al,_ne2k_next_pk
+	// do the wrap-around excercise
+	dec	%al
+	cmp	$rx_first,%al
+	jnb	1f
+	mov	_ne2k_rx_last,%al
+	dec	%al
+1:
+	out     %al,%dx
+	mov	%ch,%ah		// return value
+	jmp	of_drop_ok
+#endif
 
 of_drop_ok:
-	push	%ax	// save for return
-	mov	net_port,%dx	// set tx back to normal
-	add	$io_ne2k_tx_conf,%dx
+	// check if the ring buffer is empty
+	// may seem moot, but the 8bit interface cannot hold more than 1 full size packet
+	// in the buffer, cleaning the only packet will leave the buffer effectively empty
+	call	ne2k_getpage		// REMOVE _ JUST TEST
+	push	%ax			// save for return
+	cmp	_ne2k_next_pk,%ah
+	jz	1f
+	movw	$1,_ne2k_has_data
+	jmp	of_exit0
+1:	movw	$0,_ne2k_has_data
 
+of_exit0:
+	mov	net_port,%dx		// set tx back to normal
+	add	$io_ne2k_tx_conf,%dx
 	xor	%al,%al
 	out	%al,%dx
-	mov	net_port,%dx	// clear all interrupt bits
-	add	$io_ne2k_int_stat,%dx
-	in	%dx,%al
-	out	%al,%dx
 
-	pop	%ax	// return value as if we'd called 
-			// getpage() (for debugging)
+	call	ne2k_clr_int_reg	// clear all interrupt bits
+	//sti
+
+	pop	%ax	// return value from getpage()
+			// (for debugging)
+of_exit:
 	mov	%bp,%sp
 	pop	%bp
 	pop	%di
 	ret
-
 
 
 //-----------------------------------------------------------------------------
@@ -1192,7 +1273,7 @@ ne2k_rdc:
 ne2k_get_errstat:
 
 // Currently useful only 4 debugging: Needs a regime to regularly collect 
-// and accumulate the numbers in order to be of value.
+// and accumulate the numbers in order to be of statistical value.
 #if 0
 	push	%bp
 	mov	%si,%bp
@@ -1230,13 +1311,81 @@ ne2k_get_errstat:
 ne2k_get_tx_stat:
 	mov	net_port,%dx
 	add	$io_ne2k_int_stat,%dx
-	mov	$0x08,%al	// Clear TXE bit in ISR
+	mov	$0x0a,%al	// Clear PTX & TXE bits in ISR
 	out	%al,%dx
 
 	mov	net_port,%dx
 	add	$io_ne2k_tx_stat,%dx
 	in	%dx,%al
 	xor	%ah,%ah
+	ret
+
+//---------------------------------------------------------------------------
+// Ne2k - get RX error status
+// return the content of the RX status register in AX
+//---------------------------------------------------------------------------
+
+	.global ne2k_get_rx_stat
+
+ne2k_get_rx_stat:
+	// called from interrupt RX RDY processing, must reset the 
+	// 
+	mov	net_port,%dx
+	add	$io_ne2k_int_stat,%dx
+	mov	$1,%al		// Clear PRX bit in ISR
+	out	%al,%dx
+
+	mov	net_port,%dx
+	add	$io_ne2k_rx_stat,%dx
+	in	%dx,%al
+	xor	%ah,%ah
+	ret
+
+//--------------------------------------------------------------------------
+// Ne2k - clear interrupt status reg
+//--------------------------------------------------------------------------
+
+	.global ne2k_clr_int_reg
+
+ne2k_clr_int_reg:
+	mov	net_port,%dx
+	add	$io_ne2k_int_stat,%dx
+	in	%dx,%al
+	out	%al,%dx
+	ret
+
+//--------------------------------------------------------------------------
+// Ne2k - clear tally counters
+//	  Just read the registers to clear them
+//--------------------------------------------------------------------------
+
+	.global ne2k_clr_err_cnt
+
+ne2k_clr_err_cnt:
+	mov	net_port,%dx
+	add	$io_ne2k_int_stat,%dx
+	mov	$0x20,%al
+	out	%al,%dx
+
+	mov	net_port,%dx
+	add	$io_ne2k_frame_errs,%dx
+	in	%dx,%al
+	inc	%dx	// CRC errors
+	in	%dx,%al
+	inc	%dx	// Missed packets
+	in	%dx,%al
+	ret
+
+//-------------------------------------------------------------------------
+// Ne2k - clear the RXE bit from the interrupt status reg
+//-------------------------------------------------------------------------
+	.global ne2k_clr_rxe
+
+ne2k_clr_rxe:
+	mov	net_port,%dx
+	add	$io_ne2k_int_stat,%dx
+	mov	$0x4,%al
+	out	%al,%dx
 	ret
 
 //-----------------------------------------------------------------------------

--- a/elks/arch/i86/drivers/net/ne2k-asm.S
+++ b/elks/arch/i86/drivers/net/ne2k-asm.S
@@ -569,13 +569,14 @@ npg_next:
 npg_exit:
 	// This is effectively the replacement for the rx_stat routine,
 	// clear the has_data flag if ring buffer is empty.
-	cli			// Interrupts off (experimental)
+	cli			// Ensure we don't get a rece condition when
+				// updating _ne2k_has_data
 	call	ne2k_getpage
 	cmp	%ah,%bl		// ring buffer empty?
-	jnz	npg_more_data
+	jnz	npg_exit_ok
 	movw	$0,_ne2k_has_data
 
-npg_more_data:
+npg_exit_ok:
 	sti		// Enable interrupts
 	pop	%ax	// return byte count (from %cx)
 	//pop	%es

--- a/elks/arch/i86/drivers/net/ne2k.c
+++ b/elks/arch/i86/drivers/net/ne2k.c
@@ -4,6 +4,9 @@
  * compatible chip sets. Tested with Eagle 8390 (6321839050001 (PnP) and
  * Winbond W89C902P based cards.
  *
+ * 8bit i/f support and autoconfig added by Helge Skrivervik (@mellvik) april 2022
+ * based on the RTL8019AS chip in the interface card from Weird Electronics.
+ *
  */
 
 #include <linuxmt/errno.h>
@@ -22,6 +25,9 @@
 
 int net_irq = NE2K_IRQ;	/* default IRQ, changed by netirq= in /bootopts */
 int net_port = NE2K_PORT; /* default IO PORT, changed by netport= in /bootopts */
+word_t net_rx_errs;	/* count receive errors */
+word_t net_tx_errs;	/* transmit errors */
+word_t net_oflow_errs; /* receive buffer overflow counter */
 
 // Static data
 struct wait_queue rxwait;
@@ -29,18 +35,19 @@ struct wait_queue txwait;
 
 static byte_t ne2k_inuse = 0;
 
-static byte_t mac_addr[6]  = {0x52, 0x54, 0x00, 0x12, 0x34, 0x56};  /* QEMU default */
+static byte_t mac_addr[6]  = {0x52, 0x54, 0x00, 0x12, 0x34, 0x57};  /* QEMU default */
 			     /* Overwritten by actual HW MAC address if found */
+static word_t _ne2k_skip_cnt;
 
+extern word_t _ne2k_next_pk;
+extern word_t _ne2k_is_8bit;
 extern word_t _ne2k_has_data;
-extern word_t _ne2k_skip_cnt;	/* If the NIC ring buffer overflows, skip this # of packets,
-				 * zero means 'all'. */
 
 /*
- * Get packet
+ * Read a complete packet from the NIC buffer
  */
 
-static size_t ne2k_read(struct inode * inode, struct file * filp, char * data, size_t len)
+static size_t ne2k_read(struct inode *inode, struct file *filp, char *data, size_t len)
 {
 	size_t res;
 	word_t nhdr[2];	/* packet header from the NIC, for debugging */
@@ -48,6 +55,8 @@ static size_t ne2k_read(struct inode * inode, struct file * filp, char * data, s
 	while (1) {
 		size_t size;  // actual packet size
 
+		//printk("R");
+		//printk("R%02x;", ne2k_int_stat()&0xff);
 		prepare_to_wait_interruptible(&rxwait);
 		if (ne2k_rx_stat() != NE2K_STAT_RX) {
 
@@ -66,10 +75,29 @@ static size_t ne2k_read(struct inode * inode, struct file * filp, char * data, s
 			break;
 		}
 
+		//printk("r%04x|%04x/",nhdr[0], nhdr[1]);
 		debug_eth("eth read: req %d, got %d real %d\n", len, size, nhdr[1]);
-		if (nhdr[1] > size)
-			printk("eth: truncated read - %d %d\n", nhdr[1], size);
+		if ((nhdr[1] > size) || (nhdr[0] == 0)) {
+			/* This is a sanity check, should not happen.
+			 * 1) The buffer size is too small (should be 1536)
+			 * 2) Driver problem and nhdr[] is not the actual NIC header
+			 * 3) Hardware problem since the NIC is programmed to not accept large packets from the wire
+			 *	
+			 * Most likely: We have a 8bit interface running with 16k buffer enabled.
+			 * In that case, well end up here all the time and eventually hang.
+			 */
 
+			printk("eth: truncated read (%04x %d), clearing buffer\n", nhdr[0], nhdr[1]);
+			if (nhdr[0] == 0) { 	// must clear and reset
+				res = ne2k_clr_oflow(0); 
+				//printk("<%04x>", res);
+			} else
+				ne2k_rx_init();	// Resets the ring buffer pointers to initial values,
+						// effectively purging the buffer.
+			_ne2k_has_data = 0;
+			res = -EIO;
+			break;
+		}
 		res = size;
 		break;
 	}
@@ -82,12 +110,15 @@ static size_t ne2k_read(struct inode * inode, struct file * filp, char * data, s
  * Pass packet to driver for send
  */
 
-static size_t ne2k_write (struct inode * inode, struct file * file, char * data, size_t len)
+static size_t ne2k_write(struct inode *inode, struct file *file, char *data, size_t len)
 {
 	size_t res;
 
 	while (1) {
+		//printk("T%d,", len);
 		prepare_to_wait_interruptible(&txwait);
+
+		// tx_stat() checks the command reg, not the tx_status_reg!
 		if (ne2k_tx_stat() != NE2K_STAT_TX) {
 
 			if (file->f_flags & O_NONBLOCK) {
@@ -104,9 +135,12 @@ static size_t ne2k_write (struct inode * inode, struct file * file, char * data,
 		if (len > MAX_PACKET_ETH) len = MAX_PACKET_ETH;
 
 		if (len < 64) len = 64;  /* issue #133 */
-		if (ne2k_pack_put(data, len)) {
-			res = -EIO;
-			break;
+		if ((res = ne2k_pack_put(data, len))) {	///FIXME
+			//printk(">%d<", res);	// DEBUG STUFF
+			if (res == 0xff) {
+				res = -EIO;
+				break;
+			}
 		}
 
 		res = len;
@@ -114,6 +148,7 @@ static size_t ne2k_write (struct inode * inode, struct file * file, char * data,
 	}
 
 	finish_wait(&txwait);
+	//printk("t");
 	return res;
 }
 
@@ -121,7 +156,7 @@ static size_t ne2k_write (struct inode * inode, struct file * file, char * data,
  * Test for readiness
  */
 
-int ne2k_select(struct inode * inode, struct file * filp, int sel_type)
+int ne2k_select(struct inode *inode, struct file *filp, int sel_type)
 {
 	int res = 0;
 
@@ -154,63 +189,90 @@ int ne2k_select(struct inode * inode, struct file * filp, int sel_type)
  * Interrupt handler
  */
 
-static void ne2k_int(int irq, struct pt_regs * regs)
+static void ne2k_int(int irq, struct pt_regs *regs)
 {
 	word_t stat, page;
 
-	stat = ne2k_int_stat();
+	while (1) {	
+		stat = ne2k_int_stat();
+		if (!(stat & ~NE2K_STAT_RDC)) break;	/* In QEMU, the RDC bit is always set 
+							 * when RXE is enabled */
+		//printk("/%x", stat);
 #if 0
-	printk("/%d/", stat);
-	page = ne2k_getpage();
-	printk("|%04x|", page);
+		page = ne2k_getpage();
+		printk("$%04x.%02x$", page,_ne2k_next_pk&0xff);
 #endif
 
-        if (stat & NE2K_STAT_OF) {
-		printk("eth: NIC receive oflow (0x%x), ", stat);
-		if (_ne2k_skip_cnt) 
-			printk("skipping %d packets.\n", _ne2k_skip_cnt);
-		else
-			printk("clearing buffer.\n");
-		page = ne2k_clr_oflow(); 
-		debug_eth("/CB%04x/ ", page);
-		/* The clr_oflow routine effectively resets the NIC, clears
-		 * the ISR, so more processing of interrupt status bits is
-		 * meaningless. */
-		return;
-	}
+        	if (stat & NE2K_STAT_OF) {
+			printk("eth: receive oflow (0x%x), keep %d\n", stat, _ne2k_skip_cnt);
+			page = ne2k_clr_oflow(_ne2k_skip_cnt); 	// 1+ -> keep this # of pkts
+								// 0 -> dump all
+			debug_eth("/CB%04x/ ", page);
+			//printk("*CB%04x", page);
 
-	if (stat & NE2K_STAT_RX) {
-		_ne2k_has_data = 1; 
-		wake_up(&rxwait);
-	}
+			net_oflow_errs++;
 
-	if (stat & NE2K_STAT_TX) {
-		wake_up(&txwait);
+			if (_ne2k_has_data)
+				wake_up(&rxwait);
+
+			continue;
+		}
+
+		if (stat & NE2K_STAT_RX) {
+			ne2k_get_rx_stat();	// Clear INTR reg bit
+			_ne2k_has_data = 1; 	// data available
+			wake_up(&rxwait);
+		}
+
+		if (stat & NE2K_STAT_TX) {
+			ne2k_get_tx_stat();	// just read the tx status reg to keep the NIC
+						// happy - reset the INTR reg bit
+			wake_up(&txwait);
+		}
+#if 0	/* QEMU confuses RXE and RDC interrupts - have to turn this off
+      	 * to run in QEMU */
+		if (stat & NE2K_STAT_RDC) {
+			printk("eth: Warning - RDC intr. (0x%02x)\n", stat);
+			/* The RDC interrupt should be disabled in the low level driver.
+		 	* When real DMA transfer from NIC to system RAM is enabled, this is where
+		 	* we handle transfer completion.
+		 	* NOTICE: If we get here, a remote DMA transfer was aborted. This should
+		 	* not happen.
+		 	*/
+			ne2k_rdc();
+		}
+#endif
+		if (stat & NE2K_STAT_TXE) { 	
+			/* transmit error detected, this should not happen. */
+			/* ne2k_get_tx_stat resets this int in the ISR */
+			net_tx_errs++;
+			printk("eth: TX-error, status 0x%02x\n", ne2k_get_tx_stat());
+			ne2k_get_tx_stat();	// just read the tx status reg to keep the NIC
+		}
+		if (stat & NE2K_STAT_RXE) { 	
+			/* Receive error detected, may happen when traffic is heavy */
+			/* The 8bit interface gets lots of these */
+			/* ne2k_get_rx_stat resets this int in the ISR */
+			net_rx_errs++;
+			ne2k_clr_rxe();
+			printk("eth: RX-error, status 0x%02x\n", ne2k_get_rx_stat());
+		}
+		if (stat & NE2K_STAT_CNT) { 	
+			/* The tally counters will overflow on 8 bit interfaces with
+		 	* lots of overruns.  Just clear the condition */
+			ne2k_clr_err_cnt();
+		}
+		debug_eth("%02X/%d/", stat, _ne2k_has_data);
 	}
-	if (stat & NE2K_STAT_RDC) {
-		printk("eth: Warning - RDC intr. (0x%x)\n", stat);
-		/* The RDC interrupt should be disabled in the low level driver.
-		 * When real DMA transfer from NIC to system RAM is enabled, this is where
-		 * we handle transfer completion.
-		 * NOTICE: If we get here, a remote DMA transfer was aborted. This should
-		 * not happen.
-		 */
-		ne2k_rdc();
-	}
-	if (stat & NE2K_STAT_TXE) { 	
-		/* transmit error detected, this should not happen. */
-		printk("eth: TX-error, status 0x%x\n", ne2k_get_tx_stat());
-		/* ne2k_get_tx_stat resets this int in the ISR */
-	}
-	debug_eth("%02X/%d/",stat,_ne2k_has_data);
-	stat = page; /* to keep compiler happy */
+	//printk(".");
+	stat = page;		/* to keep compiler happy */
 }
 
 /*
  * I/O control
  */
 
-static int ne2k_ioctl(struct inode * inode, struct file * file, unsigned int cmd, unsigned int arg)
+static int ne2k_ioctl(struct inode *inode, struct file *file, unsigned int cmd, unsigned int arg)
 {
 	int err = 0;
 
@@ -229,7 +291,7 @@ static int ne2k_ioctl(struct inode * inode, struct file * file, unsigned int cmd
 			/* Get the hardware address of the NIC,	which may be different
 			 * from the currently programmed address. Be careful with this,
 			 * it may interrupt ongoing send/receives.
-			 * arg must be a 32 bytes array.
+			 * arg must be byte[32].
 			 */
 			ne2k_get_hw_addr((word_t *) arg);
 			break;
@@ -264,23 +326,18 @@ static int ne2k_ioctl(struct inode * inode, struct file * file, unsigned int cmd
  * Device open
  */
 
-static int ne2k_open(struct inode * inode, struct file * file)
+static int ne2k_open(struct inode *inode, struct file *file)
 {
-	int err;
+	int err = 0;
 
-	while (1) {
-		if (ne2k_inuse) {
-			err = -EBUSY;
-			break;
-		}
-
+	if (ne2k_inuse) {
+		err = -EBUSY;
+	} else {
 		ne2k_reset();
 		ne2k_init();
 		ne2k_start();
 
 		ne2k_inuse = 1;
-		err = 0;
-		break;
 	}
 	return err;
 }
@@ -289,10 +346,9 @@ static int ne2k_open(struct inode * inode, struct file * file)
  * Release (close) device
  */
 
-static void ne2k_release(struct inode * inode, struct file * file)
+static void ne2k_release(struct inode *inode, struct file *file)
 {
 	ne2k_stop();
-	ne2k_term();
 
 	ne2k_inuse = 0;
 }
@@ -328,70 +384,113 @@ void ne2k_display_status(void)
 
 void ne2k_drv_init(void)
 {
-	int err;
+	int err, i;
+	int is_8bit;	
 	word_t prom[16];	/* PROM containing HW MAC address and more 
 				 * (aka SAPROM, Station Address PROM).
-				 * If byte 14 & 15 == 0x57, this is a ne2k clone.
-				 * May be used to avoid attempts to use an unsupported NIC
-				 * PROM size is 32 bytes.
+				 * PROM size is 16 bytes. If read in word (16 bit) mode,
+				 * the upper byte is either a copy of the lower or 00.
+				 * depending on the chip. This may be used to detect 8 vs 16
+				 * bit cards automagically.
+				 * The address occupies the first 6 bydes, followed by a 'card signature'.
+				 * If bytes 14 & 15 == 0x57, this is a ne2k clone.
 				 */
-	byte_t hw_addr[6];
+	byte_t *cprom;
+
+	is_8bit = net_port&3;	// Set 8bit mode via /bootopts
+				// Bit 0 set: 8 bit interface
+				// Bit 1 set: use 16k buffer regardless
+
+/* 
+ * DEBUG: use the 2nd nibble of the port # for overflow skip-count
+ * obviously works only if the i/o address has zero in this nibble.
+ */
+	_ne2k_skip_cnt = 1;
+#if 0
+	i = (net_port&0xf0)>>4;
+	if (i) _ne2k_skip_cnt = i;
+	net_port &= 0xff0f;
+/* ----------------------------------*/
+#endif
+
+	net_port &= 0xfffc;
+#ifdef CONFIG_ETH_BYTE_ACCESS
+	is_8bit = 1;		// Force 8 bit, 4k mode
+#endif
 
 	while (1) {
 		err = ne2k_probe();
 		if (err) {
-			printk ("eth: NE2K not found at 0x%x, irq %d\n", net_port, net_irq);
+			printk("eth: NE2K not found at 0x%x, irq %d\n", net_port, net_irq);
 			break;
 		}
-		err = request_irq (net_irq, ne2k_int, INT_GENERIC);
+		err = request_irq(net_irq, ne2k_int, INT_GENERIC);
 		if (err) {
-			printk ("eth: NE2K IRQ %d request error: %i\n", net_irq, err);
+			printk("eth: NE2K IRQ %d request error: %i\n", net_irq, err);
 			break;
 		}
 
-		err = register_chrdev (ETH_MAJOR, "eth", &ne2k_fops);
+		err = register_chrdev(ETH_MAJOR, "eth", &ne2k_fops);
 		if (err) {
-			printk ("eth: register error: %i\n", err);
+			printk("eth: register error: %i\n", err);
 			break;
 		}
 
-		int i = 0;
+		cprom = (byte_t *)prom;
 
 		ne2k_get_hw_addr(prom);
 
-		/* If there is no prom (i.e. emulator), use default */
+		/* If there is no prom (i.e. emulator), use default MAC */
+		/* or we have QEMU which doesn't behave like physical */
 		if (((prom[0]&0xff) == 0xff) && ((prom[1]&0xff) == 0xff)) {
 			err = -1;
 		} else {
-			while (i < 6) hw_addr[i] = prom[i]&0xff,i++;
-			err = 0;
+			int j, k;
+			err = j = k = 0;
+			//for (i = 0; i < 32; i++) printk("%02x", cprom[i]);
+			//printk("\n");
+
+			// if the high byte of every word is 0, this is a 16 bit card
+			// if the high byte = low byte in every word, this is QEMU
+			for (i = 1; i < 12; i += 2) j += cprom[i];
+			for (i = 0; i < 12; i += 2) k += cprom[i]; // QEMU hack
+
+			if (j && (j!=k)) {	
+				//printk("8 bit card detected \n");
+				is_8bit |= 1;	// keep 16k override if set
+			} else {
+				for (i = 0; i < 16; i++) cprom[i] = (char)prom[i]&0xff;
+			}
+			//for (i = 0; i < 16; i++) printk("%02x", cprom[i]);
+			//printk("\n");
+
 		}
+		printk ("eth: NE2K (%d bit) at 0x%x, irq %d, ", 16-8*(is_8bit&1), net_port, net_irq);
+		if (!err) 	/* address found, interface is present */
+			memcpy(mac_addr, cprom, 6);
+		else
+			printk("No MAC address, using default\n");
 
-		printk ("eth: NE2K at 0x%x, irq %d, ", net_port, net_irq);
-		if (!err) {	/* address found, interface is present */
+		printk ("MAC %02x", mac_addr[0]);
+		i = 1;
+		while (i < 6) printk(":%02x", mac_addr[i++]);
+		printk("\n");
+		if (is_8bit&2) printk("eth: Forced 16k buffer mode\n");
+		if (!is_8bit) _ne2k_skip_cnt = 3;	// Experimental
+		//printk("eth (debug): oflow-strategy %d\n", _ne2k_skip_cnt);
 
-			printk ("MAC %02x", hw_addr[0]);
-			i = 1;
-			while (i < 6) printk(":%02x", hw_addr[i++]);
-			printk("\n");
-
-			memcpy(mac_addr, hw_addr, 6);
-			ne2k_addr_set(hw_addr);   /* Set NIC mac addr now so IOCTL works */
+		ne2k_addr_set(cprom);   /* Set NIC mac addr now so IOCTL works */
 #if DEBUG_ETH
-			debug_setcallback(ne2k_display_status);
+		debug_setcallback(ne2k_display_status);
 #endif
-		} else
-			printk("not responding.\n");
-
 		break;
 
 	}
+	net_rx_errs = 0;
+	net_tx_errs = 0;
+	net_oflow_errs = 0;
 	_ne2k_has_data = 0;
-	_ne2k_skip_cnt = 0;	/* # of packets to discard if the NIC buffer overflows. 
-                 		 * Zero is the default, discard entire buffer less one pkt.
-				 * May be changed via ioctl.
-				 * A big # will clear the entire buffer.
-				 * On a floppy based system, anything else is useless.
-				 */
+	_ne2k_is_8bit = is_8bit;
+
 	return;
 }

--- a/elks/arch/i86/drivers/net/ne2k.h
+++ b/elks/arch/i86/drivers/net/ne2k.h
@@ -7,40 +7,46 @@
 
 #define NE2K_STAT_RX    0x0001  // packet received
 #define NE2K_STAT_TX    0x0002  // packet sent
+#define NE2K_STAT_RXE	0x0004	// RX error
+#define NE2K_STAT_TXE	0x0008	// TX error
 #define NE2K_STAT_OF    0x0010  // RX ring overflow
+#define NE2K_STAT_CNT   0x0020  // Tally counter overflow
 #define NE2K_STAT_RDC   0x0040  // Remote DMA complete
-#define NE2K_STAT_TXE	0x0080	// TX error
 
 // From low level NE2K MAC
 
-extern word_t ne2k_int_stat ();
+extern word_t ne2k_int_stat();
 
-extern word_t ne2k_probe ();
-extern void   ne2k_reset ();
+extern word_t ne2k_probe();
+extern void   ne2k_reset();
 
-extern void   ne2k_init ();
-extern void   ne2k_term ();
+extern void   ne2k_init();
 
-extern void   ne2k_start ();
-extern void   ne2k_stop ();
+extern void   ne2k_start();
+extern void   ne2k_stop();
 
-extern void   ne2k_addr_set (byte_t *);
+extern void   ne2k_addr_set(byte_t *);
 
-extern word_t ne2k_rx_stat ();
-extern word_t ne2k_tx_stat ();
+extern word_t ne2k_rx_stat();
+extern word_t ne2k_tx_stat();
 
-extern word_t ne2k_pack_get (char *, word_t, word_t *);
-extern word_t ne2k_pack_put (char *, word_t);
+extern word_t ne2k_pack_get(char *, word_t, word_t *);
+extern word_t ne2k_pack_put(char *, word_t);
 
-extern word_t ne2k_test ();
+extern word_t ne2k_test();
 
 extern word_t ne2k_getpage(void);
-extern word_t ne2k_clr_oflow(void);
+extern word_t ne2k_clr_oflow(word_t);
 extern word_t ne2k_get_tx_stat(void);
+extern word_t ne2k_get_rx_stat(void);
 
+extern void ne2k_clr_int_reg(void);
 extern void ne2k_get_addr(byte_t *);
 extern void ne2k_get_hw_addr(word_t *);
 extern void ne2k_rdc(void);
 extern void ne2k_get_errstat(byte_t *);
+extern void ne2k_clr_err_cnt(void);
+extern void ne2k_clr_rxe(void);
+extern void ne2k_rx_init(void);
 
 #endif /* !NE2K_H */

--- a/elks/include/linuxmt/netstat.h
+++ b/elks/include/linuxmt/netstat.h
@@ -1,0 +1,26 @@
+#ifndef __LINUXMT_NETSTAT_H
+#define __LINUXMT_NETSTAT_H
+
+#include <linuxmt/types.h>
+
+struct netif_stat {
+	__u16 rx_errors;	/* receive errors, flagged by NIC */
+	__u16 rq_errors;	/* botched receive queue in 8bit interfaces */
+	__u16 tx_errors;	/* Transmit errors, flagged by NIC */
+	__u16 oflow_errors;	/* receive buffer overflow interrupts */
+	__u16 if_status;	/* Interface status flags */
+	int   oflow_keep;	/* # of packets to keep if overflow */
+};
+
+/* status flags for if_status */
+
+#define	NETIF_IS_8BIT	1
+#define NETIF_FORCE_16K 2
+#define NETIF_IS_OPEN	4
+#define NETIF_IS_QEMU	8
+
+
+
+
+
+#endif

--- a/elks/include/linuxmt/netstat.h
+++ b/elks/include/linuxmt/netstat.h
@@ -10,6 +10,7 @@ struct netif_stat {
 	__u16 oflow_errors;	/* receive buffer overflow interrupts */
 	__u16 if_status;	/* Interface status flags */
 	int   oflow_keep;	/* # of packets to keep if overflow */
+	char  mac_addr[6];
 };
 
 /* status flags for if_status */

--- a/elkscmd/rootfs_template/bin/net
+++ b/elkscmd/rootfs_template/bin/net
@@ -42,7 +42,7 @@ start_network()
 		ktcp="ktcp -b -p cslip -s $baud -l $device $localip $gateway $netmask"
 		;;
 	eth)
-		ktcp="ktcp -b $localip $gateway $netmask"
+		ktcp="ktcp -b $mtu $localip $gateway $netmask"
 		;;
 	*)
 		usage ;;

--- a/elkscmd/rootfs_template/etc/net.cfg
+++ b/elkscmd/rootfs_template/etc/net.cfg
@@ -9,6 +9,10 @@ if test "$LOCALIP" != ""; then localip=$LOCALIP; else localip=10.0.2.15; fi
 gateway=10.0.2.2
 netmask=255.255.255.0
 
+# MTU - must be reduced for 8bit ethernet interfaces
+mtu=""
+#mtu=720
+
 # default link layer [eth|slip|cslip]
 link=eth
 

--- a/elkscmd/rootfs_template/etc/net.cfg
+++ b/elkscmd/rootfs_template/etc/net.cfg
@@ -11,7 +11,7 @@ netmask=255.255.255.0
 
 # MTU - must be reduced for 8bit ethernet interfaces
 mtu=""
-#mtu=720
+#mtu="-m 720"
 
 # default link layer [eth|slip|cslip]
 link=eth


### PR DESCRIPTION
**Summary**
This update enhances the NE2K driver to fully support 8bit interfaces, in particular RTL8019 based interfaces, and 16 bit interfaces in 8bit mode (for 8bit ISAbus). It also adds autoconfiguration and (optionally) bootopts configuration of interface options. The buffer overflow handling has been rewritten and optimized. Error handling has been dramatically improved, catching and recovering from all known and (reasonably) conceivable error conditions. The 8bit support has 2 modes - safe and slow, fast and experimental - configurable via bootopts.
The update also includes a number of general enhancements and bugfixes.
As far as hardware configurations are concerned, there are 4 possible scenarios to accomodate:
1. 16 bit interface in 16 bit ISA bus
2. 16 bit interface in 8 bit ISA bus
3. 8 bit interface in 16 bit ISA bus
4. 8 bit interface in 8 bit ISA bus

The former version of the driver really accomodated only 1), others would possibly work under 'benign' conditions with configurable 8bit mods. This version accomodates 1, 2 and 3. 4 needs testing on real 8bit hardware. 2 has been tested by forcing 16 bit interfaces to run 8 bit mode on 16bit hardware. Also, there are variations between socalled 'compatible' chips, so mileage may vary. And finally, the QEMU NE2K emulator does not work if put in 8 bit mode. It simply hangs.

**Usage**
- The default ELKS config will accommodate both 16bit and 8bit interfaces, not changes required except changing the MTU for 8bit (see below)
- Adding CONFIG_ETH_BYTE_ACCESS will force 8bit mode, but is not required
- Adding '1' to the `netport` address will also force 8bit mode
- Adding '2' to the `netport` address will force 16k buffer usage even if the interface is 8bit
- When using the default configuration, change MTU til 720 for the 8bit interface

Almost needless to say, what started as a bughunt & expeced (fast) fix turned into a project - which eventually delivered some very unexpected results. What follows is an edit of my 'lab notes', sorry about the verboseness.

**The details**
While reorganizing some hardware recently, it was a good time to check out the 8bit NE2K interface acquired a while back. The RTL8019AS based interface from Weird Electronics (via Tindie) is as simple as they come - at a reasonable price. Also, it has been tested with ELKS before and found working after minimal driver changes introduced by @cocus.

No such luck in my case, possibly thanks to a faster machine (386/20). The interface was functional but unstable with telnet, file transfers were not possible (hung), and there was no apparent predictability in the errors. 

Literally an open invitation to take the dive, understand and fix. Luckily I had no clue as to what I was getting myself into: A long (and admittedly very frustrating) chase - I fell into the infamous rabbit hole which eventually turned out to be a cave :-).
The symptoms were lots of oversized packets in read, subsequently a hung NIC. Eventually, the problem was tracked down to an elusive memory corruption issue in the NIC. The type of bug that makes no sense because the problem keeps moving as you close in. Apparently oversized packets, actually corrupted buffer headers sending the NIC's internal dma transfers astray.

Almost accidentally, the book **Networking and Internetworking with Microcontrollers** (Fred Eady) popped up via Google (used copies available on eBay). The book devotes quite a bit of time to the RLT8019 controller and - among lots of other interesting things - reveals something I've not found in any spec:

<img width="596" alt="8-bit mode, both the CS8900A-CQ and the RTL8019AS use b on-chip RAM area" src="https://user-images.githubusercontent.com/3629880/167296554-9b4be207-fe21-4dfa-9d59-a6168c440350.png">

4k buffer max. So simple yet so elusive. Reducing the NIC RAM buffer size to 4K and the card ran like a champ. Well, not quite (see below), but a lot better. 

4K of buffer space is VERY limiting. 16 buffer blocks @ 256 bytes each, 6 of which must be dedicated to the transmit buffer. So we have 10 blocks for receiving packets, and one full size packet takes 6 blocks. Needless to say, incoming transfers create lots of overruns - with grave consequences for transfer speed while not generally a problem for telnet sessions and outgoing transfers. 

When receiving files, almost every other packet initially got 'lost' - discarded because of buffer overflow - and had to be retransmitted. The good news (yes, it's a stretch) - we now have REAL (and extensive) packet loss, which is something we haven't been able to expose ktcp to before. Fits right into the ongoing ktcp/elks-to-elks testing.

The work on handling the frequent buffer overflows exposed another elusive problem: Occasional mysterious NIC hangs during incoming file transfers, unrelated to the initial problem. Never on small files, always on bigger (>10-15k) files that required storage access (i.e. significant delay) while receiving. Another endless chase revealed that NIC buffer overflows sometimes occur while other NIC interrupts are being processed. Not surprising in itself, but it was assumed to be handled by the current setup. 

It wasn't. We had lost receive overflow interrupts, which in turn hung the NIC. Losing other interrupts is a recoverable problem, losing overflows is serious because the NIC has to run through a specific procedure to recover - every time. 
Simple fix when nailed down - just a while loop in the interrupt handler, (re-)checking pending interrupts at the top of the loop. There may be more elegant ways of doing this.

While researching the problem and testing solutions, I found that even receive and transmit interrupts occasionally occur while the interrupt service routine is running - and get lost. This may in some cases cause delays because ktcp is not aware that a) more data is available or b) a transmit has completed and the NIC is ready for the next. Pure speculation at this point, but this may be part of the occasional problem we've seen with 'hit a key to get telnet to continue'. To be investigated/tested.

The third big challenge was to get decent performance with the ultrasmall buffer. Other systems handle this via internal (kernel) buffering, ELKS avoids such buffering for many reasons. Hundreds of tests led to the preliminary (and unsurprising) conclusion that two parameters determine the file transfer speed (incoming): The MTU and the ktcp retransmit timeouts. Finding a suitable MTU reduces the number of NIC overflows, while getting the ktcp retransmits to 'match' the delay introduced by overflows, reduce the 'recovery' delay after each overflow.

For the record, here are some of the options considered and tested in the hunt for decent  performance:

- Adding a single packet receive buffer inside the driver may make a significant difference, this has not been tested.
- Stealing away 2x256b from the send buffer, thus reducing it to 1024 bytes and allowing two full size incoming packets to be buffered. Result: Some improvement - and  some unpleasant surprises, such as unpredictable results when pinging with large (>1k) packets (large outgoing packets will overwrite the read buffer). This can be fixed, but the benefits don't seem to outweigh the complications.
- Manipulate the MTU to take the strained buffer situation into account (add mtu variable to `net.cfg`): Testing indicates that MTU 700 (actually any number that keeps the received packet below 768) improves file transfer speed significantly. Further reductions (all the way down to one buffer page, MTU approx 210) make little difference. Mileage will probably vary. An option to set a lower MTU in net.cfg is part of this PR.
- Pushing the limits: Carefully go beyond the 4k limit on the NIC and see what happens. It's not that the rest of the buffer is unavailable in 8bit mode. The problem is that using it cause unpredictable behaviour as described above. Using 8K instead of 4k was tested, it did not go well. 5k looked more promising, but failed under heavy load. 
- Frequent overflows means that the overflow 'strategy' can make a big difference. The overflow handler has been completely rewritten as part of the testing, and the following strategy has been found suitable:
    - Always keep one packet (the oldest, which is always safe in the sense that it is undamaged). This is the default for 8bit.
    - When using the entire 16k buffer,  keep 3 or 4 packets (this selection may be automated). The default for 16bit is 3. 
    - Purging the entire buffer is almost as good as keeping 1 packet in the 8bit case (set `_ne2k_skip_cnt` to 0). Whether it makes a difference for ktcp, has not been tested.
    - It may be worthwhile to tune the skip_count value per machine in order to get optimal results with 8bit interfaces. Lower MTU -> higher skip_count.

Having the challenges above under control, the natural next (and presumably final) step was to ensure robustness. The driver should keep the NIC going (no crash, no hang) even in the most extreme situations (flood ping large packets from several powerful machines). Continuous long lasting overflows, no packets coming through until the flood retreats - recovery must work. 

After another endless series of fixing and testing, this goal appears to have been achieved. `ktcp` sometimes hangs, the driver does not.

The robustness enhancements required adding more error handling to the driver, to detect and handle individual error types. The previous driver left such error handling to the NIC, by telling it to ignore small, big and bad packets. This worked fine in normal situations, but not under heavy load with overruns, overflows, general overload.

At this point, the 'project' was finished, goal achieved:  8bit interfaces fully, reliably supported plus a host of enhancements. I was preparing the code (and notes) for PR.

But there still was an itch. One more test, what if there is a way to beat the 4k limit after all? Get decent performance from an 8bit interface? The performance problems caused by the limited 4k buffer was a strong incentive to take an extra round. And weeks of testing had revealed at least some patterns in the NIC behaviour when running 8bit/16k and failing.

The effort was not successful, the 'close but no cigar' variant: Improvements, but still the elusive hangs. Then - during final cleanup for the PR, a small optimization: Abort NIC reads immediately if a buffer header is found to be suspicious. It wasn't expected to have any effect on the buffer issue, just a cleanup. And the effect was discovered by accident: I had forgotten to turn off the forced 8bit/16k mode on a 16bit NIC. The error messages during a file transfer didn't make sense. What did I screw up this time? Also, it seemed slow. Until I discovered the mistake. A real 'wow'-moment.

Another round of tests and adjustments, a move to the real 8bit interface, more flood pings, actually tens of thousands of packets, and no hang. Incredible.

Eventually the final test: Remove the reduced MTU on the 8bit NIC machine. Then repeated incoming big file transfers - typically a 1.47M file to `/dev/null`. Still no hangs. Read errors, oversized packets, checksum errors, buffer resets yes, but few compared to what I'd seen before. And the numbers were incredible. File transfers clocked in at just a few percent slower than the 16bit 'real thing'.

Wow. Too good to be true. Another PR delay, but then again, no one was waiting. Now we have two 'working' setups for 8bit interfaces:  One safe and slow, one fast and (still) experimental. That's a lot better than expected just a few weeks back.

**Practical**
- For 16bit interfaces, there are no practical differences, just improvements: stability, possibly marginal speed improvements.
- The 8bit interface (4k buffers) will occasionally report transmit errors and frequently report receive errors under heavy load. These are reported, counted and ignored. In the read case, there is nothing to do. In the transmit case, the packet could be retransmitted, but this may as well be handled by `ktcp`. Adding retransmission logic at the driver level does not make sense. 
- When receiving files (8bit/4k mode), there are frequent buffer overflow errors and many other errors. They can be ignored, recovery works.
- When using the full 16k buffer in 8bit mode, the driver will report occasional oversized packets on read and `ktcp` will complain about checksum errors and read errors. These are recoverable and add minimal delay.
- The new error counters in the driver are globals, available for inclusion in `netstat` eventually.
- Given the number of error messages from the driver when using the 8bit interface, it may be necessary to encapsulate (hide) the messages in debug_eth and activate when required with ^P.

**The good news 1:** The 8bit interface in 4k mode works fine with several concurrent telnet sessions and outgoing file transfers. It is not fast, but stable and reliable for all kinds of file transfers. `ftp` a 1.47M file from Linux (Raspbian) to Elks 8bit, MTU 700 (to `/dev/null`) takes 145 seconds (10k/s). A similar transfer using the 16bit interface, 1500 MTU and no overruns clocks in at 55secs (26k/s). Interestingly, repeating the same transfer to the 16bit ELKS client while running a `ping -i 0.1 -s 800` concurrently, hardly affects the transfer speed at all, indicating that the speed (file transfer) is CPU (ktcp) bound, not hardware/driver bound.

**The good news 2:** Spending all this time in the NE2k driver (again) was opportunitiy for some optimizations and cleanups. Here's the list:
- Using menuconfig to set 8-bit mode is no longer required. All the conditional compile statements for 8bit cards are gone - except one. The driver will autoconfigure predictably on 16 bit machines, needs testing on machines with 8bit ISA only (and emulators). E.g. QEMU ne2k emulates the NIC PROM, but behaves differently than physical so special precautions had to be taken.
- 8bit mode may be forced by either setting the least significant bit in the IO address in `/bootopts` to 1, e.g. `netport=0x301`, or by using the traditional config option. The ability to force 8bit mode is useful for debugging, running a 16 bit interface in 8 bit mode even if the bus is 16 bit. And to force 8 bit mode when using a 16 bit interface in a 8bit-ISA machine.
- If the next bit of the IO address is set in `/bootopts` (e.g. `netport=0x303`), the NIC is forced to use the full 16k buffer space even if it's 8bit. See notes above.
- The driver will report 8 or 16 bit modes during boot.
- Optimizations and improvements
    - Receive error interrupts are now enabled, necessitated by the frequency of errors from the 8 bit interface.
    - Tally counter (error counter overflow) interrupts are processed in order to get rid of the extra (and confusing) status bit.
    - The buffer overflow handling really got a beating and ended up being almost completely rewritten. As mentioned above, various recovery strategies were tested. I ended up with something functionally close to the previous version, but leaner and fully tested with the ability to adapt to the requirements of different interface variants.
    - The code executed at open/release/init(Boot) has been reorganized and may still take some improvement. There are still occasional NIC interrupts before the device has been opened, which should not happen. To be fixed.
    - Some duplicated code has been removed and lots of comments added - reminders and experiences.
    - Counters for receive, transmit, overflow errors have been added for future inclusion into `netstat`
The changes have been extensively tested - using 3 different interfaces (2 16bit, 1 8bit) on physical machines (compaq 386/20). Limited QEMU testing revealed 2 QEMU ne2k bugs: One related to the reading of the HW address PROM and one related to interrupts. Both are handled in the code (and commented). There may be more.

In retrospect it may seem like sticking with a manual 8 vs 16 bit setting (via the `netport` address) would be good enough - and simpler than the automated discovery. I'm open to opinions about that. My guess is that auto-detection adds less than 50 bytes of code total.

Finally - in terms of pure speed outside the context of the overrun situations, as measured by 1 second pings w/ packet size 1200, the 8 bit interface is about 20% slower than 16bit, 10.6ms vs. 8.2ms. File transfers are a different story. Telnet sessions are just great. 8bit interfaces should always run with MTU 720 unless 16k buffer is enabled. When in 16k mode, the 8bit interface clocks in 5% behind its 16bit sibling.

The 8bit/16k 'mode' is still experimental and 'under observation'. Thus a number of debug statements have been commented out instead of removed. Given the nature of this 'hack' - going outside hardware specs - it may not work in all environments. More testing is needed to verify this.