### PR TITLE
[boot] Fix MINIX boot when root directory larger than 1 block

### DIFF
--- a/bootblocks/boot_minix.c
+++ b/bootblocks/boot_minix.c
@@ -162,8 +162,9 @@ static void load_zone (int level, zone_nr * z_start, zone_nr * z_end)
 			if (i_now) {
 				long lin_addr = loadaddr + f_pos;
 				disk_read ((*z) << 1, 2, (byte_t *) (unsigned) lin_addr, (unsigned) (lin_addr >> 4) & 0xf000);
-			} else
-				disk_read ((*z) << 1, 2, d_dir /*+ f_pos*/, seg_data ());
+			} else {
+				if (!f_pos) disk_read ((*z) << 1, 2, d_dir /*+ f_pos*/, seg_data ());
+			}
 			f_pos += BLOCK_SIZE;
 			if (f_pos >= i_data->i_size) break;
 		} else {


### PR DESCRIPTION
Fixes #1429.

The MINIX boot was reading all directory blocks into the same block buffer, which caused filesystems with large root directories to overwrite the /linux directory entry and not match. The /linux and /bootopts entries still need to reside in the first directory block: this fix adds three bytes to the MINIX boot block, and we're down to 8-9 bytes left, and can't do much more!