### PR TITLE
[libc][kernel] Rename __sighandler_t to standard sighandler_t in signal.h

### DIFF
--- a/elks/include/linuxmt/signal.h
+++ b/elks/include/linuxmt/signal.h
@@ -185,7 +185,7 @@ typedef unsigned long sigset_t;	/* at least 32 bits */
 #define SIG_SETMASK        2	/* for setting the signal mask */
 
 /* Type of a signal handler within userland.  */
-typedef void (*__sighandler_t)(int);
+typedef void (*sighandler_t)(int);
 /* Type of a signal handler which interfaces with the kernel.  This is always
    a far function that uses the `stdcall' calling convention, even for a
    user program that is being compiled for a different calling convention.  */
@@ -211,9 +211,9 @@ typedef __attribute__((__stdcall__)) __far void (*__kern_sighandler_t)(int);
  *     values can be 8-bit or smaller.  -- tkchia 20200512
  */
 
-#define SIG_DFL	((__sighandler_t) 0)	/* default signal handling */
-#define SIG_IGN	((__sighandler_t) 1)	/* ignore signal */
-#define SIG_ERR	((__sighandler_t) -1)	/* error return from signal */
+#define SIG_DFL	((sighandler_t) 0)	/* default signal handling */
+#define SIG_IGN	((sighandler_t) 1)	/* ignore signal */
+#define SIG_ERR	((sighandler_t) -1)	/* error return from signal */
 
 typedef unsigned char __sigdisposition_t;
 

--- a/elkscmd/ash/trap.c
+++ b/elkscmd/ash/trap.c
@@ -146,7 +146,7 @@ clear_traps() {
 int
 setsignal(signo) {
 	int action;
-	__sighandler_t sigact;
+	sighandler_t sigact;
 	register char *t;
 	extern void onsig();
 

--- a/elkscmd/file_utils/more.c
+++ b/elkscmd/file_utils/more.c
@@ -20,7 +20,7 @@
 static int fd;
 static int LINES = 25;
 static int MAXLINES = 25;
-static char cflag = 1;  /* -c flag: clear screen and wait for partial results */
+static char cflag = 0;  /* -c flag: clear screen on start */
 
 /* Use the DSR ESC [6n escape sequence to query the cursor position */
 static int getCursorPosition(int ifd, int ofd, int *rows, int *cols)
@@ -258,7 +258,7 @@ int main(int argc, char **argv)
 			if (more_wait(1, strcat(next, argv[1])) < 0)
 				return 0;
 		}
-		else if (cflag) more_wait(1, END_STRING);
+		else more_wait(1, END_STRING);
 		if (fd)
 			close(fd);
 	} while (--argc > 1);

--- a/elkscmd/test/signal/test_signal.c
+++ b/elkscmd/test/signal/test_signal.c
@@ -9,7 +9,7 @@ void sigint (int signo)
 	_signo = signo;
 }
 
-extern __sighandler_t _sigtable [15];
+extern sighandler_t _sigtable [15];
 
 int main (int argc, char ** argv)
 {

--- a/libc/include/signal.h
+++ b/libc/include/signal.h
@@ -2,18 +2,17 @@
 #define __SIGNAL_H
 
 #include <sys/types.h>
-#include <features.h>
 
 #undef __KERNEL__
 #include __SYSINC__(signal.h)
 
 /* BSDisms */
 #ifdef BSD
-extern __const char * __const sys_siglist[];
-#define sig_t __sighandler_t
+extern const char * const sys_siglist[];
+#define sig_t sighandler_t
 #endif
 
-__sighandler_t signal(int number, __sighandler_t pointer);
+sighandler_t signal(int number, sighandler_t pointer);
 int kill (pid_t pid, int sig);
 int killpg (int pid, int sig);
 

--- a/libc/misc/system.c
+++ b/libc/misc/system.c
@@ -8,8 +8,8 @@ int
 system(char *command)
 {
    int status, ret, pid;
-   __sighandler_t save_quit;
-   __sighandler_t save_int;
+   sighandler_t save_quit;
+   sighandler_t save_int;
 
    if( command == 0 ) return 1;
 

--- a/libc/net/in_connect.c
+++ b/libc/net/in_connect.c
@@ -19,7 +19,7 @@ int in_connect(int socket, const struct sockaddr *address, socklen_t address_len
 		int secs)
 {
 	int ret;
-	__sighandler_t old;
+	sighandler_t old;
 
 	old = signal(SIGALRM, alarm_cb);
 	alarm(secs);

--- a/libc/net/in_resolv.c
+++ b/libc/net/in_resolv.c
@@ -91,7 +91,7 @@ ipaddr_t in_resolv(char *hostname, char *server)
 	char *dnsname;
 	struct sockaddr_in addr;
 	unsigned short flags;
-	__sighandler_t old;
+	sighandler_t old;
 	char buf[256];
 
 	if (server == NULL)

--- a/libc/system/signal.c
+++ b/libc/system/signal.c
@@ -1,7 +1,7 @@
 #include <errno.h>
 #include <signal.h>
 
-typedef __sighandler_t Sig;
+typedef sighandler_t Sig;
 
 extern int _signal (int, __kern_sighandler_t);
 #if defined __TINY__ || defined __SMALL__ || defined __COMPACT__


### PR DESCRIPTION
Also reverts change to `more`: longer clears screen on start.