### PR TITLE
[kernel][libc] cleanup various header files and compiler warnings

### DIFF
--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -191,15 +191,15 @@ int INITPROC buffer_init(void)
 	bufs_to_alloc -= nbufs;
 #ifdef CONFIG_FS_XMS_BUFFER
 	if (xms_enabled) {
-	    ramdesc_t seg = xms_alloc((long_t)nbufs << BLOCK_SIZE_BITS);
-	    add_buffers(nbufs, 0, seg);
+	    ramdesc_t xmsseg = xms_alloc((long_t)nbufs << BLOCK_SIZE_BITS);
+	    add_buffers(nbufs, 0, xmsseg);
 	} else
 #endif
 	{
-	    segment_s *seg = seg_alloc (nbufs << (BLOCK_SIZE_BITS - 4),
+	    segment_s *extseg = seg_alloc (nbufs << (BLOCK_SIZE_BITS - 4),
 		SEG_FLAG_EXTBUF|SEG_FLAG_ALIGN1K);
-	    if (!seg) return 2;
-	    add_buffers(nbufs, 0, seg->base);
+	    if (!extseg) return 2;
+	    add_buffers(nbufs, 0, extseg->base);
 	}
     } while (bufs_to_alloc > 0);
 #else

--- a/elks/include/linuxmt/heap.h
+++ b/elks/include/linuxmt/heap.h
@@ -1,7 +1,8 @@
+#ifndef __LINUXMT_HEAP_H
+#define __LINUXMT_HEAP_H
+
 // Kernel library
 // Local heap management
-
-#pragma once
 
 #include <linuxmt/types.h>
 #include <linuxmt/list.h>
@@ -52,3 +53,5 @@ void heap_init ();
 #ifdef HEAP_DEBUG
 void heap_iterate (void (* cb) (heap_s * h));
 #endif /* HEAP_DEBUG */
+
+#endif

--- a/elks/include/linuxmt/init.h
+++ b/elks/include/linuxmt/init.h
@@ -33,7 +33,7 @@ extern void INITPROC tty_init(void);
 extern void INITPROC device_init(void);
 extern void INITPROC setup_dev(register struct gendisk *);
 
-extern void tz_init(char *tzstr);
+extern void tz_init(const char *tzstr);
 
 /* block device init routines*/
 extern void INITPROC blk_dev_init(void);

--- a/elks/include/linuxmt/list.h
+++ b/elks/include/linuxmt/list.h
@@ -1,7 +1,8 @@
-// Kernel library
-// Double-linked list
+#ifndef __LINUXMT_LIST_H
+#define __LINUXMT_LIST_H
 
-#pragma once
+/* Kernel library */
+/* Double-linked list */
 
 struct list {
 	struct list * prev;
@@ -16,3 +17,5 @@ void list_insert_before (list_s * next, list_s * node);
 void list_insert_after  (list_s * prev, list_s * node);
 
 void list_remove (list_s * node);
+
+#endif

--- a/elks/include/linuxmt/string.h
+++ b/elks/include/linuxmt/string.h
@@ -36,8 +36,8 @@ extern char *strstr(char *,char *);
  */
 
 extern void *memscan(void *,int,size_t);
-extern long simple_strtol(char *,int);
-extern int atoi(char *);
+extern long simple_strtol(const char *,int);
+extern int atoi(const char *);
 
 /*@+namechecks@*/
 

--- a/elks/include/linuxmt/termios.h
+++ b/elks/include/linuxmt/termios.h
@@ -146,6 +146,7 @@ struct termios {
 #define IXANY	0004000
 #define IXOFF	0010000
 #define IMAXBEL	0020000
+#define IUTF8	0040000
 
 /* c_oflag bits */
 #define OPOST	0000001

--- a/elks/kernel/time.c
+++ b/elks/kernel/time.c
@@ -46,7 +46,7 @@ static struct timezone xzone;
 /* timezone offset (in hours) from CONFIG_TIME_TZ or /bootopts TZ= string */
 int tz_offset;
 
-void tz_init(char *tzstr)
+void tz_init(const char *tzstr)
 {
     if (strlen(tzstr) > 3) {
         tz_offset = atoi(tzstr+3);

--- a/elks/lib/string.c
+++ b/elks/lib/string.c
@@ -19,7 +19,7 @@
 #define isdigit(c)	((c) >= '0' && (c) <= '9')
 #define isalpha(c)	(((c) >= 'a' && (c) <= 'z') || ((c) >= 'A' && (c) <= 'Z'))
 
-long simple_strtol(char *s, int base)
+long simple_strtol(const char *s, int base)
 {
 	register int c;
 	int neg;
@@ -58,7 +58,7 @@ long simple_strtol(char *s, int base)
 	return (neg == '-') ? -result: result;
 }
 
-int atoi(char *number)
+int atoi(const char *number)
 {
 	return (int)simple_strtol(number, 10);
 }

--- a/elkscmd/levee/levee.h
+++ b/elkscmd/levee/levee.h
@@ -123,6 +123,9 @@ extern long gemdos();
 #include <stdio.h>
 #include <fcntl.h>
 #include <ctype.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
 
 #define OPEN_OLD(n)		open(n, O_RDONLY)
 #define OPEN_NEW(n)		open(n, O_WRONLY|O_CREAT|O_TRUNC, 0666)

--- a/elkscmd/levee/wildargs.c
+++ b/elkscmd/levee/wildargs.c
@@ -63,7 +63,6 @@ char *token;
 register int *argcp;
 register char ***argvp;
 {
-    char **realloc(), **malloc();
     char *strdup();
     char **ap = *argvp;
     int ac = *argcp;
@@ -71,7 +70,7 @@ register char ***argvp;
 
     if ( ac%QUANTUM == 0) {	/* realloc more memory! */
 	size = (QUANTUM+ac)*sizeof(char**);
-	ap = (ac == 0)?malloc(size):realloc(ap, size);
+	ap = (ac == 0)? (char **)malloc(size): (char **)realloc(ap, size);
 	if (!ap) {
 	    *argcp = 0;
 	    goto memfail;

--- a/libc/include/string.h
+++ b/libc/include/string.h
@@ -1,36 +1,37 @@
-
 #ifndef __STRING_H
 #define __STRING_H
 
-#pragma once
-
-#include <features.h>
 #include <stddef.h>
 
 /* Basic string functions */
 
-extern char * strcpy __P ((char*, __const char*));
+size_t strlen(const char * s);
+char *strcpy(char*, const char*);
+char *strcat(char * dest, const char * src);
 int strcmp(const char *s1, const char *s2);
 
-extern char * strncat __P ((char*, char*, size_t));
-extern char * strncpy __P ((char*, char*, size_t));
+char * strncpy(char*, char*, size_t);
+char * strncat(char*, char*, size_t);
+int strncmp(const char * s1, const char * s2, size_t n);
 
-char * strchr  (const char * s, int c);
-char * strrchr (const char * s, int c);
+char * strstr(const char *, const char *);
+char * strchr(const char * s, int c);
+char * strrchr(const char * s, int c);
 
-extern char * strdup __P ((const char*));
+char * strdup(const char*);
 
 /* Basic mem functions */
-extern void * memccpy __P ((void*, void*, int, size_t));
-extern void * memchr __P ((__const void*, __const int, size_t));
-extern void * memset __P ((void*, int, size_t));
-extern int memcmp __P ((__const void*, __const void*, size_t));
-extern void * memmove __P ((void*, void*, size_t));
+void * memcpy(void * dest, const void * src, size_t n);
+void * memccpy(void*, void*, int, size_t);
+void * memchr(const void*, const int, size_t);
+void * memset(void*, int, size_t);
+int memcmp(const void*, const void*, size_t);
+void * memmove(void*, void*, size_t);
 
 void __far *fmemset(void __far *buf, int c, size_t l);
 
 /* Error messages */
-extern char * strerror __P ((int));
+char * strerror(int);
 
 /* Minimal (very!) locale support */
 #define strcoll strcmp
@@ -43,30 +44,20 @@ extern char * strerror __P ((int));
 /* Other common BSD functions */
 int strcasecmp(const char *s1, const char *s2);
 int strncasecmp(const char *s1, const char *s2, size_t n);
-char *strpbrk __P ((const char *, const char *));
-char *strsep __P ((char **, char *));
+char *strtok(char * str, const char * delim);
+char *strpbrk(const char *, const char *);
+char *strsep(char **, char *);
 
-char * strstr (const char *, const char *);
-
-size_t strcspn __P ((char *, char *));
-size_t strspn __P ((const char *, const char *));
+size_t strcspn(char *, char *);
+size_t strspn(const char *, const char *);
 
 /* Linux silly hour */
-char *strfry __P ((char *));
+char *strfry(char *);
 
-void bzero (void * s, size_t n);
+void bzero(void * s, size_t n);
 
 // TODO: this is removed in POSIX-1.2008
 // TODO: replace by memcpy or memmove
-#define bcopy(s, d, n) memcpy ((d), (s), (n))
-
-void * memcpy (void * dest, const void * src, size_t n);
-
-char *strcat (char * dest, const char * src);
-size_t strlen (const char * s);
-int strncmp (const char * s1, const char * s2, size_t n);
-char *strtok (char * str, const char * delim);
-
-int sprintf (char * str, const char * format, ...);
+#define bcopy(s, d, n) memcpy((d), (s), (n))
 
 #endif

--- a/libc/include/sys/select.h
+++ b/libc/include/sys/select.h
@@ -1,7 +1,12 @@
-#pragma once
+#ifndef __SYS_SELECT_H
+#define __SYS_SELECT_H
+
+#include <sys/types.h>
 
 struct timeval;
 
 int select (int __nfds, fd_set * restrict __readfds,
 	fd_set * restrict __writefds, fd_set * restrict __errorfds,
 	struct timeval * restrict __timeout);
+
+#endif

--- a/libc/include/unistd.h
+++ b/libc/include/unistd.h
@@ -1,5 +1,5 @@
-
-#pragma once
+#ifndef __UNISTD_H
+#define __UNISTD_H
 
 #include <features.h>
 #include <sys/types.h>
@@ -92,3 +92,5 @@ extern int optopt;
 extern int opterr;
 
 extern char ** environ;
+
+#endif

--- a/libc/misc/mktemp.c
+++ b/libc/misc/mktemp.c
@@ -4,6 +4,7 @@
 
 #include <unistd.h>
 #include <string.h>
+#include <stdio.h>
 #include <sys/stat.h>
 #include <errno.h>
 

--- a/libc/misc/tmpnam.c
+++ b/libc/misc/tmpnam.c
@@ -6,6 +6,7 @@
 #include <sys/stat.h>
 #include <errno.h>
 #include <string.h>
+#include <stdio.h>
 #include <paths.h>
 
 #ifndef P_tmpdir


### PR DESCRIPTION
Remove various #pragma once in libc and kernel headers.

Defines IUTF8 in termios, not yet implemented.
Fixes <sys/select.h> not including <types.h> for fd_set.

Cleans up K&R __P() define in strings.h.