### PR TITLE
[debug] Add stack backtrace and 8086 disassembler to debug library

### DIFF
--- a/elkscmd/debug/Makefile
+++ b/elkscmd/debug/Makefile
@@ -14,7 +14,12 @@ HOSTCFLAGS = -O3
 ###############################################################################
 
 PRGS = testsym
-OBJS = testsym.o syms.o
+OBJS = testsym.o syms.o stacktrace.o printreg.o
+OBJS += disasm.o
+#OBJS += ulltostr.o
+CFLAGS += -fno-optimize-sibling-calls
+CFLAGS += -fno-omit-frame-pointer
+#CFLAGS += -finstrument-functions
 #LDFLAGS += -maout-heap=12000
 
 all: nm86 $(PRGS)
@@ -28,8 +33,14 @@ testsym: $(OBJS)
 	./nm86 $@ > $@.map
 	cp $@ $(TOPDIR)/elkscmd/rootfs_template/root
 
+disasm.o: disasm.c
+	$(CC) $(CFLAGS) -fno-instrument-functions -c -o $*.o $<
+
+ulltostr.o: ulltostr.c
+	$(CC) $(CFLAGS) -fno-instrument-functions -c -o $*.o $<
+
 install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 clean:
-	rm -f $(PRGS) *.o nm86
+	rm -f $(PRGS) *.o nm86 testsym.map

--- a/elkscmd/debug/disasm.c
+++ b/elkscmd/debug/disasm.c
@@ -1,0 +1,591 @@
+/*
+ * (Standalone) single-file tiny 8086 disassembler
+ *
+ * Jan 2022 Greg Haerr
+ * Inspired by Andrew Jenner's 8086 simulator 86sim.cpp
+ */
+#include <stdio.h>
+#include "syms.h"
+
+typedef unsigned char Byte;
+typedef unsigned short int Word;
+typedef unsigned int DWord;
+typedef int bool;
+enum { false = 0, true };
+
+/* shared variables only if linked with sim.c */
+bool wordSize;
+bool sourceIsRM;
+Byte opcode;
+int f_asmout;
+
+static Word startIP;
+static Word startCS;
+static Byte d_modRM;
+static int segOver;
+static int cols;
+
+/* user-defined external functions */
+extern Byte readByte(Word offset, int seg);	/* read next instruction byte */
+
+/* read next instruction byte; note: seg is not actual segment, but =1 for CS */
+Byte readByte(Word offset, int seg)
+{
+    extern unsigned char getcsbyte(unsigned short offset);
+    //return *(unsigned char __far *)(((unsigned long)seg << 16) | offset);
+    return getcsbyte(offset);
+}
+
+static Byte d_fetchByte()
+{
+	Byte b = readByte(startIP++, 1);
+	if (!f_asmout) {
+		printf("%02x ", b);
+		cols++;
+	}
+	return b;
+}
+
+static const char *wordregs[] = {
+	"%ax", "%cx", "%dx", "%bx", "%sp", "%bp", "%si", "%di"};
+static const char *byteregs[] = {
+	"%al", "%cl", "%dl", "%bl", "%ah", "%ch", "%dh", "%bh"};
+static const char *segregs[] = { "%es", "%cs", "%ss", "%ds"};
+
+static void decode();
+Word disasm(Word cs, Word ip)
+{
+	startCS = cs;
+	startIP = ip;
+	cols = 0;
+	if (!f_asmout) printf("%04hx:%04hx  ", cs, ip);
+	decode();
+	return startIP;
+}
+static Word d_fetchWord() { Word w = d_fetchByte(); w += d_fetchByte() << 8; return w; }
+static int d_modRMReg() { return (d_modRM >> 3) & 7; }
+static void outREG() {
+	if (wordSize || opcode == 0xee || opcode == 0xec)	// OUT dx
+		printf("%s", wordregs[(d_modRM >> 3) & 7]);
+	else printf("%s", byteregs[(d_modRM >> 3) & 7]);
+}
+static void outSREG() {
+	printf("%s", segregs[(d_modRM >> 3) & 3]);
+}
+static void outRM(Word w) {
+	signed char b;
+	static const char *basemodes[] = {
+		"(%bx,%si)", "(%bx,%di)", "(%bp,%si)", "(%bp,%di)",
+        "(%si)", "(%di)", "(%bp)", "(%bx)" };
+
+    switch (d_modRM & 0xc0) {
+        case 0x00:
+            if ((d_modRM & 0xc7) == 6)
+				printf("(0x%04x)", w);
+			else printf("%s", basemodes[d_modRM & 7]);
+            break;
+        case 0x40:
+			b = (signed char) w;	/* signed */
+			if (b < 0) printf("-0x%02x", -b);
+			else printf("0x%02x", b);
+			printf("%s", basemodes[d_modRM & 7]);
+			break;
+        case 0x80:
+			printf("0x%04x%s", w, basemodes[d_modRM & 7]);
+			break;
+        case 0xc0:
+			if (wordSize) printf("%s", wordregs[d_modRM & 7]);
+			else printf("%s", byteregs[d_modRM & 7]);
+			break;
+    }
+}
+#define BW			0x0001	/* display byte/word instruction */
+#define RDMOD		0x0002	/* read modRMReg byte */
+#define OPS2		0x0004	/* display both REG & R/M operands */
+#define RM			0x0008	/* display R/M operand */
+#define SREG		0x0010	/* display SREG operand */
+#define REGOP		0x0020	/* display REG operand from opcode */
+#define IMM			0x0040	/* display immediate operand */
+#define BYTE		0x0080	/* fetch unsigned byte immediate operand */
+#define SBYTE		0x0100	/* fetch signed byte */
+#define WORD		0x0200	/* fetch word, and/or display word not immediate operand */
+#define DWORD		0x0400	/* fetch second word */
+#define MEMWORD		0x0800	/* display word memory address */
+#define ACC			0x1000	/* display accumulator */
+#define JMP			0x2000	/* display jmp w/byte, word or dword operand */
+#define SHIFTBY1	0x4000	/* display shift 1 operand */
+#define SHIFTBYCL	0x8000	/* display shift CL operand */
+void out_bw(int flags)
+{
+	int bw;
+
+	if ((flags & (BW|OPS2|RM)) == 0)
+		return;
+
+	/* discard non- BW, IMM, inc/dec and non-direct addressing */
+	bw = (flags == BW || (flags & IMM) || opcode == 0xfe || opcode == 0xff);
+	if (!bw && ((flags & (OPS2|RM)) && (d_modRM & 0xc7) != 6))
+		return;
+	/* discard immediate to register */
+	if ((flags & IMM) && ((flags & (OPS2|RM)) && ((d_modRM & 0xc0) == 0xc0)))
+		return;
+	/* discard register operands */
+	if (flags & REGOP)
+		return;
+	putchar(wordSize? 'w': 'b');
+}
+static void outs(const char *str, int flags)
+{
+	Word w = 0;
+    Word w2 = 0;
+	signed char c = 0;
+
+	if (flags & RDMOD)
+		d_modRM = d_fetchByte();
+	if (flags & (OPS2|RM)) {
+		if (((d_modRM & 0xc7) == 6) || ((d_modRM & 0xc0) == 0x80))
+			w = d_fetchWord();
+		if ((d_modRM & 0xc0) == 0x40)
+			w = d_fetchByte();
+	}
+	if ((flags & (IMM|BYTE|SBYTE|WORD)) == IMM)
+		w2 = !wordSize ? d_fetchByte() : d_fetchWord();
+
+	if (flags & (WORD|DWORD|MEMWORD))
+		w2 = d_fetchWord();
+	if (flags & BYTE)
+		w2 = d_fetchByte();
+	if (flags & SBYTE)
+		w2 = c = d_fetchByte();
+	if (flags & DWORD)
+		w = d_fetchWord();
+
+	while (cols++ < 6)
+		printf("   ");
+	printf("%s", str);
+	if (flags & BW) out_bw(flags);
+	if (flags != 0) putchar('\t');
+	if (segOver != -1) {
+		printf("%s", segregs[segOver]);
+		putchar(':');
+	}
+	if ((flags & (OPS2|SREG)) == OPS2) {
+		if (sourceIsRM) outRM(w); else outREG();
+		putchar(',');
+		if (sourceIsRM) outREG(); else outRM(w);
+	}
+	if ((flags & (OPS2|SREG)) == (OPS2|SREG)) {
+		wordSize = 1;
+		if (sourceIsRM) outRM(w); else outSREG();
+		putchar(',');
+		if (sourceIsRM) outSREG(); else outRM(w);
+	}
+	if ((flags & (IMM|BYTE|ACC)) == (IMM|BYTE|ACC)) {	// IN, OUT imm
+		if (!sourceIsRM) printf("$0x%x,%s", w2, wordSize? "%ax": "%al");
+		else printf("%s,$0x%x", wordSize? "%ax": "%al", w2);
+		flags = 0;
+	}
+	else if (flags & IMM) {
+		printf("$0x%x", w2);
+		if (flags != (flags & IMM))
+			printf(",");
+	}
+	if (flags & SHIFTBY1) printf("$1,");
+	if (flags & SHIFTBYCL) printf("%%cl,");
+	if (flags & RM) outRM(w);
+	if ((flags & (OPS2|SREG)) == SREG)  outSREG();
+	if ((flags & ACC) && sourceIsRM == 0)
+		printf("%s,", wordSize? wordregs[0]: byteregs[0]);
+	if ((flags & MEMWORD) && sourceIsRM)
+		printf("(0x%04x),", w2);
+	if ((flags & ACC) && sourceIsRM)
+		printf("%s", wordSize? wordregs[0]: byteregs[0]);
+	if ((flags & MEMWORD) && sourceIsRM == 0)
+		printf("(0x%04x)", w2);
+	if (flags & REGOP) printf("%s", wordSize? wordregs[opcode & 7]: byteregs[opcode & 7]);
+	if ((flags & (JMP|IMM|WORD)) == WORD) printf("%u", w2);
+	if (flags & JMP) {
+        int waddr = (startIP + w2) & 0xffff;
+		//if (flags & SBYTE) printf("%04x", startIP + c);
+		if (flags & SBYTE) printf(".%s%d // %04x", c>=0? "+": "", c+2, startIP+c);
+		//if (flags & WORD) printf("0x%04x // %04x", w2+2, (startIP + w2) & 0xffff);
+        if (flags & WORD) printf("%s (%04x)", sym_text_symbol((void *)waddr, 1), waddr);
+		if (flags & DWORD) printf("%04x:%04x", w, w2);
+	}
+	printf("\n");
+}
+
+static void decode(void)
+{
+	static const char *alunames[8] = {
+		"add", "or", "adc", "sbb", "and", "sub", "xor", "cmp"
+	};
+
+    bool prefix = false;
+	int flags;
+    //do {
+        //if (!repeating) {
+            if (!prefix) {
+                segOver = -1;
+                //rep = 0;
+            }
+            prefix = false;
+            //opcode = fetchByte();
+        //}
+nextopcode:
+		opcode = d_fetchByte();
+        //if (rep != 0 && (opcode < 0xa4 || opcode >= 0xb0 || opcode == 0xa8 ||
+            //opcode == 0xa9))
+            //runtimeError("REP prefix with non-string instruction");
+        wordSize = ((opcode & 1) != 0);
+        sourceIsRM = ((opcode & 2) != 0);
+        int operation = (opcode >> 3) & 7;
+        switch (opcode) {
+            case 0x00: case 0x01: case 0x02: case 0x03:
+            case 0x08: case 0x09: case 0x0a: case 0x0b:
+            case 0x10: case 0x11: case 0x12: case 0x13:
+            case 0x18: case 0x19: case 0x1a: case 0x1b:
+            case 0x20: case 0x21: case 0x22: case 0x23:
+            case 0x28: case 0x29: case 0x2a: case 0x2b:
+            case 0x30: case 0x31: case 0x32: case 0x33:
+            case 0x38: case 0x39: case 0x3a: case 0x3b:  // alu rmv,rmv
+				outs(alunames[(opcode >> 3) & 7], BW|RDMOD|OPS2);
+				break;
+            case 0x04: case 0x05: case 0x0c: case 0x0d:
+            case 0x14: case 0x15: case 0x1c: case 0x1d:
+            case 0x24: case 0x25: case 0x2c: case 0x2d:
+            case 0x34: case 0x35: case 0x3c: case 0x3d:  // alu accum,i
+				sourceIsRM = 1;	// acc dest
+				//outs(alunames[(opcode >> 3) & 7], BW|RDMOD|IMM|ACC);
+				outs(alunames[(opcode >> 3) & 7], BW|IMM|ACC);
+				break;
+            case 0x06: case 0x0e: case 0x16: case 0x1e:  // PUSH segreg
+				d_modRM = opcode;
+				outs("push", SREG);
+                break;
+            case 0x07: case 0x17: case 0x1f:  // POP segreg
+				d_modRM = opcode;
+				outs("pop", SREG);
+                break;
+            case 0x26: case 0x2e: case 0x36: case 0x3e:  // segment override
+                segOver = operation - 4;
+                prefix = true;
+				goto nextopcode;
+            case 0x27: case 0x2f:  // DA
+				outs(opcode == 0x27? "daa": "das", 0);
+                break;
+            case 0x37: case 0x3f:  // AA
+				outs(opcode == 0x37? "aaa": "aas", 0);
+                break;
+            case 0x40: case 0x41: case 0x42: case 0x43:
+            case 0x44: case 0x45: case 0x46: case 0x47:
+            case 0x48: case 0x49: case 0x4a: case 0x4b:
+            case 0x4c: case 0x4d: case 0x4e: case 0x4f:  // incdec rw
+				wordSize = 1;
+				outs((opcode & 8)? "dec": "inc", REGOP);
+				break;
+            case 0x50: case 0x51: case 0x52: case 0x53:
+            case 0x54: case 0x55: case 0x56: case 0x57:  // PUSH rw
+				wordSize = 1;
+				outs("push", REGOP);
+                break;
+            case 0x58: case 0x59: case 0x5a: case 0x5b:
+            case 0x5c: case 0x5d: case 0x5e: case 0x5f:  // POP rw
+				wordSize = 1;
+				outs("pop", REGOP);
+                break;
+            case 0x60: case 0x61: case 0x62: case 0x63:
+            case 0x64: case 0x65: case 0x66: case 0x67:
+            case 0x68: case 0x69: case 0x6a: case 0x6b:
+            case 0x6c: case 0x6d: case 0x6e: case 0x6f:
+            case 0xc0: case 0xc1: case 0xc8: case 0xc9:  // invalid
+			case 0xf1:
+            case 0xd8: case 0xd9: case 0xda: case 0xdb:
+            case 0xdc: case 0xdd: case 0xde: case 0xdf:  // escape
+			case 0x0f:  // POP CS
+				outs("???", 0);
+                break;
+            case 0x70: case 0x71: case 0x72: case 0x73:
+            case 0x74: case 0x75: case 0x76: case 0x77:
+            case 0x78: case 0x79: case 0x7a: case 0x7b:
+            case 0x7c: case 0x7d: case 0x7e: case 0x7f:  // Jcond cb
+				{
+				static const char *jumpnames[] = {
+					"jo ", "jno", "jb ", "jnb", "jz ", "jnz", "jbe", "ja ",
+					"js ", "jns", "jpe", "jpo","jl ", "jge", "jle", "jg " };
+				outs(jumpnames[opcode & 0x0f], JMP|SBYTE);
+				}
+                break;
+            case 0x80: case 0x81: case 0x82: case 0x83:  // alu rmv,iv
+				d_modRM = d_fetchByte();
+				flags = BW|IMM|RM;
+				if (opcode == 0x81) flags |= WORD;
+				else if (opcode == 0x83) flags |= SBYTE;
+				else flags |= BYTE;
+				outs(alunames[d_modRMReg()], flags);
+                break;
+            case 0x84: case 0x85:  // TEST rmv,rv
+				sourceIsRM = 0;
+				outs("test", BW|RDMOD|OPS2);
+                break;
+            case 0x86: case 0x87:  // XCHG rmv,rv
+				sourceIsRM = 0;
+				outs("xchg", BW|RDMOD|OPS2);
+                break;
+            case 0x88: case 0x89:  // MOV rmv,rv
+				sourceIsRM = 0;
+				outs("mov", BW|RDMOD|OPS2);
+                break;
+            case 0x8a: case 0x8b:  // MOV rv,rmv
+				sourceIsRM = 1;
+				outs("mov", BW|RDMOD|OPS2);
+                break;
+            case 0x8c:  // MOV rmw,segreg
+				sourceIsRM = 0;
+				outs("mov", RDMOD|OPS2);
+				break;
+            case 0x8d:  // LEA
+				sourceIsRM = 1;
+				outs("lea", RDMOD|OPS2);
+                //if (!useMemory) runtimeError("LEA needs a memory address");
+                break;
+            case 0x8e:  // MOV segreg,rmw
+				sourceIsRM = 1;
+				outs("mov", RDMOD|OPS2|SREG);
+                break;
+            case 0x8f:  // POP rmw
+				outs("pop", RDMOD|RM);
+                break;
+            case 0x90: case 0x91: case 0x92: case 0x93:
+            case 0x94: case 0x95: case 0x96: case 0x97:  // XCHG AX,rw
+				wordSize = 1;
+				sourceIsRM = 0;	// acc src
+				outs("xchg", ACC|REGOP);
+                break;
+            case 0x98:  // CBW
+                outs("cbtw", 0);
+                break;
+            case 0x99:  // CWD
+                outs("cwd", 0);
+                break;
+            case 0x9a:  // CALL cp
+				outs("call", JMP|DWORD);
+                break;
+            case 0x9b:  // WAIT
+				outs("wait", 0);
+				break;
+            case 0x9c:  // PUSHF
+                outs("pushf", 0);
+                break;
+            case 0x9d:  // POPF
+                outs("popf", 0);
+                break;
+            case 0x9e:  // SAHF
+                outs("sahf", 0);
+                break;
+            case 0x9f:  // LAHF
+                outs("lahf", 0);
+                break;
+            case 0xa0:  // MOVB accum,xv
+				wordSize = 0;
+				sourceIsRM = 1;	// acc dest
+				outs("mov", BW|MEMWORD|ACC);
+				break;
+			case 0xa1:  // MOVW accum,xv
+				wordSize = 1;
+				sourceIsRM = 1;	// acc dest
+				outs("mov", BW|MEMWORD|ACC);
+                break;
+            case 0xa2:  // MOVB xv,accum
+				wordSize = 0;
+				sourceIsRM = 0;	// acc src
+				outs("mov", BW|ACC|MEMWORD);
+				break;
+			case 0xa3:  // MOVW xv,accum
+				wordSize = 1;
+				sourceIsRM = 0;	// acc src
+				outs("mov", BW|ACC|MEMWORD);
+                break;
+            case 0xa4: case 0xa5:  // MOVSv
+				outs("movs", BW);
+                break;
+            case 0xa6: case 0xa7:  // CMPSv
+				outs("cmps", BW);
+                break;
+			case 0xa8: case 0xa9:  // TEST accum,iv
+				sourceIsRM = 1;	// acc dest
+				outs("test", BW|IMM|ACC);
+                break;
+            case 0xaa: case 0xab:  // STOSv
+				outs("stos", BW);
+                break;
+            case 0xac: case 0xad:  // LODSv
+				outs("lods", BW);
+                break;
+            case 0xae: case 0xaf:  // SCASv
+				outs("scas", BW);
+                break;
+            case 0xb0: case 0xb1: case 0xb2: case 0xb3:
+            case 0xb4: case 0xb5: case 0xb6: case 0xb7:
+				wordSize = 0;
+				outs("mov", BW|IMM|REGOP);
+                break;
+            case 0xb8: case 0xb9: case 0xba: case 0xbb:
+            case 0xbc: case 0xbd: case 0xbe: case 0xbf:  // MOV rv,iv
+				wordSize = 1;
+				outs("mov", BW|IMM|REGOP);
+                break;
+            case 0xc2: case 0xc3:  // RET
+                outs("ret", !wordSize? WORD: 0);
+				break;
+			case 0xca: case 0xcb:  // RETF
+                outs("retf", !wordSize? WORD: 0);
+                break;
+            case 0xc4: case 0xc5:  // LES/LDS
+				//if (!useMemory) runtimeError("This instruction needs a memory address");
+				wordSize = 1;
+				sourceIsRM = 1;
+				outs((opcode & 1)? "lds": "les", RDMOD|OPS2);
+                break;
+            case 0xc6: case 0xc7:  // MOV rmv,iv
+				outs("mov", BW|RDMOD|IMM|RM);
+                break;
+            case 0xcc:  // INT 3
+				outs("int\t$3", 0);
+				break;
+            case 0xcd:
+				wordSize = 0;
+				outs("int", IMM);
+                break;
+			case 0xce:  // INTO
+				outs("into", 0);
+				break;
+            case 0xcf:  // IRET
+				outs("iret", 0);
+            case 0xd0: case 0xd1: case 0xd2: case 0xd3:  // rot rmv,n
+				{
+				static const char *rotates[] = {
+					"rol", "ror", "rcl", "rcr", "shl", "shr", "SHL", "sar" };
+				d_modRM = d_fetchByte();
+				flags = BW|RM;
+				if (opcode & 2) flags |= SHIFTBYCL;
+				else flags |= SHIFTBY1;
+				outs(rotates[d_modRMReg()], flags);
+				}
+                break;
+            case 0xd4:  // AAM
+				outs("aam", 0);
+                break;
+            case 0xd5:  // AAD
+				outs("aad", 0);
+                break;
+            case 0xd6:  // SALC
+				outs("salc", 0);
+                break;
+            case 0xd7:  // XLATB
+				outs("xlatb", 0);
+                break;
+            case 0xe0: case 0xe1: case 0xe2:  // LOOPc cb
+				outs(opcode == 0xe0? "loopnz": "loopz", JMP|SBYTE);
+                break;
+            case 0xe3:  // JCXZ cb
+				outs("jcxz", JMP|SBYTE);
+                break;
+            case 0xe8:  // CALL cw
+				outs("call", JMP|WORD);
+                break;
+            case 0xe9:  // JMP cw
+				outs("jmp", JMP|WORD);
+                break;
+            case 0xea:  // JMP cp
+				outs("jmp", JMP|DWORD);
+                break;
+            case 0xeb:  // JMP cb
+				outs("jmp", JMP|SBYTE);
+                break;
+            case 0xe4: case 0xe5: case 0xe6: case 0xe7:  // IN, OUT ib
+				outs((opcode & 2)? "out": "in ", IMM|BYTE|ACC);
+				break;
+            case 0xec: case 0xed: case 0xee: case 0xef:  // IN, OUT dx
+				d_modRM = 0xd0;
+				outs((opcode & 2)? "out": "in ", OPS2);
+                break;
+			case 0xf0:  // LOCK
+				outs("lock", 0);
+				break;
+            case 0xf2:  // REPNZ
+				prefix = true;
+				outs("repnz ", 0);
+				break;
+			case 0xf3:  // REPZ
+				prefix = true;
+				outs("repz ", 0);
+				break;
+			case 0xf4:  // HLT
+				outs("hlt", 0);
+				break;
+            case 0xf5:  // CMC
+                outs("cmc", 0);
+                break;
+            case 0xf6: case 0xf7:  // math rmv
+				d_modRM = d_fetchByte();
+                //data = readEA();
+                switch (d_modRMReg()) {
+                    case 0: case 1:  // TEST rmv,iv
+						outs("test", BW|IMM|RM);
+                        break;
+                    case 2:  // NOT iv
+						outs("not", BW|RM);
+                        break;
+                    case 3:  // NEG iv
+						outs("neg", BW|RM);
+                        break;
+                    case 4: case 5:  // MUL rmv, IMUL rmv
+						outs(d_modRMReg() == 4? "mul": "imul", BW|RM);
+						break;
+                    case 6: case 7:  // DIV rmv, IDIV rmv
+						outs(d_modRMReg() == 4? "div": "idiv", BW|RM);
+						break;
+                }
+                break;
+            case 0xf8: case 0xf9:  // STC/CLC
+                outs(wordSize? "stc": "clc", 0);
+                break;
+            case 0xfa: case 0xfb:  // STI/CLI
+                outs(wordSize? "sti": "cli", 0);
+                break;
+            case 0xfc: case 0xfd:  // STD/CLD
+                outs(wordSize? "std": "cld", 0);
+                break;
+            case 0xfe: case 0xff:  // misc
+				d_modRM = d_fetchByte();
+                if ((!wordSize && d_modRMReg() >= 2 && d_modRMReg() <= 6) ||
+                    d_modRMReg() == 7) {
+					outs("???", 0);
+                } else switch (d_modRMReg()) {
+                    case 0:  // inc rmv
+						outs("inc", BW|RM);
+						break;
+					case 1:  // dec rmv
+						outs("dec", BW|RM);
+                        break;
+                    case 2:  // CALL rmv
+						outs("call", RM);
+                        break;
+                    case 3:  // CALL mp
+						outs("call", JMP|DWORD);
+                        break;
+                    case 4:  // JMP rmw
+						outs("jmp", RM);
+                        break;
+                    case 5:  // JMP mp
+						outs("jmp", JMP|DWORD);
+                        break;
+                    case 6:  // PUSH rmw
+						outs("push", RM);
+                        break;
+                }
+                break;
+        }
+    //} while (prefix == true);
+}

--- a/elkscmd/debug/printreg.S
+++ b/elkscmd/debug/printreg.S
@@ -1,0 +1,107 @@
+/* ia16-elf-gcc ASM instrumentation functions for ELKS */
+/* June 2022 Greg Haerr */
+
+	.code16
+	.text
+
+	.global print_regs
+	.global print_segs
+	.extern	printf
+
+        .global getcsbyte
+// int getcsbyte(char *addr)
+// return byte at CS:addr
+getcsbyte:
+        push %bp
+        mov  %sp,%bp
+        mov  4(%bp),%bx
+        mov  %cs:(%bx),%al
+        xor  %ah,%ah
+        pop  %bp
+        ret
+
+        .global getcs
+// int getcs(void)
+// return CS
+getcs:
+        push %cs
+        pop  %ax
+        ret
+
+        .global rdtsc
+// unsigned long long rdtsc(void)
+// 386+ only, reads CPU time stamp counter
+rdtsc:
+        mov  %sp,%bx
+        mov  2(%bx),%bx // get address for 64-bit return
+        rdtsc           // returns 64-bit EDX:EAX
+        mov  %ax,(%bx)
+        shr  $16,%eax
+        mov  %ax,2(%bx)
+        mov  %dx,4(%bx)
+        shr  $16,%edx
+        mov  %dx,6(%bx)
+        ret
+
+print_regs:
+	push %ax
+	push %sp
+	push %bp
+	mov  %sp,%bp
+	add  $4,2(%bp)	// adjust SP to before call here
+
+	push %di
+	push %si
+	push %dx
+	push %cx
+	push %bx
+	push %ax
+	mov  $fmt_regs,%ax
+	push %ax
+	call printf
+	pop %ax
+
+	pop %ax
+	pop %bx
+	pop %cx
+	pop %dx
+	pop %si
+	pop %di
+	pop %bp
+	pop %ax		// don't reset SP
+	pop %ax
+	//ret
+
+print_segs:
+	push %ax
+	push %bx
+	push %cx
+	push %dx
+	push %bp
+
+	mov %sp,%bp
+	mov %bp,%ax
+	add $12,%ax     // adjust SP to before call here
+	push %ax
+	push %ss
+	push %es
+	push %ds
+	push 10(%bp)    // orig IP
+	push %cs
+	mov $fmt_sregs,%ax
+	push %ax
+	call printf
+	add $14,%sp
+
+	pop %bp
+	pop %dx
+	pop %cx
+	pop %bx
+	pop %ax
+	ret
+
+	.data
+fmt_regs: .ascii "AX=%04x BX=%04x CX=%04x DX=%04x SI=%04x DI=%04x BP=%04x SP=%04x\n"
+	.byte	0
+fmt_sregs: .ascii "CS:IP=%04x:%04x DS=%04x ES=%04x SS:SP=%04x:%04x\n"
+	.byte	0

--- a/elkscmd/debug/stacktrace.c
+++ b/elkscmd/debug/stacktrace.c
@@ -1,0 +1,168 @@
+/*
+ * ELKS stack trace and instrumentation functions library for ia16-elf-gcc
+ *
+ * June 2022 Greg Haerr
+ */
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include "stacktrace.h"
+#include "syms.h"
+
+#define PROFILING   0   /* =1 to include instrumentation functions */
+#define STACKCOLS   8   /* # of stack address columns */
+
+/* ia-16 C function stack layout (hi to low):
++--------------+
+| arg1         | bp[4]
++--------------+
+| ret addr     | bp[3]
++--------------+
+| si           | bp[2] (optional, always 1st push)
++--------------+
+| di           | bp[1] (optional)
++--------------+
+| bp           | bp[0], <- BP (optional, always last push)
++--------------+
+| temp vars    | bp[-1], <- SP
++--------------+
+*/
+
+#define BP_PUSHED   0x0100
+#define DI_PUSHED   0x0200
+#define SI_PUSHED   0x0400
+#define COUNT_MASK  0x0007
+
+/*
+ * Return pushed word count and register bitmask by function at passed address,
+ * used to traverse BP chain and display registers.
+ */
+static int noinstrument calc_push_count(int *addr)
+{
+    int *fn = sym_fn_start_address(addr);   /* get fn start from address */
+    char *fp = (char *)fn;
+    int count = 0;
+
+    int opcode = getcsbyte(fp++);
+    if (opcode == 0x56)         /* push %si */
+        count = (count+1) | SI_PUSHED, opcode = getcsbyte(fp++);
+    if (opcode == 0x57)         /* push %di */
+        count = (count+1) | DI_PUSHED, opcode = getcsbyte(fp++);
+    if (opcode == 0x55)         /* push %bp */
+        count = (count + 1) | BP_PUSHED, opcode = getcsbyte(fp);
+    //printf("%s (%x) pushes %x\n", sym_text_symbol(addr, 1), (int)addr, count);
+    return count;
+}
+
+/* display stack line and any subsequent lines w/o BP pushed */
+static void noinstrument print_stack_line(int level, int **addr, int *fn, int flag)
+{
+    int j = 0;
+
+    printf("%4d: %04x =>", level, (int)addr);
+    do {
+        if ((j == 0 && !(flag & BP_PUSHED))
+         || (j == 1 && !(flag & DI_PUSHED))
+         || (j == 2 && !(flag & SI_PUSHED)))
+            printf("     ");
+        else printf(" %04x", (int)*addr++);
+    } while (++j < STACKCOLS);
+    printf(" %s", sym_text_symbol(fn, 1));
+    if (!(flag & BP_PUSHED))
+        printf("*");
+    printf(" (%04x)", (int)fn);
+    printf("\n");
+}
+
+/* display call stack, arg1 ignored */
+void noinstrument print_stack(int arg1)
+{
+    int **bp = (int **) &arg1 - 4;
+    int **addr = bp;
+    int *fn = (int *)print_stack;
+    int i = 0;
+
+    printf("Level Addr    BP   DI   SI   Ret  Arg  Arg2 Arg3 Arg4\n"
+           "~~~~~ ~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n");
+    do {
+        int flag = calc_push_count(fn);
+        int prev = flag;
+        print_stack_line(i, addr, fn, flag);
+        //int n = 3;
+        //for (n=0; n<2; n++) {
+            //fn = disasm(getcs(), fn);
+        //}
+        fn = addr[flag & COUNT_MASK];
+        flag = calc_push_count(fn);
+        if (flag & BP_PUSHED) {           /* caller pushed BP */
+            addr = bp = (int **)bp[0];    /* one level down to get caller BP */
+        } else {
+            addr += (prev & COUNT_MASK) + 1;        /* skip past last ret addr */
+        }
+    } while (++i < 15 && fn != 0 && addr != 0);
+}
+
+#if PROFILING
+static int count;
+static int **start_sp;
+static unsigned int max_stack;
+
+/* every function this function calls must also be noinstrument!! */
+void noinstrument __cyg_profile_func_enter(void *arg1, void *arg2)
+{
+    int **bp = (int **)&arg1 - 4;   /* find BP on stack: BP, DI, SI, ret, arg1 */
+    int *calling_fn = bp[3];        /* return address */
+    int i;
+    char callsite[32];
+
+    //assert(bp == __builtin_frame_address(0));
+    //assert(calling_fn == __builtin_return_address(0));
+
+    /* calc stack used */
+    if (count == 0) start_sp = bp;
+    unsigned int stack_used = start_sp - bp;
+    if (stack_used > max_stack) max_stack = stack_used;
+
+    //print_times();
+    //print_regs();
+    //print_stack(0xDEAD);
+
+    /* calc caller address */
+    i = calc_push_count(calling_fn);
+    if (i & BP_PUSHED) {            /* caller pushed BP */
+        bp = (int **)bp[0];         /* one level down to get caller BP */
+        i &= COUNT_MASK;
+    } else bp += 4;                 /* caller didn't push BP, skip past our ret addr */
+    if (i >= 0)
+        strcpy(callsite, sym_text_symbol(bp[i], 1));   /* return address of caller */
+    else
+        strcpy(callsite, "<unknown>");
+    for (i=0; i<count; i++)
+        putchar('|');
+    printf(">%s, from %s, stack %u/%u\n", sym_text_symbol(calling_fn, 0), callsite,
+        stack_used, max_stack);
+    ++count;
+}
+
+void noinstrument __cyg_profile_func_exit(void *arg1, void *arg2)
+{
+    --count;
+}
+#endif /* PROFILING */
+
+#if LATER
+long long ts, last_ts, diff;
+
+void noinstrument print_times(void)
+{
+    ts = rdtsc();       /* REQUIRES 386 CPU! */
+    //diff = ts - last_ts;
+    diff = ts;
+    printf("time = %08lx%08lx, (%s),", (long)(diff >> 32), (long)diff, lltohexstr(diff));
+    printf("%s\n", ulltostr(diff, 16));
+    last_ts = ts;
+}
+#endif

--- a/elkscmd/debug/stacktrace.h
+++ b/elkscmd/debug/stacktrace.h
@@ -1,0 +1,26 @@
+/* ELKS stack trace and instrumentation functions library */
+
+#define noinstrument    __attribute__((no_instrument_function))
+
+/* stacktrace.c */
+void noinstrument print_stack(int arg1);
+
+/* instrumentation functions called when -finstrument-functions set */
+void noinstrument __cyg_profile_func_enter(void *, void *);
+void noinstrument __cyg_profile_func_exit(void *, void *);
+void print_times(void);
+
+/* printreg.S */
+void noinstrument print_regs(void);
+void noinstrument print_sreg(void);
+int noinstrument getcsbyte(char *addr);
+int noinstrument getcs(void);
+unsigned long long noinstrument rdtsc(void);
+
+/* disasm.c */
+void * noinstrument disasm(unsigned short cs, void *ip);
+
+/* ulltostr.c */
+char * noinstrument lltostr(long long val, int radix);
+char * noinstrument ulltostr(unsigned long long val, int radix);
+char * noinstrument lltohexstr(unsigned long long val);

--- a/elkscmd/debug/syms.c
+++ b/elkscmd/debug/syms.c
@@ -89,7 +89,7 @@ void * noinstrument sym_fn_start_address(void *addr)
         if (!type_text(p) || ((unsigned short)addr < *(unsigned short *)(&p[ADDR])))
             break;
     }
-    return (void *) *(unsigned short *)(&lastp[ADDR]);
+    return (void *) (intptr_t) *(unsigned short *)(&lastp[ADDR]);
 }
 
 /* convert address to symbol string */
@@ -117,7 +117,7 @@ hex:
     }
     int lastaddr = *(unsigned short *)(&lastp[ADDR]);
     if (exact && addr - lastaddr) {
-        sprintf(buf, "%.*s+%x", lastp[SYMLEN], lastp+SYMBOL,
+        sprintf(buf, "%.*s+%xh", lastp[SYMLEN], lastp+SYMBOL,
                                 (unsigned int)addr - lastaddr);
     } else sprintf(buf, "%.*s", lastp[SYMLEN], lastp+SYMBOL);
     return buf;

--- a/elkscmd/debug/testsym.c
+++ b/elkscmd/debug/testsym.c
@@ -2,6 +2,34 @@
 #include <stdio.h>
 #include <string.h>
 #include "syms.h"
+#include "stacktrace.h"
+
+void disasm_function(void *fn)
+{
+    int n;
+    void *next;
+
+    printf("Disassembly of %s:\n", sym_text_symbol(fn, 1));
+    for (n=0; n<60; n++) {
+        next = disasm(getcs(), fn);
+        if (getcsbyte((char *)fn) == 0xc3)  /* RET */
+            break;
+        fn = next;
+    }
+}
+
+void z()
+{
+    printf("Stack backtrace of z:\n");
+    print_stack(0xDEAD);
+    disasm_function(z);
+    disasm_function(disasm_function);
+}
+
+void y(int a)
+{
+    z();
+}
 
 void x()
 {
@@ -9,11 +37,12 @@ void x()
     extern long lseek();
 
     printf("x = %s\n", sym_text_symbol(x, 1));
-    printf("strlen = %s\n", sym_text_symbol(strlen+3, 1));
+    printf("strlen+3 = %s\n", sym_text_symbol(strlen+3, 1));
     printf("strlen = %s\n", sym_text_symbol(sym_fn_start_address(strlen+3), 1));
-    printf("lseek = %s\n", sym_text_symbol(lseek+32, 1));
-    printf(".shift_loop = %s\n", sym_text_symbol((void *)0x0C71, 1));
+    printf("lseek+20 = %s\n", sym_text_symbol(lseek+32, 1));
+    //printf(".shift_loop = %s\n", sym_text_symbol((void *)0x0C71, 1));
     printf("errno = %s\n", sym_data_symbol(&errno, 1));
+    y(1);
 }
 
 int main(int ac, char **av)

--- a/elkscmd/misc_utils/hd.c
+++ b/elkscmd/misc_utils/hd.c
@@ -112,7 +112,7 @@ void do_mem(char *spec)
    //printf("SEG %x OFF %x CNT %ld\n", seg, off, count);
 
    addr = (unsigned char __far *)(((unsigned long)seg << 16) | off);
-   offset = (((unsigned long)seg << 4) | off);
+   offset = (((unsigned long)seg << 4) + off);
    for ( ; count > 0; count -= 16, offset += 16) {
       int j, ch;
       memset(buf, '\0', 16);


### PR DESCRIPTION
As originally mentioned in https://github.com/jbruchon/elks/issues/1366#issuecomment-1181285906, this PR adds much more comprehensive debugging capabilities for use in ELKS applications.

A comprehensive stack backtrace capability `print_stack`, allows for an application to produce a stack backtrace from the function calling print_stack backwards to `_start` in crt0.S, with the names of the routines looked up from the application's symbol table, if present. This will soon replace the previous ELKS kernel `panic` stacktrace, which was removed a while ago since it hadn't worked since the change from BCC to ia16-elf-gcc.

A in-application 8086 disassembler, called by `disasm_function(void *fnaddr)`, or `disasm(void *CS, void *IP)` will display disassembled 8086 opcodes, including symbols, for either the entire passed function (until RET), or a single line (for the latter call). The disassembler is contained within a single .c file and is just 4K bytes of code. This code was heavily inspired by Andrew Jenner's very tiny `86sim` 8086 simulator, originally retrieved from @tkchia's [reenigne](https://github.com/tkchia/reenigne) project with his 86sim patches, used for testing gcc-ia16. A portion of that project was forked in my [86sim](https://github.com/ghaerr/86sim) project, where the disassembler was added and support added to run ELKS executables. It is now very slightly modified for operation in ELKS runtime.

This tiny, single-file 8086 disassembler is perfect for ELKS because of its very small size, and the next step is to build a standalone `disasm` similar to `hd`, as well as add support for kernel disassembly using the new symbol table file format. 

This PR also fixes the `hd` displayed address problem, noted in https://github.com/jbruchon/elks/issues/1367#issuecomment-1210913480.

Use of the stack trace and disassembler are in the elkscmd/debug/testsym.c application, where the following source lines produce the attached output:
```
void disasm_function(void *fn)
{
    int n;
    void *next;

    printf("Disassembly of %s:\n", sym_text_symbol(fn, 1));
    for (n=0; n<60; n++) {
        next = disasm(getcs(), fn);
        if (getcsbyte((char *)fn) == 0xc3)  /* RET */
            break;
        fn = next;
    }
}

void z()
{
    printf("Stack backtrace of z:\n");
    print_stack(0xDEAD);
    disasm_function(z);
    disasm_function(disasm_function);
}
```
Output:

<img width="752" alt="disasm" src="https://user-images.githubusercontent.com/11985637/184025457-293c1462-6a1b-4937-adc9-571bcbd472dc.png">

The debug library is not yet automatically built with the standard ELKS build, and it requires a gcc tools rebuild using `tools/build.sh`, then running `make` in elkscmd/debug.