### PR TITLE
[misc] cleanups in ne2k driver and mknod command.

### DIFF
--- a/elks/arch/i86/drivers/net/ne2k-asm.S
+++ b/elks/arch/i86/drivers/net/ne2k-asm.S
@@ -248,51 +248,6 @@ check_dma_w:
 	pop     %cx
 	ret
 
-#if 0
-//-------------------------------------------------------------------------
-// This is an (untested) skeleton routine for DMA-assisted packet transfer
-// from the NIC to host memory.
-// TODO: Add DMA channel setup and teardown. 
-//
-dma_r:	// Use the send data command to read exactly one backet, 
-	// the nic does everything on its own, needs only ES:DI
-	
-	push	%ax
-	push	%di
-	push	%dx
-	push    %es
-
-	mov     %ds,%ax
-	mov     %ax,%es	// only required if we're setting up the dma locally
-
-	mov	net_port,%dx
-	add	$io_ne2k_tx_len2,%dx
-	mov	$0x0f,%al	// prep for using the 'send packet' cmd
-	out	%al,%dx
-
-	mov	net_port,%dx	// command register
-	mov	$0x18,%al	// send packet
-	out	%al,%dx
-	// now the dma does the rest, and an RDC interrupt is fielded when complete
-	// we can loop here while waiting, or return and handle completion separately.
-	in	%dx,%al
-	test	$0x40,%al
-	jz	rlp
-rlp1:	
-	mov	net_port,%dx
-	add	$io_ne2k_int_stat,%dx
-	mov     $0x40,%al       // reset (only this bit in) ISR
-	out     %al,%dx         // Clear RDC
-
-rlp_ret:	
-	pop     %es
-	pop	%dx
-	pop	%di
-	pop	%ax
-
-	ret
-#endif
-	
 //-----------------------------------------------------------------------------
 // Read data block from chip with internal DMA
 //-----------------------------------------------------------------------------

--- a/elks/arch/i86/drivers/net/ne2k.c
+++ b/elks/arch/i86/drivers/net/ne2k.c
@@ -272,12 +272,13 @@ static int ne2k_ioctl(struct inode *inode, struct file *file, unsigned int cmd, 
 
 	switch (cmd) {
 		case IOCTL_ETH_ADDR_GET:
-			verified_memcpy_tofs((byte_t *)arg, mac_addr, 6);
+			err = verified_memcpy_tofs((byte_t *)arg, mac_addr, 6);
 			break;
 
 #if LATER
 		case IOCTL_ETH_ADDR_SET:
-			verified_memcpy_fromfs(mac_addr, (byte_t *) arg, 6);
+			if ((err = verified_memcpy_fromfs(mac_addr, (byte_t *) arg, 6)) != 0)
+				break;
 			ne2k_addr_set(mac_addr);
 			printk("eth: MAC address changed to %02x", mac_addr[0]);
 			for (i = 1; i < 6; i++) printk(":%02x", mac_addr[i]);
@@ -287,7 +288,7 @@ static int ne2k_ioctl(struct inode *inode, struct file *file, unsigned int cmd, 
 
 		case IOCTL_ETH_GETSTAT:
 			/* Return the entire netif_struct */
-			verified_memcpy_tofs((char *)arg, &netif_stat, sizeof(netif_stat));
+			err = verified_memcpy_tofs((char *)arg, &netif_stat, sizeof(netif_stat));
 			break;
 
 		default:

--- a/elks/arch/i86/drivers/net/ne2k.c
+++ b/elks/arch/i86/drivers/net/ne2k.c
@@ -272,12 +272,12 @@ static int ne2k_ioctl(struct inode *inode, struct file *file, unsigned int cmd, 
 
 	switch (cmd) {
 		case IOCTL_ETH_ADDR_GET:
-			memcpy_tofs((byte_t *)arg, mac_addr, 6);
+			verified_memcpy_tofs((byte_t *)arg, mac_addr, 6);
 			break;
 
 #if LATER
 		case IOCTL_ETH_ADDR_SET:
-			memcpy_fromfs(mac_addr, (byte_t *) arg, 6);
+			verified_memcpy_fromfs(mac_addr, (byte_t *) arg, 6);
 			ne2k_addr_set(mac_addr);
 			printk("eth: MAC address changed to %02x", mac_addr[0]);
 			for (i = 1; i < 6; i++) printk(":%02x", mac_addr[i]);
@@ -287,7 +287,7 @@ static int ne2k_ioctl(struct inode *inode, struct file *file, unsigned int cmd, 
 
 		case IOCTL_ETH_GETSTAT:
 			/* Return the entire netif_struct */
-			memcpy_tofs((char *)arg, &netif_stat, sizeof(netif_stat));
+			verified_memcpy_tofs((char *)arg, &netif_stat, sizeof(netif_stat));
 			break;
 
 		default:

--- a/elkscmd/file_utils/mknod.c
+++ b/elkscmd/file_utils/mknod.c
@@ -49,6 +49,6 @@ int main(int argc, char **argv)
 	return 0;
 
 usage:
-	errmsg("usage: mknod [bcup] device major minor\n");
+	errmsg("usage: mknod device [bcup] major minor\n");
 	return 1;
 }


### PR DESCRIPTION
Added verified_memcpy to `ne2k` driver, cleanup in the asm-code and `usage()` fix in `mknod`.