### PR TITLE
[build] Fix Use sash as default shell when OFF

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -48,7 +48,7 @@ sys_utils/init			:boot	:sysutil    :128k
 sys_utils/getty			:boot	:sysutil    :128k
 sys_utils/login			:boot	:sysutil    :128k
 ash/ash		::bin/sh	:boot	:ash	    # install as /bin/sh
-sash/sash	::bin/sh	:boot	:defsash	# install as /bin/sh
+sash/sash	::bin/sh	    	:defsash	# install as /bin/sh
 sash/sash		    	        :sash                   :1200k  :1440k
 sys_utils/mount			:boot	:sysutil    :128k
 sys_utils/umount		:boot	:sysutil    :128k


### PR DESCRIPTION
Identified in https://github.com/jbruchon/elks/issues/1327#issuecomment-1159788192, only occurred when selecting applications by image size.

