### PR TITLE
[kernel] Problems with large files and large MINIX disks

### DIFF
--- a/elks/fs/minix/truncate.c
+++ b/elks/fs/minix/truncate.c
@@ -41,9 +41,11 @@ static int V1_trunc_direct(register struct inode *inode)
     int retry = 0;
 
   repeat:
+  printk("DIRECT_BLOCK %ld\n", DIRECT_BLOCK);
     for (i = DIRECT_BLOCK; i < 7; i++) {
 	p = &inode->u.minix_i.i_zone[i];
 	if (!(tmp = *p)) continue;
+        printk("i=%d\n", i);
 	bh = get_hash_table(inode->i_dev, (block_t) tmp);
 	if (i < DIRECT_BLOCK) {
 	    brelse(bh);
@@ -88,6 +90,7 @@ static int V1_trunc_indirect(register struct inode *inode,
     }
     map_buffer(ind_bh);
   repeat:
+  printk("INDIRECT_BLOCK %d\n", INDIRECT_BLOCK(offset));
     for (i = INDIRECT_BLOCK(offset); i < 512; i++) {
 	if (i < 0) i = 0;
 	else if (i < INDIRECT_BLOCK(offset)) goto repeat;
@@ -145,6 +148,7 @@ static int V1_trunc_dindirect(register struct inode *inode,
     }
     map_buffer(dind_bh);
   repeat:
+  printk("DINDIRECT_BLOCK %d\n", DINDIRECT_BLOCK(offset));
     for (i = DINDIRECT_BLOCK(offset); i < 512; i++) {
 	if (i < 0) i = 0;
 	if (i < DINDIRECT_BLOCK(offset)) goto repeat;

--- a/elks/fs/minix/truncate.c
+++ b/elks/fs/minix/truncate.c
@@ -11,6 +11,7 @@
 #include <linuxmt/minix_fs.h>
 #include <linuxmt/stat.h>
 #include <linuxmt/fcntl.h>
+#include <linuxmt/debug.h>
 
 #define DIRECT_BLOCK		((inode->i_size + 1023) >> 10)
 #define INDIRECT_BLOCK(offset)	((long)(DIRECT_BLOCK)-offset)
@@ -41,7 +42,7 @@ static int V1_trunc_direct(register struct inode *inode)
     int retry = 0;
 
   repeat:
-  printk("DIRECT_BLOCK %ld\n", DIRECT_BLOCK);
+    debug("DIRECT_BLOCK %ld\n", DIRECT_BLOCK);
     for (i = DIRECT_BLOCK; i < 7; i++) {
 	p = &inode->u.minix_i.i_zone[i];
 	if (!(tmp = *p)) continue;
@@ -90,7 +91,7 @@ static int V1_trunc_indirect(register struct inode *inode,
     }
     map_buffer(ind_bh);
   repeat:
-  printk("INDIRECT_BLOCK %ld\n", INDIRECT_BLOCK(offset));
+    debug("INDIRECT_BLOCK %ld\n", INDIRECT_BLOCK(offset));
     for (j = INDIRECT_BLOCK(offset); j < 512; j++) {
 	if (j < 0) j = 0;
 	else if (j < INDIRECT_BLOCK(offset)) goto repeat;
@@ -148,7 +149,7 @@ static int V1_trunc_dindirect(register struct inode *inode,
     }
     map_buffer(dind_bh);
   repeat:
-  printk("DINDIRECT_BLOCK %ld\n", DINDIRECT_BLOCK(offset));
+    debug("DINDIRECT_BLOCK %ld\n", DINDIRECT_BLOCK(offset));
     for (i = DINDIRECT_BLOCK(offset); i < 512; i++) {
 	if (i < 0) i = 0;
 	if (i < DINDIRECT_BLOCK(offset)) goto repeat;

--- a/elks/tools/mfs/main.c
+++ b/elks/tools/mfs/main.c
@@ -48,6 +48,9 @@
  * fix ln, ln -s
  * add getoptX() since Linux and OSX getopt() don't work together
  * fix -k option from always skipping zero-length files
+ * fix operation with block numbers > 32767 (requires unsigned int blkno in goto_blk)
+ * fix creating files using double indirect blocks (buggy ino_freezone)
+ * fix bad image created with files > 775K (DIND block 255 buggy ino_freezone)
  */
 
 #include <stdarg.h>

--- a/elks/tools/mfs/protos.h
+++ b/elks/tools/mfs/protos.h
@@ -1,3 +1,8 @@
+#if DEBUG
+#define debug(...)      printf(__VA_ARGS)
+#else
+#define debug(...)
+#endif
 void pver();
 void usage(const char *name);
 void parse_opts(int *argc_p, char ***argv_p);
@@ -10,7 +15,7 @@ void cmd_sysinfo(struct minix_fs_dat *fs);
 struct minix_fs_dat *close_fs(struct minix_fs_dat *fs);
 void fatalmsg(const char *s, ...);
 void die(const char *s, ...);
-FILE *goto_blk(FILE *fp, int blk);
+FILE *goto_blk(FILE *fp, unsigned int blk);
 void *dofwrite(FILE *fp, void *buff, int cnt);
 void *dofread(FILE *fp, void *buff, int cnt);
 void *domalloc(unsigned long size, int elm);

--- a/elks/tools/mfs/super.c
+++ b/elks/tools/mfs/super.c
@@ -100,7 +100,7 @@ struct minix_fs_dat *new_fs(const char *fn,int magic,unsigned long fsize,int ino
   IMAPS(fs) =UPPER(inodes + 1,BITS_PER_BLOCK);
   ZMAPS(fs)=UPPER(fsize-(1+IMAPS(fs)), BITS_PER_BLOCK);
   FIRSTZONE(fs) = NORM_FIRSTZONE(fs);
-//printf("IMAPS %u, ZMAPS %u, FIRST %u\n", IMAPS(fs), ZMAPS(fs), FIRSTZONE(fs));
+  debug("IMAPS %u, ZMAPS %u, FIRST %u\n", IMAPS(fs), ZMAPS(fs), FIRSTZONE(fs));
   if (IMAPS(fs) > MINIX_I_MAP_SLOTS)
     fatalmsg("Too many inodes requested: max is 32736\n");
 
@@ -231,9 +231,7 @@ struct minix_fs_dat *close_fs(struct minix_fs_dat *fs) {
   dofwrite(goto_blk(fs->fp,MINIX_SUPER_BLOCK+1),
 	  fs->inode_bmap,IMAPS(fs) * BLOCK_SIZE);
   // printf("ZMAPSIZE=%d\n",ZMAPS(fs));
-  // printf("%4d) FTELL=%d - %x\n",__LINE__,ftell(fs->fp),ftell(fs->fp));
   dofwrite(fs->fp,fs->zone_bmap,ZMAPS(fs) * BLOCK_SIZE);
-  // printf("%4d) FTELL=%d - %x\n",__LINE__,ftell(fs->fp),ftell(fs->fp));
   if (VERSION_2(fs))
     dofwrite(fs->fp,fs->ino.v2,INODE_BUFFER_SIZE(fs));
   else

--- a/elks/tools/mfs/utils.c
+++ b/elks/tools/mfs/utils.c
@@ -67,7 +67,7 @@ void die(const char *s,...) {
  * @param blk - Block to go to
  * @return fp
  */
-FILE *goto_blk(FILE *fp,int blk) {
+FILE *goto_blk(FILE *fp,unsigned int blk) {
   fflush(fp);
   if (fseek(fp,blk*BLOCK_SIZE,SEEK_SET)) {
     die("fseek");

--- a/elks/tools/mfs/writer.c
+++ b/elks/tools/mfs/writer.c
@@ -43,11 +43,13 @@ void writefile(struct minix_fs_dat *fs,FILE *fp,int inode) {
 
   do {
     bsz = fread(blk,1,BLOCK_SIZE,fp);
+    if (!bsz) break;
     for (j=0;j<bsz;j++) if (blk[j]) break;
     if (j != bsz) { /* This is not a hole, so better write it */
       if (bsz < BLOCK_SIZE) memset(blk+bsz,0,BLOCK_SIZE-bsz);
       write_inoblk(fs,inode,blkcnt++,blk);
     } else {
+      debug("WRITER FREE HOLE %d bsz %d\n", blkcnt, bsz);
       free_inoblk(fs,inode,blkcnt++);
     }
     count += bsz;

--- a/elkscmd/disk_utils/fsck.c
+++ b/elkscmd/disk_utils/fsck.c
@@ -962,26 +962,27 @@ int main(int argc, char ** argv)
 	check_root();
 	check();
 	if (verbose) {
-		int i, free;
+		int i;
+        unsigned int free;
 
 		for (i=1,free=0 ; i < INODES ; i++)
 			if (!inode_in_use(i))
 				free++;
-		printf("\n%6d inodes used (%d%%)\n",(INODES-free-1),
+		printf("\n%6u inodes used (%d%%)\n",(INODES-free-1),
 			100*(INODES-free-1)/(INODES-1));
 		for (i=FIRSTZONE,free=0 ; i < ZONES ; i++)
 			if (!zone_in_use(i))
 				free++;
-		printf("%6d zones used (%d%%)\n",(ZONES-free),
-			100*(ZONES-free)/ZONES);
-		printf("\n%6d regular files\n"
-		"%6d directories\n"
+		printf("%6u zones used (%d%%)\n", ZONES - free ,
+			(int)(100*((long)ZONES-free)/ZONES));
+		printf("\n%6u regular files\n"
+		"%6u directories\n"
 		"%6d character device files\n"
-		"%6d block device files\n"
-		"%6d links\n"
-		"%6d symbolic links\n"
+		"%6u block device files\n"
+		"%6u links\n"
+		"%6u symbolic links\n"
 		"------\n"
-		"%6d files\n",
+		"%6u files\n",
 		regular,directory,chardev,blockdev,
 		links-2*directory+1,symlinks,total-2*directory+1);
 	}

--- a/elkscmd/file_utils/df.c
+++ b/elkscmd/file_utils/df.c
@@ -28,7 +28,7 @@
 
 int df(char *device);
 
-typedef int bit_t;
+typedef unsigned int bit_t;
 bit_t bit_count(unsigned blocks, bit_t bits, int fd);
 char *devname(char *dirname);
 

--- a/image/Makefile
+++ b/image/Makefile
@@ -41,13 +41,13 @@ copyrom:
 compress:
 	cd $(TOPDIR)/target/bin; elks-compress *
 
-images: images-minix images-mbr images-fat
+images: images-minix images-hd images-fat
 
-images-minix: fd360-minix fd720-minix fd1200-minix fd1440-minix fd2880-minix hd32-minix
+images-minix: fd360-minix fd720-minix fd1200-minix fd1440-minix fd2880-minix
 
 images-fat: fd360-fat fd720-fat fd1200-fat fd1440-fat fd2880-fat hd32-fat hd32mbr-fat
 
-images-mbr: hd32-minix hd32mbr-minix
+images-hd: hd32-minix hd32mbr-minix hd64-minix
 
 fd360-minix:
 	echo CONFIG_APPS_360K=y		> Config

--- a/image/Makefile
+++ b/image/Makefile
@@ -113,6 +113,20 @@ hd32-minix:
 	$(MAKE) -f Make.image "CONFIG=$(TOPDIR)/image/Config" NAME=hd32-minix
 	rm Config
 
+hd64-minix:
+	echo CONFIG_APPS_2880K=y	> Config
+	echo CONFIG_IMG_HD=y		>> Config
+	echo CONFIG_IMG_BLOCKS=64008 >> Config
+	echo CONFIG_IMG_SECT=63		>> Config
+	echo CONFIG_IMG_HEAD=16		>> Config
+	echo CONFIG_IMG_CYL=127		>> Config
+	echo CONFIG_IMG_MINIX=y		>> Config
+	echo CONFIG_IMG_DEV=y		>> Config
+	echo CONFIG_IMG_BOOT=y		>> Config
+	sed -n -e '/CONFIG_TIME_/p'	>> Config < $(TOPDIR)/.config
+	$(MAKE) -f Make.image "CONFIG=$(TOPDIR)/image/Config" NAME=hd64-minix
+	rm Config
+
 fd360-fat:
 	echo CONFIG_APPS_360K=y		> Config
 	echo CONFIG_IMG_FD360=y		>> Config


### PR DESCRIPTION
Discussion and preliminary duplication of problem found in #1414.

After my comments about signed/unsigned comparison of block values in https://github.com/jbruchon/elks/pull/1414#issuecomment-1221600471, I decided to go ahead with testing ELKS operation on hard drive images larger than 32MB (64MB is MINIX v1 maximum). 

This PR contains some debug code in fs/minix/truncate.c, as well as a enhancement to produce a 64MB MINIX disk image (built using `cd image; make hd64-minix`). The 64MB image requires the ELKS kernel and applications to use all 16 bits in an integer for the block numbers, which end up causing a wrap to a negative number, producing a number of associated errors.

Right out of the gate, there are the following big problems with ELKS and 64MB MINIX disks:
- The `mfs` program doesn't seem to allocate large files correctly, as they don't take up any of the otherwise free space on the MINIX volume. This can be duplicated by adding a 32MB+ file in elkscmd/rootfs_tempate/root, and observing the booted free space - it does not include the large file space taken out.
- When 64MB disks are mounted (or booted from), the `df` and `mount` commands immediately show different results for the free space.
- The MINIX fs function truncate function fails when INDIRECT_BLOCKS go from negative to positive (see or run included debug code). This is a result of using an `(int)` cast and comparison with an `int i` count, when `unsigned` should be used.

Long story short - MINIX fs is totally broken on 64MB disks!

More commits coming, but posted this to allow others to test using 64MB disks. I'm sure there are more issues.

Here is a sample of `df` and `mount` showing different results, on an otherwise normal 64MB disk, with no large files:
```
Direct console, scan kbd 80x25 emulating ANSI (3 virtual consoles)
ttyS0 at 0x3f8, irq 4 is a 16550A
xms: A20 was on now on, using unreal mode, 2500 xms buffers, 2560000 ram
eth: ne2k at 0x300, irq 12 (16bit), MAC 52:54:00:12:34:56, flags 0x80
eth: wd80x3 at 0x240, irq 2, ram 0xce00 not found
eth: 3c509 at 0x330, irq 11 not found
rd: 64K ramdisk at d000:0000
ssd: 96K disk
bioshd: hda BIOS CHS 126,16,63
bioshd: hda  IDE CHS 127,16,63    <--- 64MB disk created with 127 cylinders, resulting in 64008 blocks total ~64MB
/dev/hda: 127 cylinders, 16 heads, 63 sectors = 62.5 Mb
Partitions: hda:(0,128016)  no mbr, none.
device_setup: BIOS drive 0x80, root device 0x300
PC/AT class machine, syscaps 0xff, 639K base ram.
ELKS kernel 0.6.0 (62832 text, 12320 ftext, 8944 data, 42672 bss, 13918 heap)
Kernel text at 2d0:0000, ftext 1227:0000, data 1529:0000, top 9fc0:0, 490K free
VFS: Mounted root 0x0300 (minix filesystem).
Running /etc/rc.sys script
Sun Aug 21 16:35:58 2022


ELKS 0.6.0

login: root
# 
# df
Filesystem    1k-Blocks     free     used    %  FUsed%
/dev/hda          64008    42056    21952  35%    19%    <--- free count incorrect, 2880K image on 64MB disk
# mount
/dev/hda  (minix) blocks  64008 free  62088 mount /   <--- likely correct free space
```