### PR TITLE
[cmds] Bugfixes in sys and cp

### DIFF
--- a/elks/arch/i86/drivers/net/el3.c
+++ b/elks/arch/i86/drivers/net/el3.c
@@ -390,7 +390,7 @@ static void el3_int(int irq, struct pt_regs *regs)
 			if (status & StatsFull)			/* Empty statistics. */
 				update_stats();
 
-#if 0			// Not currently used
+#if LATER		/* Candidate for optimization  */
 			if (status & RxEarly) {
 				//el3_rx(dev);
 				outw(AckIntr | RxEarly, ioaddr + EL3_CMD);
@@ -399,19 +399,19 @@ static void el3_int(int irq, struct pt_regs *regs)
 #endif
 			if (status & TxComplete) {		/* Really Tx error. */
 				short tx_status;
-				int i = 4;
+				int k = 4;
 
 				if (verbose) printk(EMSG_TXERR, model_name, inb(ioaddr + TX_STATUS));
 				netif_stat.tx_errors++;
-				while (--i > 0 && (tx_status = inb(ioaddr + TX_STATUS)) > 0) {
+				while (--k > 0 && (tx_status = inb(ioaddr + TX_STATUS)) > 0) {
 					//if (tx_status & 0x38) dev->stats.tx_aborted_errors++;
 					if (tx_status & 0x30) outw(TxReset, ioaddr + EL3_CMD);
 					if (tx_status & 0x3C) outw(TxEnable, ioaddr + EL3_CMD);
 					outb(0x00, ioaddr + TX_STATUS); /* Pop the status stack. */
 				}
 			}
-			// Adapter failure is either transmit overrun or receive underrun,
-			// both are really driver or host faults, should not happen.
+			/* Adapter failure is either transmit overrun or receive underrun,
+			 * both are really driver or host faults, should not happen. */
 			if (status & AdapterFailure) {
 				/* Adapter failure requires Rx reset and reinit. */
 				if (verbose) printk(EMSG_ERROR, model_name, status);
@@ -424,7 +424,7 @@ static void el3_int(int irq, struct pt_regs *regs)
 			}
 		}
 
-		if (--i < 0) {	// This should not happen
+		if (--i < 0) {		/* Should not happen */
 			printk("eth: Infinite loop in interrupt, status %4.4x.\n",
 				   status);
 

--- a/elks/arch/i86/drivers/net/ne2k.c
+++ b/elks/arch/i86/drivers/net/ne2k.c
@@ -42,8 +42,8 @@ static struct wait_queue txwait;
 static struct netif_stat netif_stat;
 static byte_t model_name[] = "ne2k";
 
-extern word_t _ne2k_next_pk;	// FIXME: CHange these to byte_t !!
-extern word_t _ne2k_is_8bit;
+extern int _ne2k_next_pk;
+extern word_t _ne2k_is_8bit;	// FIXME: Change to byte_t !!
 extern word_t _ne2k_has_data;
 extern struct eth eths[];
 
@@ -74,10 +74,7 @@ static size_t ne2k_read(struct inode *inode, struct file *filp, char *data, size
 				break;
 			}
 		}
-		if ((size = ne2k_pack_get(data, len, nhdr)) < 0) {
-			res = -EIO;
-			break;
-		}
+		size = ne2k_pack_get(data, len, nhdr);
 
 		//printk("r%04x|%04x/",nhdr[0], nhdr[1]);	// NIC buffer header
 		debug_eth("eth read: req %d, got %d real %d\n", len, size, nhdr[1]);

--- a/elkscmd/file_utils/cp.c
+++ b/elkscmd/file_utils/cp.c
@@ -25,7 +25,7 @@
 #define BUF_SIZE	BUFSIZ		/* use disk block size for stack limit and efficiency*/
 
 int opt_recurse = 0;
-int opt_verbose = 1;
+int opt_verbose = 0;
 int opt_nocopyzero = 0;
 int whole_disk_copy = 0;
 char *destination_dir;

--- a/elkscmd/rootfs_template/bin/sys
+++ b/elkscmd/rootfs_template/bin/sys
@@ -102,8 +102,7 @@ copy_bin_files()
 	cp /bin/sys	$MNT/bin
 	cp /bin/umount	$MNT/bin
 	else
-	cd /bin; cp -R . $MNT/bin
-	cd /
+	cp -R /bin $MNT/bin
 	fi
 }
 

--- a/elkscmd/rootfs_template/bin/sys
+++ b/elkscmd/rootfs_template/bin/sys
@@ -6,8 +6,8 @@ usage()
 {
 	echo "Usage: sys [-3][-M][-F] /dev/{fd0,fd1,hda1,hda2,etc}"
 	echo "	-3 will transfer minimal (360k) system"
-	echo "	-M will transfer boot MBR to /dev/hd[a-d][1-4]
-	echo "	-F required for flat non-MBR /dev/hd[a-d]
+	echo "	-M will transfer boot MBR to /dev/hd[a-d][1-4]"
+	echo "	-F required for flat non-MBR /dev/hd[a-d]"
 	exit 1
 }
 
@@ -102,7 +102,8 @@ copy_bin_files()
 	cp /bin/sys	$MNT/bin
 	cp /bin/umount	$MNT/bin
 	else
-	cp /bin/*	$MNT/bin
+	cd /bin; cp -R . $MNT/bin
+	cd /
 	fi
 }
 


### PR DESCRIPTION
The `/bin` directory is now so big that `/bin/*`  will cause `sark` problems for several apps, including `cp`. So `sys` failed. Changed the script to use `cp -R .` instead, and fixed `usage()`.

Also changed default verbose mode to off in `cp`.