### PR TITLE
[basic] Add PEEK, POKE to basic

### DIFF
--- a/elkscmd/basic/basic.c
+++ b/elkscmd/basic/basic.c
@@ -204,6 +204,8 @@ PROGMEM const TokenTableEntry tokenTable[] = {
     {"OUTB", TKN_FMT_POST},
     {"OUTW", TKN_FMT_POST},
     {"HEX$",1|TKN_RET_TYPE_STR},
+    {"PEEK", 2},
+    {"POKE", TKN_FMT_POST},
 };
 
 
@@ -1228,6 +1230,12 @@ int parseFnCallExpr() {
             if (!stackPushNum(host_inpw(tmp))) return ERROR_OUT_OF_MEMORY;
             break;
         }
+        case TOKEN_PEEK:
+        {
+            int segment = stackPopNum();
+            stackPushNum(host_peekb(stackPopNum(), segment));
+            break;
+        }
         default:
             return ERROR_UNEXPECTED_TOKEN;
         }
@@ -1442,6 +1450,7 @@ int parsePrimary() {
     case TOKEN_INPB:
     case TOKEN_INPW:
     case TOKEN_HEX:
+    case TOKEN_PEEK:
         return parseFnCallExpr();
 
         // single argument math functions
@@ -1761,6 +1770,9 @@ int parseNIntCmd(int n) {
             break;
         case TOKEN_OUTW:
             host_outw(para[0],para[1]);
+            break;
+        case TOKEN_POKE:
+            host_pokeb(para[0],para[1],para[2]);
             break;
         }
     }
@@ -2165,6 +2177,7 @@ int parseStmts()
             break;
 
         case TOKEN_CIRCLE:
+        case TOKEN_POKE:
             ret = parseNIntCmd(3);
             break;
 

--- a/elkscmd/basic/basic.h
+++ b/elkscmd/basic/basic.h
@@ -97,12 +97,14 @@
 #define TOKEN_PLOT		84
 #define TOKEN_DRAW		85
 #define TOKEN_CIRCLE	   	86
-#define TOKEN_INPB       87
-#define TOKEN_INPW       88
-#define TOKEN_OUTB       89
-#define TOKEN_OUTW       90
-#define TOKEN_HEX       91
-#define LAST_IDENT_TOKEN	91
+#define TOKEN_INPB		87
+#define TOKEN_INPW		88
+#define TOKEN_OUTB		89
+#define TOKEN_OUTW		90
+#define TOKEN_HEX		91
+#define TOKEN_PEEK		92
+#define TOKEN_POKE		93
+#define LAST_IDENT_TOKEN	93
 
 #define ERROR_NONE				0
 // parse errors

--- a/elkscmd/basic/host-pc98.c
+++ b/elkscmd/basic/host-pc98.c
@@ -8,8 +8,6 @@
 #include "host.h"
 #include "basic.h"
 
-#define _MK_FP(seg,off) ((void __far *)((((unsigned long)(seg)) << 16) | (off)))
-
 #define LIOSEG 0xF990 /* ROM Segment for LIO */
 #define LIOINT 0xA0   /* Starting LIO interrupt number */
 

--- a/elkscmd/basic/host.c
+++ b/elkscmd/basic/host.c
@@ -54,7 +54,7 @@ float adjust(float f) {
 // for float testing compatibility, use same FP formatting routines on host for now
 // floats have approx 7 sig figs, 15 for double
 
-#ifdef __ia16__
+#if __ia16__
 __STDIO_PRINT_FLOATS;		// link in libc printf float support
 
 char *host_floatToStr(float f, char *buf) {
@@ -368,6 +368,24 @@ int host_loadProgramFromFile(char *fileName) {
 	fclose(fp);
 	if (err == ERROR_EOF) err = ERROR_NONE;
 	return err;
+}
+
+int host_peekb(int offset, int segment) {
+#if __ia16__
+    unsigned char __far *peek;
+    peek = _MK_FP(segment,offset);
+    return (int) *peek;
+#else
+    return 0;
+#endif
+}
+
+void host_pokeb(int offset, int segment, int value) {
+#if __ia16__
+    unsigned char __far *poke;
+    poke = _MK_FP(segment,offset);
+    *poke = (unsigned char) value;
+#endif
 }
 
 int main(int ac, char **av) {

--- a/elkscmd/basic/host.h
+++ b/elkscmd/basic/host.h
@@ -45,6 +45,8 @@ float adjust(float f);
 #define pgm_read_word(x)        (x)
 #define pgm_read_byte_near(x)	(x)
 
+#define _MK_FP(seg,off) ((void __far *)((((unsigned long)(seg)) << 16) | (off)))
+
 void host_cls();
 void host_showBuffer();
 void host_moveCursor(int x, int y);
@@ -84,3 +86,6 @@ void host_outb(int port, int value);
 void host_outw(int port, int value);
 int host_inpb(int port);
 int host_inpw(int port);
+
+int host_peekb(int offset, int segment);
+void host_pokeb(int offset, int segment, int value);


### PR DESCRIPTION
Hello @ghaerr , @cocus 

As we discussed in  https://github.com/jbruchon/elks/issues/1312#issuecomment-1166432529
I added PEEK, POKE.

I hope this works for your system.

PEEK Interrupt vector of PC-98 LIO
![peekb_bas](https://user-images.githubusercontent.com/61556504/177006613-4fa76cc9-fec6-4516-87b4-45cee704db07.png)

POKE to Graphic VRAM of PC-98
![pokeb_bas](https://user-images.githubusercontent.com/61556504/177006633-373d3024-55f9-4c14-af30-7c955878b0b1.png)

Thank you.



