### PR TITLE
[serial driver] Removed hardcoding of IRQs for S2, S3

### DIFF
--- a/elks/arch/i86/drivers/char/serial-8250.c
+++ b/elks/arch/i86/drivers/char/serial-8250.c
@@ -27,8 +27,7 @@ struct serial_info {
     unsigned char mcr;
     unsigned int  divisor;
     struct tty *tty;
-    int index;
-    int pad1, pad2;	// round out to 16 bytes for faster addressing of ports[]
+    int pad1, pad2, pad3;	// round out to 16 bytes for faster addressing of ports[]
 };
 
 /* flags*/
@@ -59,9 +58,9 @@ struct serial_info {
 
 static struct serial_info ports[NR_SERIAL] = {
     {(char *)COM1_PORT, COM1_IRQ, 0, DEFAULT_LCR, DEFAULT_MCR, 0, NULL, 0,0,0},
-    {(char *)COM2_PORT, COM2_IRQ, 0, DEFAULT_LCR, DEFAULT_MCR, 0, NULL, 1,0,0},
-    {(char *)COM3_PORT, COM3_IRQ, 0, DEFAULT_LCR, DEFAULT_MCR, 0, NULL, 2,0,0},
-    {(char *)COM4_PORT, COM4_IRQ, 0, DEFAULT_LCR, DEFAULT_MCR, 0, NULL, 3,0,0},
+    {(char *)COM2_PORT, COM2_IRQ, 0, DEFAULT_LCR, DEFAULT_MCR, 0, NULL, 0,0,0},
+    {(char *)COM3_PORT, COM3_IRQ, 0, DEFAULT_LCR, DEFAULT_MCR, 0, NULL, 0,0,0},
+    {(char *)COM4_PORT, COM4_IRQ, 0, DEFAULT_LCR, DEFAULT_MCR, 0, NULL, 0,0,0},
 };
 
 static char irq_to_port[16];


### PR DESCRIPTION
Replaces the former hardcoding of serial IRQs which effectively ignored the IRQ settings in `ports.h` with something that works with any IRQs.

@ghaerr, there are two versions in the code - to be discussed. The commented-out version uses a function (search) to map the irq into the serial struct.  Code size 39 bytes. 
The active version uses a 16 byte array instead, which is both faster and more compact. The array could be shortened by 2 or 3, but I'm not convinced it's worth it. 
Comments solicited.

Needless to say, this one hit me real hard this last week - until I finally remembered. :-)

-M  