### PR TITLE
[fat] Fix bad directory information on large disks

### DIFF
--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -99,10 +99,11 @@ int FATPROC msdos_get_entry_long(
 	if ((int)*pos & (sizeof(struct msdos_dir_entry) - 1)) return -ENOENT;
 	is_long = 0;
 	*ino = msdos_get_entry(dir,pos,bh,&de);
+	debug_fat("get_entry_long block %lu\n", (*bh)->b_blocknr);
 	while (*ino != (ino_t)-1L) {
-		if (de->name[0] == 0)		/* empty  entry and stop reading*/
+		if (de->name[0] == 0) {		/* empty  entry and stop reading*/
 			break;
-		else if (((unsigned char *)(de->name))[0] == DELETED_FLAG) {	/* empty entry*/
+		} else if (((unsigned char *)(de->name))[0] == DELETED_FLAG) {	/* empty entry*/
 			is_long = 0;
 			oldpos = *pos;
 		} else if (de->attr ==  ATTR_EXT) {		/* long filename entry*/
@@ -193,7 +194,7 @@ int FATPROC msdos_get_entry_long(
 				else if (!strcmp(de->name,MSDOS_DOTDOT))
 					*ino = msdos_parent_ino(dir,0);
 
-				debug_fat("dir: '%s' attr %x\n", de->name, de->attr);
+				debug_fat("dir: '%s' attr %x size %lx\n", de->name, de->attr, de->size);
 				if (is_long) {
 					*namelen = long_len;
 					*dirpos = oldpos;

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -110,7 +110,7 @@ static struct super_block *msdos_read_super(struct super_block *s, char *data,
 
 	cache_init();
 	lock_super(s);
-	bh = bread(s->s_dev, (block_t)0);
+	bh = bread(s->s_dev, 0);
 	unlock_super(s);
 	if (bh == NULL) {
 /*		s->s_dev = 0;*/
@@ -323,7 +323,7 @@ void msdos_read_inode(register struct inode *inode)
 		return;
 	}
 #endif
-	if (!(bh = bread(inode->i_dev,(block_t)(inode->i_ino >> MSDOS_DPB_BITS)))) {
+	if (!(bh = bread32(inode->i_dev, inode->i_ino >> MSDOS_DPB_BITS))) {
 	    printk("FAT: read inode fail\n");
 		return;
 	}
@@ -371,7 +371,7 @@ static void msdos_write_inode(register struct inode *inode)
 #endif
 	debug_fat("write_inode %ld %d\n", (unsigned long)inode->i_ino, inode->i_dirt);
 	if (inode->i_ino == MSDOS_ROOT_INO || !inode->i_nlink) return;
-	if (!(bh = bread(inode->i_dev,(block_t)(inode->i_ino >> MSDOS_DPB_BITS)))) {
+	if (!(bh = bread32(inode->i_dev, inode->i_ino >> MSDOS_DPB_BITS))) {
 	    printk("FAT: write inode fail\n");
 	    return;
 	}

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -256,7 +256,7 @@ ino_t FATPROC msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head *
 
 		/* return value will overfow for FAT16/32 if sector is beyond 2MB boundary */
 #ifndef CONFIG_32BIT_INODES
-		if (sector > 4095) {
+		if (sector > 2047) {
 			printk("FAT: disk too large, set CONFIG_32BIT_INODES\n");
 			return -1;
 		}

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -256,7 +256,7 @@ ino_t FATPROC msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head *
 
 		/* return value will overfow for FAT16/32 if sector is beyond 2MB boundary */
 #ifndef CONFIG_32BIT_INODES
-		if (sector > 2047) {
+		if (sector > 4095) {
 			printk("FAT: disk too large, set CONFIG_32BIT_INODES\n");
 			return -1;
 		}


### PR DESCRIPTION
On large FAT volumes, the directory contents, including file size information, might be incorrect if the directory entry was not in the first 2MB of the FAT volume. There was also a possibility of filesystem corruption if a directory entry was written which was not at the first 2MB of the volume.

This problem was found by @tyama501 in https://github.com/jbruchon/elks/issues/1238#issuecomment-1138847261.

Tested on HD image provided by @tyama501.
<img width="832" alt="Screen Shot 2022-06-02 at 3 30 24 PM" src="https://user-images.githubusercontent.com/11985637/171743926-a6273e9f-f10f-4f38-812b-a1abff4a2f37.png">

