### PR TITLE
[net] Updates ports.h for 3C509

### DIFF
--- a/elks/include/arch/ports.h
+++ b/elks/include/arch/ports.h
@@ -16,7 +16,7 @@
  *  6*  HW floppy drive     CONFIG_BLK_DEV_FD       Driver doesn't compile
  *  7   Unused (LPT)
  *  8   Unused (RTC)
- *  9   EL3 (/dev/eth)      CONFIG_ETH_EL3          Optional
+ *  9   3C509/EL3 (/dev/eth) CONFIG_ETH_EL3         Optional
  * 10   Unused (USB)                                Turned off
  * 11   Unused (Sound)                              Turned off
  * 12   NE2K (/dev/eth)     CONFIG_ETH_NE2K         Optional
@@ -90,7 +90,8 @@
 #define COM4_PORT	0x2e8
 #define COM4_IRQ	2		/* unregistered unless COM4_PORT found*/
 
-/* ne2k, ne2k.c, may be overridden in /bootopts using netirq= and netport= */
+/* Ethernet card settings may be overridden in /bootopts using netirq= and netport= */ 
+/* ne2k, ne2k.c */ 
 #define NE2K_PORT	0x300
 #define NE2K_IRQ	12
 
@@ -99,10 +100,9 @@
 #define WD_IRQ		2
 #define WD_RAM		0xCE00
 
-/* el3, el3.c */
+/* el3/3C509, el3.c */
 #define EL3_PORT	0x330
 #define EL3_IRQ		9
-
 
 /* bioshd.c*/
 #define FDC_DOR		0x3F2		/* floppy digital output register*/


### PR DESCRIPTION
Comment updates only. 

For ELKS, Etherlink III is almost singularly the 3C509B card, which is what this driver supports. That said, supporting the EISA 3C529 would need only minimal alterations. There are other 3C5x9 cards - MCA, PCMCIA, ... all unimportant in this context.

So, as @ghaerr pointed out, it might have been appropriate to use the '3C509' term only (or 3C5x9) for this driver. I like the terseness of EL3. 

Other 3Com NICs need entirely different drivers. Like the 3C503, which would need just minor mods of the wd8003 driver.
If such a card pops up, we could fix that quite easily. The AMD LANCE/PCNET is a different story, an entirely different animal. PCNET support would open up VirtualBox to Elks and networking, so it is an attractive target.
