### PR TITLE
[libc] Fix regparmcall system calls with 4 and 5 parameters

### DIFF
--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -37,7 +37,8 @@ static void reparent_children(void)
 	}
 }
 
-int sys_wait4(pid_t pid, int *status, int options)
+/* note: 'usage' parameter ignored */
+int sys_wait4(pid_t pid, int *status, int options, void *usage)
 {
 	register struct task_struct *p;
 	int waitagain;

--- a/libc/system/syscall0.S
+++ b/libc/system/syscall0.S
@@ -180,7 +180,7 @@ _syscall_4:
 	xchg %ax,%bx
 	CALL_N_(_syscall)
 	pop %di
-	RET_(2)
+	RET_(8)
 
 _syscall_5:
 	push %di
@@ -193,7 +193,7 @@ _syscall_5:
 	CALL_N_(_syscall)
 	pop %si
 	pop %di
-	RET_(4)
+	RET_(10)
 #else
 # error "unknown calling convention"
 #endif

--- a/libc/system/wait.c
+++ b/libc/system/wait.c
@@ -1,9 +1,8 @@
 #include <sys/types.h>
 #include <sys/wait.h>
-#include <errno.h>
 
 pid_t
 wait(int * status)
 {
-	return wait4(-1, status, 0, (void*)0);
+	return wait4(-1, status, 0, NULL);
 }

--- a/libc/system/wait3.c
+++ b/libc/system/wait3.c
@@ -1,9 +1,10 @@
-#ifdef L_wait3
+#include <sys/types.h>
 #include <sys/wait.h>
 
-int
+#ifdef L_wait3
+pid_t
 wait3(int * status, int opts, struct rusage * usage)
 {
-   return wait4(-1, status, opts, usage);
+   return wait4(-1, status, opts, usage); /* FIXME kernel ignores 'usage' */
 }
 #endif


### PR DESCRIPTION
This took a while, but finally figured out that all system calls with 4 or 5 parameters were broken when `-mregparmcall` used. There are only a few system calls with 4 or 5 parameters, but both shells used `wait4`, which incorrectly popped the wrong argument count, thus corrupting the stack.

At this time, quick QEMU testing shows many more commands and both shells seemingly working. @Mellvik, now might be a good time to try more testing, by uncommenting the CFLBASE line in elkscmd/Make.defs.