### PR TITLE
[build] Fix build when switching from cdecl to -mregparmcall

### DIFF
--- a/elkscmd/Makefile
+++ b/elkscmd/Makefile
@@ -17,6 +17,7 @@ include $(BASEDIR)/Make.defs
 # TODO: broken command compilations
 # byacc screen m4 xvi nano
 SUBDIRS =       \
+	lib         \
 	ash         \
 	basic       \
 	bc          \

--- a/elkscmd/lib/Makefile
+++ b/elkscmd/lib/Makefile
@@ -1,0 +1,20 @@
+BASEDIR=..
+
+include $(BASEDIR)/Make.defs
+
+###############################################################################
+#
+# Include standard packaging commands.
+
+include $(BASEDIR)/Make.rules
+
+###############################################################################
+
+OBJS = \
+	tiny_vfprintf.o \
+	# END
+
+all: $(OBJS)
+
+clean:
+	rm -f *.o


### PR DESCRIPTION
Fixes a problem with all programs that used $(TINYPRINTF), which included `ps`, `df`, etc when built first with cdecl, then `cd elkscmd; edit CFLBASE += -mregparmcall; make clean; cd ..; make`. This is because lib/tiny_vfprintf.o was not rebuilt, and corrupted the stack.

Still seeing some strange build problems when setting `-mregparmcall` and not rebuilding entire system from scratch, which manifests itself on programs built with very small stacks: `-maout-stack=2048`. Not sure reason.

Known programs not working: `nxworld` and all Microwindows programs, as ASM files not compatible with calling sequence.

I haven't yet learned a way to set a local Makefile to cdecl while the rest of the build is regparmcall, which would allow unconverted applications with ASM files to be built using an otherwise standard regparmcall convention.

Most programs now seem working with regparmcall - and with it, the 2880k floppy/HD build is now 96 blocks (that's 96k bytes) smaller. Amazing savings!
