### PR TITLE
[cmds] Allow DEL from terminal to backspace in vi, enhance dd error message

### DIFF
--- a/elkscmd/elvis/curses.c
+++ b/elkscmd/elvis/curses.c
@@ -251,6 +251,8 @@ void resume_curses(quietly)
 # if UNIXV
 		ospeed = (oldtermios.c_cflag & CBAUD);
 		ERASEKEY = oldtermios.c_cc[VERASE];
+		if (ERASEKEY == '\b')		/* allow DEL as ERASEKEY also ('\b' always works) */
+			ERASEKEY = oldtermios.c_cc[VERASE2];
 		newtermios = oldtermios;
 		newtermios.c_iflag &= (IXON|IXOFF|IXANY|ISTRIP|IGNBRK);
 		newtermios.c_oflag &= ~OPOST;

--- a/elkscmd/file_utils/dd.c
+++ b/elkscmd/file_utils/dd.c
@@ -197,9 +197,10 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if (!strcmp(infile, "-")) 
+	if (!strcmp(infile, "-"))  {
 		infd = 0;
-	else {
+		infile = "stdin";
+	} else {
 		infd = open(infile, 0);
 		if (infd < 0) {
 			perror(infile);
@@ -208,9 +209,10 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if (!strcmp(outfile, "-"))
+	if (!strcmp(outfile, "-")) {
 		outfd = 1;
-	else {
+		outfile = "stdout";
+	} else {
 		outfd = creat(outfile, 0666);
 		if (outfd < 0) {
 			perror(outfile);


### PR DESCRIPTION
When running `vi` from a serial console using a terminal emulator, DEL didn't work as backspace. This fix allows much easier operation from serial or telnet sessions, and now operates identically to console.

Changed `dd` error message from `'-': No space left on device` to `'stdout': No space left on device`, for better understandability (displays `stdin` on input errors also).