### PR TITLE
[libc] Add 64-bit long long support functions lltostr, ulltostr

### DIFF
--- a/libc/include/stdlib.h
+++ b/libc/include/stdlib.h
@@ -65,7 +65,9 @@ void breakpoint();
 char *itoa(int val);
 char *ltoa(long val);
 char *ltostr(long val, int radix);
+char *lltostr(long long val, int radix);
 char *ultostr(unsigned long val, int radix);
+char *ulltostr(unsigned long long val, int radix);
 #endif
 
 #endif /* __STDLIB_H */

--- a/libc/misc/Makefile
+++ b/libc/misc/Makefile
@@ -22,6 +22,7 @@ OBJS = \
 	itoa.o \
 	ltoa.o \
 	ltostr.o \
+	lltostr.o \
 	mktemp.o \
 	popen.o \
 	putenv.o \
@@ -33,6 +34,7 @@ OBJS = \
 	system.o \
 	tmpnam.o \
 	ultostr.o \
+	ulltostr.o \
 	wildcard.o \
 	# end of list
 

--- a/libc/misc/lltostr.c
+++ b/libc/misc/lltostr.c
@@ -1,0 +1,11 @@
+/* long long to string, Jul 2022 Greg Haerr */
+#include <stdlib.h>
+
+/* max long long = 9,223,372,036,854,775,807 */
+char *lltostr(long long val, int radix)
+{
+   unsigned long long u = (val < 0)? 0u - val: val;
+   char *p = ulltostr(u, radix);
+   if(p && val < 0) *--p = '-';
+   return p;
+}

--- a/libc/misc/ulltostr.c
+++ b/libc/misc/ulltostr.c
@@ -1,10 +1,11 @@
-/* Apr 2020 Greg Haerr - made small as possible */
+/* unsigned long long to string, Jul 2022 Greg Haerr */
 #include <stdlib.h>
-#define MAX_LONG_CHARS 34
 
-char *ultostr(unsigned long val, int radix)
+#define MAX_LONG_LONG_CHARS 66
+
+char *ulltostr(unsigned long long val, int radix)
 {
-  static char buf[MAX_LONG_CHARS];
+  static char buf[MAX_LONG_LONG_CHARS];
   char *p = buf + sizeof(buf) - 1;
 
   *p = '\0';


### PR DESCRIPTION
Precursor to adding %lld/%llu format support to `printf`, which is required for upcoming function profiling routines that use 386 CPU RDTSC 64-bit counter register for nanosecond resolution timing.