### PR TITLE
[kernel] Increase max mounts to 6, other small updates

### DIFF
--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -49,7 +49,7 @@
 
 #define NR_INODE	96	/* this should be bigger than NR_FILE */
 #define NR_FILE 	64	/* this can well be larger on a larger system */
-#define NR_SUPER	5
+#define NR_SUPER	6
 
 #define BLOCK_SIZE	1024
 #define BLOCK_SIZE_BITS 10

--- a/elkscmd/basic/host.c
+++ b/elkscmd/basic/host.c
@@ -254,7 +254,7 @@ int main(int ac, char **av) {
 
 	reset();
 
-	printf("Sinclair BASIC\n");
+	printf("ELKS BASIC\n");
 	host_outputFreeMem(sysVARSTART - sysPROGEND);
 	printf("\n");
 

--- a/elkscmd/rootfs_template/etc/net.cfg
+++ b/elkscmd/rootfs_template/etc/net.cfg
@@ -9,10 +9,8 @@ if test "$LOCALIP" != ""; then localip=$LOCALIP; else localip=10.0.2.15; fi
 gateway=10.0.2.2
 netmask=255.255.255.0
 
-# MTU - must be reduced for 8bit ethernet interfaces
-# if running in 4k buffer mode. May be tuned - system dependent. 
-# The default is 1500.
-mtu=""
+# reduce for 8bit NE2K w/4K buffer
+mtu=
 #mtu="-m 1000"
 
 # default link layer [eth|slip|cslip]


### PR DESCRIPTION
Increases NR_SUPER to 6, allowing for 2 floppy and 4 HDD mounts.

Changes our basic interpreter startup line to "ELKS BASIC" (requested in https://github.com/jbruchon/elks/pull/1286#issuecomment-1135126954).

Decrease size of /etc/net.cfg to <= 1024 for fastest network start time on floppy systems.