### PR TITLE
[cmds] Add disasm 8086 disassembler tool for ELKS runtime

### DIFF
--- a/elkscmd/debug/.gitignore
+++ b/elkscmd/debug/.gitignore
@@ -1,3 +1,4 @@
 *.o
 nm86
 testsym
+disasm

--- a/elkscmd/debug/Makefile
+++ b/elkscmd/debug/Makefile
@@ -13,9 +13,8 @@ HOSTCFLAGS = -O3
 
 ###############################################################################
 
-PRGS = testsym
-OBJS = testsym.o syms.o stacktrace.o printreg.o
-OBJS += disasm.o
+PRGS = testsym disasm
+LIBOBJS += syms.o stacktrace.o printreg.o disasm.o
 #OBJS += ulltostr.o
 CFLAGS += -fno-optimize-sibling-calls
 CFLAGS += -fno-omit-frame-pointer
@@ -27,10 +26,17 @@ all: nm86 $(PRGS)
 nm86: nm86.c syms.c
 	$(HOSTCC) $(HOSTCFLAGS) -o $@ $^
 
-testsym: $(OBJS)
-	$(LD) $(LDFLAGS) -mno-post-link -o $@ $(OBJS) $(LDLIBS)
+TESTSYMOBJS = testsym.o $(LIBOBJS)
+testsym: $(TESTSYMOBJS)
+	$(LD) $(LDFLAGS) -mno-post-link -o $@ $(TESTSYMOBJS) $(LDLIBS)
 	elf2elks --symtab --heap 12000 $@
 	./nm86 $@ > $@.map
+	cp $@ $(TOPDIR)/elkscmd/rootfs_template/root
+
+DISASMOBJS = dis.o $(LIBOBJS)
+disasm: $(DISASMOBJS)
+	$(LD) $(LDFLAGS) -mno-post-link -o $@ $(DISASMOBJS) $(LDLIBS)
+	elf2elks --symtab --heap 12000 $@
 	cp $@ $(TOPDIR)/elkscmd/rootfs_template/root
 
 disasm.o: disasm.c

--- a/elkscmd/debug/dis.c
+++ b/elkscmd/debug/dis.c
@@ -1,0 +1,58 @@
+/*
+ * ELKS 8086 Disassembler
+ *
+ * Aug 2022 Greg Haerr
+ */
+#include <stdio.h>
+//#include <string.h>
+//#include <stdlib.h>
+//#include <unistd.h>
+#include "syms.h"
+#include "disasm.h"
+
+char * noinstrument getsymbol(int seg, int offset)
+{
+    static char buf[32];
+
+    if (seg == getcs())
+        return sym_text_symbol((void *)offset, 1);
+    sprintf(buf, "%04x", offset);
+    return buf;
+}
+
+#define peekb(cs,ip)  (*(unsigned char __far *)(((unsigned long)(cs) << 16) | (int)(ip)))
+
+void disassemble(int cs, void *ip, int opcount)
+{
+    int n;
+    void *nextip;
+
+    if (!opcount) opcount = 32767;
+    printf("Disassembly of %s:\n", getsymbol(cs, (int)ip));
+    for (n=0; n<opcount; n++) {
+        nextip = disasm(cs, ip);
+        if (peekb(cs, ip) == 0xc3)  /* RET */
+            break;
+        ip = nextip;
+    }
+}
+
+int main(int ac, char **av)
+{
+    unsigned long seg = 0, off = 0;
+    long count = 22;
+
+    if (ac != 2) {
+        printf("Usage: disasm seg:off[#size]\n");
+        return 1;
+    }
+    printf("CS = %x\n", getcs());
+    sscanf(av[1], "%lx:%lx#%ld", &seg, &off, &count);
+
+    if (seg > 0xffff || off > 0xffff) {
+        printf("Error: segment or offset larger than 0xffff\n");
+        return 1;
+    }
+    disassemble((int)seg, (void *)(int)off, (int)count);
+    return 0;
+}

--- a/elkscmd/debug/dis.c
+++ b/elkscmd/debug/dis.c
@@ -4,9 +4,6 @@
  * Aug 2022 Greg Haerr
  */
 #include <stdio.h>
-//#include <string.h>
-//#include <stdlib.h>
-//#include <unistd.h>
 #include "syms.h"
 #include "disasm.h"
 
@@ -31,7 +28,7 @@ void disassemble(int cs, void *ip, int opcount)
     printf("Disassembly of %s:\n", getsymbol(cs, (int)ip));
     for (n=0; n<opcount; n++) {
         nextip = disasm(cs, ip);
-        if (peekb(cs, ip) == 0xc3)  /* RET */
+        if (opcount == 32767 && peekb(cs, ip) == 0xc3)  /* RET */
             break;
         ip = nextip;
     }

--- a/elkscmd/debug/disasm.h
+++ b/elkscmd/debug/disasm.h
@@ -1,0 +1,12 @@
+/* ELKS disassembler header file */
+
+#define noinstrument    __attribute__((no_instrument_function))
+
+/* to be defined by caller of disasm() */
+char * noinstrument getsymbol(int seg, int offset);
+
+/* disasm.c */
+void * noinstrument disasm(int cs, void *ip);
+
+/* printreg.S */
+int noinstrument getcs(void);

--- a/elkscmd/debug/stacktrace.c
+++ b/elkscmd/debug/stacktrace.c
@@ -91,10 +91,6 @@ void noinstrument print_stack(int arg1)
         int flag = calc_push_count(fn);
         int prev = flag;
         print_stack_line(i, addr, fn, flag);
-        //int n = 3;
-        //for (n=0; n<2; n++) {
-            //fn = disasm(getcs(), fn);
-        //}
         fn = addr[flag & COUNT_MASK];
         flag = calc_push_count(fn);
         if (flag & BP_PUSHED) {           /* caller pushed BP */

--- a/elkscmd/debug/stacktrace.h
+++ b/elkscmd/debug/stacktrace.h
@@ -14,11 +14,7 @@ void print_times(void);
 void noinstrument print_regs(void);
 void noinstrument print_sreg(void);
 int noinstrument getcsbyte(char *addr);
-int noinstrument getcs(void);
 unsigned long long noinstrument rdtsc(void);
-
-/* disasm.c */
-void * noinstrument disasm(unsigned short cs, void *ip);
 
 /* ulltostr.c */
 char * noinstrument lltostr(long long val, int radix);

--- a/elkscmd/debug/syms.h
+++ b/elkscmd/debug/syms.h
@@ -24,4 +24,3 @@ char * noinstrument sym_text_symbol(void *addr, int exact);
 char * noinstrument sym_ftext_symbol(void *addr, int exact);
 char * noinstrument sym_data_symbol(void *addr, int exact);
 void * noinstrument sym_fn_start_address(void *addr);
-

--- a/elkscmd/debug/testsym.c
+++ b/elkscmd/debug/testsym.c
@@ -3,18 +3,32 @@
 #include <string.h>
 #include "syms.h"
 #include "stacktrace.h"
+#include "disasm.h"
 
-void disasm_function(void *fn)
+char * noinstrument getsymbol(int seg, int offset)
+{
+    static char buf[32];
+
+    if (seg == getcs())
+        return sym_text_symbol((void *)offset, 1);
+    sprintf(buf, "%04x", offset);
+    return buf;
+}
+
+#define peekb(cs,ip)  (*(unsigned char __far *)(((unsigned long)(cs) << 16) | (int)(ip)))
+
+void disassemble(int cs, void *ip, int opcount)
 {
     int n;
-    void *next;
+    void *nextip;
 
-    printf("Disassembly of %s:\n", sym_text_symbol(fn, 1));
-    for (n=0; n<60; n++) {
-        next = disasm(getcs(), fn);
-        if (getcsbyte((char *)fn) == 0xc3)  /* RET */
+    if (!opcount) opcount = 32767;
+    printf("Disassembly of %s:\n", getsymbol(cs, (int)ip));
+    for (n=0; n<opcount; n++) {
+        nextip = disasm(cs, ip);
+        if (peekb(cs, ip) == 0xc3)  /* RET */
             break;
-        fn = next;
+        ip = nextip;
     }
 }
 
@@ -22,8 +36,8 @@ void z()
 {
     printf("Stack backtrace of z:\n");
     print_stack(0xDEAD);
-    disasm_function(z);
-    disasm_function(disasm_function);
+    disassemble(getcs(), z, 0);
+    disassemble(getcs(), disassemble, 0);
 }
 
 void y(int a)

--- a/elkscmd/misc_utils/hd.c
+++ b/elkscmd/misc_utils/hd.c
@@ -102,17 +102,20 @@ void do_fd(void)
 
 void do_mem(char *spec)
 {
-   unsigned int seg = 0, off = 0;
+   unsigned long seg = 0, off = 0;
    unsigned char __far *addr;
    long   count = 256;
    char  buf[20];
    int   num[16];
 
-   sscanf(spec, "%x:%x#%ld", &seg, &off, &count);
-   //printf("SEG %x OFF %x CNT %ld\n", seg, off, count);
+   sscanf(spec, "%lx:%lx#%ld", &seg, &off, &count);
+   if (seg > 0xffff || off > 0xffff) {
+        printf("Error: segment or offset larger than 0xffff\n");
+        return;
+   }
 
-   addr = (unsigned char __far *)(((unsigned long)seg << 16) | off);
-   offset = (((unsigned long)seg << 4) + off);
+   addr = (unsigned char __far *)((seg << 16) | (unsigned short)off);
+   offset = ((seg << 4) + (unsigned short)off);
    for ( ; count > 0; count -= 16, offset += 16) {
       int j, ch;
       memset(buf, '\0', 16);
@@ -250,6 +253,5 @@ int main(int argc, char **argv)
       else
          do_fd();
    }
-
-   exit(0);
+   return 0;
 }


### PR DESCRIPTION
Adds `disasm`, a standalone disassembler, to ELKS.

`disasm` takes a command line argument just like `hd` for inspecting memory, and can disassemble any location in memory, including itself. For this initial test, when the CS value equals its own code segment, it uses its own internal symbol table for display of call addresses as symbols. Currently only .text symbols are converted (not .data/.bss yet).

Usage:
```
disasm seg:off[#size]
```
The optional size field requests how many lines to be disassembled (default 22, or until RET instruction if size specified as 0).
 
Currently, `disasm` displays its own CS value on startup, so that one can test the mnemonic symbol display when disassembling its own location while running (here's a display of disassembling itself from _start):
```
# ./disasm 56ae:0
CS = 56ae
Disassembly of _start:
56ae:0000  55                push	%bp
56ae:0001  89 e5             mov	%sp,%bp
56ae:0003  8d 5e 04          lea	0x04(%bp),%bx
56ae:0006  8b 4e 02          mov	0x02(%bp),%cx
56ae:0009  89 c8             mov	%cx,%ax
56ae:000b  40                inc	%ax
56ae:000c  d1 e0             shl	$1,%ax
56ae:000e  01 d8             add	%bx,%ax
56ae:0010  a3 f4 07          movw	%ax,(0x07f4)
56ae:0013  50                push	%ax
56ae:0014  53                push	%bx
56ae:0015  8b 1f             mov	(%bx),%bx
56ae:0017  89 1e f2 07       movw	%bx,(0x07f2)
56ae:001b  51                push	%cx
56ae:001c  e8 ab 00          call	main (00ca)
56ae:001f  83 c4 06          add	$0x6,%sp
56ae:0022  50                push	%ax
56ae:0023  e8 01 00          call	exit (0027)
56ae:0026  cc                int	$3
56ae:0027  55                push	%bp
56ae:0028  89 e5             mov	%sp,%bp
56ae:002a  8b 1e 4c 08       movw	(0x084c),%bx
```
Shortly, the ability to load the kernel symbol file `symbol.sym` will be added, which will allow disassembly of the operating kernel with symbols.

`hd` was enhanced to check for overflow in its segment:offset arguments.

@Mellvik, this tool should help you debug the BIOS problem in #1367. As mentioned previously, the toolchain needs to be upgraded using `tools/build.sh`, and then run `make` in elkscmd/debug. `disasm` will be copied to the ELKS root user directory for the time being.
