### PR TITLE
[net] Remove usecount from netstat struct, make local to the drivers.

### DIFF
--- a/elks/arch/i86/drivers/net/el3.c
+++ b/elks/arch/i86/drivers/net/el3.c
@@ -114,10 +114,10 @@ int net_irq = EL3_IRQ;  /* default IRQ, changed by netirq= in /bootopts */
 int net_port = EL3_PORT; /* default IO PORT, changed by netport= in /bootopts */
 
 struct netif_stat netif_stat =
-	{ 0, 0, 0, 0, 0, 0, 0, {0x52, 0x54, 0x00, 0x12, 0x34, 0x57}};  /* QEMU default  + 1 */
+	{ 0, 0, 0, 0, 0, 0, {0x52, 0x54, 0x00, 0x12, 0x34, 0x57}};  /* QEMU default  + 1 */
 static int ioaddr;	// FIXME  remove later
+static int usecount = 0;
 
-// Static data
 struct wait_queue rxwait;
 struct wait_queue txwait;
 
@@ -516,7 +516,7 @@ static void update_stats( void )
 
 static void el3_release(struct inode *inode, struct file *file)
 {
-	if (--netif_stat.usecount == 0) {
+	if (--usecount == 0) {
 		el3_down();
 
 		/* Switching to window 0 disables the IRQ. */
@@ -613,7 +613,7 @@ static int el3_open(struct inode *inode, struct file *file)
 
 	if (!(netif_stat.if_status & NETIF_FOUND)) 
 		return(-EINVAL);	// Does not exist 
-	if (netif_stat.usecount++)
+	if (usecount++)
 		return(0);		// Already open
 
 	EL3WINDOW(0);		// TESTING ONLY

--- a/elks/arch/i86/drivers/net/ne2k.c
+++ b/elks/arch/i86/drivers/net/ne2k.c
@@ -28,9 +28,9 @@
 int net_irq = NE2K_IRQ;	/* default IRQ, changed by netirq= in /bootopts */
 int net_port = NE2K_PORT; /* default IO PORT, changed by netport= in /bootopts */
 struct netif_stat netif_stat = 
-	{ 0, 0, 0, 0, 0, 0, {0x52, 0x54, 0x00, 0x12, 0x34, 0x57}};  /* QEMU default  + 1 */
+	{ 0, 0, 0, 0, 0, {0x52, 0x54, 0x00, 0x12, 0x34, 0x57}};  /* QEMU default  + 1 */
 
-// Static data
+static int usecount = 0;
 struct wait_queue rxwait;
 struct wait_queue txwait;
 
@@ -304,18 +304,12 @@ static int ne2k_ioctl(struct inode *inode, struct file *file, unsigned int cmd, 
 
 static int ne2k_open(struct inode *inode, struct file *file)
 {
-	int err = 0;
-
-	if (netif_stat.if_status & NETIF_IS_OPEN) {
-		err = -EBUSY;
-	} else {
+	if (usecount++ == 0) {	// Don't initialize if already open
 		ne2k_reset();
 		ne2k_init();
 		ne2k_start();
-
-		netif_stat.if_status |= NETIF_IS_OPEN;
 	}
-	return err;
+	return 0;
 }
 
 /*
@@ -324,9 +318,9 @@ static int ne2k_open(struct inode *inode, struct file *file)
 
 static void ne2k_release(struct inode *inode, struct file *file)
 {
-	ne2k_stop();
+	if (--usecount == 0)
+		ne2k_stop();
 
-	netif_stat.if_status &= ~NETIF_IS_OPEN;
 }
 
 /*

--- a/elks/include/linuxmt/netstat.h
+++ b/elks/include/linuxmt/netstat.h
@@ -10,7 +10,6 @@ struct netif_stat {
 	__u16 oflow_errors;	/* Receive buffer overflow interrupts */
 	__u16 if_status;	/* Interface status flags */
 	int   oflow_keep;	/* # of packets to keep if overflow */
-	int   usecount;		/* Count opens */
 	char  mac_addr[6];	/* Current MAC address */
 };
 


### PR DESCRIPTION
Fix re. https://github.com/jbruchon/elks/pull/1326#issuecomment-1159078240

Remove the new `usecount` counter (to allow multiple opens of `/dev/eth`) from shared netstat struct to driver static.