### PR TITLE
[basic] Add inp() and out() for both word and byte IO access

### DIFF
--- a/elkscmd/basic/README.md
+++ b/elkscmd/basic/README.md
@@ -63,6 +63,10 @@ COLOR fg,bg (PC-98 only for now)
 PLOT x,y (PC-98 only for now)
 DRAW x,y (PC-98 only for now)
 CIRCLE x,y,r (PC-98 only for now)
+INPB(port) (IO read byte from `port`)
+INPW(port) (IO read word from `port`)
+OUTB port, value (IO write byte `value` from `port`)
+OUTW port, value (IO write word `value` from `port`)
 
 Architecture-specific
 PIN pinNum, value (0 = low, non-zero = high)
@@ -70,7 +74,6 @@ PINMODE pinNum, mode - not implemented
 
 Not yet implemented
 POKE offset,segment,value
-OUT port,value
 RANDOMIZE [nmber]
 ```
 
@@ -114,7 +117,6 @@ SGN(number) sign, use IF number < 0 etc
 
 Not yet implemented
 PEEK(offset,segment)
-IN(port)
 SCREEN$(line,col)
 ATTR(line,col)
 POINT(x,y)

--- a/elkscmd/basic/basic.c
+++ b/elkscmd/basic/basic.c
@@ -198,7 +198,11 @@ PROGMEM const TokenTableEntry tokenTable[] = {
     {"COLOR",TKN_FMT_POST},
     {"PLOT",TKN_FMT_POST},
     {"DRAW",TKN_FMT_POST},
-    {"CIRCLE",TKN_FMT_POST}
+    {"CIRCLE",TKN_FMT_POST},
+    {"INPB", 1},
+    {"INPW", 1},
+    {"OUTB", TKN_FMT_POST},
+    {"OUTW", TKN_FMT_POST},
 };
 
 
@@ -1202,6 +1206,18 @@ int parseFnCallExpr() {
 #else
             return ERROR_FUNCTION_NOT_BUILTIN;
 #endif
+        case TOKEN_INPB:
+        {
+            tmp = (int)stackPopNum();
+            if (!stackPushNum(host_inpb(tmp))) return ERROR_OUT_OF_MEMORY;
+            break;
+        }
+        case TOKEN_INPW:
+        {
+            tmp = (int)stackPopNum();
+            if (!stackPushNum(host_inpw(tmp))) return ERROR_OUT_OF_MEMORY;
+            break;
+        }
         default:
             return ERROR_UNEXPECTED_TOKEN;
         }
@@ -1413,6 +1429,8 @@ int parsePrimary() {
     case TOKEN_PINREAD:
     case TOKEN_ANALOGRD:
     case TOKEN_POW:
+    case TOKEN_INPB:
+    case TOKEN_INPW:
         return parseFnCallExpr();
 
         // single argument math functions
@@ -1726,6 +1744,12 @@ int parseNIntCmd(int n) {
             break;
         case TOKEN_CIRCLE:
             host_circle(para[0],para[1],para[2]);
+            break;
+        case TOKEN_OUTB:
+            host_outb(para[0],para[1]);
+            break;
+        case TOKEN_OUTW:
+            host_outw(para[0],para[1]);
             break;
         }
     }
@@ -2105,6 +2129,8 @@ int parseStmts()
         case TOKEN_LET:
         case TOKEN_INPUT:
         case TOKEN_READ:
+        case TOKEN_INPB:
+        case TOKEN_INPW:
             lastToken = curToken;
             getNextToken();
             ret = parseAssignment(lastToken);
@@ -2122,6 +2148,8 @@ int parseStmts()
         case TOKEN_COLOR:
         case TOKEN_PLOT:
         case TOKEN_DRAW:
+        case TOKEN_OUTB:
+        case TOKEN_OUTW:
             ret = parseNIntCmd(2);
             break;
 

--- a/elkscmd/basic/basic.h
+++ b/elkscmd/basic/basic.h
@@ -97,7 +97,11 @@
 #define TOKEN_PLOT		84
 #define TOKEN_DRAW		85
 #define TOKEN_CIRCLE	   	86
-#define LAST_IDENT_TOKEN	86
+#define TOKEN_INPB       87
+#define TOKEN_INPW       88
+#define TOKEN_OUTB       89
+#define TOKEN_OUTW       90
+#define LAST_IDENT_TOKEN	90
 
 #define ERROR_NONE				0
 // parse errors

--- a/elkscmd/basic/host-8018x.c
+++ b/elkscmd/basic/host-8018x.c
@@ -3,10 +3,10 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <arch/io.h>
 
 #include "host.h"
 #include "basic.h"
-#include "arch/io.h"
 
 /**
  * NOTE: This only works on MY 80C188EB board, needs to be more
@@ -72,4 +72,20 @@ void host_draw(int x, int y) {
 }
 
 void host_circle(int x, int y, int r) {
+}
+
+void host_outb(int port, int value) {
+    outb(value, port);
+}
+
+void host_outw(int port, int value) {
+    outw(value, port);
+}
+
+int host_inpb(int port) {
+    return inb(port);
+}
+
+int host_inpw(int port) {
+    return inw(port);
 }

--- a/elkscmd/basic/host-pc98.c
+++ b/elkscmd/basic/host-pc98.c
@@ -3,6 +3,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <arch/io.h>
 
 #include "host.h"
 #include "basic.h"
@@ -362,4 +363,20 @@ int host_analogRead(int pin) {
 }
 
 void host_pinMode(int pin,int mode) {
+}
+
+void host_outb(int port, int value) {
+    outb(value, port);
+}
+
+void host_outw(int port, int value) {
+    outw(value, port);
+}
+
+int host_inpb(int port) {
+    return inb(port);
+}
+
+int host_inpw(int port) {
+    return inw(port);
 }

--- a/elkscmd/basic/host-stubs.c
+++ b/elkscmd/basic/host-stubs.c
@@ -3,6 +3,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <arch/io.h>
 
 #include "host.h"
 #include "basic.h"
@@ -40,4 +41,20 @@ void host_draw(int x, int y) {
 }
 
 void host_circle(int x, int y, int r) {
+}
+
+void host_outb(int port, int value) {
+    outb(value, port);
+}
+
+void host_outw(int port, int value) {
+    outw(value, port);
+}
+
+int host_inpb(int port) {
+    return inb(port);
+}
+
+int host_inpw(int port) {
+    return inw(port);
 }

--- a/elkscmd/basic/host.h
+++ b/elkscmd/basic/host.h
@@ -79,3 +79,8 @@ void host_color(int fgc, int bgc);
 void host_plot(int x, int y);
 void host_draw(int x, int y);
 void host_circle(int x, int y, int r);
+
+void host_outb(int port, int value);
+void host_outw(int port, int value);
+int host_inpb(int port);
+int host_inpw(int port);


### PR DESCRIPTION
Adds the INPB, INPW, OUTB and OUTW keywords for input and output
of bytes and words (8 and 16 bits).