### PR TITLE
Fix tr so that squeeze does not act like delete.

### DIFF
--- a/elkscmd/sh_utils/tr.c
+++ b/elkscmd/sh_utils/tr.c
@@ -234,7 +234,7 @@ int main(int argc, char ** argv)
 		len2 = 0;
 	}
 	/* printf("{%d,%d}",len1,len2); */
-	if (len1 > len2) {
+	if (set2 && len1 > len2) {
 		if (truncate1) {
 			set1[len2] = '\0';
 		} else {
@@ -249,13 +249,11 @@ int main(int argc, char ** argv)
 	/* printf("String 1 = %s\n", set1);
 	printf("String 2 = %s\n", set2); */
 	while ((i = getchar()) != EOF) {
-		if (set2 == NULL || delete) {
-			if (delete) {
-				if ((ip = strchr(set1, i)) != NULL) {
-					i = 0;
-				}
+		if (delete) {
+			if ((ip = strchr(set1, i)) != NULL) {
+				i = 0;
 			}
-		} else {
+		} else if (set2) {
 			if ((ip = strchr(set1, i)) != NULL) {
 				i = ip - set1;
 				ip = set2 + i;


### PR DESCRIPTION
When there is only one set, the test len1 > len2 will usually be true, so set2 would get changed from NULL to a padded copy of set1, but since set2 was empty anyway it becomes completely '\0' filled.  Since there is now a non-NULL set2, the "translate" clause of the main loop runs, which would translate the read character to '\0', which is also used to mean "do not print".