### PR TITLE
[cmds] Fix hard to read blue in fm file manager

### DIFF
--- a/elkscmd/tui/curses.c
+++ b/elkscmd/tui/curses.c
@@ -187,8 +187,10 @@ void init_pair(int ndx, int fg, int bg)
     }
 }
 
-/*                                           blk blu grn cyn red mag yel wht */
-static const unsigned char ansi_colors[8] = {30, 34, 32, 36, 31, 35, 33, 37 };
+/*                                  0   1   2   3   4   5   6   7
+                                   blk blu grn cyn red mag yel wht */
+static const int ansi_colors[16] = {30, 34, 32, 36, 31, 35, 33, 37,
+                                    90, 94, 92, 96, 91, 95, 93, 97 };
 
 void attron(int a)
 {

--- a/elkscmd/tui/fm.h
+++ b/elkscmd/tui/fm.h
@@ -27,7 +27,7 @@ struct cpair pairs[] = {
 	{ COLOR_RED,     -1 },  /* COLOR_PAIR(1) */
 	{ COLOR_GREEN,   -1 },  /* COLOR_PAIR(2) */
 	{ COLOR_YELLOW,  -1 },  /* COLOR_PAIR(3) */
-	{ COLOR_BLUE,    -1 },  /* COLOR_PAIR(4) */
+	{ COLOR_LIGHTBLUE,-1 }, /* COLOR_PAIR(4) */
 	{ COLOR_MAGENTA, -1 },  /* COLOR_PAIR(5) */
 	{ COLOR_CYAN,    -1 },  /* COLOR_PAIR(6) */
 };


### PR DESCRIPTION
Change blue color for directories to easier-to-see light blue in file manager, as requested in #1420.