### PR TITLE
[tools] Add --symfile option to elf2elks, produce system.sym symbol table

### DIFF
--- a/elks/arch/i86/Makefile
+++ b/elks/arch/i86/Makefile
@@ -48,10 +48,6 @@ ifeq ($(CONFIG_ROMCODE), y)
 ROMPOSTLINKFLAGS = --aout-seg 0x$(CONFIG_ROM_KERNEL_CODE:0x%=%) \
 		   --data-seg 0x$(CONFIG_ROM_KERNEL_DATA:0x%=%)
 
-else
-
-ROMPOSTLINKFLAGS =
-
 endif
 
 #########################################################################
@@ -135,11 +131,10 @@ boot/system:	$(XINCLUDE) $(AARCHIVES) $(ADRIVERS) boot/crt0.o
 	(cd $(BASEDIR) ; $(LD) $(CPU_LD) -M $(ARCH_LD) -T $(TOPDIR)/elks/elks-small.ld \
 		$(ARCH_DIR)/boot/crt0.o \
 		init/main.o '-(' $(ARCHIVES) $(DRIVERS) '-)' $(LIBGCC) \
-		-o $(ARCH_DIR)/boot/system > $(ARCH_DIR)/boot/system.map ; \
-		$(NM) $(ARCH_DIR)/boot/system > $(ARCH_DIR)/boot/system-nm.map; \
-		$(POSTLINK) $(ROMPOSTLINKFLAGS) $(ARCH_DIR)/boot/system)
-#		sort -k3,4 $(ARCH_DIR)/boot/system.tmp > $(ARCH_DIR)/boot/system.map ; \
-#		rm -f $(ARCH_DIR)/boot/system.tmp )
+		-o $(ARCH_DIR)/boot/system > $(ARCH_DIR)/boot/system-full.map ; \
+		$(NM) $(ARCH_DIR)/boot/system | sed -e '/&/d; /!/d' | sort > \
+			$(ARCH_DIR)/boot/system.map; \
+		$(POSTLINK) --symfile $(ARCH_DIR)/boot/system.sym $(ARCH_DIR)/boot/system)
 
 ifneq ($(CONFIG_ROMCODE), y)
 

--- a/elks/arch/i86/boot/.gitignore
+++ b/elks/arch/i86/boot/.gitignore
@@ -1,1 +1,2 @@
 *.map
+system.sym

--- a/elks/tools/elf2elks/elf2elks.c
+++ b/elks/tools/elf2elks/elf2elks.c
@@ -252,6 +252,8 @@ parse_args (int argc, char **argv)
 		{
 		    symfile = true;
 		    ++i;
+                    if (i >= argc)
+                        error_with_help ("expected filename after `%s'", argv[i - 1]);
 		    strcpy(symtab_filename, argv[i]);
 		}
 	      else if (strcmp (arg + 2, "total-data") == 0)


### PR DESCRIPTION
Adds `--symfile file` option to `elf2elks`, which is then used when building the `system` kernel to produce a `system.sym` (~15k) file that will later be used to supply symbols for stack traces or disassembly. This will likely be copied onto distribution media as /lib/system.sym in the future, for use with the debug library.

Renames `system.map` to `system-full.map` (~180k).
Renames `system-nm.map` to `system.map`, with `foo!` and `foo&` symbols removed, for easy reading (~25k).
