### PR TITLE
[8018x] add code to disable IRQs

### DIFF
--- a/elks/arch/i86/kernel/irq-8018x.c
+++ b/elks/arch/i86/kernel/irq-8018x.c
@@ -78,7 +78,8 @@ void enable_irq(unsigned int irq)
     struct irq_logical_map* map;
     map = get_from_logical_irq(irq);
     if (map) {
-        outw(map->config_word, map->pcb_register);
+        // set the priority mask and clear the MSK bit (bit 4)
+        outw(map->config_word, map->pcb_register & 0x7);
     }
 }
 
@@ -90,7 +91,12 @@ int remap_irq(int irq)
 
 void disable_irq(unsigned int irq)
 {
-    // TODO disable passed interrupt
+    struct irq_logical_map* map;
+    map = get_from_logical_irq(irq);
+    if (map) {
+        // set the priority mask and set the MSK bit (bit 4)
+        outw(map->config_word, 0x8 | (map->pcb_register & 0x7));
+    }
 }
 
 // Get interrupt vector from IRQ


### PR DESCRIPTION
Bit #4 of each IRQ source's config register selects if the interrupt
is masked or not. Provide a mechanism to disable IRQs.