### PR TITLE
[images] Fix sash overwriting ash on 2880K and HD builds

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -47,8 +47,8 @@
 sys_utils/init			:boot	:sysutil    :128k
 sys_utils/getty			:boot	:sysutil    :128k
 sys_utils/login			:boot	:sysutil    :128k
-ash/ash		::bin/sh	:boot	:ash	    # install as /bin/sh
 sash/sash	::bin/sh	    	:defsash	# install as /bin/sh
+ash/ash		::bin/sh	:boot	:ash	    # install as /bin/sh (must follow :defsash)
 sash/sash		    	        :sash                   :1200k  :1440k
 sys_utils/mount			:boot	:sysutil    :128k
 sys_utils/umount		:boot	:sysutil    :128k

--- a/elkscmd/Make.install
+++ b/elkscmd/Make.install
@@ -136,18 +136,19 @@ ifdef CONFIG_APPS_720K
 endif
 
 ifdef CONFIG_APPS_1200K
-	TAGS = :boot|:360k|:net|:720k|:1200k|:man|
+	TAGS = :boot|:360k|:net|:720k|:1200k|
 endif
 
 ifdef CONFIG_APPS_1232K
-	TAGS = :boot|:360k|:net|:720k|:man|
+	TAGS = :boot|:360k|:net|:720k|
 endif
 
 ifdef CONFIG_APPS_1440K
-	TAGS = :boot|:360k|:net|:720k|:1200k|:1440k|:man|
+	TAGS = :boot|:360k|:net|:720k|:1200k|:1440k|
 endif
 
 ifdef CONFIG_APPS_2880K
+    # below TAGS relies on :ash rule following :defsash rule in Applications
 	TAGS = :*|
 	CONFIG_APP_MAN_PAGES=y
 endif


### PR DESCRIPTION
Likely since v0.6.0, all full-sized image builds incorrectly overwrite /bin/sh with `sash`, due to TAGS= in elkscmd/Make.install. Fixes by reversing order of copy in elkscmd/Applications.