### PR TITLE
[net] Add net_flags as fourth optional parm to ne2k=/wd=/3c509= NIC opts

### DIFF
--- a/elks/arch/i86/drivers/net/el3.c
+++ b/elks/arch/i86/drivers/net/el3.c
@@ -113,6 +113,8 @@ static int max_interrupt_work = 5;
 /* runtime configuration set in /bootopts or defaults in ports.h */
 #define net_irq     (netif_parms[2].irq)
 #define net_port    (netif_parms[2].port)
+#define net_ram     (netif_parms[2].ram)
+#define net_flags   (netif_parms[2].flags)
 static int ioaddr;	// FIXME  remove later
 static word_t el3_id_port;
 

--- a/elks/arch/i86/drivers/net/ne2k.c
+++ b/elks/arch/i86/drivers/net/ne2k.c
@@ -29,6 +29,8 @@
 #define net_irq     (netif_parms[0].irq)
 #define NET_PORT    (netif_parms[0].port)
 int net_port;   // temp kluge for ne2k-asm.S
+#define net_ram     (netif_parms[0].ram)
+#define net_flags   (netif_parms[0].flags)
 
 static struct netif_stat netif_stat =
 	{ 0, 0, 0, 0, 0, 0, {0x52, 0x54, 0x00, 0x12, 0x34, 0x57}};  /* QEMU default  + 1 */

--- a/elks/include/linuxmt/netstat.h
+++ b/elks/include/linuxmt/netstat.h
@@ -10,6 +10,7 @@ struct netif_parms {
 	int	irq;
 	int	port;
 	unsigned int ram;
+    unsigned int flags;
 };
 extern struct netif_parms netif_parms[MAX_ETHS];
 

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -30,9 +30,9 @@ int root_mountflags = MS_RDONLY;
 int root_mountflags = 0;
 #endif
 struct netif_parms netif_parms[MAX_ETHS] = {
-    { NE2K_IRQ, NE2K_PORT, 0 },
-    { WD_IRQ, WD_PORT, WD_RAM },
-    { EL3_IRQ, EL3_PORT, 0 },
+    { NE2K_IRQ, NE2K_PORT, 0, 0 },
+    { WD_IRQ, WD_PORT, WD_RAM, 0 },
+    { EL3_IRQ, EL3_PORT, 0, 0 },
 };
 __u16 kernel_cs, kernel_ds;
 static int boot_console;
@@ -292,8 +292,11 @@ static void parse_nic(char *line, struct netif_parms *parms)
     parms->irq = (int)simple_strtol(line, 0);
     if ((p = strchr(line, ','))) {
         parms->port = (int)simple_strtol(p+1, 16);
-        if ((p = strchr(p+1, ',')))
+        if ((p = strchr(p+1, ','))) {
             parms->ram = (int)simple_strtol(p+1, 16);
+            if ((p = strchr(p+1, ',')))
+                parms->flags = (int)simple_strtol(p+1, 0);
+        }
     }
 }
 

--- a/elks/lib/string.c
+++ b/elks/lib/string.c
@@ -237,11 +237,11 @@ int memcmp(const void *s1, const void *s2, size_t n)
 
 char *strchr(const char *s, int c)
 {
-    while (*s) {
-        if (*s++ == (char) c)
-            return (char *)s;
+    for(; *s != (char)c; ++s) {
+        if (*s == '\0')
+            return NULL;
     }
-    return NULL;
+    return (char *)s;
 }
 
 #endif

--- a/libc/string/strchr.c
+++ b/libc/string/strchr.c
@@ -34,10 +34,10 @@ got_it:
 
 #endasm
 #else /* ifdef BCC_AX_ASM */
-    while (*s) {
-        if (*s++ == (char) c)
-        return (char *)s;
+    for(; *s != (char)c; ++s) {
+        if (*s == '\0')
+            return NULL;
     }
-    return NULL;
+    return (char *)s;
 #endif /* ifdef BCC_AX_ASM */
 }


### PR DESCRIPTION
As discussed in https://github.com/jbruchon/elks/pull/1341#issuecomment-1164672837.

Adds net_flags to ne2k.c and el3.c. As discussed, net_flags (and net_ram) will be 0 if not specified.

@Mellvik, please add the following to your work-in-process wd.c, just after the `net_ram` define:
```
#define net_ram     (netif_parms[1].ram)
#define net_flags   (netif_parms[1].flags)
```

This PR also fixes the buggy `strchr` I mistakenly broke in my last PR (#1348). That has only been merged for a few hours so hopefully that didn't affect anyone.