### PR TITLE
[net] Add netram= to /bootopts, configure WD8003 from /bootopts

### DIFF
--- a/elks/include/arch/ports.h
+++ b/elks/include/arch/ports.h
@@ -96,6 +96,7 @@
 /* wd, wd.c*/
 #define WD_PORT		0x240
 #define WD_IRQ		2
+#define WD_RAM      0xCE00
 
 /* bioshd.c*/
 #define FDC_DOR		0x3F2		/* floppy digital output register*/

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -27,7 +27,8 @@ int root_mountflags = MS_RDONLY;
 #else
 int root_mountflags = 0;
 #endif
-int net_irq, net_port, net_ram;
+int net_irq, net_port;
+unsigned int net_ram;
 static int boot_console;
 static char bininit[] = "/bin/init";
 static char *init_command = bininit;
@@ -330,7 +331,7 @@ static int parse_options(void)
 			continue;
 		}
 		if (!strncmp(line,"netram=",7)) {
-			net_ram = (int)simple_strtol(line+7, 16);
+			net_ram = (unsigned int)simple_strtol(line+7, 16);
 			continue;
 		}
 		if (!strncmp(line,"bufs=",5)) {

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -27,7 +27,7 @@ int root_mountflags = MS_RDONLY;
 #else
 int root_mountflags = 0;
 #endif
-int net_irq, net_port;
+int net_irq, net_port, net_ram;
 static int boot_console;
 static char bininit[] = "/bin/init";
 static char *init_command = bininit;
@@ -327,6 +327,10 @@ static int parse_options(void)
 		}
 		if (!strncmp(line,"netport=",8)) {
 			net_port = (int)simple_strtol(line+8, 16);
+			continue;
+		}
+		if (!strncmp(line,"netram=",7)) {
+			net_ram = (int)simple_strtol(line+7, 16);
 			continue;
 		}
 		if (!strncmp(line,"bufs=",5)) {

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -5,7 +5,7 @@
 #LOCALIP=10.0.2.16
 #HOSTNAME=elks16
 #netirq=9 netport=0x300 # NIC
-netirq=3 netport=0x280 netram=0xd000
+#netirq=3 netport=0x280 netram=0xd000
 #bufs=2500		# system buffers
 #sync=30		# autosync secs
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.sys

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -5,6 +5,7 @@
 #LOCALIP=10.0.2.16
 #HOSTNAME=elks16
 #netirq=9 netport=0x300 # NIC
+netirq=3 netport=0x280 netram=0xd000
 #bufs=2500		# system buffers
 #sync=30		# autosync secs
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.sys


### PR DESCRIPTION
Requested in https://github.com/jbruchon/elks/pull/1296#issuecomment-1136204442.

@toncho11,

I've tested the /bootopts parameters, but not actually tested on a WD card. I've attached an 1440k image with your settings in /bootopts (which you can also edit with vi, then sync to change), but these should work for you at boot.
[fd1440.img.zip](https://github.com/jbruchon/elks/files/8766582/fd1440.img.zip)