### PR TITLE
[misc] Rename mined to edit, ssd-test compilation fix, add sbrk check

### DIFF
--- a/elks/arch/i86/drivers/block/ssd-test.c
+++ b/elks/arch/i86/drivers/block/ssd-test.c
@@ -20,6 +20,8 @@
 #include <linuxmt/config.h>
 #include <linuxmt/rd.h>
 #include <linuxmt/major.h>
+#include <linuxmt/fs.h>
+#include <linuxmt/sched.h>
 #include <linuxmt/kernel.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/errno.h>

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -274,8 +274,13 @@ int sys_brk(__pptr newbrk)
 int sys_sbrk (int increment, __u16 * pbrk)
 {
 	__pptr brk = current->t_endbrk;		/* always return start of old break*/
+	int err;
+
+	err = verify_area(VERIFY_WRITE, pbrk, sizeof(*pbrk));
+	if (err)
+		return err;
 	if (increment) {
-		int err = sys_brk(brk + increment);
+		err = sys_brk(brk + increment);
 		if (err) return err;
 	}
 
@@ -290,9 +295,11 @@ int sys_fmemalloc(int paras, unsigned short *pseg)
 	int err;
 
 	err = verify_area(VERIFY_WRITE, pseg, sizeof(*pseg));
-	if (err) return err;
+	if (err)
+		return err;
 	seg = seg_alloc((segext_t)paras, SEG_FLAG_PROG);
-	if (!seg) return -ENOMEM;
+	if (!seg)
+		return -ENOMEM;
 	seg->pid = current->pid;
 	put_user(seg->base, pseg);
 	return 0;

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -117,7 +117,7 @@ misc_utils/od					:miscutil				:1200k	:1440k
 misc_utils/hd					:miscutil				:1200k	:1440k
 misc_utils/time					:miscutil			:720k
 misc_utils/kilo					:miscutil				:1200k	:1440k
-misc_utils/mined				:miscutil				:1200k	:1440k
+misc_utils/mined ::bin/edit		:miscutil				:1200k	:1440k
 misc_utils/sleep				:miscutil				:1200k	:1440k
 misc_utils/tty					:miscutil				:1200k	:1440k
 misc_utils/uuencode				:miscutil				:1200k	:1440k


### PR DESCRIPTION
Small fixes. Rename MINIX editor `mined` to `edit` on ELKS for better visibility (@toncho11, you can try this sometime, although it's only on the 1440k floppy builds for now).