### PR TITLE
[kernel][libc][cmds] Add stty erase2, fix printf %*s, ls time format

### DIFF
--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -38,23 +38,22 @@ struct termios def_vals = {
     0,							/* c_line*/
     { 3,	/* VINTR*/
     28,		/* VQUIT*/
-    /*127*/ 8,	/* VERASE*/
-    21,		/* VKILL*/
+    8,		/* VERASE*/
+    21,		/* VKILL unused*/
     4,		/* VEOF*/
     0,		/* VTIME*/
     1,		/* VMIN*/
-    0,		/* VSWTC*/
-    17,		/* VSTART*/
-    19,		/* VSTOP*/
-    26,		/* VSUSP*/
+    0,		/* VSWTCH unused*/
+    17,		/* VSTART unused*/
+    19,		/* VSTOP unused*/
+    26,		/* VSUSP unused*/
     0,		/* VEOL*/
-    18,		/* VREPRINT*/
-    15,		/* VDISCARD*/
-    23,		/* VWERASE*/
-    22,		/* VLNEXT*/
-    0,		/* VEOL2*/
-    0,
-    0 }
+    18,		/* VREPRINT unused*/
+    15,		/* VDISCARD unused*/
+    23,		/* VWERASE unused*/
+    22,		/* VLNEXT unused*/
+    127 	/* VERASE2*/
+    }
 };
 
 #define TAB_SPACES 8
@@ -265,7 +264,8 @@ static void tty_echo(register struct tty *tty, unsigned char ch)
 {
     if ((tty->termios.c_lflag & ECHO)
 		|| ((tty->termios.c_lflag & ECHONL) && (ch == '\n'))) {
-	if ((ch == tty->termios.c_cc[VERASE]) && (tty->termios.c_lflag & ECHOE)) {
+	if ((ch == tty->termios.c_cc[VERASE] || ch == tty->termios.c_cc[VERASE2])
+       && (tty->termios.c_lflag & ECHOE)) {
 	    chq_addch(&tty->outq, '\b');
 	    chq_addch(&tty->outq, ' ');
 	    chq_addch(&tty->outq, '\b');
@@ -357,7 +357,7 @@ again:
 	    ch = '\n';
 
 	if (icanon) {
-	    if (ch == tty->termios.c_cc[VERASE]) {
+	    if (ch == tty->termios.c_cc[VERASE] || ch == tty->termios.c_cc[VERASE2]) {
 		if (i > 0) {
 		    i--;
 		    k = ((get_user_char((void *)(--data)) == '\t') ? TAB_SPACES : 1);

--- a/elks/include/linuxmt/termios.h
+++ b/elks/include/linuxmt/termios.h
@@ -92,7 +92,7 @@ struct termio {
     unsigned char c_cc[NCC];	/* control characters */
 };
 
-#define NCCS 19
+#define NCCS 17
 struct termios {
     tcflag_t c_iflag;		/* input mode flags */
     tcflag_t c_oflag;		/* output mode flags */
@@ -110,7 +110,7 @@ struct termios {
 #define VEOF 4
 #define VTIME 5
 #define VMIN 6
-#define VSWTC 7
+#define VSWTCH 7
 #define VSTART 8
 #define VSTOP 9
 #define VSUSP 10
@@ -119,16 +119,16 @@ struct termios {
 #define VDISCARD 13
 #define VWERASE 14
 #define VLNEXT 15
-#define VEOL2 16
+#define VERASE2 16
 
 #ifdef __KERNEL__
-/*	intr=^C		quit=^|		erase=del	kill=^U
+/*	intr=^C		quit=^|		erase=^H	kill=^U
 	eof=^D		vtime=\0	vmin=\1		sxtc=\0
 	start=^Q	stop=^S		susp=^Z		eol=\0
 	reprint=^R	discard=^U	werase=^W	lnext=^V
-	eol2=\0
+	erase2=\177
 */
-#define INIT_C_CC "\003\034\177\025\004\0\1\0\021\023\032\0\022\017\027\026\0"
+#define INIT_C_CC "\003\034\007\025\004\0\1\0\021\023\032\0\022\017\027\026\177"
 #endif
 
 /* c_iflag bits */

--- a/elkscmd/file_utils/ls.c
+++ b/elkscmd/file_utils/ls.c
@@ -92,11 +92,16 @@ static int sortbysize = 0;
 static int nosort = 0;
 static char fmt[16] = "%s";
 
+/* return -1/0/1 based on sign of x */
+static int sign(long x)
+{
+    return (x > 0) - (x < 0);
+}
+
 static int namesort(const struct sort *a, const struct sort *b)
 {
     if (sortbytime || sortbysize) {
-	long lval = reverse * (b->longval - a->longval);
-	return (int)(lval >> 16);	/* return sign of long compare */
+	return sign(reverse * (b->longval - a->longval));
     }
     return reverse * strcmp(a->name, b->name);
 }
@@ -399,8 +404,9 @@ static char *timestring(time_t t)
     buf[12] = '\0';
 
     if ((t > now) || (t < now - 180*24*60L*60)) {
-	strcpy(&buf[7], &str[20]);
-	buf[11] = '\0';
+	buf[7] = ' ';
+	strcpy(&buf[8], &str[20]);
+	buf[12] = '\0';
     }
 
     return buf;

--- a/elkscmd/sash/utils.c
+++ b/elkscmd/sash/utils.c
@@ -119,8 +119,9 @@ timestring(time_t t)
 	buf[12] = '\0';
 
 	if ((t > now) || (t < now - 365*24*60L*60)) {
-		strcpy(&buf[7], &str[20]);
-		buf[11] = '\0';
+		buf[7] = ' ';
+		strcpy(&buf[8], &str[20]);
+		buf[12] = '\0';
 	}
 
 	return buf;

--- a/elkscmd/sh_utils/stty.c
+++ b/elkscmd/sh_utils/stty.c
@@ -55,8 +55,11 @@
 #ifndef TERASE_DEF
 #define TERASE_DEF	'\10'	/* ^H */
 #endif
+#ifndef TERASE2_DEF
+#define TERASE2_DEF	'\177'	/* ^? */
+#endif
 #ifndef TINTR_DEF
-#define TINTR_DEF	'\177'	/* ^? */
+#define TINTR_DEF	'\03'	/* ^C */
 #endif
 #ifndef TKILL_DEF
 #define TKILL_DEF	'\25'	/* ^U */
@@ -317,6 +320,7 @@ int flags;
 	print_char(termios.c_cc[VSUSP], TSUSP_DEF, "susp", all);
 	print_char(termios.c_cc[VSTART], TSTART_DEF, "start", all);
 	print_char(termios.c_cc[VSTOP], TSTOP_DEF, "stop", all);
+	print_char(termios.c_cc[VERASE2], TERASE2_DEF, "erase2", all);
 #ifdef __minix
 	print_char(termios.c_cc[VREPRINT], TREPRINT_DEF, "rprnt", all);
 	print_char(termios.c_cc[VLNEXT], TLNEXT_DEF, "lnext", all);
@@ -763,6 +767,11 @@ char *opt, *next;
 	return 1;
   }
 
+  if (match(opt, "erase2")) {
+	set_control(VERASE2, next);
+	return 1;
+  }
+
   if (match(opt, "intr")) {
 	set_control(VINTR, next);
 	return 1;
@@ -873,8 +882,9 @@ char *opt, *next;
   }
 
   if (match(opt, "ek")) {
-	termios.c_cc[VERASE]= TERASE_DEF;;
-	termios.c_cc[VKILL]= TKILL_DEF;;
+	termios.c_cc[VERASE]= TERASE_DEF;
+	termios.c_cc[VERASE2]= TERASE2_DEF;
+	termios.c_cc[VKILL]= TKILL_DEF;
 	return 0;
   }
 
@@ -899,6 +909,7 @@ char *opt, *next;
 	termios.c_cc[VEOF]= TEOF_DEF;
 	termios.c_cc[VEOL]= TEOL_DEF;
 	termios.c_cc[VERASE]= TERASE_DEF;
+	termios.c_cc[VERASE2]= TERASE2_DEF;
 	termios.c_cc[VINTR]= TINTR_DEF;
 	termios.c_cc[VKILL]= TKILL_DEF;
 	termios.c_cc[VQUIT]= TQUIT_DEF;

--- a/libc/stdio/vfprintf.c
+++ b/libc/stdio/vfprintf.c
@@ -164,8 +164,12 @@ vfprintf(FILE *op, const char *fmt, va_list ap)
 	    i = va_arg(ap, int);
 	    if (dpoint)
 	       preci = i;
-	    else
-	       width = i;
+	    else {
+		if (i < 0) {
+		    width = -i;
+		    ljustf = 1;
+		} else width = i;
+            }
 	    goto fmtnxt;
 
 	 case '.':		/* secondary width field */


### PR DESCRIPTION
Various fixes from porting new `fm` file manager to ELKS.

Adds additional stty "erase2" character, default DEL. This fixes the longstanding problem of not being able to backspace using the delete key when logging in from a terminal, as well as any program calling gets/fgets for input (like BASIC and now fm). Since the ELKS console always mapped the main keyboard delete key to BS (^H), this was only noticed when accessing via telnet or serial terminal.

Fix slightly improper year output in `ls -l` (and sash), as well as internal time/size compare function.

Fix `printf` "%*s" format string when passed width argument was negative (for left justification).
