### PR TITLE
Replacing "apt" with "apt-get"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: setup
-        run: 'sudo apt install bison flex texinfo libncurses5-dev libelf-dev mtools ncompress'
+        run: 'sudo apt-get install bison flex texinfo libncurses5-dev libelf-dev mtools ncompress'
 
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This is to remove the warning "WARNING: apt does not have a stable CLI interface." in ELKS workflows.