### PR TITLE
[kernel] Cleanup C aliasing constructs, remove -Wno-strict-aliasing

### DIFF
--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -198,7 +198,7 @@ ifneq ($(USEBCC), N)
 AS      = ia16-elf-as
 ASFLAGS = $(CPU_AS) $(ARCH_AS) --32-segelf
 CC      = $(CROSS_CC)
-CFLAGS  = $(CROSS_CFLAGS) $(CPU_CC) $(ARCH_CC) $(CFLBASE) -Wall -Os -Wno-strict-aliasing
+CFLAGS  = $(CROSS_CFLAGS) $(CPU_CC) $(ARCH_CC) $(CFLBASE) -Wall -Os
 CFLAGS += -fno-delete-null-pointer-checks -Wnull-dereference
 #CFLAGS += -Wconversion
 #CFLAGS += -Wextra

--- a/elks/fs/msdos/fat.c
+++ b/elks/fs/msdos/fat.c
@@ -275,7 +275,7 @@ sector_t FATPROC msdos_smap(struct inode *inode, sector_t sector)
 	}
 #endif
 	cluster = sector / sb->cluster_size;
-	offset = (unsigned)sector % sb->cluster_size;
+	offset = (unsigned int)sector % sb->cluster_size;
 	if (!(cluster = get_cluster(inode,cluster))) return 0;
 	return (cluster-2)*sb->cluster_size+sb->data_start+offset;
 }

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -280,10 +280,10 @@ int FATPROC msdos_scan(struct inode *dir,char *name,struct buffer_head **res_bh,
 	*res_bh = NULL;
 	while ((*ino = msdos_get_entry(dir,&pos,res_bh,&de)) != -1) {
 		if (name) {
-			if (de->name[0] && ((unsigned char *) (de->name))[0] != DELETED_FLAG
+			if (de->name[0] && (unsigned char)de->name[0] != DELETED_FLAG
 				&& !(de->attr & ATTR_VOLUME) && !strncmp(de->name,name,MSDOS_NAME)) break;
 		}
-		else if (!de->name[0] || ((unsigned char *) (de->name))[0] == DELETED_FLAG) {
+		else if (!de->name[0] || (unsigned char)de->name[0] == DELETED_FLAG) {
 				/* unset directory bit so read_inode doesn't traverse FAT table */
 				/* MSDOS sometimes has deleted DIR entries with non-zero first cluster */
 				de->attr &= ~ATTR_DIR;
@@ -329,12 +329,11 @@ static cluster_t FATPROC raw_found(struct super_block *sb, cluster_t sector,
 		if (name) {
 			if (strncmp(data[entry].name,name,MSDOS_NAME) != 0)
 				continue;
-			((unsigned short *)&start)[0] = data[entry].start;
-			((unsigned short *)&start)[1] = starthi;
+			start = data[entry].start | ((unsigned long)starthi << 16);
 	    } else {
-			if (*(unsigned char *)data[entry].name == DELETED_FLAG
+			if ((unsigned char)data[entry].name[0] == DELETED_FLAG
 				|| data[entry].start != (unsigned short)number
-				|| starthi != ((unsigned short *)&number)[1])
+				|| starthi != (unsigned short)(number >> 16))
 				continue;
 			start = number;
 	    }

--- a/elks/fs/msdos/namei.c
+++ b/elks/fs/msdos/namei.c
@@ -316,7 +316,7 @@ int msdos_rmdir(register struct inode *dir,const char *name,int len)
 		pos = 0;
 		dbh = NULL;
 		while (msdos_get_entry(inode,&pos,&dbh,&dde) != -1)
-			if (dde->name[0] && ((unsigned char *) dde->name)[0] != DELETED_FLAG
+			if (dde->name[0] && (unsigned char)dde->name[0] != DELETED_FLAG
 				&& strncmp(dde->name,MSDOS_DOT, MSDOS_NAME)
 				&& strncmp(dde->name,MSDOS_DOTDOT, MSDOS_NAME))
 					goto rmdir_done; /* linux bug ??? */

--- a/elks/include/linuxmt/msdos_fs.h
+++ b/elks/include/linuxmt/msdos_fs.h
@@ -46,12 +46,12 @@
 typedef long cluster_t;
 
 struct msdos_boot_sector {
-	char ignored[13];		/*0*/
+	char ignored[13];	    /*0*/
 	unsigned char cluster_size; /* sectors/cluster 13*/
 	unsigned short reserved;    /* reserved sectors 14*/
 	unsigned char fats;	    /* number of FATs 16*/
-	unsigned char dir_entries[2];/* root directory entries 17*/
-	unsigned char sectors[2];   /* number of sectors 19*/
+	unsigned short dir_entries; /* root directory entries 17*/
+	unsigned short sectors;     /* number of sectors 19*/
 	unsigned char media;	    /* media code (unused) 21*/
 	unsigned short fat_length;  /* sectors/FAT 22*/
 	unsigned short secs_track;  /* sectors per track (unused) 24*/
@@ -67,7 +67,7 @@ struct msdos_boot_sector {
 	__u16	info_sector;	/* filesystem info sector (unused) */
 	__u16	backup_boot;	/* backup boot sector (unused) */
 	__u16	reserved2[6];	/* Unused */
-};
+} __attribute__((packed));
 
 struct msdos_dir_entry {
 	char name[8],ext[3]; /* name and extension */

--- a/elks/include/linuxmt/msdos_fs_i.h
+++ b/elks/include/linuxmt/msdos_fs_i.h
@@ -6,8 +6,10 @@
  * ported from linux-2.0.34 by zouys, Oct 28th, 2010
  */
 
+typedef long cluster_t;
+
 struct msdos_inode_info {
-	long i_start;	/* first cluster or 0 */
+	cluster_t i_start; /* first cluster or 0 */
 	int i_attrs;	/* unused attribute bits */
 	int i_busy;	/* file is either deleted but still open, or
 			   inconsistent (mkdir) */

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -318,6 +318,7 @@ static int parse_options(void)
 	/* copy /bootops loaded by boot loader at 0050:0000*/
 	fmemcpyb(options, kernel_ds, 0, DEF_OPTSEG, sizeof(options));
 
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
 	/* check file starts with ## and max len 511 bytes*/
 	if (*(unsigned short *)options != 0x2323 || options[OPTSEGSZ-1])
 		return 0;

--- a/elks/net/Makefile
+++ b/elks/net/Makefile
@@ -31,6 +31,7 @@ NOINDENT	=
 # Include standard commands.
 
 include $(BASEDIR)/Makefile-rules
+CFLAGS += -Wno-strict-aliasing
 
 #########################################################################
 # Objects to compile.


### PR DESCRIPTION
Cleans up bad C aliasing use in FAT filesystem code.

Removes -Wno-strict-aliasing for most of kernel compilation, except networking.