### PR TITLE
[readme] Add Resource section on main page README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Help on how to use ELKS, as well as technical tutorials, are available on our [W
 
 More information is in the Documentation folder: [Index of ELKS Documentation](https://htmlpreview.github.io/?https://github.com/jbruchon/elks/blob/master/Documentation/index.html).
 
+## Resources
+
+Other projects and resources interesting to ELKS and our programming community:
+
+- [Size Optimization Tricks](https://justine.lol/sizetricks/) A great article from Justine Tunney's blog showing how big things can be done without bloat.
+- [Blinkenlights](https://justine.lol/blinkenlights/) A visual debugger shows 8086 instruction execution starting from a PC boot sector.
+- [gcc-ia16](https://github.com/tkchia/gcc-ia16) TK Chia's gcc compiler targeted for 8086, maintained and used for the ELKS kernel and all its applications.
+
 ## More information
 
 Questions? Problems? Patches? Open an issue on the ELKS GitHub project!


### PR DESCRIPTION
Adds a new section to the main page to provide more information and resources for our programming community, to which we can continue to update.

I've recently been looking at @jart's work in [Cosmopolitan](https://github.com/jart/cosmopolitan) and her [blog](https://justine.lol/index.html) articles, and have found them extremely interesting with regards to doing big things with small size. I hope to incorporate a number of Cosmopolitan's ideas into ELKS in the future.

Also adds a link to @tkchia's GCC compiler targeted to 8086, used by ELKS. ELKS increasingly depends on his work, which makes use of advanced features in the kernel and C library especially.