### PR TITLE
[net, el3] More cleanups and fixes for the el3 driver

### DIFF
--- a/elks/include/linuxmt/netstat.h
+++ b/elks/include/linuxmt/netstat.h
@@ -10,6 +10,7 @@ struct netif_stat {
 	__u16 oflow_errors;	/* Receive buffer overflow interrupts */
 	__u16 if_status;	/* Interface status flags */
 	int   oflow_keep;	/* # of packets to keep if overflow */
+	int   usecount;		/* Count opens */
 	char  mac_addr[6];	/* Current MAC address */
 };
 
@@ -19,7 +20,7 @@ struct netif_stat {
 #define NETIF_FORCE_4K	2
 #define NETIF_IS_OPEN	4
 #define NETIF_IS_QEMU	8
-#define NETIF_FOUND	16
+#define NETIF_FOUND	16	/* To avoid looping in QEMU */
 
 
 


### PR DESCRIPTION
Another round of updates for the 3C509B driver. Notably
- a bunch of important small fixes (setting the IRQ from bootopts now works)
- reworked the error handling, extensively tested (I had erroneously assumed that the AdapterFailure interrupt covered rx overruns, it does not).
- added error stats, may be retrieved via IOCTL
- added multiple opens to allow access to the IOCTL
- removed extraneous debug code

Like other interfaces, the 3C509B will be overrun by packets under heavy load. The NIC's total buffer capacity (rx & tx) is 8Kbytes. The 3C509 (without the 'B') has only 4Kbytes, and some other differences. It should still work out of the box with this driver, but will have performance problems because of the limited buffer space.

When overflows happen, the NICs needs to be reset – which is just a simple command, not a complex procedure like in 8390 based NICs. Still, when reset, all buffered data will be discarded, which may be one or more packets. The error message has thus been changed from 'packet discarded' to 'buffer cleared'. 

The ultimate 'beating' of any NIC is a flood ping (very large or very small packets depending on what we want to test) from a fast machine like a recent PC or a Mac (my RaspberryPi 2B maxes out at about 120 1200byte packets per second which is a good beating but slow compared to the other 'beasts') while running the mount command with a (big) FAT file system mounted. In my case this will render the system literally dead for 10-15 seconds.

Such a test will deliver tens - more likely hundreds - of overflow errors, depending on the size of the mounted file system. The test is how well the NIC recovers - repeatedly. I.e. no additional errors, no hang, full functionality when the 'service blockade' from the disk IO is over.

The EL3 driver and NIC now passes this test with flying colors, as does the NE2k 16bit driver. The NE2k 8 also passes, but no 'flying colors'.

The EL3 FIFO architecture provides for 'early read' and 'early write' - the ability to start reading a packet into memory before reception is complete and similarly, transfer data to the NIC FIFO when there is enough space instead of waiting for the previous packet to complete sending. It is likely that taking advantage of these abilities would increase performance in the ELKS environment. For example, since there is always a significant delay in ELKS between the arrival of a RX interrupt and the actual reading of data, using early interrupt (say interrupt @ 60 or 100 bytes) could make a significant difference for incoming file transfers (large packets). That's an experiment for a later day and time.
