### PR TITLE
Fix bug in msdos_readdir: only call filldir() when success

### DIFF
--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -246,7 +246,7 @@ static int msdos_readdir(struct inode *dir, struct file *filp, char *dirbuf,
 	}
 
 	res = msdos_get_entry_long(dir, &filp->f_pos, &bh, name, &namelen, &dirpos, &ino);
-	if (res)
+	if (res > 0)
 		filldir(dirbuf, name, namelen, dirpos, ino);
 	if (bh)
 		unmap_brelse(bh);


### PR DESCRIPTION
Fixes this clang --analyze error:
/dir.c:250:3: warning: 3rd function call argument is an uninitialized value [core.CallAndMessage]
                filldir(dirbuf, name, namelen, dirpos, ino);

Probably not much of a change in practice: error path would have only copied length-limited garbage data into userspace before returning the error.