### PR TITLE
[boot] Disable whole-track reads for PC-98, for now

### DIFF
--- a/bootblocks/boot_sect.S
+++ b/bootblocks/boot_sect.S
@@ -40,7 +40,13 @@
 //
 // Whole-track reads are disabled for the FAT bootloader because we are a
 // bit short of code space :-(
-#ifndef BOOT_FAT
+//
+// Whole-track reads are also disabled for the NEC PC98 platform for now;
+// it seems that, instead of a DDPT, we need to frob the PC98's F2DD_POINTER
+// (http://www.webtech.co.jp/company/doc/undocumented_mem/memsys.txt)
+// mechanism for configuring the "end of track" value; we will need to
+// somehow figure out this mechanism and test it :-( :-(
+#if !defined BOOT_FAT && !defined CONFIG_ARCH_PC98
 #   define FAST_READ
 #else
 #   undef FAST_READ


### PR DESCRIPTION
We probably need to deal with the NEC PC-98's F2DD_POINTER (http://www.webtech.co.jp/company/doc/undocumented_mem/memsys.txt) to properly configure whole-track reads on that platform.