### PR TITLE
[net][ne2k] Change default buffer size for 8bit (ne1k) mode

### DIFF
--- a/elks/arch/i86/drivers/net/ne2k-asm.S
+++ b/elks/arch/i86/drivers/net/ne2k-asm.S
@@ -10,8 +10,7 @@
 // Updated by Santiago Hormazabal on Dec 2021:
 //  . 8 bit access if CONFIG_ETH_BYTE_ACCESS is set, using a ne1k patch from
 //    NCommander.
-// apr-2022 (HS) : Support auto detection of 8bit mode, set 4k or 16k buffer size when in 8bit mode
-//	     depending on configuration, 16k is the default, 4k is 'per spec'.
+// apr-2022 (HS) : Support auto detection of 8bit mode, set 8k buffer size when in 8bit mode.
 //	     Rewrote overflow handler, added direct access to many registers from C code
 //	     Cleaned up initialization code, optimized 8bit I/O
 //
@@ -22,7 +21,7 @@
 // 'BOUNDARY' points to the next block to be read from the NIC
 // The two must not be equal. If the ring buffer is empty, BOUNDARY = CURRENT -1
 // So the next block to read is not BOUNDARY but BOUNDARY + 1. Easy - except at
-// the wrap-around point: BOUNDARY may be 80 or 50, while the next block to read is 46.
+// the wrap-around point: BOUNDARY may be 80 (60 if 8bit), while the next block to read is 46.
 // For simplicity (to avoid the ring wraparound logic on every read)
 // the driver uses a variable to hold the next block to read - _ne2k_next_pk.
 // For debugging, this variable is also available to the C part of the driver.
@@ -79,7 +78,7 @@ io_ne2k_reset      = 0x1F	// Really a port, not a register, force HW reset of th
 tx_first           = 0x40
 rx_first           = 0x46
 rx_last_16	   = 0x80
-rx_last_8	   = 0x50	// For 4k in 8 bit mode - per spec. 
+rx_last_8	   = 0x60	// For 8k in 8 bit mode - per spec. 
 
 //-----------------------------------------------------------------------------
 	.data
@@ -99,7 +98,7 @@ _ne2k_is_8bit:
 	.word 0
 
 _ne2k_rx_last:
-	.byte rx_last_16	// default to the 16 bit value
+	.byte rx_last_16	// default to 16K
 
 	.text
 
@@ -210,7 +209,7 @@ dma_write:
 	mov	current,%bx		// setup for far memory xfer
 	mov	TASK_USER_DS(%bx),%ds
 	cld
-	test	$1,%ax		// checking _ne2k_is_8bit
+	test	$0x80,%ax		// checking _ne2k_is_8bit
 	jz	wr_loop_w
 
 	// Byte loop
@@ -287,7 +286,7 @@ buf_local:
 	//mov	net_port,%dx
 	add	$io_ne2k_data_io,%dx
 	cld			// clear direction flag
-	testw	$1,_ne2k_is_8bit
+	testw	$0x80,_ne2k_is_8bit
 	jz	word_loop0
 
 byte_loop:
@@ -662,7 +661,7 @@ ne2k_base_init:
 	//mov	net_port,%dx
 	add	$io_ne2k_data_conf,%dx
 	mov     $0x49,%al	// set word access
-	testw	$1,_ne2k_is_8bit
+	testw	$0x80,_ne2k_is_8bit
 	jz	1f
 	dec     %al	// if in 8bit mode, 
 			// set byte access, data_conf reg = 0x48
@@ -683,6 +682,7 @@ ne2k_base_init:
 //-----------------------------------------------------------------------------
 // NE2K initialization
 // Called from device open
+// Uses AX, DX only
 //-----------------------------------------------------------------------------
 
 	.global ne2k_init
@@ -703,25 +703,43 @@ ne2k_init:
 
 	mov	net_port,%dx
 	add	$io_ne2k_tx_conf,%dx
-	mov     $2,%al  // 2 for loopback
+	mov     $2,%al		// 2 for loopback
 	out     %al,%dx
 
 	// set RX ring limits - 16KB on-chip memory
-	// except one TX frame at beginning (6 x 256B).
-	// If bit 1 (0x2) in _ne2k_is_8bit is set, use only 4k
-	// buffer.
+	// less one TX frame at the beginning (6 x 256B).
+	// The defaults are 16k if 16 bit NIC, 8k if 8bit NIC.
+	// Flags may force other sizes (up to 32k), no 
+	//  sanity checking is done. See flags in netstat.h
 
 	mov	net_port,%dx
 	add	$io_ne2k_rx_first,%dx
 	mov     $rx_first,%al	// start of ring, usually 0x46
 	out     %al,%dx
 
-	// set page at which the ring buffer ends,
-	// defaults to the 16 bit value (0x80) 
-	movb	$rx_last_16,%al
-	testw	$2,_ne2k_is_8bit
+	// set ending page for the ring buffer,
+	// check for forced buffer size
+	movw	_ne2k_is_8bit,%ax
+	and	$0x7,%al
+	jz	2f
+	movb	$0x10,%ah	// 4k minimum
+	push	%cx		// FIXME: Is this required??
+	and	$3,%al		// remove the 4k bit (0x04)
+	mov	%al,%cl
+	shl	%cl,%ah		// %AL is the block number to add to 
+				// the buffer start address (usually 0x40)
+				// becoming the PSTOP value
+	add	$tx_first,%ah	// NOTE: tx_first is where the buffer starts,
+				// we don't want rx_first here.
+	pop	%cx
+	mov	%ah,%al
+	jmp	1f
+
+	// The normal case, use defaults
+2:	movb	$rx_last_16,%al
+	testw	$0x80,_ne2k_is_8bit
 	jz	1f
-	movb	$rx_last_8,%al	// Force 4K buffer restriction
+	movb	$rx_last_8,%al	// It's an 8 bit NIC, use 8K buffer
 1:	movb	%al,_ne2k_rx_last
 
 	mov	net_port,%dx
@@ -750,7 +768,7 @@ ne2k_init:
 	mov     $0x1f,%al	// 0x53 = RDC, Overflow, RX, TX 
 				// 0x13 = Overflow, RX, TX
 				// 0x1F = Overflow, TXE, RXE, RX, TX
-	testw	$1,_ne2k_is_8bit
+	testw	$0x80,_ne2k_is_8bit
 	jnz	1f
 	and	$0xfb,%al	// RXE is useful (mostly) if 8bit interface, clear
 				// it if 16bit.
@@ -1074,7 +1092,13 @@ of_drop_packets:
 	mov	_ne2k_next_pk,%ah	// The 'real' BOUNDARY ptr
 	and	$0x7,%bx		// limit the drop count and check for ZERO
 	jnz	of_drop_loop1
-	call	ne2k_rx_init		// purge everything
+
+	//call	ne2k_rx_init		// purge everything
+	// EXPERIMENTAL - reset the NIC completely
+	// Need more testing to see if this is useful
+	call	ne2k_reset		// THE HARD WAY
+	call	ne2k_init
+	call	ne2k_start		// enable transmitter
 	jmp	of_drop_ok		// ... and exit
 
 of_drop_loop1:
@@ -1138,9 +1162,8 @@ of_drop_2:
 #endif
 
 of_drop_ok:
-	// check if the ring buffer is empty
-	// may seem moot, but the 8bit interface cannot hold more than 1 full size packet
-	// in the buffer, removing the only packet will leave the buffer effectively empty
+	// insurance: check if the ring buffer is empty.
+	// we may have removed all packets in the buffer (if 4k buffer)
 	call	ne2k_getpage
 	push	%ax			// save for return
 	cmp	_ne2k_next_pk,%ah

--- a/elks/include/linuxmt/netstat.h
+++ b/elks/include/linuxmt/netstat.h
@@ -45,13 +45,13 @@ struct netif_stat {
 /* Config flags for WD */
 /* The first 3 make a number - for coding simplicity (a power of two),
  * the rest are regular flag bits */
-#define ETHF_8K_BUF	0x01	/* Force 8K NIC (default on SMC/WD memory mapped NICs) */
+#define ETHF_8K_BUF	0x01	/* Force  8K NIC (default on SMC/WD memory mapped NICs) */
 #define ETHF_16K_BUF	0x02	/* Force 16k NIC buffer */
 #define ETHF_32K_BUF	0x03	/* Force 32k NIC buffer */
-#define ETHF_4K_BUF	0x04	/* Force 32k NIC buffer */
-#define ETHF_8BIT_BUS	0x10	/* Force 8 bit */
-#define ETHF_16BIT_BUS 	0x20	/* Force 16 bit */
-#define ETHF_USE_AUI	0x40	/* Use AUI interface */
+#define ETHF_4K_BUF	0x04	/* Force  4k NIC buffer */
+#define ETHF_8BIT_BUS	0x10	/* Force  8 bit bus */
+#define ETHF_16BIT_BUS 	0x20	/* Force 16 bit bus */
+#define ETHF_USE_AUI	0x40	/* Use AUI connection */
 #define ETHF_VERBOSE	0x80U	/* turn on verbose console error messages */
 
 #endif


### PR DESCRIPTION
**Important Ne1k update**
The short version: The assumption that the NE1K is limited to use only 4k of buffer space to run reliably, is wrong and based on a typo. This update changes the ne1k default buffer setting to 8k and makes that the default when 8bit bus is activated - automatically or manually. The change has been extensively tested and eliminates the peculiarities of the forced 16k buffer setting and the very limiting 4k buffer setting. This is a great (and overdue) simplification and performance improvement for the ne1k.

The narrative below is the mostly boring story about how my mistake was discovered. Unless you have too much time on your hands, skip to the summary of changes at the end.


**Background** 
When the ne2k driver was expanded to cover the 8bit ne1k, a lot of time was spent chasing an elusive NIC buffer problem. Eventually a quote from the book Networking and Internetworking with Microcontrollers (Fred Eady, 2004) popped up in a Google search and shed some light on the problem. The Realtek RTL8019AS controller chip (functionally equivalent to the DP8390C) does not support 16k buffer space when running in 8 bit mode. The book says:
_"In 8-bit mode, … the RTL8019AS use a 4 Kb on-chip RAM area despite the RTL8019AS' 16 Kb specification."_ 

Unsurprisingly, when reducing the buffer used to 4k, the ne1k worked fine - with one serious caveat: With no OS/driver level packet buffering in ELKS and a very small on-NIC buffer, the packet loss when under load became unbearable. A reduced MTU alleviated the problem while also reducing the overall throughput of file transfers. Mtu=1000 turned out to be a reasonable compromise.

Given the penalties of the 4k buffer, experimentation with the full 16k continued. It eventually turned out that recovery from the weird buffer errors was possible in most cases, generating many errors (and thus retransmits) but still delivering higher throughput than the 4k setting. After heavy testing, 16k buffer was made the default for the ne1k - with 4k as an option, with mtu=1000 recommended in the latter case.

All testing was done on Compaq portables - 286/12.5 MHz & 386/20MHz, using 2 different ne2k interfaces (for reference) and a recent ne1k from Weird Electronics (yes, interesting name). Also - and as it turns out later not so smart - most of the heavy testing was done with large packet short interval pings.

**New environment, new results**
Fast forward to December 2022: While running all kinds of tests on 'driver/interface mixing' and manpage preparations (#1467) recently, I discovered erratic behaviour from the ne1k while running file transfers (FTP) on a faster system than the Compaqs, the 40MHz AMI 386SX. Interestingly, the errors came when fetching files FROM the ELKS system: No buffer overruns, just a lot of small ack packets. Typically I got 6-7 bad packets (some 10% of the total), then a hard hang requiring power cycling the machine.

Completely repeatable, certainly not acceptable - and hard to diagnose, not the least because the symptoms (errors) were timing sensitive. A printk in the driver's interrupt service routine eliminated the problem (of course with severe consequences for speed). IOW lowering the packet rate made the entire NIC buffer useable. What all errors had in common though, was that they happened in the same part of the buffer - somewhere between the 8k and 10k marks. Interesting but why does it go away when we slow down the rate via printk?

Hitting the wall on testing, which included running similar tests on a ne2k in forced 8bit mode on a Compaq and getting the exact same results, I decided to go back to the source of the 4k limitation, the book mentioned above, which in the meanwhile had made it to my bookshelf from some used-books store online.

Having the full text and taking the time to read the whole chapter (aptly named "Let's Do It Again") revealed the 'secret'  I had missed thus far. The 4k limit is a TYPO. Seriously. 

The quote above is from page 294 in the book. Six pages later, in a figure caption, it says "_.. note that only 8K buffer RAM is available in the RTL8019AS._" What? With considerable scepticism I read it again. It had to be typo. After all, what it says is objectively incorrect. The RTL8019AS has 16k SRAM, not 8K. Discarded. 

Fast forward to page 318 which is where the  bomb exploded: "_The RTL8019AS' datasheet tells us point blank to not exceed 0x60 as a PSTOP register value in 8-bit mode._" PSTOP being the upper endpoint of the buffer. 0x60 is the exact middle of the 16k buffer space which is divided into 256B pages, starting at 0x40, ending at 0x80. Meaning 'do not use the upper half of the buffer'. Really? 8K? So the caption was no typo after all? How did I miss that? 
I went back to the RTL8019AS datasheet (http://www.ethernut.de/pdf/8019asds.pdf), searched for 'PSTOP' and sure enough: Top of page 15 defines PSTOP and says
"_The Page Stop register sets the stop page address of the receive buffer ring. In 8 bit mode the PSTOP register should not exceed to 0x60, in 16 bit mode the PSTOP register should not exceed to 0x80._" [sic]
Loud and clear. Well, clear enough. The language isn't all that good (as in 'exceed to' and more), but I'm being picky trying to share the blame with someone. The truth is I didn't use the Realtek documentation much at all. I used the NS DP8390C datasheet (https://usermanual.wiki/m/abdcdadc75f1281ab4d06ff4c58665a3afeef164405e3755943029d89c6445be.pdf) which doesn't mention this limitation even though its presence in the 8390 has been verified. 

Back to the driver, a minor adjustment to the buffer parameters and more testing: Voila! 'Normal' behaviour (no odd errors requiring special recovery) and decent performance. In addition to fixing the mentioned problems, the 8K buffer gives the ne1k performance on par with (or slightly better than) the wd8003 - as should be expected.

The special recovery code is still in the driver, pending more testing and enabling debug runs with 4/8/16k buffers. 

Summary of changes
- When a ne1k NIC is detected, the NIC buffer is set to 8K (instead of 16k)
- When 8 bit mode is forced via a flag setting, the buffer is also set to 8K
- Buffer size overrides via flag settings still work as before (it's actually possible to force buffer size to 32k, if someone is playing with the flags, it's assumed they know what they're doing (manpage will be updated to that effect)).
- A lower MTU is no longer required for the 'native' NE1K buffer setting.

File transfer speed (FTP) for the ne1k on the 40MHz 386SX is 96KB/s incoming (to /dev/null), 50KB/s outgoing (512b max packet size).
