### PR TITLE
[bootopts] Add serial IRQ setting at boot time

### DIFF
--- a/elks/arch/i86/drivers/char/serial-8250.c
+++ b/elks/arch/i86/drivers/char/serial-8250.c
@@ -50,7 +50,6 @@ struct serial_info {
  * afaik 8250 works fine up to 19200
  */
 
-#define DEFAULT_BAUD_RATE	9600	/* FIXME: also set in ntty.c */
 #define DEFAULT_LCR		UART_LCR_WLEN8
 
 #define DEFAULT_MCR		\
@@ -93,7 +92,8 @@ extern struct tty ttys[];
 #define	RS_IALLMOSTEMPTY	(    INQ_SIZE / 4)
 
 /* allow init to easily update the port irq from bootopts */
-void set_serial_irq(int tty, int irq) {
+void set_serial_irq(int tty, int irq)
+{
 	ports[tty].irq = irq;
 }
 	

--- a/elks/arch/i86/drivers/char/serial-8250.c
+++ b/elks/arch/i86/drivers/char/serial-8250.c
@@ -50,7 +50,7 @@ struct serial_info {
  * afaik 8250 works fine up to 19200
  */
 
-#define DEFAULT_BAUD_RATE	9600
+#define DEFAULT_BAUD_RATE	9600	/* FIXME: also set in ntty.c */
 #define DEFAULT_LCR		UART_LCR_WLEN8
 
 #define DEFAULT_MCR		\
@@ -92,6 +92,11 @@ extern struct tty ttys[];
 #define	RS_IALLMOSTFULL 	(3 * INQ_SIZE / 4)
 #define	RS_IALLMOSTEMPTY	(    INQ_SIZE / 4)
 
+/* allow init to easily update the port irq from bootopts */
+void set_serial_irq(int tty, int irq) {
+	ports[tty].irq = irq;
+}
+	
 /*
  * Flush input by reading RX register.
  * Not used when FIFO enabled, as HW fifo cleared when enabled.

--- a/elks/include/arch/ports.h
+++ b/elks/include/arch/ports.h
@@ -14,7 +14,7 @@
  *  5*  HW IDE hard drive   CONFIG_BLK_DEV_HD       Driver doesn't work
  *  6*  Unused
  *  6*  HW floppy drive     CONFIG_BLK_DEV_FD       Driver doesn't compile
- *  7   Unused (LPT)
+ *  7   Unused (LPT, Com4)
  *  8   Unused (RTC)
  *  9   3C509/EL3 (/dev/eth) CONFIG_ETH_EL3         Optional
  * 10   Unused (USB)                                Turned off
@@ -88,7 +88,7 @@
 #define COM3_IRQ	5		/* unregistered unless COM3_PORT found*/
 
 #define COM4_PORT	0x2e8
-#define COM4_IRQ	2		/* unregistered unless COM4_PORT found*/
+#define COM4_IRQ	7		/* unregistered unless COM4_PORT found*/
 
 /* Ethernet card settings may be overridden in /bootopts using netirq= and netport= */ 
 /* ne2k, ne2k.c */ 

--- a/elks/include/linuxmt/ntty.h
+++ b/elks/include/linuxmt/ntty.h
@@ -106,6 +106,7 @@ extern void ttystd_release(struct tty *tty);
 extern int tty_allocq(struct tty *tty, int insize, int outsize);
 extern void tty_freeq(struct tty *tty);
 		/* Allocate and free character queues*/
+extern void set_serial_irq(int tty, int irq);
 
 extern void set_console(dev_t dev);
 

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -292,16 +292,18 @@ static int INITPROC parse_dev(char * line)
 
 static void comirq(char *line) {
 	int i;
-	char *l, *m;
+	char *l, *m, c;
 
 	l = line;
-	for (i = 0; i < 4; i++) {	/* assume decimal digits only */
+	for (i = 0; i < MAX_SERIAL; i++) {	/* assume decimal digits only */
 		m = l;
 		while ((*l) && (*l != ',')) l++;
+		c = *l;		/* ensure robust eol handling */
 		if (l > m) {
 			*l = '\0';
 			set_serial_irq(i, (int)simple_strtol(m, 0));
 		}
+		if (!c) break;
 		l++;
 	}
 }

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -63,10 +63,12 @@ static unsigned char options[OPTSEGSZ];
 extern int boot_rootdev;
 extern int boot_bufs;
 extern int dprintk_on;
+extern int set_serial_irq(int tty, int irq);
 static char * INITPROC root_dev_name(int dev);
 static int parse_options(void);
 static void INITPROC finalize_options(void);
 static char * INITPROC option(char *s);
+
 #endif
 
 static void init_task(void);
@@ -288,6 +290,22 @@ static int INITPROC parse_dev(char * line)
 	return (base + atoi(line));
 }
 
+static void comirq(char *line) {
+	int i;
+	char *l, *m;
+
+	l = line;
+	for (i = 0; i < 4; i++) {	/* assume decimal digits only */
+		m = l;
+		while ((*l) && (*l != ',')) l++;
+		if (l > m) {
+			*l = '\0';
+			set_serial_irq(i, (int)simple_strtol(m, 0));
+		}
+		l++;
+	}
+}
+
 static void parse_nic(char *line, struct netif_parms *parms)
 {
     char *p;
@@ -401,6 +419,10 @@ static int parse_options(void)
 		}
 		if (!strncmp(line,"bufs=",5)) {
 			boot_bufs = (int)simple_strtol(line+5, 10);
+			continue;
+		}
+		if (!strncmp(line,"comirq=",7)) {
+			comirq(line+7);
 			continue;
 		}
 		if (!strncmp(line,"TZ=",3)) {

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -63,7 +63,6 @@ static unsigned char options[OPTSEGSZ];
 extern int boot_rootdev;
 extern int boot_bufs;
 extern int dprintk_on;
-extern int set_serial_irq(int tty, int irq);
 static char * INITPROC root_dev_name(int dev);
 static int parse_options(void);
 static void INITPROC finalize_options(void);
@@ -290,7 +289,8 @@ static int INITPROC parse_dev(char * line)
 	return (base + atoi(line));
 }
 
-static void comirq(char *line) {
+static void comirq(char *line)
+{
 	int i;
 	char *l, *m, c;
 


### PR DESCRIPTION
Add `bootopts` option to set serial line IRQs at boot time, supplementing the fixed IRQs in `ports.h`.

Syntax:
```
comirq=,,10,5
comirq=5,7,9,
comirq=,4
```

There is no validation of input values, separators must be `,`, otherwise input handling is robust.  
Tested on physical machines only - with up to 4 serial lines.

@ghaerr - I'm adding a change to `ports.h` to this PR. The default IRQ2 for COM4 is not good as it sometimes collides with networks cards @ IRQ9. IRQ7 is a better choice - the chance that a system has 4 COM lines and a parallel port in use should be minimal.

-M