### PR TITLE
[cmds] Enhance disasm to disassemble binary file

### DIFF
--- a/elkscmd/debug/Makefile
+++ b/elkscmd/debug/Makefile
@@ -14,7 +14,7 @@ HOSTCFLAGS = -O3
 ###############################################################################
 
 PRGS = testsym disasm
-LIBOBJS += syms.o stacktrace.o printreg.o disasm.o
+LIBOBJS += syms.o stacktrace.o printreg.o
 #OBJS += ulltostr.o
 CFLAGS += -fno-optimize-sibling-calls
 CFLAGS += -fno-omit-frame-pointer
@@ -33,7 +33,7 @@ testsym: $(TESTSYMOBJS)
 	./nm86 $@ > $@.map
 	cp $@ $(TOPDIR)/elkscmd/rootfs_template/root
 
-DISASMOBJS = dis.o $(LIBOBJS)
+DISASMOBJS = dis.o disasm.o $(LIBOBJS)
 disasm: $(DISASMOBJS)
 	$(LD) $(LDFLAGS) -mno-post-link -o $@ $(DISASMOBJS) $(LDLIBS)
 	elf2elks --symtab --heap 12000 $@

--- a/elkscmd/debug/dis.c
+++ b/elkscmd/debug/dis.c
@@ -23,59 +23,59 @@ char * noinstrument getsymbol(int seg, int offset)
 
 #define peekb(cs,ip)  (*(unsigned char __far *)(((unsigned long)(cs) << 16) | (int)(ip)))
 
-void disasm_mem(int cs, void *ip, int opcount)
+static int nextbyte_mem(int cs, int ip)
+{
+    int b = peekb(cs, ip);
+    printf("%02x ", b);
+    return b;
+}
+
+void disasm_mem(int cs, int ip, int opcount)
 {
     int n;
-    void *nextip;
+    int nextip;
 
     if (!opcount) opcount = 32767;
     printf("Disassembly of %s:\n", getsymbol(cs, (int)ip));
     for (n=0; n<opcount; n++) {
-        nextip = disasm(cs, ip);
+        printf("%04hx:%04hx  ", cs, ip);
+        nextip = disasm(cs, ip, nextbyte_mem);
         if (opcount == 32767 && peekb(cs, ip) == 0xc3)  /* RET */
             break;
         ip = nextip;
     }
 }
 
-void disasm_buf(char *addr, int size)
+static FILE *infp;
+
+static int nextbyte_file(int cs, int ip)
 {
-    char *ip = addr;
-    void *nextip;
-
-    while (ip < addr + size) {
-        nextip = disasm(__builtin_ia16_near_data_segment(), ip);
-        ip = nextip;
-    }
+    int b = fgetc(infp);
+    printf("%02x ", b);
+    return b;
 }
-
-char buf[32767];
 
 int disasm_file(char *filename)
 {
-    int fd, n;
+    int ip = 0;
+    int nextip;
+    long filesize;
     struct stat sbuf;
 
-    if ((fd = open(filename, O_RDONLY)) < 0) {
-        perror(filename);
+    if ((infp = fopen(filename, "r")) == NULL) {
+        printf("Can't open %s\n", filename);
         return 1;
     }
-    if (fstat(fd, &sbuf) < 0) {
-        perror("fstat");
-        return 1;
+    if (stat(filename, &sbuf) < 0)
+        filesize = 0;
+    else filesize = sbuf.st_size;
+
+    while (ip < filesize) {
+        printf("%04hx  ", ip);
+        nextip = disasm(0, ip, nextbyte_file);
+        ip = nextip;
     }
-    if (sbuf.st_size > 32767) {
-        fprintf(stderr, "Can't disassemble file > 32k bytes\n");
-        close(fd);
-        return 1;
-    }
-    if ((n = read(fd, buf, (ssize_t)sbuf.st_size)) != (int)sbuf.st_size) {
-        perror("read");
-        close(fd);
-        return 1;
-    }
-    close(fd);
-    disasm_buf(buf, n);
+    fclose(infp);
     return 0;
 }
 
@@ -97,7 +97,7 @@ int main(int ac, char **av)
             printf("Error: segment or offset larger than 0xffff\n");
             return 1;
         }
-        disasm_mem((int)seg, (void *)(int)off, (int)count);
+        disasm_mem((int)seg, (int)off, (int)count);
     } else return disasm_file(av[1]);
     return 0;
 }

--- a/elkscmd/debug/disasm.h
+++ b/elkscmd/debug/disasm.h
@@ -6,7 +6,7 @@
 char * noinstrument getsymbol(int seg, int offset);
 
 /* disasm.c */
-void * noinstrument disasm(int cs, void *ip);
+int disasm(int cs, int ip, int (*nextbyte)(int, int));
 
 /* printreg.S */
 int noinstrument getcs(void);

--- a/elkscmd/debug/testsym.c
+++ b/elkscmd/debug/testsym.c
@@ -3,41 +3,11 @@
 #include <string.h>
 #include "syms.h"
 #include "stacktrace.h"
-#include "disasm.h"
-
-char * noinstrument getsymbol(int seg, int offset)
-{
-    static char buf[32];
-
-    if (seg == getcs())
-        return sym_text_symbol((void *)offset, 1);
-    sprintf(buf, "%04x", offset);
-    return buf;
-}
-
-#define peekb(cs,ip)  (*(unsigned char __far *)(((unsigned long)(cs) << 16) | (int)(ip)))
-
-void disassemble(int cs, void *ip, int opcount)
-{
-    int n;
-    void *nextip;
-
-    if (!opcount) opcount = 32767;
-    printf("Disassembly of %s:\n", getsymbol(cs, (int)ip));
-    for (n=0; n<opcount; n++) {
-        nextip = disasm(cs, ip);
-        if (peekb(cs, ip) == 0xc3)  /* RET */
-            break;
-        ip = nextip;
-    }
-}
 
 void z()
 {
     printf("Stack backtrace of z:\n");
     print_stack(0xDEAD);
-    disassemble(getcs(), z, 0);
-    disassemble(getcs(), disassemble, 0);
 }
 
 void y(int a)


### PR DESCRIPTION
Adds capability to disassemble binary files using `disasm filename`.

@Mellvik, this is a quick update to allow you to disassemble your MBR for #1367, while we're still focused on it. The current version must be run on ELKS. A subsequent enhancement will allow running on Linux and macOS hosts. A capability to load a separate .sym file when running on a development host is also needed.

Note also that with the MBR binary, that when disassembling .data areas of the MBR, of course instruction data will seem incorrect, and may become permanently desynchronized even when .text is re-encountered. Of course, disassembling .o files is almost always superior, when we have access to them.

Thus, I'd like to hear your results from using this tool for debugging, and we can then use that to further enhance the tool.

[EDIT: `disasm` enhanced for displaying binary files.]

Here's a partial display of disassembling the standard elks/bootblocks/mbr.bin file, on ELKS:
```
# ./disasm mbr.bin 
0000  fa                cli
0001  b8 60 00          mov	$0x60,%ax
0004  8e c0             mov	%ax,%es
0006  8e d0             mov	%ax,%ss
0008  31 e4             xor	%sp,%sp
000a  31 ff             xor	%di,%di
000c  57                push	%di
000d  8e df             mov	%di,%ds
000f  be 00 7c          mov	$0x7c00,%si
0012  b9 00 01          mov	$0x100,%cx
0015  fc                cld
0016  f3                repz 
0017  a5                movsw	
0018  06                push	%es
0019  1f                pop	%ds
001a  07                pop	%es
001b  16                push	%ss
001c  b9 21 00          mov	$0x21,%cx
001f  51                push	%cx
0020  cb                retf
0021  88 36 7c 01       movb	%dh,(0x017c)
0025  fb                sti
0026  e8 57 00          call	0080 (0080)
0029  e8 8c 00          call	00b8 (00b8)
002c  be be 01          mov	$0x1be,%si
002f  80 3c 80          cmpb	$0x80,(%si)
0032  74 0b             jz 	.+13 // 003f
0034  83 c6 10          add	$0x10,%si
0037  81 fe fe 01       cmp	$0x1fe,%si
003b  75 f2             jnz	.-12 // 002f
003d  eb 33             jmp	.+53 // 0072
003f  bf 03 00          mov	$0x3,%di
0042  8b 14             mov	(%si),%dx
0044  8b 4c 02          mov	0x02(%si),%cx
0047  bb 00 7c          mov	$0x7c00,%bx
004a  b8 01 02          mov	$0x201,%ax
004d  cd 13             int	$0x13
004f  73 0c             jnb	.+14 // 005d
0051  31 c0             xor	%ax,%ax
0053  cd 13             int	$0x13
0055  4f                dec	%di
0056  75 ea             jnz	.-20 // 0042
0058  be 92 00          mov	$0x92,%si
005b  eb 18             jmp	.+26 // 0075
005d  bf fe 7d          mov	$0x7dfe,%di
0060  26 81 3d 55 aa    cmpw	%es:$0xaa55,(%di)
0065  75 cd             jnz	.-49 // 0034
0067  8a 36 7c 01       movb	(0x017c),%dh
006b  89 f5             mov	%si,%bp
006d  ea 00 7c 00 00    jmp	0000:7c00
```