### PR TITLE
[cmds] Enhance sys and hostbasic commands

### DIFF
--- a/elkscmd/basic/host-stubs.c
+++ b/elkscmd/basic/host-stubs.c
@@ -3,8 +3,14 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#if __ia16__
 #include <arch/io.h>
-
+#else
+#define inb(port)           0
+#define inw(port)           0
+#define outb(value,port)
+#define outw(value,port)
+#endif
 #include "host.h"
 #include "basic.h"
 

--- a/elkscmd/basic/host.c
+++ b/elkscmd/basic/host.c
@@ -88,7 +88,7 @@ static void tty_raw(void)
 
     fflush(stdout);
     tcgetattr(0, &termios);
-    termios.c_iflag &= ~(ICRNL|IGNCR|INLCR);
+    //termios.c_iflag &= ~(ICRNL|IGNCR|INLCR);
     termios.c_lflag &= ~(ECHO|ECHOE|ECHONL|ICANON);
     termios.c_lflag |= ISIG;
     tcsetattr(0, TCSADRAIN, &termios);
@@ -104,7 +104,7 @@ static void tty_isig(void)
 
     fflush(stdout);
     tcgetattr(0, &termios);
-    termios.c_iflag |= (ICRNL|IGNCR|INLCR);
+    //termios.c_iflag |= (ICRNL|IGNCR|INLCR);
     termios.c_lflag |= (ECHO|ECHOE|ECHONL|ICANON);
     termios.c_lflag |= ISIG;
 
@@ -160,6 +160,7 @@ int host_breakPressed() {
     return intflag;
 }
 
+#if __ia16__
 /* replacement fread to fix fgets not returning ferror/errno properly on SIGINT*/
 size_t fread(void *buf, size_t size, size_t nelm, FILE *fp)
 {
@@ -214,6 +215,7 @@ size_t fread(void *buf, size_t size, size_t nelm, FILE *fp)
 
    return (got + len) / size;
 }
+#endif
 
 void host_outputFreeMem(unsigned int val)
 {

--- a/elkscmd/rootfs_template/bin/sys
+++ b/elkscmd/rootfs_template/bin/sys
@@ -113,7 +113,7 @@ copy_etc_files()
 }
 
 # sys script starts here
-MNT=/tmp
+MNT=/tmp/mnt
 small=0
 
 if test "$1" = "-M"; then shift; arg=-M; fi
@@ -125,9 +125,10 @@ if test "$#" -lt 1; then usage; fi
 makeboot $arg $1
 FSTYPE=$?
 
+mkdir -p $MNT
 case "$FSTYPE" in
-1) mount $1 $MNT ;;
-2) mount -t msdos $1 $MNT ;;
+1) mount $1 $MNT || exit 1 ;;
+2) mount -t msdos $1 $MNT || exit 1 ;;
 *) exit 1 ;;
 esac
 
@@ -142,4 +143,5 @@ copy_etc_files
 
 sync
 umount $1
+rmdir $MNT
 sync

--- a/elkscmd/sys_utils/makeboot.c
+++ b/elkscmd/sys_utils/makeboot.c
@@ -442,7 +442,7 @@ usage:
 	}
 
 	if (mkdir(MOUNTDIR, 0777) < 0)
-		fprintf(stderr, "Can't create temp mount point %s, may already exist\n", MOUNTDIR);
+		fprintf(stderr, "Temp mount point %s not created (may already exist)\n", MOUNTDIR);
 
 	if (mount(targetdevice, MOUNTDIR, fstype, 0) < 0) {
 		fprintf(stderr, "Error: Can't mount %s on %s\n", targetdevice, MOUNTDIR);


### PR DESCRIPTION
Adds some protection and better messaging to `sys` command when mount fails, discussed in https://github.com/jbruchon/elks/issues/1155#issuecomment-1151298598.

@Mellvik, this should help detect when the filesystem can't be mounted, and error instead of trying to copy.

Changes to allow `hostbasic` to compile on macOS.