### PR TITLE
[kernel][libc] Fix memcmp

### DIFF
--- a/elks/arch/i86/drivers/char/eth.c
+++ b/elks/arch/i86/drivers/char/eth.c
@@ -8,6 +8,7 @@
 #include <linuxmt/errno.h>
 #include <linuxmt/fs.h>
 #include <linuxmt/netstat.h>
+#include <linuxmt/string.h>
 
 /* character devices and their minor numbers */
 extern struct file_operations ne2k_fops;    /* 0 CONFIG_ETH_NE2K */

--- a/elks/lib/string.c
+++ b/elks/lib/string.c
@@ -226,7 +226,7 @@ int memcmp(const void *s1, const void *s2, size_t n)
     char res = 0;
 
     for (; n > 0; n--)
-        if (!(res = *su1++ - *su2++))
+        if ((res = *su1++ - *su2++))
             break;
 
     return res;

--- a/elkscmd/file_utils/cmp.c
+++ b/elkscmd/file_utils/cmp.c
@@ -112,7 +112,7 @@ int main(int argc, char **argv)
 			pos++;
 
 		errmsg("Files differ at byte position ");
-		char *p = ltoa(pos);
+		char *p = ltoa(pos+1);
 		errstr(p);
 		errmsg("\n");
 		return 1;

--- a/libc/string/memcmp.c
+++ b/libc/string/memcmp.c
@@ -8,7 +8,7 @@ memcmp(const void *s1, const void *s2, size_t n)
     char res = 0;
 
     for (; n > 0; n--)
-        if (!(res = *su1++ - *su2++))
+	if ((res = *su1++ - *su2++))
             break;
 
     return res;


### PR DESCRIPTION
Some small fixes:

- `memcmp` was broken in both libc and kernel.
- the `cmp` command (which led to the fixes above) reported differences one byte off.
- added `string.h` to `eth.c` to get rid of compiler warnings.