### PR TITLE
[cmds] New and updated commands, man-pages

### DIFF
--- a/elkscmd/file_utils/Makefile
+++ b/elkscmd/file_utils/Makefile
@@ -13,7 +13,7 @@ include $(BASEDIR)/Make.rules
 # note: grep doesn't read stdin, replaced with minix1/grep
 # removed: l
 PRGS = ln ls mkdir mkfifo mknod more mv rm rmdir sync touch \
-	cat chgrp chmod chown cmp cp dd df grep
+	cat chgrp chmod chown cmp cp dd df grep split
 
 all: $(PRGS)
 
@@ -73,6 +73,9 @@ rm: rm.o $(TINYPRINTF)
 
 rmdir: rmdir.o
 	$(LD) $(LDFLAGS) -o rmdir rmdir.o $(LDLIBS)
+
+split: split.o
+	$(LD) $(LDFLAGS) -o split split.o $(LDLIBS)
 
 sync: sync.o
 	$(LD) $(LDFLAGS) -o sync sync.o $(LDLIBS)

--- a/elkscmd/file_utils/df.c
+++ b/elkscmd/file_utils/df.c
@@ -22,20 +22,33 @@
 #include <stdlib.h>
 #include <string.h>
 #include <dirent.h>
+#include <sys/mount.h>
 #include <linuxmt/minix_fs.h>
+#include <linuxmt/fs.h>
 
 #define BLOCK_SIZE	1024
 
-int df(char *device);
+int df(char *device, char *mpnt);
 
 typedef unsigned int bit_t;
 bit_t bit_count(unsigned blocks, bit_t bits, int fd);
-char *devname(char *dirname);
+struct dnames {
+	char *name;
+	char *mpoint;
+};
+struct dnames *devname(char *);
+static char *dev_name(dev_t);
 
 int iflag= 0;	/* Focus on inodes instead of blocks. */
 int Pflag= 0;	/* Posix standard output. */
 int kflag= 0;	/* Output in kilobytes instead of 512 byte units for -P. */
 int istty;	/* isatty(1) */
+
+/* (num / tot) in percentages rounded up. */
+#define percent(num, tot)  ((int) ((100L * (num) + ((tot) - 1)) / (tot)))
+
+/* One must be careful printing all these _t types. */
+#define L(n)	((long) (n))
 
 void usage(void)
 {
@@ -47,6 +60,8 @@ int main(int argc, char *argv[])
 {
   char *device = "/";
   char *blockdev;
+  struct dnames *dname;
+  struct statfs statfs;
 
   while (argc > 1 && argv[1][0] == '-') {
   	char *opt= argv[1]+1;
@@ -56,8 +71,7 @@ int main(int argc, char *argv[])
   		case 'i':	iflag= 1;	break;
   		case 'k':	kflag= 1;	break;
   		case 'P':	Pflag= 1;	break;
-		default:
-			usage();
+		default:	usage();
 		}
 	}
 	argc--;
@@ -69,38 +83,49 @@ int main(int argc, char *argv[])
   if (argc > 1)
 	device = argv[1];
 
-  if (!(blockdev = devname(device))) {
+  dname = devname(device);
+  if (!(blockdev = dname->name)) {
 	fprintf(stderr, "Can't find /dev/ device for %s\n", device);
 	exit(1);
   }
 
-  if (Pflag) {
-	printf(!iflag ? "\
-Filesystem    %4d-blocks    Used  Available  Capacity\n" : "\
-Filesystem       Inodes     IUsed    IFree    %%IUsed\n",
-		kflag ? 1024 : 512);
+  if (iflag) {
+	printf("Filesystem       Inodes     IUsed    IFree    %%IUsed   Mounted on\n");
   } else {
-	printf("%s\n", !iflag ? "\
-Filesystem    1k-Blocks     free     used    %  FUsed%" : "\
-Filesystem        Files     free     used    %  BUsed%"
-	);
+	if (!Pflag) 
+		printf("Filesystem    1k-Blocks     free     used    %%  FUsed%%  Mounted on\n");
+	else 
+		printf("Filesystem    %4d-blocks    Used  Available  Capacity   Mounted on\n",
+			kflag ? 1024 : 512);
   }
 
-
-  return df(blockdev);
+  if (argc == 1) {	/* loop through all mounted devices */
+	int i;
+  	for (i = 0; i < NR_SUPER; i++) {
+		if (ustatfs(i, &statfs) >= 0) {
+			char *nm = dev_name(statfs.f_dev);
+			if (statfs.f_type > 2 || (statfs.f_type == 2 && (Pflag||iflag))) 
+				printf("%s     -- Not a MINIX filesystem\n", nm);
+			else if (statfs.f_type == 2 && !Pflag)
+				printf("%-15s %7ld  %7ld  %7ld %3d%%          %s (FAT)\n", nm,\
+				    statfs.f_blocks, statfs.f_bfree,\
+				    statfs.f_blocks-statfs.f_bfree,\
+				    percent(statfs.f_blocks-statfs.f_bfree, statfs.f_blocks),\
+				    statfs.f_mntonname);
+			else
+				df(nm, statfs.f_mntonname);
+		}
+	}
+	return 0;
+  } else
+  	return df(blockdev, dname->mpoint);
 }
 
-/* (num / tot) in percentages rounded up. */
-#define percent(num, tot)  ((int) ((100L * (num) + ((tot) - 1)) / (tot)))
-
-/* One must be careful printing all these _t types. */
-#define L(n)	((long) (n))
-
-int df(char *device)
+int df(char *device, char *mpnt)
 {
   int fd;
   bit_t i_count, z_count;
-  block_t totblocks, busyblocks;
+  long totblocks, busyblocks;
   int n;
   struct minix_super_block super, *sp;
 
@@ -153,26 +178,28 @@ int df(char *device)
 
   /* Print results. */
   printf("%s", device);
-  n= strlen(device);
+  n = strlen(device);
   if (n > 15 && istty) { printf("\n"); n= 0; }
   while (n < 15) { printf(" "); n++; }
 
+  if (iflag) {
+	printf(" %7ld   %7ld  %7ld     %4d%%   %s\n",
+		L(sp->s_ninodes),			/* Inodes */
+		L(i_count),				/* IUsed */
+		L(sp->s_ninodes - i_count),		/* IAvail */
+		percent(i_count, sp->s_ninodes),	/* Capacity */
+		mpnt					/* Mount pnt */
+
+	);
+  }
   if (!Pflag && !iflag) {
-	printf(" %7ld  %7ld  %7ld %3d%%   %3d%%\n",
+	printf(" %7ld  %7ld  %7ld %3d%%   %3d%%   %s\n",
 		L(totblocks),				/* Blocks */
 		L(totblocks - busyblocks),		/* free */
 		L(busyblocks),				/* used */
 		percent(busyblocks, totblocks),		/* % */
-		percent(i_count, sp->s_ninodes)	/* FUsed% */
-	);
-  }
-  if (!Pflag && iflag) {
-	printf(" %7ld  %7ld  %7ld %3d%%   %3d%%\n",
-		L(sp->s_ninodes),			/* Files */
-		L(sp->s_ninodes - i_count),		/* free */
-		L(i_count),				/* used */
-		percent(i_count, sp->s_ninodes),	/* % */
-		percent(busyblocks, totblocks)		/* BUsed% */
+		percent(i_count, sp->s_ninodes),	/* FUsed% */
+		mpnt					/* Mount point */
 	);
   }
   if (Pflag && !iflag) {
@@ -181,19 +208,12 @@ int df(char *device)
   		totblocks *= 2;
   		busyblocks *= 2;
 	}
-	printf(" %7ld   %7ld  %7d     %4d%%\n",
+	printf(" %7ld   %7ld  %7ld     %4d%%     %s\n",
 		L(totblocks),				/* Blocks */
 		L(busyblocks),				/* Used */
 		totblocks - busyblocks,			/* Available */
-		percent(busyblocks, totblocks)		/* Capacity */
-	);
-  }
-  if (Pflag && iflag) {
-	printf(" %7ld   %7ld  %7ld     %4d%%\n",
-		L(sp->s_ninodes),			/* Inodes */
-		L(i_count),				/* IUsed */
-		L(sp->s_ninodes - i_count),		/* IAvail */
-		percent(i_count, sp->s_ninodes)	/* Capacity */
+		percent(busyblocks, totblocks),		/* Capacity */
+		mpnt					/* Mount point */
 	);
   }
   close(fd);
@@ -245,17 +265,22 @@ bit_t bit_count(unsigned blocks, bit_t bits, int fd)
  * $PchId: df.c,v 1.7 1998/07/27 18:42:17 philip Exp $
  */
 
-/* return /dev/ device from dirname*/
-char *devname(char *dirname)
+/* return /dev/ device from dirname */
+struct dnames *devname(char *dirname)
 {
    static char dev[] = "/dev";
    struct stat st, dst;
    DIR  *fp;
    struct dirent *d;
+   static struct statfs statfs;
+   static struct dnames dn;
    static char name[16]; /* should be MAXNAMLEN but that's overkill */
 
-   if (!strncmp(dirname, "/dev/", 5))
-	return dirname;
+   if (!strncmp(dirname, "/dev/", 5)) {
+	dn.name = dirname;
+	dn.mpoint = dirname;
+	return &dn;
+   }
 
    if (stat(dirname, &st) < 0)
       return 0;
@@ -271,12 +296,60 @@ char *devname(char *dirname)
          continue;
       strcpy(name + sizeof(dev), d->d_name);
       if (stat(name, &dst) == 0) {
-		if (st.st_dev == dst.st_rdev) {
-			closedir(fp);
-			return name;
+	 if (st.st_dev == dst.st_rdev) {
+	     if (ustatfs(st.st_dev, &statfs) < 0) {
+		dn.mpoint = NULL;
+	     } else {
+		dn.mpoint = statfs.f_mntonname;
+	     }
+	     closedir(fp);
+	     dn.name = name;
+	     return &dn;
         }
       }
    }
    closedir(fp);
-   return 0;
+   return NULL;
 }
+
+/*
+ * Convert a block device number to name.
+ * From mount.c
+ */
+static struct dev_name_struct {
+        char *name;
+        dev_t num;
+} devices[] = {
+        /* root_dev_name needs first 5 in order*/
+        { "hda",     0x0300 },
+        { "hdb",     0x0320 },
+        { "hdc",     0x0340 },
+        { "hdd",     0x0360 },
+        { "fd0",     0x0380 },
+        { "fd1",     0x03a0 },
+        { "ssd",     0x0200 },
+        { "rd",      0x0100 },
+        { NULL,           0 }
+};
+
+static char *dev_name(dev_t dev)
+{
+	int i;
+#define NAMEOFF 5
+	static char name[10] = "/dev/";
+
+	for (i=0; i<sizeof(devices)/sizeof(devices[0])-1; i++) {
+		if (devices[i].num == (dev & 0xfff0)) {
+			strcpy(&name[NAMEOFF], devices[i].name);
+			if (i < 4) {
+				if (dev & 0x07) {
+					name[NAMEOFF+3] = '0' + (dev & 7);
+					name[NAMEOFF+4] = 0;
+				}
+			}
+			return name;
+		}
+	}
+	return NULL;
+}
+

--- a/elkscmd/file_utils/split.c
+++ b/elkscmd/file_utils/split.c
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 1987 Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms are permitted
+ * provided that: (1) source distributions retain this entire copyright
+ * notice and comment, and (2) distributions including binaries display
+ * the following acknowledgement:  ``This product includes software
+ * developed by the University of California, Berkeley and its contributors''
+ * in the documentation or other materials provided with the distribution
+ * and in all advertising materials mentioning features or use of this
+ * software. Neither the name of the University nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <sys/param.h>
+//#include <sys/file.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+#define DEFLINE	1000			/* default num lines per file */
+#define ERR	-1			/* general error */
+#define NO	0			/* no/false */
+#define OK	0			/* okay exit */
+#define YES	1			/* yes/true */
+
+#ifndef MAXPATHLEN
+#define MAXPATHLEN      256
+#endif
+#define MAXBSIZE        2048
+
+static long	bytecnt,		/* byte count to split on */
+		numlines;		/* lines in each file */
+static int	ifd = ERR,		/* input file descriptor */
+		ofd = ERR;		/* output file descriptor */
+static short	file_open;		/* if a file open */
+static char	bfr[MAXBSIZE],		/* I/O buffer */
+		fname[MAXPATHLEN];	/* file name */
+
+void split1(void);
+void split2(void);
+void newfile(void);
+void wrerror(void);
+void usage(void);
+
+int main(int argc, char **argv)
+{
+	register int cnt;
+	//long atol();
+	//char *strcpy();
+
+	for (cnt = 1; cnt < argc; ++cnt) {
+		if (argv[cnt][0] == '-')
+			switch(argv[cnt][1]) {
+			case 0:		/* stdin by request */
+				if (ifd != ERR)
+					usage();
+				ifd = 0;
+				break;
+			case 'b':	/* byte count split */
+				if (numlines)
+					usage();
+				if (!argv[cnt][2])
+					bytecnt = atol(argv[++cnt]);
+				else
+					bytecnt = atol(argv[cnt] + 2);
+				if (bytecnt <= 0) {
+					fputs("split: byte count must be greater than zero.\n", stderr);
+					usage();
+				}
+				break;
+			default:
+				if (!isdigit(argv[cnt][1]) || bytecnt)
+					usage();
+				if ((numlines = atol(argv[cnt] + 1)) <= 0) {
+					fputs("split: line count must be greater than zero.\n", stderr);
+					usage();
+				}
+				break;
+			}
+		else if (ifd == ERR) {		/* input file */
+			if ((ifd = open(argv[cnt], O_RDONLY, 0)) < 0) {
+				perror(argv[cnt]);
+				exit(1);
+			}
+		}
+		else if (!*fname)		/* output file prefix */
+			strcpy(fname, argv[cnt]);
+		else
+			usage();
+	}
+	if (ifd == ERR)				/* stdin by default */
+		ifd = 0;
+	if (bytecnt)
+		split1();
+	if (!numlines)
+		numlines = DEFLINE;
+	split2();
+	exit(0);
+}
+
+/*
+ * split1 --
+ *	split by bytes
+ */
+void split1(void)
+{
+	register long bcnt;
+	register int dist, len;
+	register char *C;
+
+	for (bcnt = 0;;) {
+		switch(len = read(ifd, bfr, MAXBSIZE)) {
+		case 0:
+			exit(OK);
+		case ERR:
+			perror("read");
+			exit(1);
+		default:
+			if (!file_open) {
+				newfile();
+				file_open = YES;
+			}
+			if (bcnt + len >= bytecnt) {
+				dist = bytecnt - bcnt;
+				if (write(ofd, bfr, dist) != dist)
+					wrerror();
+				len -= dist;
+				for (C = bfr + dist; len >= bytecnt; len -= bytecnt, C += bytecnt) {
+					newfile();
+					if (write(ofd, C, (int)bytecnt) != bytecnt)
+						wrerror();
+				}
+				if (len) {
+					newfile();
+					if (write(ofd, C, len) != len)
+						wrerror();
+				}
+				else
+					file_open = NO;
+				bcnt = len;
+			}
+			else {
+				bcnt += len;
+				if (write(ofd, bfr, len) != len)
+					wrerror();
+			}
+		}
+	}
+}
+
+/*
+ * split2 --
+ *	split by lines
+ */
+void split2(void)
+{
+	register char *Ce, *Cs;
+	register long lcnt;
+	register int len, bcnt;
+
+	for (lcnt = 0;;)
+		switch(len = read(ifd, bfr, MAXBSIZE)) {
+		case 0:
+			exit(0);
+		case ERR:
+			perror("read");
+			exit(1);
+		default:
+			if (!file_open) {
+				newfile();
+				file_open = YES;
+			}
+			for (Cs = Ce = bfr; len--; Ce++)
+				if (*Ce == '\n' && ++lcnt == numlines) {
+					bcnt = Ce - Cs + 1;
+					if (write(ofd, Cs, bcnt) != bcnt)
+						wrerror();
+					lcnt = 0;
+					Cs = Ce + 1;
+					if (len)
+						newfile();
+					else
+						file_open = NO;
+				}
+			if (Cs < Ce) {
+				bcnt = Ce - Cs;
+				if (write(ofd, Cs, bcnt) != bcnt)
+					wrerror();
+			}
+		}
+}
+
+/*
+ * newfile --
+ *	open a new file
+ */
+void newfile(void)
+{
+	static long fnum;
+	static short defname;
+	static char *fpnt;
+
+	if (ofd == ERR) {
+		if (fname[0]) {
+			fpnt = fname + strlen(fname);
+			defname = NO;
+		}
+		else {
+			fname[0] = 'x';
+			fpnt = fname + 1;
+			defname = YES;
+		}
+		ofd = fileno(stdout);
+	}
+	/*
+	 * hack to increase max files; original code just wandered through
+	 * magic characters.  Maximum files is 3 * 26 * 26 == 2028
+	 */
+#define MAXFILES	676
+	if (fnum == MAXFILES) {
+		if (!defname || fname[0] == 'z') {
+			fputs("split: too many files.\n", stderr);
+			exit(1);
+		}
+		++fname[0];
+		fnum = 0;
+	}
+	fpnt[0] = fnum / 26 + 'a';
+	fpnt[1] = fnum % 26 + 'a';
+	++fnum;
+	if (!freopen(fname, "w", stdout)) {
+		fprintf(stderr, "split: unable to write to %s.\n", fname);
+		exit(ERR);
+	}
+}
+
+/*
+ * usage --
+ *	print usage message and die
+ */
+void usage(void)
+{
+	fputs("usage: split [-] [-#] [-b byte_count] [file [prefix]]\n", stderr);
+	exit(1);
+}
+
+/*
+ * wrerror --
+ *	write error
+ */
+void wrerror(void)
+{
+	perror("split: write");
+	exit(1);
+}

--- a/elkscmd/man/man1/df.1
+++ b/elkscmd/man/man1/df.1
@@ -6,8 +6,9 @@ df \- report on free disk space
 .SH DESCRIPTION
 .B Df
 lists the amount of free space on the currently mounted devices (no arguments),
-or the devices given as arguments.  If the argument is not a device then the
-device it resides on is listed.
+or the device given as an argument.  If the argument is not a device buf a file or a directory, then the
+device it resides on is listed. FAT file systems are supported if the result would 
+be meaningful. I.e. not when using the \fB-i\fP or \fB-P\fP options.
 .SS OPTIONS
 Without options,
 .B df
@@ -15,20 +16,25 @@ will give a listing like this:
 .sp
 .nf
 Filesystem    1k-Blocks     free     used    %  FUsed%  Mounted on
-/dev/fd0           1440      635      805  56%    26%   /
-/dev/hda1         32768    32390      378   2%     1%   /tmp
-/dev/hda2        784657   517809   266848  35%    29%   /usr
+/dev/hda3         65535    61443     4092   7%     6%   /
+/dev/fd0           1440      380     1060  74%    73%   /fd
+/dev/hda1        348226   345512     2714   1%          /mnt (FAT)
+/dev/hdb1           726      554      172  24%          /mnt5 (FAT)
+/dev/hda2         65535    59812     5723   9%     2%   /mnt3
+/dev/hda4         41328    37129     4199  11%     3%   /mnt4
 .fi
 .PP
 The
 .B \-i
-option shifts the focus to the files:
+option shifts the focus to inodes:
 .sp
 .nf
-Filesystem        Files     free     used    %  BUsed%  Mounted on
-/dev/hda1          1024      759      265  26%    56%   /
-/dev/hda2          5472     5468        4   1%     2%   /tmp
-/dev/hdb1         65535    46734    18801  29%    35%   /usr
+Filesystem       Inodes     IUsed    IFree    %IUsed   Mounted on
+/dev/hda3         21845      1187    20658        6%   /
+/dev/fd0            256       185       71       73%   /fd
+/dev/hdb1     -- Not a MINIX filesystem
+/dev/hda2         21845       228    21617        2%   /mnt3
+/dev/hda4         13776       313    13463        3%   /mnt4
 .fi
 .PP
 Option
@@ -38,24 +44,20 @@ makes
 use \s-2POSIX\s+2 defined output in 512 byte units:
 .sp
 .nf
-Filesystem     512-blocks    Used  Available  Capacity  Mounted on
-/dev/fd1           2880      1628     1252       57%    /
-/dev/hda1         65536       756    64780        2%    /tmp
-/dev/hda2       1569314    533748  1035566       35%    /usr
+Filesystem     512-blocks    Used  Available  Capacity   Mounted on
+/dev/hda3        131070      8184   122886        7%     /
+/dev/fd0           2880      2120      760       74%     /fd
+/dev/hda1     -- Not a MINIX filesystem
+/dev/hda2        131070     11446   119624        9%     /mnt3
+/dev/hda4         82656      8398    74258       11%     /mnt4
 .fi
 .PP
 With
 .B \-k
-1024 byte units would be used.
-.PP
-The
-.B \-t
-option limits
-.BR df 's
-output to file systems of the given
-.IR type .
+forces the use of 1024 byte units with the -P option.
 .SH BUGS
 Default output should also be in 512 byte units says \s-2POSIX\s+2.
+Getting data for FAT filesystems is slow.
 .SH AUTHOR
 Kees J. Bot (kjb@cs.vu.nl)
 .SH "SEE ALSO"

--- a/elkscmd/man/man1/split.1
+++ b/elkscmd/man/man1/split.1
@@ -1,0 +1,22 @@
+.TH SPLIT 1
+.SH NAME
+split \- split a file into pieces
+.SH SYNOPSIS
+\fBsplit\fP [ -\fBn\fP ] [ -\fBb\fP byte_cnt ] [ file [ name ] ]
+.SH DESCRIPTION
+\fISplit\fP reads \fIfile\fP and writes it in
+.IR n -line
+pieces or in \fIbyte_cnt\fP byte pieces to a set of output
+files.  The default is in 1000 line pieces.  The name of the
+first output file is \fIname\fP with "aa" appended, and so
+on, lexicographically, to "zz".  If no output name is given,
+"x" is the default, in which case \fIsplit\fP will create
+files from "xaa" to "zzz".
+.PP
+If no input file is given, or if \fB-\fP is given in its stead, then
+the standard input file is used.
+.SH BUGS
+If you provide \fIname\fP, \fIsplit\fP can only create 676 separate
+files.  The default naming convention allows 2028 separate files.
+.SH AUTHOR
+Ported from 4.3BSD Reno


### PR DESCRIPTION
Added `split` command (source from BSD4.3reno), very useful for (among other things) file system testing: Generate 10.000 files in a minute...
Includes `man page`.

Updated `df` command to list all mounted file systems when entered without arguments (borrowing some code from `mount`). Previously listed only the root file system. The new behaviour incidentally matches the `man page` - which has been adjusted. Also -
- Removed the old (and non-standard) 'file' mode which was essentially the same as the inode mode.
- Added support for FAT file systems in the default listing, other listings (POSIX, inode) are not meaningful for FAT

@ghaerr - I'm sure there is a fast way to figure out the type of a mounted file system without calling `ustat` and waiting forever. Hints? That would make the usability of df when there are mount FAT filesystems much better.
Actually a Unix/Linux style `mtab` file maintained by `mount` which always has the mounted filesystems and their parameters, would be convenient, but possibly overkill.

Also, when creating lots of files i a directory, `ls` and other utilities run out of heap pretty fast. It would be tempting to use a far segment for increased buffering. How do we `read()`  into a far segment?

Output from `df`: 
```
elks17# ./df
Filesystem    1k-Blocks     free     used    %  FUsed%  Mounted on
/dev/hda3         65535    61443     4092   7%     6%   /
/dev/fd0           1440      380     1060  74%    73%   /fd
/dev/hda1        348226   345512     2714   1%          /mnt (FAT)
/dev/hdb1           726      554      172  24%          /mnt5 (FAT)
/dev/hda2         65535    59812     5723   9%     2%   /mnt3
/dev/hda4         41328    37129     4199  11%     3%   /mnt4
elks17# ./df -i
Filesystem       Inodes     IUsed    IFree    %IUsed   Mounted on
/dev/hda3         21845      1187    20658        6%   /
/dev/fd0            256       185       71       73%   /fd
/dev/hda1     -- Not a MINIX filesystem
/dev/hdb1     -- Not a MINIX filesystem
/dev/hda2         21845       228    21617        2%   /mnt3
/dev/hda4         13776       313    13463        3%   /mnt4
elks17# ./df -P
Filesystem     512-blocks    Used  Available  Capacity   Mounted on
/dev/hda3        131070      8184   122886        7%     /
/dev/fd0           2880      2120      760       74%     /fd
/dev/hda1     -- Not a MINIX filesystem
/dev/hdb1     -- Not a MINIX filesystem
/dev/hda2        131070     11446   119624        9%     /mnt3
/dev/hda4         82656      8398    74258       11%     /mnt4
elks17# 

```
