### PR TITLE
[kernel] Add UF_NOFREESPACE flag to ustatfs system call

### DIFF
--- a/elks/arch/i86/kernel/syscall.dat
+++ b/elks/arch/i86/kernel/syscall.dat
@@ -90,7 +90,7 @@ fchown		+66	3
 dlload		+67	2	- Removed support for dynamic libraries
 setsid		+68	0
 sbrk		+69	2	* Legacy number from Linux
-ustatfs		+70	2
+ustatfs		+70	3
 uname		+74	1	. was knlvsn
 #
 # From /usr/include/asm-generic/unistd.h

--- a/elks/fs/minix/inode.c
+++ b/elks/fs/minix/inode.c
@@ -237,7 +237,7 @@ struct super_block *minix_read_super(register struct super_block *s, char *data,
     return NULL;
 }
 
-void minix_statfs(struct super_block *s, struct statfs *sf)
+void minix_statfs(struct super_block *s, struct statfs *sf, int flags)
 {
     sf->f_bsize = BLOCK_SIZE;
     sf->f_blocks = s->u.minix_sb.s_nzones << s->u.minix_sb.s_log_zone_size;

--- a/elks/fs/open.c
+++ b/elks/fs/open.c
@@ -38,7 +38,7 @@ int sys_statfs(char *path, register struct statfs *ubuf)
 	return -ENOSYS;
     }
     s = inode->i_sb;
-    s->s_op->statfs_kern(inode->i_sb, &sbuf);
+    s->s_op->statfs_kern(inode->i_sb, &sbuf, 0);
     sbuf.f_type = s->s_type->type;
     sbuf.f_flags = s->s_flags;
     sbuf.f_dev = s->s_dev;

--- a/elks/fs/romfs/romfs.c
+++ b/elks/fs/romfs/romfs.c
@@ -294,7 +294,7 @@ static void romfs_put_super (struct super_block * sb)
 
 
 /* FIXME not implemented */
-static void romfs_statfs(struct super_block *s, struct statfs *sf)
+static void romfs_statfs(struct super_block *s, struct statfs *sf, int flags)
 {
 	memset(sf, 0, sizeof(struct statfs));
 	//sf->f_bsize = ROMBSIZE;

--- a/elks/fs/super.c
+++ b/elks/fs/super.c
@@ -137,7 +137,7 @@ void put_super(kdev_t dev)
     }
 }
 
-int sys_ustatfs(dev_t dev, struct statfs *ubuf)
+int sys_ustatfs(dev_t dev, struct statfs *ubuf, int flags)
 {
     struct super_block *s;
     struct statfs sbuf;
@@ -147,11 +147,12 @@ int sys_ustatfs(dev_t dev, struct statfs *ubuf)
     s = get_super(to_kdev_t(dev));
     if (s == NULL) return -EINVAL;
 
-    if (ubuf == NULL) return 0;	/* for querying mounted filesystem w/o statfs */
+    /* for querying mounted filesystem w/o statfs */
+    if (ubuf == NULL) return s->s_type->type;
 
     if (!(s->s_op->statfs_kern)) return -ENOSYS;
 
-    s->s_op->statfs_kern(s, &sbuf);
+    s->s_op->statfs_kern(s, &sbuf, flags);
     sbuf.f_type = s->s_type->type;
     sbuf.f_flags = s->s_flags;
     sbuf.f_dev = s->s_dev;

--- a/elks/include/arch/statfs.h
+++ b/elks/include/arch/statfs.h
@@ -3,6 +3,9 @@
 
 #define MNAMELEN	32	/* length of buffer for returned name */
 
+/* ustatfs flags */
+#define UF_NOFREESPACE      1   /* don't calculate time-expensive free blocks */
+
 struct statfs {
 	int	f_type;		/* filesystem type */
 	unsigned short f_flags;	/* copy of mount flags */

--- a/elks/include/linuxmt/minix_fs.h
+++ b/elks/include/linuxmt/minix_fs.h
@@ -98,7 +98,7 @@ extern struct super_block *minix_read_super(register struct super_block *,
 extern int minix_remount(register struct super_block *,int *,char *);
 extern int minix_rmdir(register struct inode *,char *,size_t);
 extern void minix_set_ops(struct inode *);
-extern void minix_statfs(struct super_block *,struct statfs *);
+extern void minix_statfs(struct super_block *,struct statfs *, int);
 extern int minix_symlink(struct inode *,char *,size_t,char *);
 extern int minix_sync_inode(register struct inode *);
 extern void minix_truncate(register struct inode *);

--- a/elkscmd/file_utils/df.c
+++ b/elkscmd/file_utils/df.c
@@ -102,11 +102,11 @@ int main(int argc, char *argv[])
   if (argc == 1) {	/* loop through all mounted devices */
 	int i;
   	for (i = 0; i < NR_SUPER; i++) {
-		if (ustatfs(i, &statfs) >= 0) {
+		if (ustatfs(i, &statfs, 0) >= 0) {
 			char *nm = dev_name(statfs.f_dev);
-			if (statfs.f_type > 2 || (statfs.f_type == 2 && (Pflag||iflag))) 
+			if (statfs.f_type > FST_MSDOS || (statfs.f_type == FST_MSDOS && (Pflag||iflag)))
 				printf("%s     -- Not a MINIX filesystem\n", nm);
-			else if (statfs.f_type == 2 && !Pflag)
+			else if (statfs.f_type == FST_MSDOS && !Pflag)
 				printf("%-15s %7ld  %7ld  %7ld %3d%%          %s (FAT)\n", nm,\
 				    statfs.f_blocks, statfs.f_bfree,\
 				    statfs.f_blocks-statfs.f_bfree,\
@@ -297,7 +297,7 @@ struct dnames *devname(char *dirname)
       strcpy(name + sizeof(dev), d->d_name);
       if (stat(name, &dst) == 0) {
 	 if (st.st_dev == dst.st_rdev) {
-	     if (ustatfs(st.st_dev, &statfs) < 0) {
+	     if (ustatfs(st.st_dev, &statfs, 0) < 0) {
 		dn.mpoint = NULL;
 	     } else {
 		dn.mpoint = statfs.f_mntonname;

--- a/elkscmd/sys_utils/mount.c
+++ b/elkscmd/sys_utils/mount.c
@@ -65,7 +65,7 @@ static int show_mount(dev_t dev)
 {
 	struct statfs statfs;
 
-	if (ustatfs(dev, &statfs) < 0)
+	if (ustatfs(dev, &statfs, 0) < 0)
 		return -1;
 
 	printf("%-9s (%s) blocks %6lu free %6lu mount %s\n",

--- a/libc/include/sys/mount.h
+++ b/libc/include/sys/mount.h
@@ -21,6 +21,6 @@
 int mount(const char *dev, const char *dir, int type, int flags);
 int umount(const char *dir);
 
-int ustatfs(dev_t dev, struct statfs *statfs);
+int ustatfs(dev_t dev, struct statfs *statfs, int flags);
 
 int reboot(int magic1, int magic2, int magic3);


### PR DESCRIPTION
Enhances `ustatfs` as discussed in https://github.com/jbruchon/elks/pull/1419#issuecomment-1228548373.

Passing the UF_NOFREESPACE flag as the final parameter to `ustatfs` will cause free space calculations to be omitted (for FAT filesystem only) and -1 filled in the `statfs` structure instead.

Tested on QEMU.

@Mellvik, you should be able to take this from here, if you want to change `mount` to not perform free space calculation on FAT filesystems. Since the UF_NOFREESPACE flag is only implemented for FAT, this means you can always pass it in mount, and just check for a freespace == -1L value and display "Not avail" instead of a number in that case.

For `df`, I suppose it ought to always calculate free space, so no changes needed, unless you want to fix the case where `df` is run with an argument, and call `ustatfs` first, instead of directly calling `df()`.