### PR TITLE
Add missing const to some libc declarations

### DIFF
--- a/libc/include/arpa/inet.h
+++ b/libc/include/arpa/inet.h
@@ -4,6 +4,6 @@
 ipaddr_t in_aton(const char *str);
 int	     in_connect(int socket, const struct sockaddr *address, socklen_t address_len,
 			int secs);
-ipaddr_t in_gethostbyname(char *str);
+ipaddr_t in_gethostbyname(const char *str);
 char *   in_ntoa(ipaddr_t in);
 ipaddr_t in_resolv(char *hostname, char *server);

--- a/libc/include/string.h
+++ b/libc/include/string.h
@@ -10,8 +10,8 @@ char *strcpy(char*, const char*);
 char *strcat(char * dest, const char * src);
 int strcmp(const char *s1, const char *s2);
 
-char * strncpy(char*, char*, size_t);
-char * strncat(char*, char*, size_t);
+char * strncpy(char*, const char*, size_t);
+char * strncat(char*, const char*, size_t);
 int strncmp(const char * s1, const char * s2, size_t n);
 
 char * strstr(const char *, const char *);
@@ -22,11 +22,11 @@ char * strdup(const char*);
 
 /* Basic mem functions */
 void * memcpy(void * dest, const void * src, size_t n);
-void * memccpy(void*, void*, int, size_t);
+void * memccpy(void*, const void*, int, size_t);
 void * memchr(const void*, const int, size_t);
 void * memset(void*, int, size_t);
 int memcmp(const void*, const void*, size_t);
-void * memmove(void*, void*, size_t);
+void * memmove(void*, const void*, size_t);
 
 void __far *fmemset(void __far *buf, int c, size_t l);
 
@@ -46,9 +46,9 @@ int strcasecmp(const char *s1, const char *s2);
 int strncasecmp(const char *s1, const char *s2, size_t n);
 char *strtok(char * str, const char * delim);
 char *strpbrk(const char *, const char *);
-char *strsep(char **, char *);
+char *strsep(char **, const char *);
 
-size_t strcspn(char *, char *);
+size_t strcspn(const char *, const char *);
 size_t strspn(const char *, const char *);
 
 /* Linux silly hour */

--- a/libc/net/in_gethostbyname.c
+++ b/libc/net/in_gethostbyname.c
@@ -10,7 +10,7 @@
  */
 
 /* return ip address in network byte order of host by reading /etc/hosts file*/
-ipaddr_t in_gethostbyname(char *str)
+ipaddr_t in_gethostbyname(const char *str)
 {
 	char *p, *cp;
 	FILE *fp;

--- a/libc/string/memccpy.c
+++ b/libc/string/memccpy.c
@@ -2,9 +2,10 @@
 #include <string.h>
 
 void *
-memccpy(void * d, void * s, int c, size_t l)	/* Do we need a fast one ? */
+memccpy(void * d, const void * s, int c, size_t l)	/* Do we need a fast one ? */
 {
-   register char *s1=d, *s2=s;
+   char *s1=d;
+   const char *s2=s;
    while(l-- > 0)
       if((*s1++ = *s2++) == c )
          return s1;

--- a/libc/string/memmove.c
+++ b/libc/string/memmove.c
@@ -1,9 +1,10 @@
 #include <string.h>
 
 void *
-memmove(void *d, void *s, size_t l)
+memmove(void *d, const void *s, size_t l)
 {
-   register char *s1=d, *s2=s;
+   char *s1=d;
+   const char *s2=s;
    /* This bit of sneakyness c/o Glibc, it assumes the test is unsigned */
    if( s1-s2 >= l ) return memcpy(d,s,l);
 

--- a/libc/string/strcspn.c
+++ b/libc/string/strcspn.c
@@ -4,9 +4,7 @@
 
 #include <string.h>
 
-size_t strcspn(string, set)
-register char *string;
-char *set;
+size_t strcspn(const char *string, const char *set)
 /*
  *	Return the length of the sub-string of <string> that consists
  *	entirely of characters not found in <set>.  The terminating '\0'
@@ -14,8 +12,8 @@ char *set;
  *	character if <string> is in <set>, 0 is returned.
  */
 {
-    register char *setptr;
-    char *start;
+    const char *setptr;
+    const char *start;
 
     start = string;
     while (*string)

--- a/libc/string/strncat.c
+++ b/libc/string/strncat.c
@@ -1,7 +1,7 @@
 #include <string.h>
 
 char *
-strncat(char *d, char *s, size_t l)
+strncat(char *d, const char *s, size_t l)
 {
    register char *s1=d+strlen(d), *s2;
 

--- a/libc/string/strncpy.c
+++ b/libc/string/strncpy.c
@@ -1,8 +1,9 @@
 #include <string.h>
 
-char * strncpy (char * d, char * s, size_t l)
+char * strncpy (char * d, const char * s, size_t l)
 {
-   register char *s1=d, *s2=s;
+   char *s1=d;
+   const char *s2=s;
    while(l > 0)
    {
       l--;


### PR DESCRIPTION
Obviously this may help catch bugs, but also makes it easier to use various static analyzers that expect the standard decl.