### PR TITLE
[build] Fix kernel build when CONFIG_CHAR_DEV_RS not set

### DIFF
--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -291,7 +291,7 @@ static int INITPROC parse_dev(char * line)
 
 static void comirq(char *line)
 {
-#ifdef CONFIG_ARCH_IBMPC
+#if defined(CONFIG_ARCH_IBMPC) && defined(CONFIG_CHAR_DEV_RS)
 	int i;
 	char *l, *m, c;
 


### PR DESCRIPTION
Fixes the build issue in https://github.com/jbruchon/elks/issues/1327#issuecomment-1364385635.