### PR TITLE
[kernel] Multi-NICs step 2: add /bootopts configration options and /devices

### DIFF
--- a/elks/arch/i86/drivers/char/eth.c
+++ b/elks/arch/i86/drivers/char/eth.c
@@ -6,15 +6,13 @@
 #include <linuxmt/init.h>
 #include <linuxmt/major.h>
 #include <linuxmt/errno.h>
-#include <linuxmt/kernel.h>
-#include <linuxmt/sched.h>
+#include <linuxmt/fs.h>
+#include <linuxmt/netstat.h>
 
 /* character devices and their minor numbers */
 extern struct file_operations ne2k_fops;    /* 0 CONFIG_ETH_NE2K */
 extern struct file_operations wd_fops;      /* 1 CONFIG_ETH_WD */
 extern struct file_operations el3_fops;     /* 2 CONFIG_ETH_EL3 */
-
-#define MAX_ETHS    3
 
 struct eth {
     struct file_operations *ops;
@@ -41,8 +39,6 @@ static int eth_open(struct inode *inode, struct file *file)
 
     if (!ops)
         return -ENODEV;
-
-    printk("ETH open pid %d\n", current->pid);
     return ops->open(inode, file);
 }
 
@@ -52,8 +48,6 @@ static void eth_release(struct inode *inode, struct file *file)
 
     if (!ops)
         return;
-
-    printk("ETH close pid %d\n", current->pid);
     ops->release(inode, file);
 }
 

--- a/elks/arch/i86/drivers/net/el3.c
+++ b/elks/arch/i86/drivers/net/el3.c
@@ -110,8 +110,9 @@ extern void el3_mdelay(int);
 /* Maximum events (Rx packets, etc.) to handle at each interrupt. */
 static int max_interrupt_work = 5;
 
-int net_irq = EL3_IRQ;  /* default IRQ, changed by netirq= in /bootopts */
-int net_port = EL3_PORT; /* default IO PORT, changed by netport= in /bootopts */
+/* runtime configuration set in /bootopts or defaults in ports.h */
+#define net_irq     (netif_parms[1].irq)
+#define net_port    (netif_parms[1].port)
 
 struct netif_stat netif_stat =
 	{ 0, 0, 0, 0, 0, 0, {0x52, 0x54, 0x00, 0x12, 0x34, 0x57}};  /* QEMU default  + 1 */

--- a/elks/arch/i86/drivers/net/el3.c
+++ b/elks/arch/i86/drivers/net/el3.c
@@ -111,8 +111,8 @@ extern void el3_mdelay(int);
 static int max_interrupt_work = 5;
 
 /* runtime configuration set in /bootopts or defaults in ports.h */
-#define net_irq     (netif_parms[1].irq)
-#define net_port    (netif_parms[1].port)
+#define net_irq     (netif_parms[2].irq)
+#define net_port    (netif_parms[2].port)
 
 struct netif_stat netif_stat =
 	{ 0, 0, 0, 0, 0, 0, {0x52, 0x54, 0x00, 0x12, 0x34, 0x57}};  /* QEMU default  + 1 */

--- a/elks/arch/i86/drivers/net/ne2k.c
+++ b/elks/arch/i86/drivers/net/ne2k.c
@@ -26,7 +26,7 @@
 #include "ne2k.h"
 
 /* runtime configuration set in /bootopts or defaults in ports.h */
-#define NET_IRQ     (netif_parms[0].irq)
+#define net_irq     (netif_parms[0].irq)
 #define NET_PORT    (netif_parms[0].port)
 int net_port;   // temp kluge for ne2k-asm.S
 
@@ -309,9 +309,9 @@ static int ne2k_ioctl(struct inode *inode, struct file *file, unsigned int cmd, 
 static int ne2k_open(struct inode *inode, struct file *file)
 {
 	if (usecount++ == 0) {	// Don't initialize if already open
-		int err = request_irq(NET_IRQ, ne2k_int, INT_GENERIC);
+		int err = request_irq(net_irq, ne2k_int, INT_GENERIC);
 		if (err) {
-			printk("eth: NE2K unable to use IRQ %d (errno %d)\n", NET_IRQ, err);
+			printk("eth: NE2K unable to use IRQ %d (errno %d)\n", net_irq, err);
 			return err;
 		}
 		ne2k_reset();
@@ -329,7 +329,7 @@ static void ne2k_release(struct inode *inode, struct file *file)
 {
 	if (--usecount == 0) {
 		ne2k_stop();
-		free_irq(NET_IRQ);
+		free_irq(net_irq);
 	}
 }
 
@@ -406,7 +406,7 @@ void ne2k_drv_init(void)
 	while (1) {
 		err = ne2k_probe();
 		if (err) {
-			printk("eth: NE2K not found at 0x%x, irq %d\n", NET_PORT, NET_IRQ);
+			printk("eth: NE2K not found at 0x%x, irq %d\n", NET_PORT, net_irq);
 			break;
 		}
 
@@ -440,7 +440,7 @@ void ne2k_drv_init(void)
 			//printk("\n");
 
 		}
-		printk ("eth: NE2K (%d bit) at 0x%x, irq %d, ", 16-8*(is_8bit&1), NET_PORT, NET_IRQ);
+		printk ("eth: NE2K (%d bit) at 0x%x, irq %d, ", 16-8*(is_8bit&1), NET_PORT, net_irq);
 		if (!err) 	/* address found, interface is present */
 			memcpy(mac_addr, cprom, 6);
 		else

--- a/elks/arch/i86/drivers/net/wd.c
+++ b/elks/arch/i86/drivers/net/wd.c
@@ -18,11 +18,12 @@
 #include <linuxmt/limits.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/debug.h>
+#include <linuxmt/netstat.h>
 
 /* runtime configuration set in /bootopts or defaults in ports.h */
-int net_irq = WD_IRQ;	        /* default IRQ, set via netirq= */
-int net_port = WD_PORT;         /* default IO port, set via netport= */
-unsigned int net_ram = WD_RAM;  /* default shared memory address, set via netram= */
+#define net_irq     (netif_parms[1].irq)
+#define net_port    (netif_parms[1].port)
+#define net_ram     (netif_parms[1].ram)
 
 /* I/O delay settings */
 #define INB	inb	/* use inb_p for 1us delay */

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -58,7 +58,9 @@ struct msdos_devdir_entry devnods[DEVDIR_SIZE] = {
     { "ttyp1",	S_IFCHR | 0644, MKDEV(4, 9) },
     { "ptyp1",	S_IFCHR | 0644, MKDEV(2, 9) },
     { "tcpdev",	S_IFCHR | 0644, MKDEV(8, 0) },
-    { "eth",	S_IFCHR | 0644, MKDEV(9, 0) },
+    { "ne2k",	S_IFCHR | 0644, MKDEV(9, 0) },
+    { "wd8003",	S_IFCHR | 0644, MKDEV(9, 1) },
+    { "3c509",	S_IFCHR | 0644, MKDEV(9, 2) },
 };
 #endif
 

--- a/elks/include/linuxmt/msdos_fs_sb.h
+++ b/elks/include/linuxmt/msdos_fs_sb.h
@@ -47,7 +47,7 @@ struct msdos_sb_info { /* space in struct super_block is 28 bytes */
 #endif
 
 #ifdef CONFIG_FS_DEV
-#define DEVDIR_SIZE             41              /* # entries in FAT device table */
+#define DEVDIR_SIZE             43              /* # entries in FAT device table */
 #define DEVINO_BASE             (MSDOS_DPB*2)   /* (DEVDIR_SIZE+MSDOS_DBP-1) & ~(MSDOS_DBP-1) */
 
 struct msdos_devdir_entry {

--- a/elks/include/linuxmt/netstat.h
+++ b/elks/include/linuxmt/netstat.h
@@ -3,6 +3,17 @@
 
 #include <linuxmt/types.h>
 
+#define MAX_ETHS	3	/* max NICs */
+
+/* /bootopts parms for each NIC */
+struct netif_parms {
+	int	irq;
+	int	port;
+	unsigned int ram;
+};
+extern struct netif_parms netif_parms[MAX_ETHS];
+
+/* status for each NIC, returned through ioctl */
 struct netif_stat {
 	__u16 rx_errors;	/* Receive errors, flagged by NIC */
 	__u16 rq_errors;	/* Receive queue errors (in 8bit interfaces) */
@@ -14,7 +25,6 @@ struct netif_stat {
 };
 
 /* status flags for if_status */
-
 #define	NETIF_IS_8BIT	1
 #define NETIF_FORCE_4K	2
 #define NETIF_IS_OPEN	4

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -44,7 +44,7 @@ ipaddr_t netmask_ip;
 
 /* defaults*/
 int linkprotocol = 	LINK_ETHER;
-char ethdev[] = 	"/dev/eth";
+char ethdev[14] = 	"/dev/ne2k";
 char *serdev = 		"/dev/ttyS0";
 speed_t baudrate = 	57600;
 
@@ -178,7 +178,7 @@ void catch(int sig)
 
 static void usage(void)
 {
-    printf("Usage: ktcp [-b] [-d] [-m MTU] [-p eth|slip|cslip] [-s baud] [-l device] [local_ip] [gateway] [netmask]\n");
+    printf("Usage: ktcp [-b] [-d] [-m MTU] [-p ne2k|wd8003|3c509|slip|cslip] [-s baud] [-l device] [local_ip] [gateway] [netmask]\n");
     exit(1);
 }
 
@@ -188,7 +188,7 @@ int main(int argc,char **argv)
     int bflag = 0;
     int mtu = 0;
     char *p;
-    static char *linknames[3] = { "ethernet", "slip", "cslip" };
+    static char *linknames[3] = { "", "slip", "cslip" };
 
     while ((ch = getopt(argc, argv, "bdm:p:s:l:")) != -1) {
 	switch (ch) {
@@ -202,11 +202,15 @@ int main(int argc,char **argv)
 		mtu = (int)atol(optarg);
 		break;
 	case 'p':		/* link protocol*/
-	    linkprotocol = !strcmp(optarg, "eth")? LINK_ETHER :
+	    linkprotocol = !strcmp(optarg, "ne2k")? LINK_ETHER :
+			   !strcmp(optarg, "wd8003")? LINK_ETHER :
+			   !strcmp(optarg, "3c509")? LINK_ETHER :
 			   !strcmp(optarg, "slip")? LINK_SLIP :
 			   !strcmp(optarg, "cslip")? LINK_CSLIP:
 			   -1;
 	    if (linkprotocol < 0) usage();
+	    if (linkprotocol == LINK_ETHER)
+		strcpy(&ethdev[5], optarg);
 	    break;
 	case 's':		/* serial speed*/
 	    baudrate = atol(optarg);
@@ -248,10 +252,10 @@ int main(int argc,char **argv)
     printf("gateway %s, ", in_ntoa(gateway_ip));
     printf("netmask %s\n", in_ntoa(netmask_ip));
 
-    printf("ktcp: %s ", linknames[linkprotocol]);
+    printf("ktcp: ");
     if (linkprotocol == LINK_ETHER)
-	printf("%s", mac_ntoa(eth_local_addr));
-    else printf("%s baud %lu", serdev, baudrate);
+	printf("%s mac %s", ethdev, mac_ntoa(eth_local_addr));
+    else printf("%s %s baud %lu", linknames[linkprotocol], serdev, baudrate);
     printf(" mtu %u\n", MTU);
 
     signal(SIGHUP, catch);

--- a/elkscmd/rootfs_template/bin/net
+++ b/elkscmd/rootfs_template/bin/net
@@ -1,9 +1,9 @@
 # Start/stop ELKS networking
 #
-# Usage: net [start|stop|restart|show] [eth|slip|cslip] [baud] [device]
+# Usage: net [start|stop|restart|show] [ne2k|slip|cslip] [baud] [device]
 #
 # Examples:
-#	net start eth			start ethernet networking
+#	net start ne2k			start ethernet networking
 #	net start slip			start slip networking
 #	net start slip 19200	start slip at 19200 baud
 #	net start cslip 4800 /dev/ttyS1
@@ -18,7 +18,7 @@ source /etc/net.cfg
 
 usage()
 {
-	echo "Usage: net [start|stop|show] [eth|slip|cslip] [baud] [device]"
+	echo "Usage: net [start|stop|show] [ne2k|wd8003|3c509|slip|cslip] [baud] [device]"
 	exit 1
 }
 
@@ -41,8 +41,8 @@ start_network()
 		getty_off
 		ktcp="ktcp -b -p cslip -s $baud -l $device $localip $gateway $netmask"
 		;;
-	eth)
-		ktcp="ktcp -b $mtu $localip $gateway $netmask"
+	ne2k|wd8003|3c509)
+		ktcp="ktcp -b -p $link $mtu $localip $gateway $netmask"
 		;;
 	*)
 		usage ;;
@@ -88,7 +88,7 @@ restart)
 	start_network ;;
 show)
 	echo -n ip $localip gateway $gateway mask $netmask $link
-	if test "$link" != "eth"; then echo "" $baud $device; else echo; fi ;;
+	if test "$link" = "slip"; then echo "" $baud $device; else echo; fi ;;
 *) usage ;;
 esac
 

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,11 +1,11 @@
-## boot options max size 511 bytes
-#console=ttyS0,57600 debug net=eth 3 # sercons, multiuser, networking
+## boot options max 511 bytes
+#console=ttyS0,57600 debug net=ne2k 3 # sercons, multiuser, networking
 #QEMU=1			# to use ftp/ftpd in qemu
 #TZ=MDT7
 #LOCALIP=10.0.2.16
 #HOSTNAME=elks16
-#netirq=9 netport=0x300 # NIC
-#netirq=3 netport=0x280 netram=0xd000
+#ne2k=9,0x300
+#wd8003=3,0x280,0xD000
 #bufs=2500		# system buffers
 #sync=30		# autosync secs
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.sys

--- a/elkscmd/rootfs_template/etc/net.cfg
+++ b/elkscmd/rootfs_template/etc/net.cfg
@@ -1,6 +1,4 @@
-#
-# /etc/net.cfg - ELKS Networking Configuration File / Shell Script
-#
+# ELKS Networking Configuration File
 # sourced by /bin/net for ktcp and daemons
 
 # Default IP address, gate and network mask.
@@ -13,8 +11,8 @@ netmask=255.255.255.0
 mtu=
 #mtu="-m 1000"
 
-# default link layer [eth|slip|cslip]
-link=eth
+# default link layer [ne2k|wd8003|3c509|slip|cslip]
+link=ne2k
 
 # default serial port and baud rate if slip/cslip
 device=/dev/ttyS0

--- a/elkscmd/rootfs_template/etc/rc.sys
+++ b/elkscmd/rootfs_template/etc/rc.sys
@@ -20,8 +20,8 @@ fi
 #
 # check /bootopts "net=" env variable
 case "$net" in
-eth)
-	net start eth
+ne2k|wd8003|3c509)
+	net start $net
 	;;
 slip)
 	net start slip

--- a/image/Make.devices
+++ b/image/Make.devices
@@ -180,9 +180,11 @@ endif
 	$(MKDEV) /dev/tcpdev c 8 0
 
 ##############################################################################
-# Ethernet device
+# Ethernet devices
 
-	$(MKDEV) /dev/eth c 9 0
+	$(MKDEV) /dev/ne2k c 9 0
+	$(MKDEV) /dev/wd8003 c 9 1
+	$(MKDEV) /dev/ec509 c 9 2
 
 ##############################################################################
 # CGATEXT


### PR DESCRIPTION
Adds /dev/ne2k, /dev/wd8003, /dev/3c509, discussed in https://github.com/jbruchon/elks/issues/1312#issuecomment-1160558400.
Adds `ne2k=`, `wd8003=`, and `3c509=` config settings in bootopts:
```
ne2k=irq,port
wd8003=irq,port,ram
3c509=irq,port
```
Adds `net start NICname`:
```
net start ne2k
net start wd8003
net start 3c509
```
Default is set by `net=` in bootopts, or /etc/net.cfg.

@Mellvik: we're all set for testing with a single compiled-in driver. Note: wd8003 probe is always succeeding in QEMU, which could cause problems. Other probes seem to be OK in QEMU. Needs real hardware testing.

We have a small kluge in ne2k.c/ne2k-asm.S in that the ASM routine uses the global 'net_port' when it should be passed as a paramater. I have worked around this for the time being. (There is no longer a net_port global, as NIC configuration is stored in an array). Also, it is bad practice to actually rewrite the value of net_port, as this could fail on multiple opens, but this can still work if we leave the init code in at boot time where it is changed.

Next PR will allow for compiling in all three NIC drivers.