### PR TITLE
[kernel] Fix duplicate character received in serial driver on QEMU

### DIFF
--- a/elks/arch/i86/drivers/char/serial-8250.c
+++ b/elks/arch/i86/drivers/char/serial-8250.c
@@ -287,14 +287,15 @@ void rs_irq(int irq, struct pt_regs *regs)
     char *io = sp->io;
     struct ch_queue *q = &sp->tty->inq;
 
-#if 0	// turn on for serial stats
     int status = INB(io + UART_LSR);			/* check for data overrun*/
+    if ((status & UART_LSR_DR) == 0)			/* QEMU may interrupt w/no data*/
+	return;
+
+#if 0	// turn on for serial stats
     if (status & UART_LSR_OE)
 	printk("serial: data overrun\n");
     if (status & (UART_LSR_FE|UART_LSR_PE))
 	printk("serial: frame/parity error\n");
-    if ((status & UART_LSR_DR) == 0)			/* QEMU may interrupt w/no data*/
-	printk("serial: interrupt w/o data available\n");
 #endif
 
     /* read uart/fifo until empty*/


### PR DESCRIPTION
This fixes a long-standing problem with QEMU and the serial driver: on occasion, QEMU somehow triggers a second serial interrupt and the last received character is "received" again. The fix is to look at the UART data ready register and return if no character is ready to be received.

During the new `fm` file manager port, which uses an ANSI sequence to tell the remote terminal to send streaming mouse data immediately when the mouse is moved, large streams of input data were being received quickly, and it was finally found that this is the problem that caused some mouse and arrow key keypresses to be ignored. The reason is that ELKS received a random portion of the ANSI sequence twice, thus throwing off the application (fm, vi, dflat, etc) that was doing the ANSI sequence recognition. This could also be the reason that `vi` isn't always able to determine the remote terminal window size correctly (using ANSI DSR) every time, but I haven't checked that yet.

@Mellvik, this hasn't been tested on real hardware, but shouldn't be an issue, as some older code was uncommented, which previously recognized this problem. It does add about 10 more instructions per interrupt to our serial IRQ processing, but has to be done in order for the terminal sequences to work properly. This will also fix any serial hardware that might have the same issue. I suspect the QEMU issue is related to their emulation of the 8259 IRQ line being held high for a bit too long, causing another "fake" interrupt, but not sure. Hopefully adding his extra code won't materially affect our serial driver max input baud rate, although the interrupt routine does already operate with interrupts allowed, so it shouldn't, unless the UART gets a receiver overrun.
