### PR TITLE
[libc] Initialize environ &/or _program_filename only if needed

### DIFF
--- a/elks/elks-medium.ld
+++ b/elks/elks-medium.ld
@@ -4,6 +4,7 @@ SECTIONS {
 	.text 0x10000 : {
 		/* IA-16 segment start markers. */
 		KEEP (*(".inithead!"))
+		KEEP (*(SORT (".preinit!*") SORT (".preinit.*!")))
 		KEEP (*(SORT (".init!*") SORT (".init.*!")))
 		KEEP (*(".inittail!"))
 		*(".text!*" ".text.*!"
@@ -15,6 +16,7 @@ SECTIONS {
 
 		/* Actual segment contents. */
 		KEEP (*(.inithead .inithead$))
+		KEEP (*(.preinit SORT (.preinit$*) SORT (".preinit.*[^&]")))
 		KEEP (*(.init SORT (.init$*) SORT (".init.*[^&]")))
 		KEEP (*(.inittail .inittail$))
 		*(.text .text$* ".text.*[^&]"
@@ -32,6 +34,7 @@ SECTIONS {
 
 		/* IA-16 segment end markers. */
 		KEEP (*(".inithead&"))
+		KEEP (*(SORT (".preinit&*") SORT (".preinit.*&")))
 		KEEP (*(SORT (".init&*") SORT (".init.*&")))
 		KEEP (*(".inittail&"))
 		*(".text&*" ".text.*&"
@@ -48,7 +51,7 @@ SECTIONS {
 		*(".fartext!*" ".fartext.*!")
 
 		/* Actual segment contents. */
-		*(.fartext .fartext$ ".fartext.*[^&]")
+		*(.fartext .fartext$* ".fartext.*[^&]")
 
 		/* IA-16 segment end markers. */
 		*(".fartext&*" ".fartext.*&")

--- a/elks/elks-small.ld
+++ b/elks/elks-small.ld
@@ -4,6 +4,7 @@ SECTIONS {
 	.text 0x10000 : {
 		/* IA-16 segment start markers. */
 		KEEP (*(".inithead!"))
+		KEEP (*(SORT (".preinit!*") SORT (".preinit.*!")))
 		KEEP (*(SORT (".init!*") SORT (".init.*!")))
 		KEEP (*(".inittail!"))
 		*(".text!*" ".text.*!")
@@ -13,6 +14,7 @@ SECTIONS {
 
 		/* Actual segment contents. */
 		KEEP (*(.inithead .inithead$))
+		KEEP (*(.preinit SORT (.preinit$*) SORT (".preinit.*[^&]")))
 		KEEP (*(.init SORT (.init$*) SORT (".init.*[^&]")))
 		KEEP (*(.inittail .inittail$))
 		*(.text .text$* ".text.*[^&]")
@@ -22,6 +24,7 @@ SECTIONS {
 
 		/* IA-16 segment end markers. */
 		KEEP (*(".inithead&"))
+		KEEP (*(SORT (".preinit&*") SORT (".preinit.*&")))
 		KEEP (*(SORT (".init&*") SORT (".init.*&")))
 		KEEP (*(".inittail&"))
 		*(".text&*" ".text.*&")

--- a/libc/crt0.S
+++ b/libc/crt0.S
@@ -36,14 +36,14 @@ _start:
 	inc %ax
 	shl $1,%ax
 	add %bx,%ax	// envp [0]
-	mov %ax,environ
 	push %ax
 	push %bx
-	mov (%bx),%bx
-	mov %bx,_program_filename
 	push %cx
 
-// ...Code fragments from .init & .init.* sections will go here...
+// ...Code fragments from .preinit & .preinit.* sections will go here...
+//    NOTE: these assume ax = envp, bx = argv, & may clobber dx
+
+// ...Then code fragments from .init & .init.* sections will go here...
 //    NOTE: these are allowed to clobber ax, bx, cx, dx, si
 
 	.section .inittail,"ax",@progbits

--- a/libc/system/environ.S
+++ b/libc/system/environ.S
@@ -1,0 +1,13 @@
+// Define and initialize the environ variable, if needed
+// Assume ax = envp from entry point, from libc/crt0.S
+
+	.arch i8086, nojumps
+	.code16
+
+	.section .preinit,"ax",@progbits
+
+	mov %ax,environ
+
+//------------------------------------------------------------------------------
+
+	.comm environ,2

--- a/libc/system/environ.c
+++ b/libc/system/environ.c
@@ -1,2 +1,0 @@
-char ** environ;
-char * _program_filename;

--- a/libc/system/out.mk
+++ b/libc/system/out.mk
@@ -35,6 +35,7 @@ OBJS = \
 	lseek.o \
 	mkfifo.o \
 	opendir.o \
+	program_filename.o \
 	readdir.o \
 	rewinddir.o \
 	seekdir.o \

--- a/libc/system/program_filename.S
+++ b/libc/system/program_filename.S
@@ -1,0 +1,14 @@
+// Define and initialize the _program_filename variable, if needed
+// Assume bx = argv from entry point, from libc/crt0.S
+
+	.arch i8086, nojumps
+	.code16
+
+	.section .preinit,"ax",@progbits
+
+	mov (%bx),%dx
+	mov %dx,_program_filename
+
+//------------------------------------------------------------------------------
+
+	.comm _program_filename,2


### PR DESCRIPTION
This patch allows the C program startup code to skip the initialization (& definition) of the variables `environ` & `_program_filename`, if the program will not actually use these.