### PR TITLE
[kernel][libc] Fix ANSI colors, libc strtol/strtoul, net script

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -8,6 +8,7 @@ To build ELKS, you need a GNU development environment, including:
 - texinfo
 - libncurses5-dev
 - mtools-4.0.23 (for MSDOS/FAT images)
+- compress (for compressed man pages; use `sudo apt-get install ncompress`)
 
 ## Quickstart
 

--- a/elks/arch/i86/drivers/char/console.c
+++ b/elks/arch/i86/drivers/char/console.c
@@ -163,13 +163,11 @@ static void AnsiCmd(register Console * C, char c)
 	  n = atoi(p);
 	  if (n >= 30 && n <= 37) {
 	    C->attr &= 0xf8;
-	    //C->attr |= (n-30) & 0x07;
 	    C->attr |= ega_color[n-30] & 0x0F;  /* some colors bright by default */
 	    C->color = C->attr;
 	  }
 	  else if (n >= 40 && n <= 47) {
 	    C->attr &= 0x8f;
-	    //C->attr |= ((n-40) << 4) & 0x70;
 	    C->attr |= (ega_color[n-40] << 4) & 0x70;
 	    C->color = C->attr;
 	  }

--- a/elks/arch/i86/drivers/char/console.c
+++ b/elks/arch/i86/drivers/char/console.c
@@ -74,6 +74,10 @@ static void itoaQueue(int i)
 	Console_conin(*b++);
 }
 
+/* reverse map table ANSI -> ega      blk red grn yel blu mag cyn wht */
+static unsigned char ega_color[8] = {   0,8+4,  2,8+6,8+1,  5,  3, 7 };
+
+/* ESC [ processing */
 static void AnsiCmd(register Console * C, char c)
 {
     int n;
@@ -84,7 +88,7 @@ static void AnsiCmd(register Console * C, char c)
     if (!isalpha(c)) {
 	return;
     }
-    *(C->parmptr) = 0;
+    *C->parmptr = '\0';
 
     switch (c) {
     case 's':			/* Save the current location */
@@ -159,12 +163,14 @@ static void AnsiCmd(register Console * C, char c)
 	  n = atoi(p);
 	  if (n >= 30 && n <= 37) {
 	    C->attr &= 0xf8;
-	    C->attr |= (n-30) & 0x07;
+	    //C->attr |= (n-30) & 0x07;
+	    C->attr |= ega_color[n-30] & 0x0F;  /* some colors bright by default */
 	    C->color = C->attr;
 	  }
 	  else if (n >= 40 && n <= 47) {
 	    C->attr &= 0x8f;
-	    C->attr |= ((n-40) << 4) & 0x70;
+	    //C->attr |= ((n-40) << 4) & 0x70;
+	    C->attr |= (ega_color[n-40] << 4) & 0x70;
 	    C->color = C->attr;
 	  }
 	  else switch (n) {
@@ -214,12 +220,25 @@ static void AnsiCmd(register Console * C, char c)
     C->fsm = std_char;
 }
 
-/* Escape character processing */
+/* ANSI emulator - ESC seen */
 static void esc_char(register Console * C, char c)
 {
     /* Parse CSI sequence */
     C->parmptr = C->params;
-    C->fsm = (c == '[' ? AnsiCmd : std_char);
+    switch (c) {
+    case '[':
+        C->fsm = AnsiCmd;
+        return;
+    case '7':           /* DEC save cursor pos */
+        C->savex = C->cx;
+        C->savey = C->cy;
+        break;
+    case '8':           /* DEC restore cursor pos */
+        C->cx = C->savex;
+        C->cy = C->savey;
+        break;
+    }
+    C->fsm = std_char;
 }
 #endif
 

--- a/elks/include/linuxmt/netstat.h
+++ b/elks/include/linuxmt/netstat.h
@@ -15,7 +15,7 @@ struct netif_parms {
 	int	irq;
 	int	port;
 	unsigned int ram;
-    unsigned int flags;
+	unsigned int flags;
 };
 // Should put this into the eths struct 
 extern struct netif_parms netif_parms[MAX_ETHS];

--- a/elkscmd/Make.install
+++ b/elkscmd/Make.install
@@ -214,15 +214,20 @@ ifdef CONFIG_APP_CGATEXT
 endif
 ifdef CONFIG_APP_MAN_PAGES
 	mkdir -p $(DESTDIR)/lib/man1
-	cp -rp man/man1 $(DESTDIR)/lib; compress -b 12 $(DESTDIR)/lib/man1/*
+	cp -rp man/man1 $(DESTDIR)/lib
+	-compress -b 12 $(DESTDIR)/lib/man1/*
 	mkdir -p $(DESTDIR)/lib/man2
-	cp -rp man/man2 $(DESTDIR)/lib; compress -b 12 $(DESTDIR)/lib/man2/*
+	cp -rp man/man2 $(DESTDIR)/lib
+	-compress -b 12 $(DESTDIR)/lib/man2/*
 	mkdir -p $(DESTDIR)/lib/man5
-	cp -rp man/man5 $(DESTDIR)/lib; compress -b 12 $(DESTDIR)/lib/man5/*
+	cp -rp man/man5 $(DESTDIR)/lib
+	-compress -b 12 $(DESTDIR)/lib/man5/*
 	mkdir -p $(DESTDIR)/lib/man7
-	cp -rp man/man7 $(DESTDIR)/lib; compress -b 12 $(DESTDIR)/lib/man7/*
+	cp -rp man/man7 $(DESTDIR)/lib
+	-compress -b 12 $(DESTDIR)/lib/man7/*
 	mkdir -p $(DESTDIR)/lib/man8
-	cp -rp man/man8 $(DESTDIR)/lib; compress -b 12 $(DESTDIR)/lib/man8/*
+	cp -rp man/man8 $(DESTDIR)/lib
+	-compress -b 12 $(DESTDIR)/lib/man8/*
 endif
 
 

--- a/elkscmd/file_utils/more.c
+++ b/elkscmd/file_utils/more.c
@@ -11,11 +11,16 @@
 #include <termios.h>
 #include "futils.h"
 
-#define MORE_STRING	"\e[7m--More--\e[0m"
+#define MORE_STRING  "\e[7m--More--\e[0m"
+#define END_STRING   "\e[7m(END)\e[0m"
+#define CLEAR_SCREEN "\e[H\e[2J"
+
+#define WRITE(fd,str)   write(fd, str, strlen(str))
 
 static int fd;
 static int LINES = 25;
 static int MAXLINES = 25;
+static char cflag = 1;  /* -c flag: clear screen and wait for partial results */
 
 /* Use the DSR ESC [6n escape sequence to query the cursor position */
 static int getCursorPosition(int ifd, int ofd, int *rows, int *cols)
@@ -201,6 +206,7 @@ int main(int argc, char **argv)
 			}
 			continue;
 		}
+		if (cflag) WRITE(1, CLEAR_SCREEN);
 		while ((fd > -1) && ((read(fd, &ch, 1)) != 0)) {
 			switch (ch) {
 				case '\r':
@@ -252,6 +258,7 @@ int main(int argc, char **argv)
 			if (more_wait(1, strcat(next, argv[1])) < 0)
 				return 0;
 		}
+		else if (cflag) more_wait(1, END_STRING);
 		if (fd)
 			close(fd);
 	} while (--argc > 1);

--- a/elkscmd/ktcp/arp.c
+++ b/elkscmd/ktcp/arp.c
@@ -27,8 +27,7 @@
 #include "netconf.h"
 
 struct arp_cache arp_cache [ARP_CACHE_MAX];
-void arp_prep_request(struct arp *, ipaddr_t);
-
+static void arp_prep_request(struct arp *, ipaddr_t);
 
 int arp_init (void)
 {
@@ -171,8 +170,8 @@ void arp_reply(unsigned char *packet)
 }
 
 /* build arp request */
-void arp_prep_request(struct arp *ar, ipaddr_t ip) {
-
+static void arp_prep_request(struct arp *ar, ipaddr_t ip)
+{
     memset(ar->ll_eth_dest, 0xFF, 6);	/* broadcast*/
     memcpy(ar->ll_eth_src, eth_local_addr, 6);
     /*specify below in big endian*/ //FIXME

--- a/elkscmd/misc_utils/kilo.c
+++ b/elkscmd/misc_utils/kilo.c
@@ -930,9 +930,7 @@ int editorUpdateSyntax(erow *row) {
     return 0;
 }
 
-/* ELKS colors (obsolete):
- * 31=blue, 32=green, 33=cyan, 34=red, 35=magenta, 36=yellow/orange, 37=white
- * ANSI colors:
+/* ANSI colors:
  * 31=red, 32=green, 33=yellow, 34=blue, 35=magenta, 36=cyan, 37=white
  */
 /* Maps syntax highlight token types to terminal colors. */

--- a/elkscmd/misc_utils/kilo.c
+++ b/elkscmd/misc_utils/kilo.c
@@ -930,8 +930,10 @@ int editorUpdateSyntax(erow *row) {
     return 0;
 }
 
-/* ELKS colors:
+/* ELKS colors (obsolete):
  * 31=blue, 32=green, 33=cyan, 34=red, 35=magenta, 36=yellow/orange, 37=white
+ * ANSI colors:
+ * 31=red, 32=green, 33=yellow, 34=blue, 35=magenta, 36=cyan, 37=white
  */
 /* Maps syntax highlight token types to terminal colors. */
 int editorSyntaxToColor(int hl) {

--- a/elkscmd/rootfs_template/bin/net
+++ b/elkscmd/rootfs_template/bin/net
@@ -12,6 +12,7 @@
 # See slattach.sh for Linux slip setup
 # See qemu.sh NET= line for host forwarding into ELKS using QEMU
 #
+#set -x
 
 # read net configuration file
 source /etc/net.cfg
@@ -25,7 +26,7 @@ usage()
 getty_off()
 {
 	# turn off any serial gettys running
-	init 1
+	#init 1
 }
 
 start_network()

--- a/elkscmd/rootfs_template/etc/perror
+++ b/elkscmd/rootfs_template/etc/perror
@@ -5,7 +5,7 @@
 5 I/O error 
 6 No such device or address 
 7 Arg list too long 
-8 Exec format error 
+8 Exec format error (install ash for shell scripts) 
 9 Bad file number 
 10 No child processes 
 11 Try again 

--- a/libc/include/sys/param.h
+++ b/libc/include/sys/param.h
@@ -1,0 +1,8 @@
+#ifndef __SYS_PARAM_H
+#define __SYS_PARAM_H
+
+#include <limits.h>
+
+#define MAXSYMLINKS 8
+
+#endif

--- a/libc/misc/strtol.c
+++ b/libc/misc/strtol.c
@@ -25,6 +25,8 @@ static int digit(char c, int base)
 	int d;
 	if (c <= '9') {
 		d = c - '0';
+	} else if (c < 'A') {	/* NEATLIBC bugfix */
+		return -1;
 	} else if (c <= 'Z') {
 		d = 10 + c - 'A';
 	} else {

--- a/libc/misc/strtoul.c
+++ b/libc/misc/strtoul.c
@@ -25,6 +25,8 @@ static int digit(char c, int base)
 	int d;
 	if (c <= '9') {
 		d = c - '0';
+	} else if (c < 'A') {	/* NEATLIBC bugfix */
+		return -1;
 	} else if (c <= 'Z') {
 		d = 10 + c - 'A';
 	} else {


### PR DESCRIPTION
Fixes and small enhancements to various issues.

Corrects console color sequences to ANSI standard - ELKS was using CGA/EGA colors instead of ANSI in ESC [ fg;bg m sequence.

Adds ESC 7 and ESC 8 save/restore cursor position for ANSI console.

Enhances `more` to behave like `more -c`, which displays "(END)" even when file total lines are less than 25, and also clears screen on start. This is to work with upcoming `fm` ELKS file manager.

Fixes incorrect result returned in libc `strtol` and `strtoul` when numeric string didn't end in NUL.

Adds <sys/param> libc header file.

Removes `init 1` from `net start slip` script, changing init run levels turned off, so stopping network doesn't turn off any multiuser mode. (#1368).

In testing this PR for colors, I noticed that `kilo`s syntax color scheme is mostly broken... will look further into that.




