### PR TITLE
[libc] Cleanup dirent struct and libs/programs that use it

### DIFF
--- a/elks/include/linuxmt/dirent.h
+++ b/elks/include/linuxmt/dirent.h
@@ -3,11 +3,13 @@
 
 #include <linuxmt/types.h>
 
+#define MAXNAMLEN       26      /* 14 for MINIX, 26 for FAT */
+
 struct dirent {
-    u_ino_t d_ino;
-    off_t d_offset;
-    __u16 d_namlen;
-    char d_name[255+1];
+    u_ino_t         d_ino;
+    off_t           d_offset;
+    unsigned short  d_namlen;
+    char            d_name[MAXNAMLEN+1];
 };
 
 #endif

--- a/elkscmd/file_utils/df.c
+++ b/elkscmd/file_utils/df.c
@@ -274,7 +274,7 @@ struct dnames *devname(char *dirname)
    struct dirent *d;
    static struct statfs statfs;
    static struct dnames dn;
-   static char name[16]; /* should be MAXNAMLEN but that's overkill */
+   static char name[MAXNAMLEN];
 
    if (!strncmp(dirname, "/dev/", 5)) {
 	dn.name = dirname;
@@ -352,4 +352,3 @@ static char *dev_name(dev_t dev)
 	}
 	return NULL;
 }
-

--- a/elkscmd/man/man5/dir.5
+++ b/elkscmd/man/man5/dir.5
@@ -4,17 +4,18 @@ dir \- directory layout
 .SH SYNOPSIS
 .nf
 .ft B
-#include <sys/types.h>
-#include <sys/dir.h>
+#include <dirent.h>
 .SH DESCRIPTION
-The directories of the V1 and V2 file systems are arrays of the
-following structure defined in <sys/dir.h>:
+The directories of the MINIX and FAT file systems are arrays of the
+following structure defined in <dirent.h>:
 .PP
 .nf
 .ta +5n +15n +15n
-struct direct {
-	ino_t	d_ino;	/* I-node number */
-	char	d_name[14];	/* Name of up to 14 characters */
+#define MAXMANLEN	26		   /* 14 for MINIX, 26 for FAT */
+struct dirent {
+	u_ino_t	d_ino;	        /* I-node number */
+	unsigned short d_namlen;
+	char	d_name[MAXNAMLEN+1];   /* File name */
 };
 .fi
 .DT
@@ -30,12 +31,12 @@ returned by
 .BR stat (2)
 unless the entry is mounted on.
 .B D_name
-is the name of up to 14 characters, null-terminated only if less then 14
-in length.  Any character other than null or '\fB/\fP' is allowed.
+is the name of up to 26 characters, null-terminated.
+Any character other than null or '\fB/\fP' is allowed.
 .PP
 See
 .BR directory (3)
-for a portable way to access directories, MINIX 3 is probably the last system
+for a portable way to access directories, ELKS and MINIX 3 are probably the last systems
 with these old V7 format directories.
 .SH "SEE ALSO"
 .BR directory (3).

--- a/elkscmd/misc_utils/tar.c
+++ b/elkscmd/misc_utils/tar.c
@@ -55,10 +55,6 @@
 #define ELKS            1
 #define DO_REPLACE      0   /* =1 for tar 'r' option, requires awk */
 
-/* TODO: add to libc */
-#define telldir(dirp)       lseek((dirp)->dd_fd, 0L, SEEK_CUR)
-#define seekdir(dirp,off)   lseek((dirp)->dd_fd, off, SEEK_SET)
-
 typedef unsigned long daddr_t;
 daddr_t	bsrch();
 daddr_t	lookup();

--- a/elkscmd/sys_utils/ps.c
+++ b/elkscmd/sys_utils/ps.c
@@ -75,7 +75,7 @@ char *devname(unsigned int minor)
 	dev_t ttydev = MKDEV(TTY_MAJOR, minor);
 	struct stat st;
 	static char dev[] = "/dev";
-	static char name[16]; /* should be MAXNAMLEN but that's overkill */
+	static char name[MAXNAMLEN+1];
 
 	DIR *fp = opendir(dev);
 	if (fp == 0)

--- a/elkscmd/tui/util.h
+++ b/elkscmd/tui/util.h
@@ -12,7 +12,7 @@
 #define LINE_MAX    80
 
 #if ELKS
-#define NAME_MAX    15
+#define NAME_MAX    15      /* could be expanded to 26 for FAT */
 #define NAME_COLS   20
 #else
 #define NAME_MAX    79

--- a/libc/include/dirent.h
+++ b/libc/include/dirent.h
@@ -6,41 +6,36 @@
 #include <sys/types.h>
 #include __SYSINC__(dirent.h)
 
-#ifndef	MAXNAMLEN
-#define	MAXNAMLEN	255
-#endif
-
-/* Directory stream type.  */
+/* Directory stream type from opendir().  */
 typedef struct {
-  int dd_fd;			/* file descriptor */
-  int dd_loc;			/* offset in buffer */
-  int dd_size;			/* # of valid entries in buffer */
-  struct dirent *dd_buf;	/* -> directory buffer */
-} DIR;				/* stream data from opendir() */
+    int dd_fd;                  /* file descriptor */
+    int dd_loc;                 /* offset in buffer UNUSED */
+    int dd_size;                /* # of valid entries in buffer UNUSED */
+    struct dirent *dd_buf;      /* -> directory buffer */
+} DIR;
 
-typedef int (*__dir_select_fn_t) __P ((__const struct dirent *));
-
-typedef int (*__dir_compar_fn_t) __P ((
-                __const struct dirent * __const *,
-                __const struct dirent * __const *
-                ));
-
-extern DIR *opendir __P ((__const char *__name));
-extern int closedir __P ((DIR * __dirp));
-extern struct dirent *readdir __P ((DIR * __dirp));
-extern int _readdir(int fd, struct dirent *buf, int count);
-extern void rewinddir __P ((DIR * __dirp));
-
-extern void seekdir __P ((DIR * __dirp, off_t __pos));
-extern off_t telldir __P ((DIR * __dirp));
+DIR *opendir (const char *dname);
+int closedir(DIR * dirp);
+struct dirent *readdir(DIR * dirp);
+int _readdir(int fd, struct dirent *buf, int count);
+void rewinddir(DIR * dirp);
+void seekdir(DIR * dirp, off_t pos);
+off_t telldir(DIR * dirp);
 
 /* Scan the directory DIR, calling SELECT on each directory entry.
    Entries for which SELECT returns nonzero are individually malloc'd,
    sorted using qsort with CMP, and collected in a malloc'd array in
    *NAMELIST.  Returns the number of entries selected, or -1 on error.  */
-extern int scandir __P ((__const char *__dir,
-			 struct dirent ***__namelist,
-			 __dir_select_fn_t __select,
-			 __dir_compar_fn_t __compar));
+typedef int(*__dir_select_fn_t) (const struct dirent *);
+
+typedef int (*__dir_compar_fn_t) (
+                const struct dirent * const *,
+                const struct dirent * const *
+                );
+
+int scandir(const char *__dir,
+             struct dirent ***__namelist,
+             __dir_select_fn_t __select,
+             __dir_compar_fn_t __compar);
 
 #endif /* dirent.h  */

--- a/libc/system/out.mk
+++ b/libc/system/out.mk
@@ -35,11 +35,13 @@ OBJS = \
 	opendir.o \
 	readdir.o \
 	rewinddir.o \
+	seekdir.o \
 	setjmp.o \
 	setpgrp.o \
 	signal.o \
 	sleep.o \
 	syscall0.o \
+	telldir.o \
 	time.o \
 	times.o \
 	usleep.o \

--- a/libc/system/readdir.c
+++ b/libc/system/readdir.c
@@ -8,8 +8,5 @@ readdir(DIR *dirp)
    cc = _readdir(dirp->dd_fd, dirp->dd_buf, 1);
    if (cc <= 0)
       return 0;
-   if (cc>1) dirp->dd_buf->d_name[cc] = 0;
-
    return dirp->dd_buf;
 }
-

--- a/libc/system/seekdir.c
+++ b/libc/system/seekdir.c
@@ -1,0 +1,9 @@
+#include <dirent.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+void
+seekdir(DIR *dirp, off_t pos)
+{
+   lseek(dirp->dd_fd, pos, SEEK_SET);
+}

--- a/libc/system/telldir.c
+++ b/libc/system/telldir.c
@@ -1,0 +1,9 @@
+#include <dirent.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+off_t
+telldir(DIR *dirp)
+{
+   return lseek(dirp->dd_fd, 0L, SEEK_CUR);
+}

--- a/libc/termios/ttyname.c
+++ b/libc/termios/ttyname.c
@@ -11,7 +11,7 @@ char * ttyname (int fd)
    struct stat st, dst;
    DIR  *fp;
    struct dirent *d;
-   static char name[16]; /* should be MAXNAMLEN but that's overkill */
+   static char name[MAXNAMLEN];
    int noerr = errno;
 
    if (fstat(fd, &st) < 0)
@@ -38,9 +38,9 @@ char * ttyname (int fd)
       if (stat(name, &dst) == 0
          && st.st_dev == dst.st_dev && st.st_ino == dst.st_ino)
       {
-	 closedir(fp);
-	 errno = noerr;
-	 return name;
+         closedir(fp);
+         errno = noerr;
+         return name;
       }
    }
    closedir(fp);


### PR DESCRIPTION
Reduces size of MAXNAMLEN and d_name to 26, which is the max FAT filename size (MINIX is 14).

`opendir` calls `malloc` on dirent struct, which where sizeof d_name was previously 256, wasting memory.

Cleans up other source using d_name, and to use MAXNAMLEN.