### PR TITLE
[cmds] Add -a option to disasm to output ASM input

### DIFF
--- a/elkscmd/debug/disasm.h
+++ b/elkscmd/debug/disasm.h
@@ -7,6 +7,8 @@ char * noinstrument getsymbol(int seg, int offset);
 
 /* disasm.c */
 int disasm(int cs, int ip, int (*nextbyte)(int, int));
+extern int f_asmout;    /* =1 for asm output (no addresses or hex values) */
+extern int f_outcol;    /* output column number (if !f_asmout) */
 
 /* printreg.S */
 int noinstrument getcs(void);


### PR DESCRIPTION
`disasm` can now be given the `-a` option to allow its output to be used as input to the gcc assembler `ia16-elf-as`:
```
# ./disasm -a mbr.bin 
               cli
               mov	$0x60,%ax
               mov	%ax,%es
               mov	%ax,%ss
               xor	%sp,%sp
               xor	%di,%di
               push	%di
               mov	%di,%ds
               mov	$0x7c00,%si
               mov	$0x100,%cx
               cld
               repz 
               movsw	
               push	%es
               pop	%ds
               pop	%es
               push	%ss
               mov	$0x21,%cx
               push	%cx
               retf
               movb	%dh,(0x017c)
               sti or
               call	0080 // 0080
```
As can be seen, the output doesn't yet contain the needed `.code16` , `.text` or `.arch i8086` statements. This work is in preparation for a building a test suite that can assemble `disasm` output for 256 instruction opcodes for regression testing.

With this option, unknown instructions are not displayed as "???", but instead as ".byte 0x65", for instance. It is still untested as to exactly how the non-relocatable (i.e. absolute) references will be converted (possibly using .org statements for .text and .data?) so as to produce the same binary when the disasm output is run through the assembler.

Hello @tkchia, are you aware of the location of any such lists of opcode testing .asm/.s files that might be useful for testing the disassembly/assembly process? Thank you!