### PR TITLE
[build] Fix non-working ps on PC-98 CI build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -72,6 +72,7 @@ if [ "$1" = "auto" ]; then
 	echo "Building 8018X image..."
     cp 8018x.config .config
     make kclean || clean_exit 7
+    rm elkscmd/basic/*.o
     make -j1 || clean_exit 8
 fi
 
@@ -82,6 +83,7 @@ if [ "$1" = "auto" ]; then
     make kclean || clean_exit 9
     rm elkscmd/sys_utils/clock.o
     rm elkscmd/basic/*.o
+    rm elkscmd/sys_utils/ps.o
     rm elkscmd/nano-X/*.o
     make -j1 || clean_exit 10
 fi


### PR DESCRIPTION
Fixes #1436.

The problem was not CONFIG_CPU_USAGE, which defaults enabled in PC-98, 8018X and IBM PC, but rather KSTACK_BYTES, which is included in the task structure, and has a different size between PC-98 and IBM PC builds. Unfortunately, the `ps` command must know the correct task_struct size per OS build in order to work, so it must be built separately for each as well.

Also corrects problem for proper `basic` build for 8018X.