### PR TITLE
[irq] Fixing PC-98 freezing issue : remove calling bios for timer

### DIFF
--- a/elks/arch/i86/kernel/irq-8259.c
+++ b/elks/arch/i86/kernel/irq-8259.c
@@ -60,10 +60,17 @@ int remap_irq(int irq)
 
 int irq_vector (int irq)
 	{
+#ifdef CONFIG_ARCH_PC98
+	// IRQ 0-7  are mapped to vectors INT 08h-0Fh
+	// IRQ 8-15 are mapped to vectors INT 10h-17h
+
+	return irq + 0x08;
+#else
 	// IRQ 0-7  are mapped to vectors INT 08h-0Fh
 	// IRQ 8-15 are mapped to vectors INT 70h-77h
 
 	return irq + ((irq >= 8) ? 0x68 : 0x08);
+#endif
 	}
 
 void disable_irq(unsigned int irq)

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -296,8 +296,12 @@ updct:
 //
 	cmp	$16,%ax
 	jge	was_trap	// Traps need no reset
+#ifdef CONFIG_ARCH_PC98
+	jmp	do_eoi
+#else
 	or	%ax,%ax		// Is int #0?
 	jnz	do_eoi
+#endif
 
 //
 //	IRQ 0 (timer) has to go on to the bios for some systems

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -51,7 +51,7 @@
 #define SETUP_ELKS_FLAGS	setupb(0x1f6)	/* flags for root device type */
 #define SETUP_PART_OFFSETLO	setupw(0x1e2)	/* partition offset low word */
 #define SETUP_PART_OFFSETHI	setupw(0x1e4)	/* partition offset high word */
-#define SYS_CAPS		0	/* no XT/AT capabilities */
+#define SYS_CAPS		CAP_IRQ8TO15	/* enable capabilities */
 #define UTS_MACHINE		"pc-98 i8086"
 
 #define CONFIG_VAR_SECTOR_SIZE	/* sector size may vary across disks */
@@ -79,12 +79,12 @@
  * Normally, all capabilities will be set if arch_cpu > 5 (PC/AT),
  * except when SYS_CAPS is defined for custom installations or emulations.
  */
-#define CAP_PC_AT       0x01      /* PC/AT capabilities */
+#define CAP_PC_AT       (CAP_IRQ8TO15|CAP_IRQ2MAP9)      /* PC/AT capabilities */
 #define CAP_DRIVE_PARMS	0x02      /* has INT 13h fn 8 drive parms */
 #define CAP_KBD_LEDS    0x04      /* has keyboard LEDs */
 #define CAP_HD_IDE      0x08      /* can do hard drive IDE probes */
-#define CAP_IRQ8TO15    CAP_PC_AT /* has IRQ 8 through 15 */
-#define CAP_IRQ2MAP9    CAP_PC_AT /* map IRQ 2 to 9 */
+#define CAP_IRQ8TO15    0x10      /* has IRQ 8 through 15 */
+#define CAP_IRQ2MAP9    0x20      /* map IRQ 2 to 9 */
 #define CAP_ALL         0xFF      /* all capabilities if PC/AT only */
 
 /* Don't touch these, unless you really know what you are doing. */


### PR DESCRIPTION
This pull request is to fix PC-98 freezing issue starting from
https://github.com/jbruchon/elks/issues/1325#issuecomment-1295904023

Also interrupt vector map is modified for PC-98.

Hello @ghaerr,

I modified capability as 
https://github.com/jbruchon/elks/issues/1325#issuecomment-1326756135

Thank you. 