### PR TITLE
[kernel] More enhanced compiler checking with gcc options

### DIFF
--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -205,13 +205,17 @@ CFLAGS += -Wredundant-decls -Wuninitialized -Winline -Wswitch -Wshadow
 CFLAGS += -Wchar-subscripts -Wwrite-strings
 CFLAGS += -Wdiscarded-qualifiers -Wcast-align -Wcast-qual
 
+# uncomment for strong checking, won't work with CONFIG_FARTEXT_KERNEL
+#CFLAGS += -std=gnu99 -Wpedantic -D__STRICT_ANSI__
+
 # TODO: remove/add the following
 #CFLAGS += -Wbad-function-cast
 CFLAGS += -Wno-sign-compare
 CFLAGS += -Wno-cast-qual
-CFLAGS += -Wno-unused-parameter -Wno-missing-prototypes -Wno-empty-body
-#CFLAGS += -std=c11
-#CFLAGS += -ansi -Wstrict-prototypes -pedantic
+CFLAGS += -Wno-unused-parameter
+CFLAGS += -Wno-missing-prototypes
+CFLAGS += -Wno-empty-body
+#CFLAGS += -Wstrict-prototypes
 #CFLAGS += -Wconversion
 #CFLAGS += -Wextra
 

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -148,7 +148,7 @@ static int _hd_count = 0;  		/* number of hard disks */
 
 #define SPT		4	/* DDPT offset of sectors per track*/
 static unsigned char DDPT[14];	/* our copy of diskette drive parameter table*/
-unsigned long FAR *vec1E = _MK_FP(0, 0x1E << 2);
+unsigned long __far *vec1E = _MK_FP(0, 0x1E << 2);
 
 static int bioshd_ioctl(struct inode *, struct file *, unsigned int, unsigned int);
 static int bioshd_open(struct inode *, struct file *);
@@ -482,7 +482,7 @@ static void copy_ddpt(void)
 	fmemcpyw(DDPT, _FP_SEG(DDPT), (void *)(unsigned)oldvec, _FP_SEG(oldvec),
 		sizeof(DDPT)/2);
 	debug_bios("bioshd: DDPT vector %x:%x SPT %d\n", _FP_SEG(oldvec), (unsigned)oldvec, DDPT[SPT]);
-	*vec1E = (unsigned long)(void FAR *)DDPT;
+	*vec1E = (unsigned long)(void __far *)DDPT;
 }
 
 /* As far as I can tell this doesn't actually work, but we might
@@ -570,7 +570,7 @@ static void probe_floppy(int target, struct hd_struct *hdp)
 	 * If it exists, we can obtain the disk geometry from it.
 	 */
 	if (!read_sector(target, 0, 1)) {
-	    struct elks_disk_parms FAR *parms = _MK_FP(DMASEG, drivep->sector_size -
+	    struct elks_disk_parms __far *parms = _MK_FP(DMASEG, drivep->sector_size -
 		2 - sizeof(struct elks_disk_parms));
 
 	    /* first check for ELKS parm block */
@@ -590,7 +590,7 @@ static void probe_floppy(int target, struct hd_struct *hdp)
 	    }
 
 	    /* second check for valid FAT BIOS parm block */
-	    unsigned char FAR *boot = _MK_FP(DMASEG, 0);
+	    unsigned char __far *boot = _MK_FP(DMASEG, 0);
 	    if (
 		//(boot[510] == 0x55 && boot[511] == 0xAA) &&	/* bootable sig*/
 		((boot[3] == 'M' && boot[4] == 'S') ||		/* OEM 'MSDOS'*/

--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -322,14 +322,14 @@ static void floppy_ready(void);
 static void delay_loop(int cnt)
 {
     while (cnt > 0) {
-	__asm__("nop");
+	asm("nop");
 	cnt--;
     }
 }
 
 #ifdef TRP_ASM
 #define copy_buffer(from,to) \
-__asm__("cld ; rep ; movsl" \
+asm("cld ; rep ; movsl" \
 	: \
 	:"c" (BLOCK_SIZE/4),"S" ((long)(from)),"D" ((long)(to)) \
 	:"cx","di","si")

--- a/elks/arch/i86/drivers/block/ssd-sd.c
+++ b/elks/arch/i86/drivers/block/ssd-sd.c
@@ -64,7 +64,7 @@ static enum SdTypes _sd_type = Unknown;
  * Delays some amount of time (not exactly microseconds)
  */
 static void delay_us(uint16_t n) {
-    while (n--) __asm("nop");
+    while (n--) asm("nop");
 }
 
 /**

--- a/elks/arch/i86/drivers/net/wd.c
+++ b/elks/arch/i86/drivers/net/wd.c
@@ -238,7 +238,7 @@ static void wd_reset(void)
 static void wd_init_8390(int strategy)
 {
 	unsigned u;
-	const e8390_pkt_hdr FAR *rxhdr;
+	const e8390_pkt_hdr __far *rxhdr;
 	word_t hdr_start;
 	byte_t *mac_addr = (byte_t *)&netif_stat.mac_addr;
 
@@ -347,7 +347,7 @@ static void wd_clr_oflow(int keep)
 
 static size_t wd_pack_get(char *data, size_t len)
 {
-	const e8390_pkt_hdr FAR *rxhdr;
+	const e8390_pkt_hdr __far *rxhdr;
 	word_t hdr_start;
 	unsigned char this_frame, update = 1;
 	size_t res = -EIO;

--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -86,7 +86,7 @@ void stack_check(void)
  *	so we fork onto our kernel stack.
  */
 
-void kfork_proc(void (*addr))
+void kfork_proc(void (*addr)())
 {
     register struct task_struct *t;
 
@@ -198,12 +198,12 @@ void arch_setup_sighandler_stack(register struct task_struct *t,
  * function in the case of kfork_proc().
  */
 
-void arch_build_stack(struct task_struct *t, char *addr)
+void arch_build_stack(struct task_struct *t, void (*addr)())
 {
     register __u16 *tsp = ((__u16 *)(&(t->t_regs.ax))) - 1;
 
     if (addr == NULL)
-	addr = (char *)ret_from_syscall;
+	addr = ret_from_syscall;
     *tsp = (__u16)addr;			/* Start execution address */
 #ifdef __ia16__
     *(tsp-2) = kernel_ds;		/* Initial value for ES register */
@@ -220,7 +220,7 @@ void arch_build_stack(struct task_struct *t, char *addr)
  */
 int restart_syscall(void)
 {
-    struct uregs FAR *user_stack;
+    struct uregs __far *user_stack;
 
     user_stack = _MK_FP(current->t_regs.ss, current->t_regs.sp);
     user_stack->ip -= 2;		/* backup to INT 80h*/

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -62,7 +62,8 @@ static struct elks_supl_hdr esuph;
 #   define bytes_to_paras(bytes) __extension__({ \
 	segext_t __w; \
 	asm("addw $15, %0; rcrw %0" \
-	      : "=&r" (__w) : "0" (bytes) \
+	      : "=&r" (__w) \
+              : "0" (bytes) \
 	      : "cc"); \
 	__w >> 3; })
 #endif

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -59,13 +59,12 @@ static struct elks_supl_hdr esuph;
 	((segext_t)(((unsigned long)(bytes) + 15) >> 4))
 #else
 #   define add_overflow	__builtin_add_overflow
-#   define bytes_to_paras(bytes) ({ \
+#   define bytes_to_paras(bytes) __extension__({ \
 	segext_t __w; \
-	__asm("addw $15, %0; rcrw %0" \
+	asm("addw $15, %0; rcrw %0" \
 	      : "=&r" (__w) : "0" (bytes) \
 	      : "cc"); \
-	__w >> 3; \
-    })
+	__w >> 3; })
 #endif
 
 #ifdef CONFIG_EXEC_MMODEL

--- a/elks/fs/msdos/namei.c
+++ b/elks/fs/msdos/namei.c
@@ -325,7 +325,7 @@ int msdos_rmdir(register struct inode *dir,const char *name,int len)
 	inode->i_nlink = 0;
 	dir->i_mtime = CURRENT_TIME;
 	inode->i_dirt = dir->i_dirt = 1;
-	de->name[0] = DELETED_FLAG;
+	de->name[0] = (unsigned char)DELETED_FLAG;
 	debug_fat("rmdir block write %lu\n", buffer_blocknr(bh));
 	mark_buffer_dirty(bh);
 	res = 0;
@@ -364,7 +364,7 @@ int msdos_unlink(register struct inode *dir,const char *name,int len)
 	inode->i_nlink = 0;
 	inode->u.msdos_i.i_busy = 1;
 	inode->i_dirt = 1;
-	de->name[0] = DELETED_FLAG;
+	de->name[0] = (unsigned char)DELETED_FLAG;
 	dir->i_dirt = 1;
 	debug_fat("unlink block write %lu\n", buffer_blocknr(bh));
 	mark_buffer_dirty(bh);

--- a/elks/include/arch/io.h
+++ b/elks/include/arch/io.h
@@ -5,44 +5,56 @@
 
 #ifdef __ia16__
 
-#define outb(value,port) \
-        asm ("outb %%al,%%dx"::"Ral" ((unsigned char)(value)),"d" (port))
+#define outb(value,port)            \
+        asm ("outb %%al,%%dx"       \
+            : /* no output */       \
+            :"Ral" ((unsigned char)(value)),"d" (port))
 
-#define inb(port) __extension__({ \
-        unsigned char _v; \
-        asm volatile ("inb %%dx,%%al":"=Ral" (_v):"d" (port)); \
+#define inb(port) __extension__ ({      \
+        unsigned char _v;               \
+        asm volatile ("inb %%dx,%%al"   \
+            :"=Ral" (_v)                \
+            :"d" (port));               \
         _v; })
 
-#define outw(value,port) \
-        asm ("outw %%ax,%%dx"::"a" ((unsigned short)(value)),"d" (port))
+#define outw(value,port)                \
+        asm ("outw %%ax,%%dx"           \
+            : /* no output */           \
+            :"a" ((unsigned short)(value)),"d" (port))
 
-#define inw(port) __extension__({ \
-        unsigned short _v; \
-        asm volatile ("inw %%dx,%%ax":"=a" (_v):"d" (port)); \
+#define inw(port) __extension__ ({      \
+        unsigned short _v;              \
+        asm volatile ("inw %%dx,%%ax"   \
+            :"=a" (_v)                  \
+            :"d" (port));               \
         _v; })
 
-#define outb_p(value,port) \
-        asm volatile ("outb %%al,%%dx\n" \
+#define outb_p(value,port)                \
+        asm volatile ("outb %%al,%%dx\n"  \
                       "outb %%al,$0x80\n" \
-                        ::"Ral" ((unsigned char)(value)),"d" (port))
+                        : /* no output */ \
+                        :"Ral" ((unsigned char)(value)),"d" (port))
 
-#define inb_p(port) __extension__({ \
-        unsigned char _v; \
-        asm volatile ("inb %%dx,%%al\n" \
+#define inb_p(port) __extension__ ({      \
+        unsigned char _v;                 \
+        asm volatile ("inb %%dx,%%al\n"   \
                       "outb %%al,$0x80\n" \
-                        :"=Ral" (_v):"d" (port)); \
+                        :"=Ral" (_v)      \
+                        :"d" (port));     \
         _v; })
 
-#define outw_p(value,port) \
-        asm volatile ("outw %%ax,%%dx\n" \
+#define outw_p(value,port)                \
+        asm volatile ("outw %%ax,%%dx\n"  \
                       "outb %%al,$0x80\n" \
-                        ::"a" ((unsigned short)(value)),"d" (port))
+                        : /* no output */ \
+                        :"a" ((unsigned short)(value)),"d" (port))
 
-#define inw_p(port) __extension__({ \
-        unsigned short _v; \
-        asm volatile ("inw %%dx,%%ax\n" \
+#define inw_p(port) __extension__ ({      \
+        unsigned short _v;                \
+        asm volatile ("inw %%dx,%%ax\n"   \
                       "outb %%al,$0x80\n" \
-                        :"=a" (_v):"d" (port)); \
+                        :"=a" (_v)        \
+                        :"d" (port));     \
         _v; })
 
 #endif /* __ia16__ */

--- a/elks/include/arch/io.h
+++ b/elks/include/arch/io.h
@@ -6,48 +6,44 @@
 #ifdef __ia16__
 
 #define outb(value,port) \
-__asm__ ("outb %%al,%%dx"::"Ral" ((unsigned char)(value)),"d" (port))
+        asm ("outb %%al,%%dx"::"Ral" ((unsigned char)(value)),"d" (port))
 
-#define inb(port) ({ \
-unsigned char _v; \
-__asm__ volatile ("inb %%dx,%%al":"=Ral" (_v):"d" (port)); \
-_v; \
-})
+#define inb(port) __extension__({ \
+        unsigned char _v; \
+        asm volatile ("inb %%dx,%%al":"=Ral" (_v):"d" (port)); \
+        _v; })
 
 #define outw(value,port) \
-__asm__ ("outw %%ax,%%dx"::"a" ((unsigned short)(value)),"d" (port))
+        asm ("outw %%ax,%%dx"::"a" ((unsigned short)(value)),"d" (port))
 
-#define inw(port) ({ \
-unsigned short _v; \
-__asm__ volatile ("inw %%dx,%%ax":"=a" (_v):"d" (port)); \
-_v; \
-})
+#define inw(port) __extension__({ \
+        unsigned short _v; \
+        asm volatile ("inw %%dx,%%ax":"=a" (_v):"d" (port)); \
+        _v; })
 
 #define outb_p(value,port) \
-__asm__ volatile ("outb %%al,%%dx\n" \
-        "outb %%al,$0x80\n" \
-        ::"Ral" ((unsigned char)(value)),"d" (port))
+        asm volatile ("outb %%al,%%dx\n" \
+                      "outb %%al,$0x80\n" \
+                        ::"Ral" ((unsigned char)(value)),"d" (port))
 
-#define inb_p(port) ({ \
-unsigned char _v; \
-__asm__ volatile ("inb %%dx,%%al\n" \
-        "outb %%al,$0x80\n" \
-        :"=Ral" (_v):"d" (port)); \
-_v; \
-})
+#define inb_p(port) __extension__({ \
+        unsigned char _v; \
+        asm volatile ("inb %%dx,%%al\n" \
+                      "outb %%al,$0x80\n" \
+                        :"=Ral" (_v):"d" (port)); \
+        _v; })
 
 #define outw_p(value,port) \
-__asm__ volatile ("outw %%ax,%%dx\n" \
-        "outb %%al,$0x80\n" \
-        ::"a" ((unsigned short)(value)),"d" (port))
+        asm volatile ("outw %%ax,%%dx\n" \
+                      "outb %%al,$0x80\n" \
+                        ::"a" ((unsigned short)(value)),"d" (port))
 
-#define inw_p(port) ({ \
-unsigned short _v; \
-__asm__ volatile ("inw %%dx,%%ax\n" \
-        "outb %%al,$0x80\n" \
-        :"=a" (_v):"d" (port)); \
-_v; \
-})
+#define inw_p(port) __extension__({ \
+        unsigned short _v; \
+        asm volatile ("inw %%dx,%%ax\n" \
+                      "outb %%al,$0x80\n" \
+                        :"=a" (_v):"d" (port)); \
+        _v; })
 
 #endif /* __ia16__ */
 

--- a/elks/include/arch/irq.h
+++ b/elks/include/arch/irq.h
@@ -29,15 +29,15 @@ void idle_halt(void);
 
 #ifdef __ia16__
 #define save_flags(x)                   \
-        asm volatile("pushfw\n"         \
-                     "\tpopw %0\n"      \
+        asm volatile ("pushfw\n"        \
+                      "popw %0\n"       \
                         :"=r" (x)       \
                         : /* no input */\
                         :"memory")
 
 #define restore_flags(x)                \
-        asm volatile("pushw %0\n"       \
-                     "\tpopfw\n"        \
+        asm volatile ("pushw %0\n"      \
+                      "popfw\n"         \
                         : /* no output*/\
                         :"r" (x)        \
                         :"memory")
@@ -46,12 +46,18 @@ void idle_halt(void);
 // Note the memory barrier for the compiler
 
 /* disable interrupts */
-#define clr_irq()       \
-        asm volatile ("cli": : :"memory")
+#define clr_irq()               \
+        asm volatile ("cli\n"   \
+            : /* no output */   \
+            : /* no input */    \
+            :"memory")
 
 /* enable interrupts */
-#define set_irq()       \
-        asm volatile ("sti": : :"memory")
+#define set_irq()               \
+        asm volatile ("sti\n"   \
+            : /* no output */   \
+            : /* no input */    \
+            :"memory")
 #endif
 
 #endif

--- a/elks/include/arch/irq.h
+++ b/elks/include/arch/irq.h
@@ -27,7 +27,7 @@ int irq_vector (int irq);
 
 void idle_halt(void);
 
-#if defined(__ia16__) && !defined(__STRICT_ANSI__)
+#ifdef __ia16__
 #define save_flags(x)                   \
         asm volatile("pushfw\n"         \
                      "\tpopw %0\n"      \
@@ -46,19 +46,12 @@ void idle_halt(void);
 // Note the memory barrier for the compiler
 
 /* disable interrupts */
-#define clr_irq()       asm volatile ("cli": : :"memory")
+#define clr_irq()       \
+        asm volatile ("cli": : :"memory")
 
 /* enable interrupts */
-#define set_irq()       asm volatile ("sti": : :"memory")
-#else
-
-#define save_flags(flags)       save_flags_asm(&flags)
-#define restore_flags(flags)    restore_flags_asm(&flags)
-void save_flags_asm(flag_t *);
-void restore_flags_asm(flag_t *);
-void clr_irq(void);
-void set_irq(void);
-
+#define set_irq()       \
+        asm volatile ("sti": : :"memory")
 #endif
 
 #endif

--- a/elks/include/arch/types.h
+++ b/elks/include/arch/types.h
@@ -66,10 +66,4 @@ typedef __u16			__pptr;
 #define NULL		((void *) 0)
 #endif
 
-#ifndef __STRICT_ANSI__
-#define FAR             __far
-#else
-#define FAR
-#endif
-
 #endif /* !__ARCH_8086_TYPES_H */

--- a/elks/include/linuxmt/debug.h
+++ b/elks/include/linuxmt/debug.h
@@ -46,7 +46,7 @@
 #if DEBUG_EVENT
 void dprintk(char *, ...);		/* printk when debugging on*/
 void debug_event(void);			/* generate debug event*/
-void debug_setcallback(void (*cbfunc));	/* callback on debug event*/
+void debug_setcallback(void (*cbfunc)()); /* callback on debug event*/
 #define PRINTK		dprintk
 #else
 #define PRINTK		printk

--- a/elks/include/linuxmt/init.h
+++ b/elks/include/linuxmt/init.h
@@ -58,7 +58,7 @@ extern void meta_init(void);
 extern void pty_init(void);
 extern void tcpdev_init(void);
 
-extern void kfork_proc(void (*addr));
+extern void kfork_proc(void (*addr)());
 extern void arch_setup_user_stack(struct task_struct *, word_t entry);
 
 #endif

--- a/elks/include/linuxmt/memory.h
+++ b/elks/include/linuxmt/memory.h
@@ -27,9 +27,9 @@ word_t fmemcmpb (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg, s
 word_t fmemcmpw (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg, size_t count);
 
 /* macros for far pointers (a la Turbo C++ and Open Watcom) */
-#define _FP_SEG(fp)	((unsigned)((unsigned long)(void FAR *)(fp) >> 16))
-#define _FP_OFF(fp)	((unsigned)(unsigned long)(void FAR *)(fp))
-#define _MK_FP(seg,off)	((void FAR *)((((unsigned long)(seg)) << 16) | (off)))
+#define _FP_SEG(fp)     ((unsigned)((unsigned long)(void __far *)(fp) >> 16))
+#define _FP_OFF(fp)     ((unsigned)(unsigned long)(void __far *)(fp))
+#define _MK_FP(seg,off)	((void __far *)((((unsigned long)(seg)) << 16) | (off)))
 
 /* unreal mode, A20 gate management */
 int check_unreal_mode(void);	/* check if unreal mode capable, returns > 0 on success */

--- a/elks/include/linuxmt/msdos_fs.h
+++ b/elks/include/linuxmt/msdos_fs.h
@@ -43,8 +43,6 @@
 
 #define MSDOS_FAT12_MAX_CLUSTERS    4084 /* maximum number of clusters in a 12 bit FAT */
 
-typedef long cluster_t;
-
 struct msdos_boot_sector {
 	char ignored[13];	    /*0*/
 	unsigned char cluster_size; /* sectors/cluster 13*/

--- a/elks/include/linuxmt/msdos_fs_i.h
+++ b/elks/include/linuxmt/msdos_fs_i.h
@@ -6,8 +6,6 @@
  * ported from linux-2.0.34 by zouys, Oct 28th, 2010
  */
 
-typedef long cluster_t;
-
 struct msdos_inode_info {
 	cluster_t i_start; /* first cluster or 0 */
 	int i_attrs;	/* unused attribute bits */

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -166,7 +166,7 @@ extern void kill_all(sig_t);
 extern void add_to_runqueue(struct task_struct *);
 
 extern struct task_struct *find_empty_process(void);
-extern void arch_build_stack(struct task_struct *, char *);
+extern void arch_build_stack(struct task_struct *, void (*)());
 extern int restart_syscall(void);
 extern unsigned int get_ustack(struct task_struct *,int);
 extern void put_ustack(register struct task_struct *,int,int);

--- a/elks/include/linuxmt/signal.h
+++ b/elks/include/linuxmt/signal.h
@@ -189,7 +189,10 @@ typedef void (*__sighandler_t)(int);
 /* Type of a signal handler which interfaces with the kernel.  This is always
    a far function that uses the `stdcall' calling convention, even for a
    user program that is being compiled for a different calling convention.  */
-typedef __attribute__((__stdcall__)) FAR void (*__kern_sighandler_t)(int);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+typedef __attribute__((__stdcall__)) __far void (*__kern_sighandler_t)(int);
+#pragma GCC diagnostic pop
 
 /*@+namechecks@*/ /*@ignore@*/
 

--- a/elks/include/linuxmt/types.h
+++ b/elks/include/linuxmt/types.h
@@ -18,6 +18,7 @@ typedef __u32			block32_t;
 typedef __u32			sector_t;
 typedef __u16			dev_t;
 typedef __u16			flag_t;
+typedef long			cluster_t;
 
 typedef __u32			u_ino_t;
 #ifndef __KERNEL__

--- a/elks/kernel/Makefile
+++ b/elks/kernel/Makefile
@@ -36,7 +36,8 @@ include $(BASEDIR)/Makefile-rules
 # Objects to compile.
 # unused: wait.o lock.o
 
-OBJS  = sched.o printk.o sleepwake.o dma.o version.o sys.o sys2.o fork.o \
+UNUSED = dma.o
+OBJS  = sched.o printk.o sleepwake.o version.o sys.o sys2.o fork.o \
 	exit.o time.o signal.o
 
 #########################################################################

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -280,7 +280,7 @@ int dprintk_on = DEBUG_STARTDEF;	/* toggled by debug events*/
 #if DEBUG_EVENT
 static void (*dprintk_cb)();		/* debug event callback function*/
 
-void debug_setcallback(void (*cbfunc))
+void debug_setcallback(void (*cbfunc)())
 {
     dprintk_cb = cbfunc;
 }


### PR DESCRIPTION
Adds `__extension__` keyword to allow -Wpedantic checking and kernel compilation with suppressed messages for gcc extensions. This is useful for allowing various `asm()` constructs that use GCC's "statement-expression" extension, without producing warnings.

Use only `asm` and `volatile`, replaces `__asm__`, `__asm` and `__volatile__`.
Reverts previous change of `__far` to `FAR`.

By default, `CFLAGS += -std=gnu99 -Wpedantic` is turned off, as it won't work to build CONFIG_FARTEXT_KERNEL kernels. Turning it on in elks/Makefile-rules will allow for higher level of C code checking, which should be done on occasion.