### PR TITLE
Libc size of time and strerror

### DIFF
--- a/elkscmd/test/Makefile
+++ b/elkscmd/test/Makefile
@@ -3,6 +3,7 @@
 SUBDIRS =  \
 	eth    \
 	fat    \
+	libc   \
 	pty    \
 	socket \
 	select \

--- a/elkscmd/test/libc/Makefile
+++ b/elkscmd/test/libc/Makefile
@@ -6,7 +6,7 @@ include $(BASEDIR)/Make.defs
 
 PGM = test_libc
 
-SRCS = main.c time.c
+SRCS = error.c main.c time.c
 
 OBJS = $(SRCS:.c=.o)
 

--- a/elkscmd/test/libc/Makefile
+++ b/elkscmd/test/libc/Makefile
@@ -1,0 +1,25 @@
+# Makefile for libc tests
+
+BASEDIR=../..
+
+include $(BASEDIR)/Make.defs
+
+PGM = test_libc
+
+SRCS = main.c time.c
+
+OBJS = $(SRCS:.c=.o)
+
+
+include $(BASEDIR)/Make.rules
+
+all: $(PGM)
+
+$(PGM): $(OBJS)
+	$(LD) $(LDFLAGS) -o $(PGM) $(OBJS) $(LDLIBS)
+
+install: $(PGM)
+	$(INSTALL) $(PGM) $(DESTDIR)/bin
+
+clean:
+	rm -f $(OBJS) $(PGM)

--- a/elkscmd/test/libc/error.c
+++ b/elkscmd/test/libc/error.c
@@ -1,0 +1,32 @@
+#include "test.h"
+
+#include <string.h>
+
+#define N_ERR_TESTS 5
+struct err_tests {
+	int errno;
+	const char *msg;
+} err_map[N_ERR_TESTS] = {
+	{  -1, "Unknown error -1" },
+	{   0, "Unknown error 0" },
+	{   1, "Operation not permitted " },
+	{ 129, "Server error " },
+	{ 999, "Unknown error 999" },
+};
+
+/* FIXME /etc/perror is generated with trailing spaces */
+void test_strerror()
+{
+	int i;
+	for (i = 0; i < N_ERR_TESTS; ++i) {
+		const char *msg = strerror(err_map[i].errno);
+		if (strcmp(msg, err_map[i].msg)) {
+			printf("strerror: incorrect message: errno=%d\n"
+				"\tactual   '%s'\n"
+				"\texpected '%s'\n",
+				err_map[i].errno, msg, err_map[i].msg);
+			fail++;
+		}
+	}
+}
+

--- a/elkscmd/test/libc/main.c
+++ b/elkscmd/test/libc/main.c
@@ -1,0 +1,9 @@
+int fail = 0;
+
+int main(void)
+{
+	test_gmtime();
+	test_mktime();
+
+	return !!fail;
+}

--- a/elkscmd/test/libc/main.c
+++ b/elkscmd/test/libc/main.c
@@ -4,6 +4,7 @@ int main(void)
 {
 	test_gmtime();
 	test_mktime();
+	test_strerror();
 
 	return !!fail;
 }

--- a/elkscmd/test/libc/test.h
+++ b/elkscmd/test/libc/test.h
@@ -1,0 +1,1 @@
+extern int fail;

--- a/elkscmd/test/libc/time.c
+++ b/elkscmd/test/libc/time.c
@@ -1,0 +1,82 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include "test.h"
+
+#define N_TM_TESTS 2
+struct tm_map {
+	time_t offset;
+	struct tm tm;
+} tm_tests[N_TM_TESTS] = {
+	{          0, { 0, 0, 0, 1, 0, 70, 4, 0, -1 } },
+	{ 1668875025, { 45, 23, 16, 19, 10, 122, 6, 322, -1 } },
+	/*{           , { 8, 14, 3, 19, 0, 138, 2, 18, -1 } },*/
+};
+
+int tm_cmp(struct tm *a, struct tm *b)
+{
+	return  a->tm_sec   != b->tm_sec  ||
+		a->tm_min   != b->tm_min  ||
+		a->tm_hour  != b->tm_hour ||
+		a->tm_mday  != b->tm_mday ||
+		a->tm_mon   != b->tm_mon  ||
+		a->tm_year  != b->tm_year ||
+		a->tm_wday  != b->tm_wday ||
+		a->tm_yday  != b->tm_yday ||
+		a->tm_isdst != b->tm_isdst;
+}
+
+char *tm_str(struct tm *tm)
+{
+	static char s[64];
+	sprintf(s, "s=%d m=%d h=%d mday=%d mon=%d year=%d wday=%d yday=%d isdst=%d",
+		tm->tm_sec, tm->tm_min, tm->tm_hour, tm->tm_mday, tm->tm_mon,
+		tm->tm_year, tm->tm_wday, tm->tm_yday, tm->tm_isdst);
+	return s;
+}
+
+void check_tm(struct tm *a, struct tm *b)
+{
+	if (tm_cmp(a, b)) {
+		puts("incorrect tm");
+		puts("\tactual   "); puts(tm_str(a));
+		puts("\texpected "); puts(tm_str(b));
+		fail++;
+	}
+}
+
+void check_time(time_t a, time_t b)
+{
+	if (a != b) {
+		puts("incorrect time_t");
+		printf("\tactual   %lu\n", a);
+		printf("\texpected %lu\n", b);
+		fail++;
+	}
+}
+
+void test_gmtime()
+{
+	struct tm *tm;
+	int i;
+
+	for (i = 0; i < N_TM_TESTS; ++i) {
+		tm = gmtime(&tm_tests[i].offset);
+		check_tm(tm, &tm_tests[i].tm);
+	}
+}
+
+/* FIXME currently fails */
+void test_mktime()
+{
+	struct tm *tm;
+	int i;
+
+	for (i = 0; i < N_TM_TESTS; ++i) {
+		time_t t;
+		struct tm tm = tm_tests[i].tm;
+		tm.tm_isdst = 0;
+		t = mktime(&tm);
+		check_time(t, tm_tests[i].offset);
+	}
+}

--- a/libc/error/error.c
+++ b/libc/error/error.c
@@ -20,12 +20,6 @@ strerror(int err)
    char inbuf[256];
    static char retbuf[60];
 
-   if( __sys_nerr )
-   {
-      if( err < 0 || err >= __sys_nerr ) goto unknown;
-      return __sys_errlist[err];
-   }
-
    if( err <= 0 ) goto unknown;	/* NB the <= allows comments in the file */
    fd = open(_PATH_ERRSTRING, 0);
    if( fd < 0 ) goto unknown;
@@ -41,8 +35,8 @@ strerror(int err)
 	    if( err == atoi(retbuf) )
 	    {
 	       char * p = strchr(retbuf, ' ');
-	       if( p == 0 ) goto unknown;
-	       while(*p == ' ') p++;
+	       if( p == 0 ) goto done;
+	       while(*++p == ' ') ;
 	       close(fd);
 	       return p;
 	    }
@@ -52,8 +46,9 @@ strerror(int err)
 	    retbuf[bufoff++] = inbuf[i];
       }
    }
+done:
+   close(fd);
 unknown:
-   if( fd >= 0 ) close(fd);
    strcpy(retbuf, "Unknown error ");
    strcpy(retbuf+14, itoa(err));
    return retbuf;

--- a/libc/time/tm_conv.c
+++ b/libc/time/tm_conv.c
@@ -74,7 +74,7 @@ static int   moffset[] =
 
 #include <time.h>
 
-static const unsigned short int __mon_lengths[2][12] =
+static const char __mon_lengths[2][12] =
   {
     /* Normal years.  */
     { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 },
@@ -87,8 +87,9 @@ void
 __tm_conv(struct tm *tmbuf, time_t *t, time_t offset)
 {
   long days, rem;
+  int yday;
   register int y;
-  register const unsigned short *ip;
+  register const char *ip;
 
   days = *t / SECS_PER_DAY;
   rem = *t % SECS_PER_DAY;
@@ -122,13 +123,14 @@ __tm_conv(struct tm *tmbuf, time_t *t, time_t offset)
       --y;
       days += __isleap(y) ? 366 : 365;
     }
+  yday = days;
   tmbuf->tm_year = y - 1900;
-  tmbuf->tm_yday = days;
+  tmbuf->tm_yday = yday;
   ip = __mon_lengths[__isleap(y)];
-  for (y = 0; days >= ip[y]; ++y)
-    days -= ip[y];
+  for (y = 0; yday >= ip[y]; ++y)
+    yday -= ip[y];
   tmbuf->tm_mon = y;
-  tmbuf->tm_mday = days + 1;
+  tmbuf->tm_mday = yday + 1;
   tmbuf->tm_isdst = -1;
 }
 


### PR DESCRIPTION
These changes save 4k on the default-configured CONFIG_ARCH_IBMPC floppy.

Before:
blocks inuse 1392, free 36, overhead 12, total 1440
After:
blocks inuse 1388, free 40, overhead 12, total 1440