### PR TITLE
[cmds] Change heap setting on fsck

### DIFF
--- a/elkscmd/disk_utils/Makefile
+++ b/elkscmd/disk_utils/Makefile
@@ -23,7 +23,7 @@ install: all
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 fsck: fsck.o
-	$(LD) $(LDFLAGS) -o fsck -maout-heap=0xffff fsck.o $(LDLIBS)
+	$(LD) $(LDFLAGS) -o fsck -maout-heap=23000 fsck.o $(LDLIBS)
 
 fdisk: fdisk.o
 	$(LD) $(LDFLAGS) -o fdisk fdisk.o $(LDLIBS)

--- a/elkscmd/disk_utils/fsck.c
+++ b/elkscmd/disk_utils/fsck.c
@@ -953,10 +953,10 @@ int main(int argc, char ** argv)
 	 */
 	if (!(SupeP->s_state & MINIX_ERROR_FS) &&
 		(SupeP->s_state & MINIX_VALID_FS) && !force) {
-		if (repair)
+		if (repair || verbose)
 			printf("%s is clean, no check.\n", device_name);
 		if (repair && !automatic)
-			tcsetattr(0,TCSANOW,&termios);
+			tcsetattr(0, TCSANOW, &termios);
 		return retcode;
 	}
 	else if (force)


### PR DESCRIPTION
Change heap setting on `fsck` to 23000 per #1460.

Also ensure that `fsck` emits the `filesystem clean, no checks` in `-v` (verbose)  mode. 

Actually it would be good if `fsck` always prints something when stdin is a tty, even when there are no errors. Such as `No errors` or `Filesystem clean` or something similar. The utter silence have me worried some times.

-M