### PR TITLE
[kernel] Fix MINIX block allocation routine for out of space issues

### DIFF
--- a/elks/arch/i86/lib/bitops.c
+++ b/elks/arch/i86/lib/bitops.c
@@ -12,13 +12,13 @@ unsigned char clear_bit(unsigned int bit, register void *addr)
     flag_t flags;
     unsigned int mask;
 
-    addr = (void *)(((unsigned char *)addr) + (bit >> 3));
+    addr = (unsigned char *)addr + (bit >> 3);
     bit &= 0x07;
-    mask = (1 << bit);
+    mask = 1 << bit;
     save_flags(flags);
     clr_irq();
-    mask &= *((unsigned char *)addr);
-    *((unsigned char *)addr) &= ~mask;
+    mask &= *(unsigned char *)addr;
+    *(unsigned char *)addr &= ~mask;
     restore_flags(flags);
     return mask >> bit;
 }
@@ -28,21 +28,20 @@ unsigned char set_bit(unsigned int bit, register void *addr)
     flag_t flags;
     unsigned int mask, r;
 
-    addr = (void *)(((unsigned char *)addr) + (bit >> 3));
+    addr = (unsigned char *)addr + (bit >> 3);
     bit &= 0x07;
-    mask = (1 << bit);
+    mask = 1 << bit;
     save_flags(flags);
     clr_irq();
-    r = *((unsigned char *)addr) & mask;
-    *((unsigned char *)addr) |= mask;
+    r = *(unsigned char *)addr & mask;
+    *(unsigned char *)addr |= mask;
     restore_flags(flags);
     return r >> bit;
 }
 
 unsigned char test_bit(unsigned int bit,void *addr)
 {
-	return ( ((1 << (bit & 0x07))
-			  & *((unsigned char *)addr + (bit >> 3))) != 0);
+    return (((1 << (bit & 0x07)) & *((unsigned char *)addr + (bit >> 3))) != 0);
 }
 
 /* Ack... nobody even seemed to try to write to a file before 0.0.49a was
@@ -53,9 +52,9 @@ unsigned char test_bit(unsigned int bit,void *addr)
 
 #ifdef BLOAT_FS
 /* Use the old faithful version */
-unsigned int find_first_non_zero_bit(register int *addr, unsigned int len)
+unsigned int find_first_non_zero_bit(int *addr, unsigned int len)
 {
-    register char *bit = 0;
+    unsigned int bit = 0;
     unsigned int mask;
 
     do {
@@ -68,17 +67,17 @@ unsigned int find_first_non_zero_bit(register int *addr, unsigned int len)
 	    break;
 	}
 	addr++;
-    } while ((unsigned int)(bit += 16) < len);
-    if ((unsigned int)bit > len)
-	bit = (char *)len;
-    return (unsigned int)bit;
+    } while ((bit += 16) < len);
+    if (bit > len)
+	bit = len;
+    return bit;
 }
 #endif
 
 /* Use the old faithful version */
-unsigned int find_first_zero_bit(register int *addr, unsigned int len)
+unsigned int find_first_zero_bit(int *addr, unsigned int len)
 {
-    register char *bit = 0;
+    unsigned int bit = 0;
     unsigned int mask;
 
     do {
@@ -91,8 +90,8 @@ unsigned int find_first_zero_bit(register int *addr, unsigned int len)
 	    break;
 	}
 	addr++;
-    } while ((unsigned int)(bit += 16) < len);
-    if ((unsigned int)bit > len)
-	bit = (char *)len;
-    return (unsigned int)bit;
+    } while ((bit += 16) < len);
+    if (bit > len)
+	bit = len;
+    return bit;
 }

--- a/elks/fs/minix/bitmap.c
+++ b/elks/fs/minix/bitmap.c
@@ -87,46 +87,50 @@ void minix_free_block(register struct super_block *sb, unsigned short block)
 	}
     }
     if (s != NULL)
-	printk("mfb (%s:%u): %s\n", kdevname(sb->s_dev), block, s);
+	printk("free_block (%s:%u): %s\n", kdevname(sb->s_dev), block, s);
 }
 
-block_t minix_new_block(register struct super_block *sb)
+block_t minix_new_block(struct super_block *sb)
 {
-    register struct buffer_head *bh;
-    block_t i, j, k;
-
+    struct buffer_head *bh = NULL;
+    block_t i, j;
     if (!sb) return 0;
 
-    i = 0;
-    do {
-	bh = sb->u.minix_sb.s_zmap[i];
-	map_buffer(bh);
-	j = (block_t) find_first_zero_bit((void *)(bh->b_data), 8192);
-	k = j + i * 8192 + sb->u.minix_sb.s_firstdatazone - 1;
-	if (k < sb->u.minix_sb.s_nzones) {
-	    if (set_bit(j, bh->b_data)) {
-			printk("mnb: already set %d %d\n", j, bh->b_data);
-			return 0;
-	    }
-	    if (j == (block_t)find_first_zero_bit((void *)(bh->b_data), 8192)) {
-			printk("mnb: still zero bit!%d\n", j);
-			return 0;
-		}
-	    mark_buffer_dirty(bh);
-	    unmap_buffer(bh);
-	    if (!k)
-		break;
-	    bh = getblk(sb->s_dev, k);
-	    map_buffer(bh);
-	    memset(bh->b_data, 0, BLOCK_SIZE);
-	    mark_buffer_uptodate(bh, 1);
-	    mark_buffer_dirty(bh);
-	    unmap_brelse(bh);
-	    return k;
-	}
-	unmap_buffer(bh);
-    } while (++i < sb->u.minix_sb.s_zmap_blocks);
-    return 0;
+repeat:
+    j = 8192;
+    for (i = 0; i < sb->u.minix_sb.s_zmap_blocks; i++) {
+        if (i > 0)
+            unmap_buffer(bh);
+        if ((bh = sb->u.minix_sb.s_zmap[i]) != NULL) {
+            map_buffer(bh);
+            if ((j = find_first_zero_bit((void *)bh->b_data, 8192)) < 8192)
+                break;
+        }
+    }
+    if (i >= sb->u.minix_sb.s_zmap_blocks || !bh || j >= 8192) {
+        if (bh) unmap_buffer(bh);
+        return 0;
+    }
+    if (set_bit(j, bh->b_data)) {
+        printk("new_block: bit already set %d", j);
+        unmap_buffer(bh);
+        goto repeat;
+    }
+    mark_buffer_dirty(bh);
+    unmap_buffer(bh);
+    j += i*8192 + sb->u.minix_sb.s_firstdatazone - 1;
+    if (j < sb->u.minix_sb.s_firstdatazone || j >= sb->u.minix_sb.s_nzones)
+        return 0;
+    if (!(bh = getblk(sb->s_dev, j))) {
+        printk("new_block: cannot get block %u", j);
+        return 0;
+    }
+    map_buffer(bh);
+    memset(bh->b_data, 0, BLOCK_SIZE);
+    mark_buffer_uptodate(bh, 1);
+    mark_buffer_dirty(bh);
+    unmap_brelse(bh);
+    return j;
 }
 
 void minix_free_inode(register struct inode *inode)

--- a/elkscmd/file_utils/cat.c
+++ b/elkscmd/file_utils/cat.c
@@ -14,8 +14,10 @@ static int copyfd(int fd)
 {
 	int n;
 
-	while ((n = read(fd, readbuf, sizeof(readbuf))) > 0)
-		write(STDOUT_FILENO, readbuf, n);
+	while ((n = read(fd, readbuf, sizeof(readbuf))) > 0) {
+		if (write(STDOUT_FILENO, readbuf, n) != n)
+			return 1;
+    }
 	return n < 0? 1: 0;
 }
 


### PR DESCRIPTION
The MINIX filesystem new block allocation routine was incorrectly handling the MINIX ZMAP free blocklist bitmap, which resulted in incorrect identification of disk out of space, as well as improper "mnb: still zero bit!8192" messages. Both of these are fixed.

This was first identified by @Mellvik in https://github.com/jbruchon/elks/issues/1367#issuecomment-1203781403.

Rather than rewriting the routine from scratch, a revised version of the Linux v2.0 MINIX block allocation routine was used for replacement, then rewritten with map_buffer and unmap_buffer added for ELKS. In addition, the set_bit/clear_bit code was cleaned up.

Also, it was noticed that `cat` did not report filesystem out of space when writing. This is also fixed.

It was also noticed that in the prior block allocation routine, when the disk was "out of space", the mapped L1 buffers were not released. This would result in an L1 buffer being permanently allocated, which would have the result of possibly running out of L1 buffers at a later point in time. This has also been fixed.

Tested on QEMU.

@Mellvik, I recommend you update to this latest PR, then restart your testing for #1367.