### PR TITLE
[kernel][cmds] Correct ANSI console colors pass 2, add rmdir, fix find

### DIFF
--- a/elks/arch/i86/drivers/char/console.c
+++ b/elks/arch/i86/drivers/char/console.c
@@ -75,8 +75,8 @@ static void itoaQueue(int i)
 }
 
 /* reverse map table ANSI -> ega      blk red grn yel blu mag cyn wht */
-static unsigned char ega_color[16] = {   0,8+4,  2,8+6,8+1,  5,  3, 7,
-                                         8, 12, 10, 14,  9, 13, 11, 15 };
+static unsigned char ega_color[16] = {  0,  4,  2,  6,  1,  5,  3,  7,
+                                        8, 12, 10, 14,  9, 13, 11, 15 };
 
 /* ESC [ processing */
 static void AnsiCmd(register Console * C, int c)
@@ -164,7 +164,7 @@ static void AnsiCmd(register Console * C, int c)
 	  n = atoi(p);
 	  if (n >= 30 && n <= 37) {             /* set fg color */
 	    C->attr &= 0xf0;                    /* don't save bright bit */
-	    C->attr |= ega_color[n-30];         /* some colors bright by default */
+	    C->attr |= ega_color[n-30];
 	  }
 	  else if (n >= 40 && n <= 47) {
 	    C->attr &= 0x8f;                    /* save blink bit */

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -72,7 +72,7 @@ file_utils/mv					:fileutil		:360k
 file_utils/ln					:fileutil			:720k
 file_utils/ls					:fileutil		:360k   :128k
 file_utils/rm					:fileutil		:360k
-file_utils/rmdir				:fileutil			:720k
+file_utils/rmdir				:fileutil		:360k
 file_utils/sync					:fileutil		:360k
 file_utils/touch				:fileutil			:720k
 sys_utils/chmem					:sysutil			:720k

--- a/elkscmd/minix3/Makefile
+++ b/elkscmd/minix3/Makefile
@@ -28,7 +28,7 @@ file: file.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -o file file.o $(TINYPRINTF) $(LDLIBS)
 
 find: find.o
-	$(LD) $(LDFLAGS) -o find find.o $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-heap=0x4000 -maout-stack=0x2000 -o find find.o $(LDLIBS)
 
 head: head.o
 	$(LD) $(LDFLAGS) -o head head.o $(LDLIBS)


### PR DESCRIPTION
This PR includes various small fixes:

Replaces non-standard highlighted colors with standard colors on ANSI console. This is required in order for D-Flat and other programs that expect correct ANSI colors to work properly. 

Fixes `find` heap/stack overflow identified in https://github.com/jbruchon/elks/pull/1389#issuecomment-1207192275.

Adds `rmdir` to 360k floppy for sys command, reported by @toncho11.