### PR TITLE
[driver] Bring console-bios.c in sync with console.c

### DIFF
--- a/elks/arch/i86/drivers/char/console-bios.c
+++ b/elks/arch/i86/drivers/char/console-bios.c
@@ -78,7 +78,7 @@ static int Current_VCminor = 0;
 #define TERM_TYPE " dumb "
 #endif
 
-static void std_char(register Console *, char);
+static void std_char(register Console *, int);
 
 static void PositionCursor(register Console * C)
 {


### PR DESCRIPTION
Parameter type update in `console-bios.c` fixing compilation problem reported in  #1453.