### PR TITLE
[cmds] Update sys script and add -3 option for small disks

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -57,7 +57,7 @@ sh_utils/uname			:boot	:be-shutil  :128k
 sh_utils/date           :boot	:be-shutil  :128k
 file_utils/cat			:boot	:be-fileutil    :128k
 file_utils/chgrp				:be-fileutil			:1200k	:1440k
-file_utils/chmod				:be-fileutil			:1200k	:1440k
+file_utils/chmod				:be-fileutil    :360k
 file_utils/chown				:be-fileutil			:1200k	:1440k
 file_utils/cmp					:be-fileutil			:1200k	:1440k
 file_utils/cp					:be-fileutil	:360k

--- a/elkscmd/ash/Makefile
+++ b/elkscmd/ash/Makefile
@@ -33,7 +33,7 @@ OBJS=	builtins.o cd.o dirent.o error.o eval.o exec.o expand.o input.o \
 OBJS += bltin/echo.o
 OBJS += bltin/expr.o bltin/regexp.o bltin/operators.o
 
-LDFLAGS += -maout-heap=8192 -maout-stack=2304
+LDFLAGS += -maout-heap=12288 -maout-stack=2304
 
 #
 # Set READLINE in shell.h and add -ledit to LIBS if you want to use the

--- a/elkscmd/rootfs_template/bin/sys
+++ b/elkscmd/rootfs_template/bin/sys
@@ -1,14 +1,13 @@
-# sys - System Transfer Script
-#
-# Usage: sys [-M] /dev/{fd0,fd1,hda1,hda2,etc}
-# -M will also transfer an MBR
-# -F will allow writing flat (non-MBR) hard drive
+# sys - create bootable system
 #
 #set -x
 
 usage()
 {
-	echo "Usage: sys [-M][-F] /dev/{fd0,fd1,hda1,hda2,etc}"
+	echo "Usage: sys [-3][-M][-F] /dev/{fd0,fd1,hda1,hda2,etc}"
+	echo "	-3 will transfer minimal (360k) system"
+	echo "	-M will transfer boot MBR to /dev/hd[a-d][1-4]
+	echo "	-F required for flat non-MBR /dev/hd[a-d]
 	exit 1
 }
 
@@ -18,6 +17,9 @@ create_dev_dir()
 	mkdir $MNT/dev
 	mknod $MNT/dev/hda	b 3 0
 	mknod $MNT/dev/hda1	b 3 1
+	mknod $MNT/dev/hda2	b 3 2
+	mknod $MNT/dev/hda3	b 3 3
+	mknod $MNT/dev/hda4	b 3 4
 	mknod $MNT/dev/fd0	b 3 128
 	mknod $MNT/dev/fd1	b 3 160
 	mknod $MNT/dev/kmem	c 1 2
@@ -28,10 +30,35 @@ create_dev_dir()
 	mknod $MNT/dev/ptyp0	c 2 8
 	mknod $MNT/dev/ttyp0	c 4 8
 	mknod $MNT/dev/tty1	c 4 0
-	mknod $MNT/dev/ttys0	c 4 64
-	mknod $MNT/dev/ttys1	c 4 65
+	mknod $MNT/dev/ttyS0	c 4 64
+	mknod $MNT/dev/ttyS1	c 4 65
 	mknod $MNT/dev/console	c 4 254
+	chmod 0600 $MNT/dev/console
 	mknod $MNT/dev/tty	c 4 255
+	chmod 0666 $MNT/dev/tty
+	if test "$small" = "1"; then return; fi
+
+	mknod $MNT/dev/hdb	b 3 32
+	mknod $MNT/dev/hdb1	b 3 33
+	mknod $MNT/dev/hdb2	b 3 34
+	mknod $MNT/dev/hdb3	b 3 35
+	mknod $MNT/dev/hdb4	b 3 36
+	mknod $MNT/dev/hdc	b 3 64
+	mknod $MNT/dev/hdc1	b 3 65
+	mknod $MNT/dev/hdd	b 3 96
+	mknod $MNT/dev/hdd1	b 3 97
+	mknod $MNT/dev/rd0	b 2 0
+	mknod $MNT/dev/rd1	b 2 1
+	mknod $MNT/dev/tty2	c 4 1
+	mknod $MNT/dev/tty3	c 4 2
+	mknod $MNT/dev/ttyS2	c 4 66
+	mknod $MNT/dev/ttyS3	c 4 67
+	mknod $MNT/dev/ttyp1	c 4 9
+	mknod $MNT/dev/ttyp2	c 4 10
+	mknod $MNT/dev/ttyp3	c 4 11
+	mknod $MNT/dev/ptyp1	c 2 9
+	mknod $MNT/dev/ptyp2	c 2 10
+	mknod $MNT/dev/ptyp3	c 2 11
 }
 
 create_directories()
@@ -40,52 +67,64 @@ create_directories()
 	mkdir $MNT/bin
 	mkdir $MNT/etc
 	mkdir $MNT/mnt
+	mkdir $MNT/tmp
 	mkdir $MNT/root
 }
 
 copy_bin_files()
 {
 	echo "Copying files from /bin..."
+	if test "$small" = "1"; then
 	cp /bin/sh	$MNT/bin
+	cp /bin/chmod	$MNT/bin
 	cp /bin/cp	$MNT/bin
+	cp /bin/df	$MNT/bin
 	cp /bin/echo	$MNT/bin
+	cp /bin/fdisk	$MNT/bin
 	cp /bin/init	$MNT/bin
 	cp /bin/getty	$MNT/bin
 	cp /bin/login	$MNT/bin
 	cp /bin/ls	$MNT/bin
 	cp /bin/makeboot $MNT/bin
+	cp /bin/meminfo $MNT/bin
 	cp /bin/mkdir	$MNT/bin
+	cp /bin/mkfat	$MNT/bin
+	cp /bin/mkfs	$MNT/bin
 	cp /bin/mknod	$MNT/bin
 	cp /bin/mount	$MNT/bin
+	cp /bin/mv	$MNT/bin
+	cp /bin/printenv $MNT/bin
 	cp /bin/ps	$MNT/bin
 	cp /bin/pwd	$MNT/bin
+	cp /bin/reboot	$MNT/bin
+	cp /bin/rm	$MNT/bin
 	cp /bin/sync	$MNT/bin
 	cp /bin/sys	$MNT/bin
-	cp /bin/test	$MNT/bin
 	cp /bin/umount	$MNT/bin
+	else
+	cp /bin/*	$MNT/bin
+	fi
 }
 
 copy_etc_files()
 {
 	echo "Copy files from /etc..."
-	cp /etc/inittab	$MNT/etc
-	cp /etc/passwd	$MNT/etc
-	cp /etc/profile	$MNT/etc
-	cp /etc/issue	$MNT/etc
+	cp /etc/*	$MNT/etc
 }
 
 # sys script starts here
-MNT=/mnt
+MNT=/tmp
+small=0
 
-# sys script requires target argument
+if test "$1" = "-M"; then shift; arg=-M; fi
+if test "$1" = "-F"; then shift; arg=-F; fi
+if test "$1" = "-3"; then shift; small=1; fi
 if test "$#" -lt 1; then usage; fi
 
-# makeboot returns filesystem type, 1=MINIX, 2=FAT
-makeboot $1 $2 $3
-
+# returns fstype, 1=MINIX, 2=FAT
+makeboot $arg $1
 FSTYPE=$?
-if test "$1" = "-M"; then shift; fi
-if test "$1" = "-F"; then shift; fi
+
 case "$FSTYPE" in
 1) mount $1 $MNT ;;
 2) mount -t msdos $1 $MNT ;;
@@ -95,16 +134,12 @@ esac
 # if MINIX, create /dev entries
 if test "$FSTYPE" = "1"; then create_dev_dir; fi
 
-# create important directories
 create_directories
 
-# copy some files from /bin
 copy_bin_files
 
-# copu some files from /etc
 copy_etc_files
 
-# done
+sync
 umount $1
-
-exit 0
+sync


### PR DESCRIPTION
Enhances `sys` command as described in https://github.com/jbruchon/elks/issues/1155#issuecomment-1145827115.

`sys /dev/fd1` will create a full bootable system image on /dev/fd1 (for floppies > 360k).
`sys -3 /dev/fd1` will create a small bootable system image for 360k floppies.
`sys /dev/hda1` will create a full bootable system image on first partition of first hard drive.
`sys -M /dev/hda1` will create a full bootable system image and new MBR on first hard drive.