### PR TITLE
[debug] Correct disasm disassembly errors

### DIFF
--- a/elkscmd/debug/disasm.c
+++ b/elkscmd/debug/disasm.c
@@ -45,7 +45,7 @@ int disasm(int cs, int ip, int (*nextbyte)(int, int))
 {
 	startCS = cs;
 	startIP = (int)ip;
-    fetchbyte = nextbyte;
+	fetchbyte = nextbyte;
 	cols = 0;
 	//if (!f_asmout) printf("%04hx:%04hx  ", cs, ip);
 	decode();
@@ -276,7 +276,7 @@ nextopcode:
 #else
                 segOver = operation - 4;
                 prefix = true;
-				goto nextopcode;
+                goto nextopcode;
 #endif
             case 0x27: case 0x2f:  // DA
 				outs(opcode == 0x27? "daa": "das", 0);

--- a/elkscmd/debug/disasm.c
+++ b/elkscmd/debug/disasm.c
@@ -205,10 +205,11 @@ static void outs(const char *str, int flags)
 	if (flags & JMP) {
 		//if (flags & SBYTE) printf("%04x", startIP + c);
 		if (flags & SBYTE) printf(".%s%d // %04x", c>=0? "+": "", c+2, startIP+c);
-		if (flags & WORD) {
-			int waddr = (startIP + w2) & 0xffff;
-			printf("%s (%04x)", getsymbol(startCS, waddr), waddr);
-		}
+        if (flags & WORD) {
+            int waddr = (startIP + w2) & 0xffff;
+            if (opcode == 0xfe || opcode == 0xff) printf("*0x%04x", w2);
+            else printf("%s (%04x)", getsymbol(startCS, waddr), waddr);
+        }
 		if (flags & DWORD) printf("$%04x:$%04x", w, w2);
 	}
 	printf("\n");
@@ -580,13 +581,13 @@ nextopcode:
 						outs("call", RM);
                         break;
                     case 3:  // CALL mp
-						outs("call", JMP|DWORD);
+						outs("lcallw", JMP|WORD);
                         break;
                     case 4:  // JMP rmw
 						outs("jmp", RM);
                         break;
                     case 5:  // JMP mp
-						outs("jmp", JMP|DWORD);
+						outs("ljmpw", JMP|WORD);
                         break;
                     case 6:  // PUSH rmw
 						outs("push", RM);

--- a/elkscmd/debug/disasm.c
+++ b/elkscmd/debug/disasm.c
@@ -505,7 +505,7 @@ nextopcode:
 				outs("jmp", JMP|WORD);
                 break;
             case 0xea:  // JMP cp
-				outs("jmp", JMP|DWORD);
+				outs("ljmpw", JMP|DWORD);
                 break;
             case 0xeb:  // JMP cb
 				outs("jmp", JMP|SBYTE);

--- a/elkscmd/debug/disasm.c
+++ b/elkscmd/debug/disasm.c
@@ -210,7 +210,7 @@ static void outs(const char *str, int flags)
             if (opcode == 0xfe || opcode == 0xff) printf("*0x%04x", w2);
             else printf("%s (%04x)", getsymbol(startCS, waddr), waddr);
         }
-		if (flags & DWORD) printf("$%04x:$%04x", w, w2);
+		if (flags & DWORD) printf("$0x%04x,$0x%04x", w, w2);
 	}
 	printf("\n");
 }
@@ -270,15 +270,17 @@ nextopcode:
 				outs("pop", SREG);
                 break;
             case 0x26: case 0x2e: case 0x36: case 0x3e:  // segment override
+                {
 #if 1
-                d_modRM = (operation - 4) << 3;
-                outs("seg", SREG);
+                static const char *segprefix[] = { "es", "cs", "ss", "ds"};
+                outs(segprefix[operation - 4], 0);
                 break;
 #else
                 segOver = operation - 4;
                 prefix = true;
                 goto nextopcode;
 #endif
+                }
             case 0x27: case 0x2f:  // DA
 				outs(opcode == 0x27? "daa": "das", 0);
                 break;


### PR DESCRIPTION
As described by @tkchia in https://github.com/jbruchon/elks/issues/1367#issuecomment-1214190526, this PR fixes the following errors in `disasm`:
```
0141  8c 0e 4e 00       mov	%cs,(0x004e)    // show %cs instead of %cl
```
```
0145  ea 00 00 70 00    ljmpw   $0070:$0000    // use GNU as syntax for far jumps
```
```
00b1  2e                seg	%cs            // segment override on separate line
00b2  c7 06 48 01 c0 07 movw	$0x7c0,(0x0148)
```
For the time being, a segment override is shown on a separate line, rather than directly preceding the correct instruction operand. This is because displaying the latter is proving a bit complicated. Thus, the segment overrides are displayed the same way that repeat prefixes are - on the preceding line (s). @tkchia, are you OK with this?

Instructions with six bytes are now displayed properly, without having the hex instruction byte display overflow into the mnemonic instruction display column.

Also, the `shl` instruction was sometimes capitalized, which is fixed.
