### PR TITLE
[kernel] Add KIOCSOUND ioctl for console terminal

### DIFF
--- a/elks/arch/i86/drivers/char/conio-pc98.c
+++ b/elks/arch/i86/drivers/char/conio-pc98.c
@@ -16,6 +16,14 @@ void bell(void)
 {
 }
 
+void soundp(unsigned period)
+{
+}
+
+void nosound(void)
+{
+}
+
 int conio_poll(void)
 {
     int cdata;

--- a/elks/arch/i86/drivers/char/console-bios.c
+++ b/elks/arch/i86/drivers/char/console-bios.c
@@ -18,6 +18,7 @@
 #include <linuxmt/errno.h>
 #include <linuxmt/chqueue.h>
 #include <linuxmt/ntty.h>
+#include <linuxmt/kd.h>
 #include "console.h"
 #include "console-bios.h"
 

--- a/elks/arch/i86/drivers/char/console-direct-pc98.c
+++ b/elks/arch/i86/drivers/char/console-direct-pc98.c
@@ -22,6 +22,7 @@
 #include <linuxmt/errno.h>
 #include <linuxmt/chqueue.h>
 #include <linuxmt/ntty.h>
+#include <linuxmt/kd.h>
 #include <arch/io.h>
 #include "console.h"
 #include "conio-pc98-asm.h"

--- a/elks/arch/i86/drivers/char/console-direct.c
+++ b/elks/arch/i86/drivers/char/console-direct.c
@@ -18,6 +18,7 @@
 #include <linuxmt/errno.h>
 #include <linuxmt/chqueue.h>
 #include <linuxmt/ntty.h>
+#include <linuxmt/kd.h>
 #include <arch/io.h>
 #include "console.h"
 

--- a/elks/arch/i86/drivers/char/console.c
+++ b/elks/arch/i86/drivers/char/console.c
@@ -419,6 +419,15 @@ static int Console_ioctl(struct tty *tty, int cmd, char *arg)
 	    return 1;
 	}
 	break;
+    case KIOCSOUND:
+	{
+	    unsigned period = (unsigned) arg;
+	    if (period)
+		soundp(period);
+	    else
+		nosound();
+	}
+	return 0;
     case TCSETS:
     case TCSETSW:
     case TCSETSF:

--- a/elks/arch/i86/drivers/char/console.h
+++ b/elks/arch/i86/drivers/char/console.h
@@ -7,6 +7,8 @@ extern struct tty ttys[];
 void kbd_init(void);
 extern char kbd_name[];
 
+void soundp(unsigned);
+void nosound(void);
 void bell(void);
 
 /* for direct and bios consoles only*/

--- a/elks/include/linuxmt/kd.h
+++ b/elks/include/linuxmt/kd.h
@@ -1,0 +1,14 @@
+#ifndef __LINUXMT_KD_H
+#define __LINUXMT_KD_H
+
+#include <linuxmt/types.h>
+
+/*@-namechecks@*/
+
+#define __KD_MAJ 	('K'<<8)
+
+/*@+namechecks@*/
+
+#define KIOCSOUND	(__KD_MAJ + 0x2f)
+
+#endif


### PR DESCRIPTION
This ioctl allows a program to play sounds of arbitrary pitches on the PC speaker.  E.g.:

```
int
main (void)
{
  ioctl(1, KIOCSOUND, (void *) ((1193181 + 440 / 2) / 440));
  sleep(1);
  ioctl(1, KIOCSOUND, (void *) 0);
  return 0;
}
```

This `ioctl` can be used to implement userland functions akin to the `sound` and `nosound` functions in Turbo C and Watcom C (https://github.com/jbruchon/elks/issues/871).

(To test the sound output under `qemu-system-i386`, one way is to supply an option `-soundhw pcspk`.)