### PR TITLE
[cmds] Update df and mount to use the enhanced ustatfs

### DIFF
--- a/elkscmd/man/man1/df.1
+++ b/elkscmd/man/man1/df.1
@@ -9,6 +9,8 @@ lists the amount of free space on the currently mounted devices (no arguments),
 or the device given as an argument.  If the argument is not a device buf a file or a directory, then the
 device it resides on is listed. FAT file systems are supported if the result would 
 be meaningful. I.e. not when using the \fB-i\fP or \fB-P\fP options.
+.PP
+File systems are always displayed in the order they were mounted.
 .SS OPTIONS
 Without options,
 .B df
@@ -30,11 +32,11 @@ option shifts the focus to inodes:
 .sp
 .nf
 Filesystem       Inodes     IUsed    IFree    %IUsed   Mounted on
-/dev/hda3         21845      1187    20658        6%   /
-/dev/fd0            256       185       71       73%   /fd
-/dev/hdb1     -- Not a MINIX filesystem
-/dev/hda2         21845       228    21617        2%   /mnt3
+/dev/hda3         21845      2298    19547       11%   /
+/dev/hda1         [Not a MINIX filesystem]             /mnt
+/dev/hda2         21845       228    21617        2%   /mnt2
 /dev/hda4         13776       313    13463        3%   /mnt4
+/dev/hdb1         [Not a MINIX filesystem]             /mnt5
 .fi
 .PP
 Option
@@ -44,12 +46,12 @@ makes
 use \s-2POSIX\s+2 defined output in 512 byte units:
 .sp
 .nf
-Filesystem     512-blocks    Used  Available  Capacity   Mounted on
-/dev/hda3        131070      8184   122886        7%     /
-/dev/fd0           2880      2120      760       74%     /fd
-/dev/hda1     -- Not a MINIX filesystem
-/dev/hda2        131070     11446   119624        9%     /mnt3
-/dev/hda4         82656      8398    74258       11%     /mnt4
+Filesystem     512-blocks    Used Available Capacity Mounted on
+/dev/hda3        131070     13876    117194      11% /
+/dev/hda1         [Not a MINIX filesystem]           /mnt
+/dev/hda2        131070     11446    119624       9% /mnt2
+/dev/hda4         82656      8398     74258      11% /mnt4
+/dev/hdb1         [Not a MINIX filesystem]           /mnt5
 .fi
 .PP
 With
@@ -57,8 +59,10 @@ With
 forces the use of 1024 byte units with the -P option.
 .SH BUGS
 Default output should also be in 512 byte units says \s-2POSIX\s+2.
-Getting data for FAT filesystems is slow.
+Getting data for FAT filesystems is slow. To just get a fast listing of mounted file systems, 
+use the \fBmount\fP command without parameters.
 .SH AUTHOR
 Kees J. Bot (kjb@cs.vu.nl)
 .SH "SEE ALSO"
-.BR du (1).
+.BR du (1)
+.BR mount (8).

--- a/elkscmd/sys_utils/mount.c
+++ b/elkscmd/sys_utils/mount.c
@@ -65,12 +65,16 @@ static int show_mount(dev_t dev)
 {
 	struct statfs statfs;
 
-	if (ustatfs(dev, &statfs, 0) < 0)
+	if (ustatfs(dev, &statfs, UF_NOFREESPACE) < 0)
 		return -1;
 
-	printf("%-9s (%s) blocks %6lu free %6lu mount %s\n",
+	if (statfs.f_type < FST_MSDOS) 
+		printf("%-9s (%5s) blocks %6lu free %6lu mount %s\n",
 		dev_name(statfs.f_dev), fs_typename[statfs.f_type], statfs.f_blocks,
 		statfs.f_bfree, statfs.f_mntonname);
+	else
+		printf("%-9s (%5s)                           mount %s\n",
+		dev_name(statfs.f_dev), fs_typename[statfs.f_type], statfs.f_mntonname);
 	return 0;
 }
 


### PR DESCRIPTION
Updated `mount` and `df` to take advantage of the new `UF_NOFREESPACE`option to `ustatfs`:
- `mount` without arguments no longer waits for the calculation of available free space on FAT file systems
- `df` without arguments lists all mounted filesystems including available and used space - like before
- `df` with options `[ikP]` reports no statistics for FAT filesystems 
- `df` man page updated.
