### PR TITLE
[libc] Fix regparmcall system calls with no arguments

### DIFF
--- a/elks/arch/i86/kernel/syscall.dat
+++ b/elks/arch/i86/kernel/syscall.dat
@@ -45,7 +45,7 @@ setuid		+23	1
 getuid		+24	1	* this gets both uid and euid
 stime		25	2	- this must not exist - even as a libc.
 ptrace		26	4	@ adb/sdb/dbx need this.
-alarm		+27	2
+alarm		+27	1
 fstat		+28	2	 
 pause		29	0	 
 utime		+30	2	 

--- a/elkscmd/Make.defs
+++ b/elkscmd/Make.defs
@@ -75,7 +75,7 @@ ELKS_VSN=$(shell printf '%s.%s.%s-pre%s' $(E_V) | sed 's/-pre$$//')
 ifeq ($(PLATFORM),i86-ELKS)
 	CC=ia16-elf-gcc
 	CFLBASE=-fno-inline -melks-libc -mcmodel=small -mno-segment-relocation-stuff -mtune=i8086 -Wall -Os
-	#CFLBASE += -mregparmcall -march=any_186
+	#CFLBASE += -mregparmcall
 	LD=ia16-elf-gcc
 	LDFLAGS=$(CFLBASE)
 	CHECK=gcc -c -o .null.o -Wall -pedantic

--- a/elkscmd/Make.defs
+++ b/elkscmd/Make.defs
@@ -75,6 +75,7 @@ ELKS_VSN=$(shell printf '%s.%s.%s-pre%s' $(E_V) | sed 's/-pre$$//')
 ifeq ($(PLATFORM),i86-ELKS)
 	CC=ia16-elf-gcc
 	CFLBASE=-fno-inline -melks-libc -mcmodel=small -mno-segment-relocation-stuff -mtune=i8086 -Wall -Os
+	#CFLBASE += -mregparmcall -march=any_186
 	LD=ia16-elf-gcc
 	LDFLAGS=$(CFLBASE)
 	CHECK=gcc -c -o .null.o -Wall -pedantic

--- a/elkscmd/bc/Makefile
+++ b/elkscmd/bc/Makefile
@@ -31,7 +31,7 @@ LEX = flex -I -8
 LOCALFLAGS=-D_POSIX_SOURCE
 
 # Try compiling this program using the `stdcall' calling convention...
-CFLBASE += -mrtd
+#CFLBASE += -mrtd
 
 # For ELKS, bc needs more data segment space than the kernel-given default.
 LDFLAGS += -maout-heap=0xb000

--- a/libc/string/strcpy-c.c
+++ b/libc/string/strcpy-c.c
@@ -10,7 +10,10 @@ char * strcpy (char * dest, const char * src)
 {
    /* This is probably the quickest on an 8086 but a CPU with a cache will
     * prefer to do this in one pass */
-   return memcpy(d, s, strlen(s)+1);
+   /*return memcpy(dest, src, strlen(src)+1);*/
+   char *ret = dest;
+   while (*dest++ = *src++) ;
+   return ret;
 }
 
 #endif

--- a/libc/system/syscall0.S
+++ b/libc/system/syscall0.S
@@ -16,6 +16,7 @@
 	.global _syscall_4
 	.global _syscall_5
 
+#ifndef __IA16_CALLCVT_REGPARMCALL
 _syscall_0:
 	int    $0x80
 
@@ -28,6 +29,7 @@ _syscall_test:
 
 _syscall_ok:
 	RET_(0)
+#endif
 
 #if defined __IA16_CALLCVT_CDECL
 _syscall_1:
@@ -154,8 +156,21 @@ _syscall_2:
 _syscall_3:
 	xchg %cx,%dx
 _syscall_1:
+_syscall_0:
 	xchg %ax,%bx
-	jmp _syscall_0
+
+_syscall:
+	int    $0x80
+
+_syscall_test:
+	test   %ax,%ax
+	jns    _syscall_ok
+	neg    %ax
+	mov    %ax,errno
+	mov    $-1,%ax
+
+_syscall_ok:
+	RET_(0)
 
 _syscall_4:
 	push %di
@@ -163,7 +178,7 @@ _syscall_4:
 	mov 4+FAR_ADJ_(%di),%di
 	xchg %cx,%dx
 	xchg %ax,%bx
-	CALL_N_(_syscall_0)
+	CALL_N_(_syscall)
 	pop %di
 	RET_(2)
 
@@ -175,7 +190,7 @@ _syscall_5:
 	mov 4+FAR_ADJ_(%di),%di
 	xchg %cx,%dx
 	xchg %ax,%bx
-	CALL_N_(_syscall_0)
+	CALL_N_(_syscall)
 	pop %si
 	pop %di
 	RET_(4)


### PR DESCRIPTION
Fixes regparmcall calling convention bug for system calls with no arguments; initially discussed in https://github.com/jbruchon/elks/pull/1459#issuecomment-1364752365.

The problem was that AX/BX needed to be swapped in the no argument case, as well as the one argument case.

Fixes minor argument count error in `alarm` system call definition.
Adds more debug info to /bin/init, which was used to track down this bug.
Adds commented out CFLBASE definition in elkscmd/Make.defs to turn on regparmcall passing for ELKS applications. Many programs work with the notable exception still of /bin/sh (ash).

Note: programs compiled with regparmcall are **much** smaller than using cdecl! More information and testing coming.
