### PR TITLE
[misc] minor fixes and adjustments: cp, fdisk, truncate.c

### DIFF
--- a/elks/fs/minix/truncate.c
+++ b/elks/fs/minix/truncate.c
@@ -41,18 +41,14 @@ static int V1_trunc_direct(register struct inode *inode)
     int retry = 0;
 
   repeat:
-    for (i = (int)DIRECT_BLOCK; i < 7; i++) {
+    for (i = DIRECT_BLOCK; i < 7; i++) {
 	p = &inode->u.minix_i.i_zone[i];
 	if (!(tmp = *p)) continue;
 	bh = get_hash_table(inode->i_dev, (block_t) tmp);
-
-	if (i < (int)DIRECT_BLOCK) {	/* In case the file shrunk while
-					 * we were truncating. Unlikely
-					 * if at all possible. */
+	if (i < DIRECT_BLOCK) {
 	    brelse(bh);
 	    goto repeat;
 	}
-
 	if ((bh && buffer_count(bh) != 1) || tmp != *p) {
 	    retry = 1;
 	    brelse(bh);

--- a/elks/fs/minix/truncate.c
+++ b/elks/fs/minix/truncate.c
@@ -41,14 +41,18 @@ static int V1_trunc_direct(register struct inode *inode)
     int retry = 0;
 
   repeat:
-    for (i = DIRECT_BLOCK; i < 7; i++) {
+    for (i = (int)DIRECT_BLOCK; i < 7; i++) {
 	p = &inode->u.minix_i.i_zone[i];
 	if (!(tmp = *p)) continue;
 	bh = get_hash_table(inode->i_dev, (block_t) tmp);
-	if (i < DIRECT_BLOCK) {
+
+	if (i < (int)DIRECT_BLOCK) {	/* In case the file shrunk while
+					 * we were truncating. Unlikely
+					 * if at all possible. */
 	    brelse(bh);
 	    goto repeat;
 	}
+
 	if ((bh && buffer_count(bh) != 1) || tmp != *p) {
 	    retry = 1;
 	    brelse(bh);

--- a/elkscmd/disk_utils/fdisk.c
+++ b/elkscmd/disk_utils/fdisk.c
@@ -418,10 +418,10 @@ int main(int argc, char **argv)
 
 
     if (mode == MODE_LIST) {
-	if (*dev != 0) {
-	    list_partition(dev);
-	    exit(0);
-	} else goto usage;
+	if (*dev == 0)
+	    strcpy(dev,DEFAULT_DEV);
+	list_partition(dev);
+	exit(0);
     }
 
     if (mode == MODE_EDIT) {

--- a/elkscmd/file_utils/cp.c
+++ b/elkscmd/file_utils/cp.c
@@ -476,7 +476,7 @@ int copy_directory(char *source_dir, char *dest_dir)
 		return 1;
 	}
 
-	printf("Copying %d files, %lu blocks from %s to %s\n", inodes.count, numblocks,
+	if (opt_verbose) printf("Copying %d files, %lu blocks from %s to %s\n", inodes.count, numblocks,
 		source_dir, destination_dir);
 
 	err = do_copies();


### PR DESCRIPTION
`truncate.c` - adding cast in `V1_trunc_direct` per discussion in https://github.com/jbruchon/elks/issues/1367#issuecomment-1202165859

`fdisk`: Use default drive when no drive is specified with `-l` option,  just like `fdisk` with no options.

`cp`:  Require verbose mode (`-v`) to show the `Copying ...` message when using recursive copy (`-R`). Avoids messing up output from `makeboot`.

