### PR TITLE
[kernel] Add fmemalloc sys call, fix fsck on 65M disks

### DIFF
--- a/elks/arch/i86/drivers/char/console-bios.c
+++ b/elks/arch/i86/drivers/char/console-bios.c
@@ -13,6 +13,9 @@
 #include <linuxmt/types.h>
 #include <linuxmt/config.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/sched.h>
+#include <linuxmt/string.h>
+#include <linuxmt/errno.h>
 #include <linuxmt/chqueue.h>
 #include <linuxmt/ntty.h>
 #include "console.h"

--- a/elks/arch/i86/drivers/char/console-direct-pc98.c
+++ b/elks/arch/i86/drivers/char/console-direct-pc98.c
@@ -17,6 +17,9 @@
 #include <linuxmt/types.h>
 #include <linuxmt/config.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/sched.h>
+#include <linuxmt/string.h>
+#include <linuxmt/errno.h>
 #include <linuxmt/chqueue.h>
 #include <linuxmt/ntty.h>
 #include <arch/io.h>

--- a/elks/arch/i86/drivers/char/console-direct.c
+++ b/elks/arch/i86/drivers/char/console-direct.c
@@ -13,6 +13,9 @@
 #include <linuxmt/types.h>
 #include <linuxmt/config.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/sched.h>
+#include <linuxmt/string.h>
+#include <linuxmt/errno.h>
 #include <linuxmt/chqueue.h>
 #include <linuxmt/ntty.h>
 #include <arch/io.h>

--- a/elks/arch/i86/drivers/char/mem.c
+++ b/elks/arch/i86/drivers/char/mem.c
@@ -22,6 +22,7 @@
 #include <linuxmt/fs.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/sched.h>
 #include <linuxmt/debug.h>
 #include <linuxmt/mem.h>
 #include <linuxmt/heap.h>

--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -19,6 +19,7 @@
 #include <linuxmt/fcntl.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/string.h>
 #include <linuxmt/termios.h>
 #include <linuxmt/chqueue.h>
 #include <linuxmt/ntty.h>

--- a/elks/arch/i86/drivers/net/ne2k.c
+++ b/elks/arch/i86/drivers/net/ne2k.c
@@ -17,6 +17,7 @@
 #include <linuxmt/sched.h>
 #include <linuxmt/limits.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/string.h>
 #include <linuxmt/debug.h>
 #include <linuxmt/netstat.h>
 

--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -2,6 +2,7 @@
 #include <linuxmt/debug.h>
 #include <linuxmt/kernel.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/string.h>
 #include <linuxmt/sched.h>
 #include <linuxmt/signal.h>
 #include <linuxmt/types.h>

--- a/elks/arch/i86/kernel/strace.h
+++ b/elks/arch/i86/kernel/strace.h
@@ -250,6 +250,7 @@ struct syscall_info elks_table[] = {
     { "connect",	packinfo(3, P_SSHORT, P_PDATA,   P_SSHORT ) },
     { "setsockopt",	packinfo(5, P_SSHORT, P_SSHORT,  P_SSHORT ) }, /* +2 args*/
     { "getsocknam",	packinfo(4, P_SSHORT, P_DATA,    P_PUSHORT) }, /* +1 arg*/
+    { "fmemalloc",	packinfo(2, P_USHORT, P_PUSHORT, P_NONE)    },
 };
 
 #endif

--- a/elks/arch/i86/kernel/syscall.dat
+++ b/elks/arch/i86/kernel/syscall.dat
@@ -102,6 +102,7 @@ accept		+202	3	= CONFIG_SOCKET
 connect		+203	3	= CONFIG_SOCKET
 setsockopt	+204	5	= CONFIG_SOCKET
 getsocknam	+205	4	= CONFIG_SOCKET
+fmemalloc	+206	2	*
 #
 # Name			No	Args	Flag&comment
 #

--- a/elks/arch/i86/kernel/timer.c
+++ b/elks/arch/i86/kernel/timer.c
@@ -1,5 +1,6 @@
 #include <linuxmt/config.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/sched.h>
 #include <linuxmt/timer.h>
 #include <linuxmt/ntty.h>
 #include <linuxmt/fixedpt.h>

--- a/elks/fs/file_table.c
+++ b/elks/fs/file_table.c
@@ -11,6 +11,7 @@
 #include <linuxmt/stat.h>
 #include <linuxmt/string.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/errno.h>
 
 /*
  * first_file points to a doubly linked list of all file structures in

--- a/elks/fs/minix/symlink.c
+++ b/elks/fs/minix/symlink.c
@@ -11,6 +11,7 @@
 #include <linuxmt/sched.h>
 #include <linuxmt/fs.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/string.h>
 #include <linuxmt/minix_fs.h>
 #include <linuxmt/stat.h>
 

--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -16,6 +16,7 @@
 #include <linuxmt/errno.h>
 #include <linuxmt/stat.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/string.h>
 #include <linuxmt/debug.h>
 
 static size_t msdos_dir_read(struct inode *dir, struct file *filp, char *buf, size_t count)

--- a/elks/include/linuxmt/mm.h
+++ b/elks/include/linuxmt/mm.h
@@ -9,35 +9,27 @@ struct segment {
 	list_s    free;
 	seg_t     base;
 	segext_t  size;
-	word_t    flags;
-	word_t    ref_count;
+	byte_t    flags;
+	byte_t    ref_count;
+	word_t    pid;
 };
 
 typedef struct segment segment_s;
 
 // TODO: convert to tag
-#define SEG_FLAG_FREE    0x0000
-#define SEG_FLAG_USED	 0x0080
-#define SEG_FLAG_ALIGN1K 0x0040
-#define SEG_FLAG_TYPE	 0x000F
-#define SEG_FLAG_CSEG	 0x0001
-#define SEG_FLAG_DSEG	 0x0002
-#define SEG_FLAG_EXTBUF	 0x0003
-#define SEG_FLAG_RAMDSK	 0x0004
+#define SEG_FLAG_FREE    0x00
+#define SEG_FLAG_USED	 0x80
+#define SEG_FLAG_ALIGN1K 0x40
+#define SEG_FLAG_TYPE	 0x0F
+#define SEG_FLAG_CSEG	 0x01
+#define SEG_FLAG_DSEG	 0x02
+#define SEG_FLAG_EXTBUF	 0x03
+#define SEG_FLAG_RAMDSK	 0x04
+#define SEG_FLAG_PROG	 0x05
 
 #ifdef __KERNEL__
 
-#include <linuxmt/sched.h>
-#include <linuxmt/errno.h>
 #include <linuxmt/kernel.h>
-#include <linuxmt/string.h>
-
-#define VERIFY_READ 0
-#define VERIFY_WRITE 1
-
-#include <linuxmt/memory.h>
-
-#define verify_area(mode,point,size) verfy_area(point,size)
 
 /*@-namechecks@*/
 
@@ -46,6 +38,11 @@ void memcpy_tofs(void *,void *,size_t);
 int strlen_fromfs(void *,size_t);
 
 /*@+namechecks@*/
+
+#define VERIFY_READ 0
+#define VERIFY_WRITE 1
+
+#define verify_area(mode,point,size) verfy_area(point,size)
 
 int verfy_area(void *,size_t);
 void put_user_char(unsigned char,void *);
@@ -65,8 +62,9 @@ void seg_free (segment_s *);
 
 segment_s * seg_get (segment_s *);
 void seg_put (segment_s *);
-
 segment_s * seg_dup (segment_s *);
+
+void seg_free_pid(pid_t pid);
 
 void mm_get_usage (unsigned int * free, unsigned int * used);
 

--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -110,8 +110,10 @@ void do_exit(int status)
 	seg_put(current->mm.seg_code);
     if (current->mm.seg_data)
 	seg_put(current->mm.seg_data);
-
     current->mm.seg_code = current->mm.seg_data = 0;
+
+    /* free program allocated memory */
+    seg_free_pid(current->pid);
 
 #if BLOAT
     /* Keep all of the family stuff straight */

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -28,6 +28,8 @@
 #include <linuxmt/config.h>
 #include <arch/segment.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/kernel.h>
+#include <linuxmt/sched.h>
 #include <linuxmt/kdev_t.h>
 #include <linuxmt/major.h>
 #include <linuxmt/ntty.h>

--- a/elks/kernel/time.c
+++ b/elks/kernel/time.c
@@ -29,6 +29,7 @@
 #include <linuxmt/sched.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/string.h>
 
 #include <linuxmt/config.h>
 #include <arch/system.h>

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -11,4 +11,4 @@
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.sys
 #init=/bin/sh		# singleuser shell
 #root=hda1 ro		# root hd partition 1, read-only
-#console=ttyS0,19200 3	# serial console
+console=ttyS0,19200 3	# serial console

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -11,4 +11,4 @@
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.sys
 #init=/bin/sh		# singleuser shell
 #root=hda1 ro		# root hd partition 1, read-only
-console=ttyS0,19200 3	# serial console
+#console=ttyS0,19200 3	# serial console

--- a/elkscmd/sys_utils/meminfo.c
+++ b/elkscmd/sys_utils/meminfo.c
@@ -55,7 +55,7 @@ void dump_heap(int fd)
 	word_t total_free = 0;
 	long total_segsize = 0;
 	static char *heaptype[] = { "free", "SEG ", "STR ", "TTY ", "INT ", "BUFH", "PIPE" };
-	static char *segtype[] = { "free", "CSEG", "DSEG", "BUF ", "RDSK" };
+	static char *segtype[] = { "free", "CSEG", "DSEG", "BUF ", "RDSK", "PROG" };
 
 	printf("  HEAP   TYPE  SIZE    SEG   TYPE    SIZE  CNT\n");
 

--- a/libc/include/malloc.h
+++ b/libc/include/malloc.h
@@ -29,4 +29,7 @@ extern void *(*__alloca_alloc) __P((size_t));
 #define malloc(x) ((*__alloca_alloc)(x))
 #endif
 
+/* alloc from main memory */
+void __far *fmemalloc(unsigned long size);
+
 #endif

--- a/libc/include/string.h
+++ b/libc/include/string.h
@@ -25,8 +25,9 @@ extern void * memccpy __P ((void*, void*, int, size_t));
 extern void * memchr __P ((__const void*, __const int, size_t));
 extern void * memset __P ((void*, int, size_t));
 extern int memcmp __P ((__const void*, __const void*, size_t));
-
 extern void * memmove __P ((void*, void*, size_t));
+
+void __far *fmemset(void __far *buf, int c, size_t l);
 
 /* Error messages */
 extern char * strerror __P ((int));

--- a/libc/malloc/Makefile
+++ b/libc/malloc/Makefile
@@ -24,6 +24,7 @@ OBJS = \
 	noise.o \
 	realloc.o \
 	sbrk.o \
+	fmemalloc.o \
 
 .PHONY: all
 

--- a/libc/malloc/fmemalloc.c
+++ b/libc/malloc/fmemalloc.c
@@ -1,0 +1,17 @@
+#include <malloc.h>
+
+#define _MK_FP(seg,off) ((void __far *)((((unsigned long)(seg)) << 16) | (off)))
+
+/* request paras from main memory, returns segment */
+int _fmemalloc(int paras, unsigned short *pseg);
+
+/* alloc from main memory */
+void __far *fmemalloc(unsigned long size)
+{
+    unsigned short seg;
+    unsigned int paras = (unsigned int)((size + 15) >> 4);
+
+    if (_fmemalloc(paras, &seg))
+        return 0;
+    return _MK_FP(seg, 0);
+}

--- a/libc/string/Makefile
+++ b/libc/string/Makefile
@@ -10,6 +10,7 @@ OBJS = \
 	memcpy-c.o \
 	memmove.o \
 	memset-c.o \
+	fmemset-c.o \
 	movedata.o \
 	strcasecmp.o \
 	strcat.o \

--- a/libc/string/fmemset-c.c
+++ b/libc/string/fmemset-c.c
@@ -1,0 +1,15 @@
+#include <string.h>
+#include <asm/config.h>
+
+#ifndef LIBC_ASM_FMEMSET
+
+void __far *fmemset(void __far *str, int c, size_t l)
+{
+    char __far *s1 = str;
+
+    while (l-- > 0)
+        *s1++ = c;
+    return str;
+}
+
+#endif


### PR DESCRIPTION
Adds `_fmemalloc` system call to allow processes to allocate far memory for themselves. Memory is automatically freed at process exit.
Adds `fmemalloc` wrapper and `fmemset` C library routines.
Enhances `fsck` to use far memory (up to 64K), which now allows working on max sized (65M) hard disks.
Rearranges some multiply-included kernel header files.

Fixes fsck as requested in #1312. 