### PR TITLE
[cmds] Updated functionality in makeboot

### DIFF
--- a/bootblocks/Makefile
+++ b/bootblocks/Makefile
@@ -26,7 +26,7 @@ all: $(TARGETS)
 
 minix.bin: boot_sect.o boot_minix.o
 	$(LD) $(LDFLAGS) -M -o minix.bin boot_sect.o boot_minix.o > minix.map
-	dd if=minix.bin obs=1k conv=osync of=minix.tmp; mv minix.tmp minix.bin
+	dd if=minix.bin ibs=1k conv=sync of=minix.tmp; mv minix.tmp minix.bin
 
 probe.bin: boot_sect.o boot_probe.o
 	$(LD) $(LDFLAGS) -M -o probe.bin boot_sect.o boot_probe.o > probe.map

--- a/bootblocks/Makefile
+++ b/bootblocks/Makefile
@@ -26,6 +26,7 @@ all: $(TARGETS)
 
 minix.bin: boot_sect.o boot_minix.o
 	$(LD) $(LDFLAGS) -M -o minix.bin boot_sect.o boot_minix.o > minix.map
+	dd if=minix.bin obs=1k conv=osync of=minix.tmp; mv minix.tmp minix.bin
 
 probe.bin: boot_sect.o boot_probe.o
 	$(LD) $(LDFLAGS) -M -o probe.bin boot_sect.o boot_probe.o > probe.map

--- a/elkscmd/man/man8/makeboot.8
+++ b/elkscmd/man/man8/makeboot.8
@@ -1,0 +1,104 @@
+.TH MAKEBOOT 8
+.SH NAME
+makeboot \- prepare device as a system boot device
+.SH SYNOPSIS
+\fBmakeboot\fP [\fB\-M|F\fP] [\fB\-s\fP] [\fB\-f file\fR] \fIdevice\fR
+.br
+.SH OPTIONS
+.TP 5
+.B \-M
+Write the ELKS MBR (Master Boot Record) to the first sector of the specified device.
+.TP 5
+.B \-F
+Create a 'flat' (unpartitioned) device. 
+.TP 5
+.B \-f file
+Take the bootblock from the specified instead of the current root device.
+.TP 5
+.B \-s
+Copy system files from the current root to the target device.
+.SH EXAMPLES
+.TP 5
+Copy the bootblock from the current root partition to \fB/dev/hda4\fP:
+.sp
+.nf
+# makeboot /dev/hda4
+System on /dev/hda1: Minix (CHS 7818/16/63 at offset 63)
+Target on /dev/hda4: Minix (CHS 7818/16/63 at offset 7560000)
+Bootblock written
+.fi
+.TP 5
+Write the ELKS MBR til the specified device:
+.sp
+.nf
+# makeboot \-M /dev/hda4
+Writing MBR on /dev/hda
+.fi
+.sp
+Notice that while a partition (/dev/hda4) is specified on the command line, 
+.B makeboot
+changes that into a device (/dev/hda) since that's where the MBR goes.
+.TP 5
+Replace the bootblock on \fB/dev/hda4\fP with the one in \fB./minix.bin\fP and copy system files to the target partition.
+.sp
+.nf
+# makeboot \-s \-f ./minix.bin /dev/hda4
+Target on /dev/hda4: Minix (CHS 7818/16/63 at offset 7560000)
+Bootblock written
+Copying /linux to /tmp/mnt/linux
+Copying /bootopts to /tmp/mnt/bootopts
+System copied
+.fi
+.SH DESCRIPTION
+\fBmakeboot\fR prepares a device or partition for booting by installing a 
+bootloader and \- if the \fB-s\fP option is present \- some system files.
+The partition or device must already contain a file system, which may be either FAT (MSDOS) 
+or Minix.
+.PP
+Without options, a bootblock is copied from the current root device to the target. 
+A different bootblock may be specifying via the \fB-f\fP option, see examples above.
+Such transfer requires that the running system and the target has the same file system types.
+.B makeboot
+will complain and exit if this is not the case.
+.PP
+If the 
+.B -s
+option is present, the ELKS kernel (\fI/linux\fR) and the kernel configuration file 
+.I /bootopts
+will be copied to the target.
+.PP
+The 
+.B -M
+option may be used to write a Master Boot Record (MBR) to the target device. The 
+MBR will preserve the partition information currently present in the first sector of the target device.
+This operation is similar to the MSDOS 
+'fdisk /MBR' command.
+Refer to the
+.BR MBR (8)
+manpage for details about the ELKS MBR.
+.PP
+.B makeboot
+also supports 'flat devices' - aka unpartitioned devices. While lloppies are always unpartitioned,
+hard sisks usually have partitions and a Master Boot Record. By writing the 
+.I bootblock 
+to the first sector(s) of the disk, the entire disk becomes a single partition. The
+.I -F
+option does this.
+.PP
+.B makeboot
+is used by the 
+.B sys
+command to build a fully pouplated and bootable ELKS system from floppy or from another disk.
+.PP
+\fBfloppy\fP:
+on the specified devices.
+.SH BUGS
+.B makeboot
+cannot replace the MBR on the current root device.
+.SH "SEE ALSO"
+.BR sys (8),
+.BR mkfs (8),
+.BR minix (8),
+.BR FAT (8),
+.BR MBR (8),
+.BR boot (8).

--- a/elkscmd/man/man8/setup.8
+++ b/elkscmd/man/man8/setup.8
@@ -1,0 +1,43 @@
+.TH SETUP 8
+.SH NAME
+setup \- set up some basic parameters for ELKS runtime
+.SH SYNOPSIS
+\fBsetup\fP \fInumber\fR \fIbootopts-string\fR
+.br
+.SH DESCRIPTION
+\fBsetup\fR is a simple script to enable fast setup of several ELKS systems in a network. 
+The first parameter is the 'host number', the rightmost number of the system's IP address. 
+By default, an ELKS system has the IP address 10.0.2.15. The command
+.sp
+.B setup 17
+.sp
+will edit the 
+.I /etc/hosts
+file so that the local address becomes 10.0.2.17 and also set the hostname to
+.IR elks17 .
+.PP
+The second argument - if present - is a quick way to uncomment a line in the standard 
+.I /bootopts
+file. By default most lines in 
+.I /bootopts 
+are commented out with a leading hash (#) mark.
+.B setup 
+removes the hash mark from the first line containing the string in the second argument - if any. For example,
+if 
+.I /bootopts
+contains the line
+.sp
+.B #console=ttyS0,57600 debug net=ne2k 3 # sercons, multiuser, networking
+.sp
+then the command
+.sp
+.B setup 16 debug
+.sp
+will remove the hash and thus enable that line.
+.SH BUGS
+.B setup
+is very limited in its current incarnation and subject to rapid changes.
+.SH "SEE ALSO"
+.BR setup (8),
+.BR hosts (4),
+.BR bootopts (4).

--- a/elkscmd/man/man8/sys.8
+++ b/elkscmd/man/man8/sys.8
@@ -1,0 +1,64 @@
+.TH SYS 8
+.SH NAME
+sys \- transfer ELKS to a new device or partition
+.SH SYNOPSIS
+\fBsys\fP [\fB\-M|F\fP] [\fB\-3\fP] \fIdevice\fR
+.br
+.SH OPTIONS
+.TP 5
+.B \-M
+Add a ELKS MBR (Master Boot Record) to the target drive.
+.TP 5
+.B \-F
+Create a 'flat' (unpartitioned) device. 
+.TP 5
+.B \-3
+Create a minimal system for a 360K floppy.
+.SH DESCRIPTION
+\fBsys\fR uses the currently running system to build a complete and bootable ELKS partition or drive. 
+The common case would be to boot ELKS from a floppy disk and build a hard disk based system 
+from there with a single command, such as
+.sp
+.B # sys -M /dev/hda1
+.PP
+If the 
+.B \-M
+option is included, the ELKS MBR will replace the current MBR - if any - on the taget drive.
+.PP
+.B sys
+will report progress as it runs, which will take some time if the system is running off of a floppy disk.
+Unless the 
+.B \-3 
+option is present, the entire system with 
+.I /bin
+and
+.I /etc
+directories will be copied and the device directory will be fully populated. With
+.B \-3
+only a subset suitable for very small floppy disks will be transferred.
+.PP
+The target file system - Minix of FAT - must exist before 
+.B sys
+can be run.
+.PP
+After running 
+.B sys
+successfully, the target drive/partition will be bootable and configured exactly like the source system.
+The next step could then be to use the
+.B setup 
+command to set the hostname and basic parameters (see the
+.B setup
+man-page for details).
+.SH BUGS
+.B sys
+performs limited option checking, so some error messages appear to come from 
+.B makeboot
+instead.
+.SH "SEE ALSO"
+.BR makeboot (8),
+.BR setup (8),
+.BR mkfs (8),
+.BR minix (8),
+.BR FAT (8),
+.BR MBR (8),
+.BR boot (8).

--- a/elkscmd/rootfs_template/bin/sys
+++ b/elkscmd/rootfs_template/bin/sys
@@ -5,9 +5,9 @@
 usage()
 {
 	echo "Usage: sys [-3][-M][-F] /dev/{fd0,fd1,hda1,hda2,etc}"
-	echo "	-3 will transfer minimal (360k) system"
-	echo "	-M will transfer boot MBR to /dev/hd[a-d][1-4]"
-	echo "	-F required for flat non-MBR /dev/hd[a-d]"
+	echo "	-3  Build minimal (360k) system"
+	echo "	-M  add MBR to target device"
+	echo "	-F  required for flat non-MBR /dev/hd[a-d]"
 	exit 1
 }
 
@@ -26,7 +26,9 @@ create_dev_dir()
 	mknod $MNT/dev/null	c 1 3
 	mknod $MNT/dev/zero	c 1 5
 	mknod $MNT/dev/tcpdev	c 8 0
-	mknod $MNT/dev/eth	c 9 0
+	mknod $MNT/dev/ne2k	c 9 0
+	mknod $MNT/dev/wd8003	c 9 1
+	mknod $MNT/dev/3c509	c 9 2
 	mknod $MNT/dev/ptyp0	c 2 8
 	mknod $MNT/dev/ttyp0	c 4 8
 	mknod $MNT/dev/tty1	c 4 0
@@ -115,22 +117,19 @@ copy_etc_files()
 # sys script starts here
 MNT=/tmp/mnt
 small=0
-
-if test "$1" = "-M"; then shift; arg=-M; fi
-if test "$1" = "-F"; then shift; arg=-F; fi
+arg=-s
+if test "$1" = "-M"; then shift; arg="-M -s"; fi
+if test "$1" = "-F"; then shift; arg="-F -s"; fi
 if test "$1" = "-3"; then shift; small=1; fi
 if test "$#" -lt 1; then usage; fi
 
 # returns fstype, 1=MINIX, 2=FAT
 makeboot $arg $1
 FSTYPE=$?
+if test "$FSTYPE" = "255"; then exit 1; fi;
 
 mkdir -p $MNT
-case "$FSTYPE" in
-1) mount $1 $MNT || exit 1 ;;
-2) mount -t msdos $1 $MNT || exit 1 ;;
-*) exit 1 ;;
-esac
+mount $1 $MNT 
 
 # if MINIX, create /dev entries
 if test "$FSTYPE" = "1"; then create_dev_dir; fi

--- a/elkscmd/sys_utils/makeboot.c
+++ b/elkscmd/sys_utils/makeboot.c
@@ -192,7 +192,7 @@ int setMBRparms(int fd)
 {
 	int n;
 	char MBR[512];
-	short *bsect = (short *)MBR;
+	unsigned short *bsect = (unsigned short *)MBR;
 
 	lseek(fd, 0L, SEEK_SET);
 	n = read(fd, MBR, 512);
@@ -310,7 +310,7 @@ void fatalmsg(const char *s, ...)
 void get_bootblock(char *bootf) 
 {
 	int fd, n;
-	short *bsect = (short *)bootblock;
+	unsigned short *bsect = (unsigned short *)bootblock;
 	
 	if (bootf == NULL) {	/* get bootblock from current root */
 		fd = open(rootdevice, O_RDONLY);


### PR DESCRIPTION
Updates to `makeboot` to enable singular operations: MBR only, bootblock only. Fixes loading bootblock from file by padding the `minix.bin` file with NULLS to 1024. Also the new bootblock is signature checked (aa55) as an extra guard against botches.

I noticed after pushing the commit that Linux doesn't like the `dd` options I've used (padding) (which works on MacOS), a small update to fix this is forthcoming.

`makeboot` without any of the new options works like before (which is not optimal, but compatible with `sys`, comments below).

New options:
- `-m` Update  MBR only, no bootblock, no system copy
- `-s` Skip system copy, useful to update bootblock only

Opinion: With the new functionality, it would be beneficial to change `makeboot` options to be more logical, for example:
- no options: Copy bootblock
- `-f` Copy bootblock from file
- `-s` Copy system (in addition to bootblock)
- `-M` Write new MBR to the drive, nothing else unless `-s` is also specified, implies bootblock transfer
- `-F` Write bootblock to drive (flat drive), nothing else unless `-s` is also specified

Such change would require only a very minor change to `sys`.

BTW - it may be a good idea to add an updated version of `sys` to this PR in any case, to fix `/dev/ne2k` and add `/dev/3c509` and `/dev/wd8003`.
