### PR TITLE
[debug] Add disasm -k option to disassemble running kernel with symbols

### DIFF
--- a/elks/arch/i86/drivers/char/mem.c
+++ b/elks/arch/i86/drivers/char/mem.c
@@ -27,6 +27,7 @@
 #include <linuxmt/mem.h>
 #include <linuxmt/heap.h>
 #include <linuxmt/timer.h>
+#include <linuxmt/init.h>
 
 #include <arch/io.h>
 #include <arch/segment.h>
@@ -262,6 +263,9 @@ int kmem_ioctl(struct inode *inode, struct file *file, int cmd, char *arg)
     case MEM_GETDS:
 	retword = kernel_ds;
 	break;
+    case MEM_GETFARTEXT:
+        retword = (unsigned)((long)kernel_init >> 16);
+        break;
     case MEM_GETUSAGE:
 	mm_get_usage (&(mu.free_memory), &(mu.used_memory));
 	memcpy_tofs(arg, &mu, sizeof(struct mem_usage));

--- a/elks/include/linuxmt/mem.h
+++ b/elks/include/linuxmt/mem.h
@@ -8,6 +8,7 @@
 #define MEM_GETCS	6
 #define MEM_GETHEAP	7
 #define MEM_GETUPTIME	8
+#define MEM_GETFARTEXT  9
 
 struct mem_usage {
 	unsigned int free_memory;

--- a/elkscmd/debug/Makefile
+++ b/elkscmd/debug/Makefile
@@ -26,18 +26,18 @@ all: nm86 $(PRGS)
 nm86: nm86.c syms.c
 	$(HOSTCC) $(HOSTCFLAGS) -o $@ $^
 
-TESTSYMOBJS = testsym.o $(LIBOBJS)
-testsym: $(TESTSYMOBJS)
-	$(LD) $(LDFLAGS) -mno-post-link -o $@ $(TESTSYMOBJS) $(LDLIBS)
+testsym: testsym.o $(LIBOBJS)
+	$(LD) $(LDFLAGS) -mno-post-link -o $@ $^ $(LDLIBS)
 	elf2elks --symtab --heap 12000 $@
 	./nm86 $@ > $@.map
 	cp $@ $(TOPDIR)/elkscmd/rootfs_template/root
 
-DISASMOBJS = dis.o disasm.o $(LIBOBJS)
-disasm: $(DISASMOBJS)
-	$(LD) $(LDFLAGS) -mno-post-link -o $@ $(DISASMOBJS) $(LDLIBS)
-	elf2elks --symtab --heap 12000 $@
-	cp $@ $(TOPDIR)/elkscmd/rootfs_template/root
+disasm: dis.o disasm.o $(LIBOBJS)
+	$(LD) $(LDFLAGS) -mno-post-link -o $@ $^ $(LDLIBS)
+	elf2elks --symtab --heap 0xffff $@
+	cp -p $@ $(TOPDIR)/elkscmd/rootfs_template/root
+	-mkdir $(TOPDIR)/elkscmd/rootfs_template/lib
+	cp -p $(TOPDIR)/elks/arch/i86/boot/system.sym $(TOPDIR)/elkscmd/rootfs_template/lib
 
 disasm.o: disasm.c
 	$(CC) $(CFLAGS) -fno-instrument-functions -c -o $*.o $<

--- a/elkscmd/debug/dis.c
+++ b/elkscmd/debug/dis.c
@@ -110,29 +110,31 @@ int disasm_file(char *filename)
     return 0;
 }
 
+void usage(void)
+{
+    printf("Usage: disasm [-k] [-a] [[seg:off[#size] | filename]\n");
+    exit(1);
+}
+
 int main(int ac, char **av)
 {
     unsigned long seg = 0, off = 0;
+    int fd;
     long count = 22;
 
     while (ac > 1 && av[1][0] == '-') {
-        if (!strcmp(av[1], "-a")) {
+        if (av[1][1] == 'a')
             f_asmout = 1;
-            ac--;
-            av++;
-        }
-        if (!strcmp(av[1], "-k")) {
+        else if (av[1][1] == 'k')
             f_ksyms = 1;
-            ac--;
-            av++;
-        }
+        else usage();
+        ac--;
+        av++;
     }
-    if (ac != 2) {
-        printf("Usage: disasm [-k] [-a] [[seg:off[#size] | filename]\n");
-        return 1;
-    }
+    if (ac != 2)
+        usage();
+
     if (f_ksyms) {
-        int fd;
         if (!sym_read_symbols(KSYMTAB)) {
             printf("Can't open %s\n", KSYMTAB);
             exit(1);

--- a/elkscmd/debug/disasm.c
+++ b/elkscmd/debug/disasm.c
@@ -207,17 +207,22 @@ static void outs(const char *str, int flags)
 		printf("(0x%04x)", w2);
 	if (flags & REGOP) printf("%s", wordSize? wordregs[opcode & 7]: byteregs[opcode & 7]);
 	if ((flags & (JMP|IMM|WORD)) == WORD) printf("%u", w2);
-	if (flags & JMP) {
-		//if (flags & SBYTE) printf("%04x", startIP + c);
-		if (flags & SBYTE) printf(".%s%d // %04x", c>=0? "+": "", c+2, startIP+c);
+    if (flags & JMP) {
+        if (flags & SBYTE) {
+            if (f_asmout) printf(".%s%d // %04x", c>=0? "+": "", c+2, startIP+c);
+            else printf("%04x", startIP + c);
+        }
         if (flags & WORD) {
             int waddr = (startIP + w2) & 0xffff;
-            if (opcode == 0xfe || opcode == 0xff) printf("*0x%04x", w2);
-            else printf("%s // %04x", getsymbol(startCS, waddr), waddr);
+            if (opcode == 0xfe || opcode == 0xff) {
+                printf("*%s", getsymbol(startCS, w2));
+            } else printf("%s // %04x", getsymbol(startCS, waddr), waddr);
         }
-		if (flags & DWORD) printf("$0x%04x,$0x%04x", w, w2);
-	}
-	printf("\n");
+        if (flags & DWORD) {
+            printf("$%s,$%s", getsegsymbol(w), getsymbol(w, w2));
+        }
+    }
+    printf("\n");
 }
 
 static void decode(void)

--- a/elkscmd/debug/disasm.h
+++ b/elkscmd/debug/disasm.h
@@ -4,6 +4,7 @@
 
 /* to be defined by caller of disasm() */
 char * noinstrument getsymbol(int seg, int offset);
+char * noinstrument getsegsymbol(int seg);
 
 /* disasm.c */
 int disasm(int cs, int ip, int (*nextbyte)(int, int));

--- a/elkscmd/debug/nm86.c
+++ b/elkscmd/debug/nm86.c
@@ -6,7 +6,7 @@
 
 void nm(char *path)
 {
-    unsigned char *syms = sym_read_symbols(path);
+    unsigned char *syms = sym_read_exe_symbols(path);
     unsigned char *p;
 
     if (!syms) {

--- a/elkscmd/debug/syms.h
+++ b/elkscmd/debug/syms.h
@@ -19,6 +19,7 @@
 
 #define noinstrument    __attribute__((no_instrument_function))
 
+unsigned char * noinstrument sym_read_exe_symbols(char *path);
 unsigned char * noinstrument sym_read_symbols(char *path);
 char * noinstrument sym_text_symbol(void *addr, int exact);
 char * noinstrument sym_ftext_symbol(void *addr, int exact);

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -12,4 +12,4 @@
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.sys
 #init=/bin/sh		# singleuser shell
 #root=hda1 ro		# root hd partition 1, read-only
-console=ttyS0,19200 3	# serial console
+#console=ttyS0,19200 3	# serial console


### PR DESCRIPTION
`disasm -k` can now be used to load the kernel symbol table (currently copied when building `disasm` to /lib/system.sym) to show called functions which match the kernel source code name. In addition, `disasm` will now show both .text and .fartext symbols during kernel disassembly.


For ease of reading disassembly, jump and call targets are now shown as 4-digit hex numbers (unless matched by the current symbol table file), without the 0x prefix. When the `-a` option is given (asm output), the 0x prefix is added.

`disasm` gets the segment values for .text and .data using an existing `ioctl` from /dev/kmem, and an additional ioctl was added for retrieving the .fartext segment value.

Here's an example of showing the disassembly of a live kernel (using .text at 2d0 from the kernel startup display). Address 2d0:0 is _start, the very first code the kernel executes:
```
# ./disasm -k 2d0:0#55
Disassembly of _start:
02d0:0000  89 1e d6 16       movw	%bx,(0x16d6)
02d0:0004  89 3e d8 16       movw	%di,(0x16d8)
02d0:0008  89 36 da 16       movw	%si,(0x16da)
02d0:000c  01 d6             add	%dx,%si
02d0:000e  89 36 dc 16       movw	%si,(0x16dc)
02d0:0012  8b 3e da 16       movw	(0x16da),%di
02d0:0016  89 d1             mov	%dx,%cx
02d0:0018  31 c0             xor	%ax,%ax
02d0:001a  d1 e9             shr	$1,%cx
02d0:001c  fc                cld
02d0:001d  f3                repz 
02d0:001e  ab                stosw	
02d0:001f  8c 0e 4a 68       mov	%cs,(0x684a)
02d0:0023  8c 1e 4c 68       mov	%ds,(0x684c)
02d0:0027  8c d8             mov	%ds,%ax
02d0:0029  8e d0             mov	%ax,%ss
02d0:002b  bc c6 25          mov	$0x25c6,%sp
02d0:002e  e8 8e 03          call	start_kernel // 03bf
02d0:0031  cc                int	$3
02d0:0032  c3                ret
02d0:0033  89 e3             mov	%sp,%bx
02d0:0035  8a 47 02          mov	0x02(%bx),%al
02d0:0038  b4 0e             mov	$0xe,%ah
02d0:003a  bb 07 00          mov	$0x7,%bx
02d0:003d  cd 10             int	$0x10
02d0:003f  c3                ret
02d0:0040  56                push	%si
02d0:0041  57                push	%di
02d0:0042  55                push	%bp
02d0:0043  89 e5             mov	%sp,%bp
02d0:0045  1e                push	%ds
02d0:0046  1e                push	%ds
02d0:0047  8b 76 0a          mov	0x0a(%bp),%si
02d0:004a  31 c0             xor	%ax,%ax
02d0:004c  50                push	%ax
02d0:004d  ff 76 08          push	0x08(%bp)
02d0:0050  e8 0a 3d          call	simple_strtol // 3d5d
02d0:0053  89 04             mov	%ax,(%si)
```
When calling functions using the two-word (segment:offset) address, `disasm -k` will show ".text" or ".fartext" as the segment value if matching the running kernel text or fartext segment (partial output from `disasm -k 1219:0#55`):
```
1219:0052  50                push	%ax
1219:0053  b8 04 00          mov	$0x4,%ax
1219:0056  50                push	%ax
1219:0057  57                push	%di
1219:0058  bb 73 3e          mov	$0x3e73,%bx
1219:005b  9a 5a f4 d0 02    call	$.text,$__ia16_far_call_thunk.bx.6
1219:0060  83 c4 06          add	$0x6,%sp
```

