### PR TITLE
[cmds] Another pass at reducing build compilation warnings

### DIFF
--- a/elkscmd/Makefile
+++ b/elkscmd/Makefile
@@ -14,8 +14,8 @@ include $(BASEDIR)/Make.defs
 
 # All subdirectories to build & clean
 
-# TODO: broken command compilations
-# byacc screen m4 xvi nano
+# TODO: broken command compilations: byacc m4 xvi
+# unused commands but working compilations: mtools nano prems
 SUBDIRS =       \
 	lib         \
 	ash         \
@@ -32,9 +32,7 @@ SUBDIRS =       \
 	minix2      \
 	minix3      \
 	misc_utils  \
-	mtools      \
 	nano-X      \
-	prems       \
 	sash        \
 	screen      \
 	cron        \

--- a/elkscmd/ash/cd.c
+++ b/elkscmd/ash/cd.c
@@ -60,7 +60,7 @@ static char sccsid[] = "@(#)cd.c	5.2 (Berkeley) 3/13/91";
 #ifdef __STDC__
 STATIC int docd(char *, int, int);
 STATIC void updatepwd(char *);
-STATIC void getpwd(void);
+/*STATIC void getpwd(void);*/
 STATIC char *getcomponent(void);
 #else
 STATIC int docd();

--- a/elkscmd/ash/eval.c
+++ b/elkscmd/ash/eval.c
@@ -666,11 +666,11 @@ evalcommand(cmd, flags, backcmd)
 
 	/* Fork off a child process if necessary. */
 	if (cmd->ncmd.backgnd
-	 || cmdentry.cmdtype == CMDNORMAL && (flags & EV_EXIT) == 0
-	 || (flags & EV_BACKCMD) != 0
+	 || (cmdentry.cmdtype == CMDNORMAL && (flags & EV_EXIT) == 0)
+	 || ((flags & EV_BACKCMD) != 0
 	    && (cmdentry.cmdtype != CMDBUILTIN
 		 || cmdentry.u.index == DOTCMD
-		 || cmdentry.u.index == EVALCMD)) {
+		 || cmdentry.u.index == EVALCMD))) {
 		jp = makejob(cmd, 1);
 		mode = cmd->ncmd.backgnd;
 		if (flags & EV_BACKCMD) {

--- a/elkscmd/ash/exec.c
+++ b/elkscmd/ash/exec.c
@@ -339,7 +339,7 @@ hashcmd(argc, argv)  char **argv; {
 	while ((name = *argptr) != NULL) {
 		if ((cmdp = cmdlookup(name, 0)) != NULL
 		 && (cmdp->cmdtype == CMDNORMAL
-		     || cmdp->cmdtype == CMDBUILTIN && builtinloc >= 0))
+		     || (cmdp->cmdtype == CMDBUILTIN && builtinloc >= 0)))
 			delete_cmd_entry();
 		find_command(name, &entry, 1);
 		if (verbose) {
@@ -567,7 +567,7 @@ hashcd() {
 	for (pp = cmdtable ; pp < &cmdtable[CMDTABLESIZE] ; pp++) {
 		for (cmdp = *pp ; cmdp ; cmdp = cmdp->next) {
 			if (cmdp->cmdtype == CMDNORMAL
-			 || cmdp->cmdtype == CMDBUILTIN && builtinloc >= 0)
+			 || (cmdp->cmdtype == CMDBUILTIN && builtinloc >= 0))
 				cmdp->rehash = 1;
 		}
 	}
@@ -599,8 +599,8 @@ changepath(newval)
 	for (;;) {
 		if (*old != *new) {
 			firstchange = index;
-			if (*old == '\0' && *new == ':'
-			 || *old == ':' && *new == '\0')
+			if ((*old == '\0' && *new == ':')
+			 || (*old == ':' && *new == '\0'))
 				firstchange++;
 			old = new;	/* ignore subsequent differences */
 		}
@@ -637,8 +637,8 @@ clearcmdentry(firstchange) {
 	for (tblp = cmdtable ; tblp < &cmdtable[CMDTABLESIZE] ; tblp++) {
 		pp = tblp;
 		while ((cmdp = *pp) != NULL) {
-			if (cmdp->cmdtype == CMDNORMAL && cmdp->param.index >= firstchange
-			 || cmdp->cmdtype == CMDBUILTIN && builtinloc >= firstchange) {
+			if ((cmdp->cmdtype == CMDNORMAL && cmdp->param.index >= firstchange)
+			 || (cmdp->cmdtype == CMDBUILTIN && builtinloc >= firstchange)) {
 				*pp = cmdp->next;
 				ckfree(cmdp);
 			} else {

--- a/elkscmd/ash/expand.c
+++ b/elkscmd/ash/expand.c
@@ -348,7 +348,7 @@ again: /* jump here after setting a variable with ${var=text} */
 		val = NULL;
 	} else {
 		val = lookupvar(var);
-		if (val == NULL || (flags & VSNUL) && val[0] == '\0') {
+		if (val == NULL || ((flags & VSNUL) && val[0] == '\0')) {
 			val = NULL;
 			set = 0;
 		} else
@@ -890,7 +890,7 @@ expmeta(enddir, name)
 		*endname++ = '\0';
 	}
 	matchdot = 0;
-	if (start[0] == '.' || start[0] == CTLESC && start[1] == '.')
+	if (start[0] == '.' || (start[0] == CTLESC && start[1] == '.'))
 		matchdot++;
 	while (! int_pending() && (dp = readdir(dirp)) != NULL) {
 		if (dp->d_name[0] == '.' && ! matchdot)

--- a/elkscmd/ash/jobs.c
+++ b/elkscmd/ash/jobs.c
@@ -1030,7 +1030,7 @@ cmdputs(s)
 			subtype = 0;
 		} else if (c == CTLENDVAR) {
 			*q++ = '}';
-		} else if (c == CTLBACKQ | c == CTLBACKQ+CTLQUOTE)
+		} else if (c == CTLBACKQ || c == CTLBACKQ+CTLQUOTE)
 			cmdnleft++;		/* ignore it */
 		else
 			*q++ = c;

--- a/elkscmd/ash/machdep.h
+++ b/elkscmd/ash/machdep.h
@@ -47,5 +47,5 @@ union align {
 	char *cp;
 };
 
-#define ALIGN(nbytes)	((nbytes) + sizeof(union align) - 1 &~ (sizeof(union align) - 1))
+#define ALIGN(nbytes)	(((nbytes) + sizeof(union align) - 1) &~ (sizeof(union align) - 1))
 #endif

--- a/elkscmd/ash/options.c
+++ b/elkscmd/ash/options.c
@@ -134,7 +134,7 @@ options(cmdline) {
 		argptr++;
 		if ((c = *p++) == '-') {
 			val = 1;
-                        if (p[0] == '\0' || p[0] == '-' && p[1] == '\0') {
+                        if (p[0] == '\0' || (p[0] == '-' && p[1] == '\0')) {
                                 if (!cmdline) {
                                         /* "-" means turn off -x and -v */
                                         if (p[0] == '\0')

--- a/elkscmd/ash/var.c
+++ b/elkscmd/ash/var.c
@@ -314,7 +314,7 @@ bltinlookup(name, doall)
 	for (v = *hashvar(name) ; v ; v = v->next) {
 		if (varequal(v->text, name)) {
 			if (v->flags & VUNSET
-			 || ! doall && (v->flags & VEXPORT) == 0)
+			 || (! doall && (v->flags & VEXPORT) == 0))
 				return NULL;
 			return strchr(v->text, '=') + 1;
 		}

--- a/elkscmd/minix1/cut.c
+++ b/elkscmd/minix1/cut.c
@@ -148,7 +148,7 @@ void get_args()
 
 void cut()
 {
-  int i, j, length, maxcol;
+  int i, j, length, maxcol = 0;
   char *columns[MAX_FIELD];
 
   while (fgets(line, BUFSIZ, fd)) {

--- a/elkscmd/minix1/uniq.c
+++ b/elkscmd/minix1/uniq.c
@@ -125,7 +125,7 @@ static int ourgetline(char *buf, int count)
 int main(int argc, char **argv)
 {
   char *p;
-  int inf = -1, outf;
+  int inf = -1;
 
   setbuf(stdout, buffer);
   for (--argc, ++argv; argc > 0 && (**argv == '-' || **argv == '+');
@@ -161,9 +161,7 @@ int main(int argc, char **argv)
 	xfopen(*argv++, "r");
 	argc--;
   }
-  if (argc == 0)
-	outf = 1;
-  else {
+  if (argc > 0) {
 	fclose(stdout);
 	xfopen(*argv++, "w");
 	argc--;

--- a/elkscmd/minix2/Makefile
+++ b/elkscmd/minix2/Makefile
@@ -13,7 +13,8 @@ include $(BASEDIR)/Make.rules
 ###############################################################################
 
 # TODO: lpd man mt install	# Do not compile.
-PRGS=env lp pwdauth remsync synctree tget
+# compiling but unused: pwdauth
+PRGS=env lp remsync synctree tget
 
 env: env.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -o env env.o $(TINYPRINTF) $(LDLIBS)

--- a/elkscmd/minix2/tget.c
+++ b/elkscmd/minix2/tget.c
@@ -7,9 +7,9 @@
 #include <string.h>
 #include <termcap.h>
 
-void fputchar(int c)
+int fputchar(int c)
 {
-	putchar(c);
+	return putchar(c);
 }
 
 void usage(void)
@@ -20,7 +20,7 @@ void usage(void)
 	exit(-1);
 }
 
-void main(int argc, char **argv)
+int main(int argc, char **argv)
 {
 	char termbuf[1024];
 	char string[256], *pstr;

--- a/elkscmd/minix3/find.c
+++ b/elkscmd/minix3/find.c
@@ -175,7 +175,7 @@ struct oper {
 char **ipp;			/* pointer to next argument during parsing       */
 char *prog;			/* program name (== argv [0])                    */
 char *epath;			/* value of PATH environment string              */
-long current_time;		/* for computing age                             */
+time_t current_time;		/* for computing age                             */
 int tty;			/* fd for /dev/tty when using -ok                */
 int xdev_flag = 0;		/* cross device boundaries?                      */
 int devnr;			/* device nr of first inode                      */
@@ -273,7 +273,7 @@ char *path, *last;
 struct node *pred;
 {
   char spath[PATH_MAX];
-  register char *send = spath, *p;
+  register char *send = spath;
   struct stat st;
   DIR *dp;
   struct dirent *de;
@@ -310,7 +310,6 @@ struct node *pred;
 		}
 		send[-1] = '/';
 		while ((de = readdir(dp)) != NULL) {
-			p = de->d_name;
 			if ((de->d_name[0] != '.') || ((de->d_name[1])
 					  && ((de->d_name[1] != '.')
 					      || (de->d_name[2])))) {

--- a/elkscmd/misc_utils/ed.c
+++ b/elkscmd/misc_utils/ed.c
@@ -982,7 +982,7 @@ printlines(num1, num2, expandflag)
 		 * Show control characters and characters with the
 		 * high bit set specially.
 		 */
-		cp = lp->data;
+		cp = (unsigned char *)lp->data;
 		count = lp->len;
 		if ((count > 0) && (cp[count - 1] == '\n'))
 			count--;

--- a/elkscmd/misc_utils/miniterm.c
+++ b/elkscmd/misc_utils/miniterm.c
@@ -368,10 +368,10 @@ int main(int argc, char **argv)
 	speed_t baudrate = 9600;
 	enum terminal_mode mode = MODE_TEXT;
 	bool escape = false, rtscts = false;
-	bool enable_rts = false, enable_dtr = false;
 	bool add_lf = false;
 	const char *device = "/dev/ttyS0";
 	bool no_reset = false;
+	/*bool enable_rts = false, enable_dtr = false;*/
 
 	while ((ch = getopt(argc, argv, "s:SrdRlxh")) != -1) {
 		switch (ch) {
@@ -381,12 +381,14 @@ int main(int argc, char **argv)
 			case 'r':
 				rtscts = true;
 				break;
+#if later
 			case 'd':
 				enable_dtr = true;
 				break;
 			case 'R':
 				enable_rts = true;
 				break;
+#endif
 			case 'l':
 				add_lf = true;
 				break;

--- a/elkscmd/nano-X/demos/landmine.c
+++ b/elkscmd/nano-X/demos/landmine.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
+#include <string.h>
 #if UNIX
 #include <fcntl.h>
 #include <unistd.h>
@@ -756,10 +757,10 @@ drawbutton(window, label)
 	GR_SIZE		height;
 	GR_SIZE		base;
 
-	GrGetGCTextSize(buttongc, label, strlen(label), &width, &height, &base);
+	GrGetGCTextSize(buttongc, (unsigned char *)label, strlen(label), &width, &height, &base);
 	GrText(window, buttongc, (BUTTONWIDTH - width) / 2,
 		(BUTTONHEIGHT - height) / 2 + height - 1,
-		label, strlen(label));
+		(unsigned char *)label, strlen(label));
 }
 
 
@@ -902,7 +903,7 @@ static void printline(GR_COORD row, char * fmt, ...)
 		}
 		if (width) {
 			GrText(statwid, statgc, charxpos, charypos,
-				cp - cc, cc);
+				(unsigned char *)cp - cc, cc);
 			charxpos += width;
 		}
 

--- a/elkscmd/nano-X/demos/nterm.c
+++ b/elkscmd/nano-X/demos/nterm.c
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <signal.h>
+#include <string.h>
 #include "nano-X.h"
 /*
  * Nano-X terminal emulator
@@ -189,7 +190,7 @@ GR_SIZE		base;		/* height of baseline */
 
 void text_init()
 {
-	GrGetGCTextSize(gc1, "A", 1, &width, &height, &base);
+	GrGetGCTextSize(gc1, (unsigned char *)"A", 1, &width, &height, &base);
 }
 
 void char_del(GR_COORD x, GR_COORD y)

--- a/elkscmd/nano-X/demos/world.c
+++ b/elkscmd/nano-X/demos/world.c
@@ -7,6 +7,8 @@
  */
 #include <stdio.h>
 #include <unistd.h>
+#include <stdlib.h>
+#include <fcntl.h>
 #include <string.h>
 #include "nano-X.h"
 
@@ -436,7 +438,7 @@ showcoords(show)
 		mintostr(coordstring + strlen(coordstring), curlat);
 	}
 
-	GrText(mapwid, xorgc, coordx, coordy, coordstring, strlen(coordstring));
+	GrText(mapwid, xorgc, coordx, coordy, (unsigned char *)coordstring, strlen(coordstring));
 	coordvisible = show;
 }
 
@@ -454,7 +456,7 @@ mintostr(buf, min)
 		min = -min;
 		*buf++ = '-';
 	}
-	sprintf(buf, "%d'%02d", min / 60, min % 60);
+	sprintf(buf, "%d'%02d", (int)min / 60, (int)min % 60);
 }
 
 
@@ -512,9 +514,9 @@ load(fn)
 	register DBPOINT	*pp;
 	DBPOINT		*pend;
 	FLOAT		x, y, LonPrv, LatPrv;
-	long		oldlong;
+	long		oldlong = 0;
 	GR_COORD	xnew, ynew;
-	GR_COORD	xold, yold;
+	GR_COORD	xold = 0, yold = 0;
 	GR_BOOL		is_out;
 	GR_BOOL		was_out;
 	GR_BOOL		newseg;

--- a/elkscmd/nano-X/drivers/vgaplan4.c
+++ b/elkscmd/nano-X/drivers/vgaplan4.c
@@ -58,11 +58,13 @@ ega_init(PSD psd)
 
 #if MSDOS | ELKS
 	/* fill in screendevice struct if not framebuffer driver*/
-	psd->addr = SCREENBASE;		/* long ptr -> short on 16bit sys*/
+	psd->addr = (char *)SCREENBASE;		/* long ptr -> short on 16bit sys*/
 	psd->linelen = BYTESPERLINE;
-#endif
+	psd->size = 65535;
+#else
 	/* framebuffer mmap size*/
 	psd->size = 0x10000;
+#endif
 
 	/* Set up some default values for the VGA Graphics Registers. */
 	set_enable_sr (0x0f);

--- a/elkscmd/nano-X/engine/devdraw.c
+++ b/elkscmd/nano-X/engine/devdraw.c
@@ -52,7 +52,7 @@ GdOpenScreen(void)
 	extern RGBENTRY	stdpal1[2];
 	extern RGBENTRY	stdpal2[4];
 	extern RGBENTRY	stdpal4[16];
-	extern RGBENTRY	stdpal8[256];
+	/*extern RGBENTRY	stdpal8[256];*/
 
 	if(scrdev.Open(&scrdev) < 0)
 		return -1;
@@ -588,7 +588,7 @@ GdFillRect(PSD psd, COORD x1, COORD y1, COORD width, COORD height)
 void
 GdGetTextSize(PSD psd, char *str, int cc, COORD *pwidth, COORD *pheight)
 {
-	psd->GetTextSize(psd, str, cc, pwidth, pheight, gr_font);
+	psd->GetTextSize(psd, (unsigned char *)str, cc, pwidth, pheight, gr_font);
 }
 
 /* Draw a text string at a specifed coordinates in the foreground color

--- a/elkscmd/nano-X/engine/devmouse.c
+++ b/elkscmd/nano-X/engine/devmouse.c
@@ -13,6 +13,7 @@
  * Bradley D. LaRonde added absolute coordinates and z (pen pressure) Oct-1999
  */
 #include "device.h"
+#include <string.h>
 
 static COORD	xpos;		/* current x position of mouse */
 static COORD	ypos;		/* current y position of mouse */

--- a/elkscmd/sash/cmd_dd.c
+++ b/elkscmd/sash/cmd_dd.c
@@ -25,13 +25,13 @@ typedef	struct {
 
 
 static PARAM	params[] = {
-	"if",		PAR_IF,
-	"of",		PAR_OF,
-	"bs",		PAR_BS,
-	"count",	PAR_COUNT,
-	"seek",		PAR_SEEK,
-	"skip",		PAR_SKIP,
-	NULL,		PAR_NONE
+	{ "if",		PAR_IF     },
+	{ "of",		PAR_OF     },
+	{ "bs",		PAR_BS     },
+	{ "count",	PAR_COUNT  },
+	{ "seek",	PAR_SEEK   },
+	{ "skip",	PAR_SKIP   },
+	{ NULL,		PAR_NONE   }
 };
 
 

--- a/elkscmd/sash/sash.c
+++ b/elkscmd/sash/sash.c
@@ -13,195 +13,155 @@
 #include <errno.h>
 
 typedef struct {
-	char	*name;
-	char	*usage;
-	void	(*func)();
-	int	minargs;
-	int	maxargs;
+    char    *name;
+    char    *usage;
+    void    (*func)();
+    int minargs;
+    int maxargs;
 } CMDTAB;
 
 
-static	CMDTAB	cmdtab[] = {
+static  CMDTAB  cmdtab[] = {
 #ifdef CMD_ALIAS
-	"alias",	"[name [command]]", 	do_alias,
-	1,		MAXARGS,
+    { "alias",  "[name [command]]",     do_alias, 1, MAXARGS },
 #endif
 
-	"cd",		"[dirname]",		do_cd,
-	1,		2,
+    { "cd",     "[dirname]",            do_cd,    1, 2 },
 
 #ifdef CMD_CHGRP
-	"chgrp",	"gid filename ...",	do_chgrp,
-	3,		MAXARGS,
+    { "chgrp",  "gid filename ...",     do_chgrp, 3, MAXARGS },
 #endif
 
 #ifdef CMD_CHMOD
-	"chmod",	"mode filename ...",	do_chmod,
-	3,		MAXARGS,
+    { "chmod",  "mode filename ...",    do_chmod, 3, MAXARGS },
 #endif
 
 #ifdef CMD_CHOWN
-	"chown",	"uid filename ...",	do_chown,
-	3,		MAXARGS,
+    { "chown",  "uid filename ...",     do_chown, 3, MAXARGS },
 #endif
 
 #ifdef CMD_CMP
-	"cmp",		"filename1 filename2",	do_cmp,
-	3,		3,
+    { "cmp",    "filename1 filename2", do_cmp,3, 3 },
 #endif
 
 #ifdef CMD_CP
-	"cp",		"srcname ... destname",	do_cp,
-	3,		MAXARGS,
+    { "cp",     "srcname ... destname", do_cp,    3, MAXARGS },
 #endif
 
 #ifdef CMD_DD
-	"dd",		"if=name of=name [bs=n] [count=n] [skip=n] [seek=n]", do_dd,
-	3,		MAXARGS,
+    { "dd",     "if=name of=name [bs=n] [count=n] [skip=n] [seek=n]", do_dd, 3, MAXARGS },
 #endif
 
 #ifdef CMD_ECHO
-	"echo",	"[args] ...",		do_echo,
-	1,		MAXARGS,
+    { "echo",   "[args] ...",           do_echo,  1, MAXARGS },
 #endif
 
 #ifdef CMD_ED
-	"ed",		"[filename]",		do_ed,
-	1,		2,
+    { "ed",     "[filename]",           do_ed,    1, 2 },
 #endif
 
-	"exec",		"filename [args]",	do_exec,
-	2,		MAXARGS,
-
-	"exit",		"",			do_exit,
-	1,		1,
+    { "exec",   "filename [args]",      do_exec,  2, MAXARGS },
+    { "exit",   "",                     do_exit,  1, 1 },
 
 #ifdef CMD_GREP
-	"grep",	"[-in] word filename ...",	do_grep,
-	3,		MAXARGS,
+    { "grep",   "[-in] word filename ...", do_grep, 3, MAXARGS },
 #endif
 
 #ifdef CMD_HELP
-	"help",		"",			do_help,
-	1,		MAXARGS,
+    { "help",       "",                 do_help,  1, MAXARGS },
 #endif
 
 #ifdef CMD_HISTORY
-	"history",	"", 			do_history,
-	1,		1,
+    { "history",    "",                 do_history, 1, 1 },
 #endif
 
 #ifdef CMD_KILL
-	"kill",	"[-sig] pid ...",	do_kill,
-	2,		MAXARGS,
+    { "kill",   "[-sig] pid ...",       do_kill,    2, MAXARGS },
 #endif
 
 #ifdef CMD_LN
-	"ln",		"[-s] srcname ... destname",	do_ln,
-	3,		MAXARGS,
+    { "ln",     "[-s] srcname ... destname", do_ln, 3, MAXARGS },
 #endif
 
 #ifdef CMD_LS
-	"ls",		"[-lid] filename ...",	do_ls,
-	1,		MAXARGS,
+    { "ls",     "[-lid] filename ...",  do_ls,    1, MAXARGS },
 #endif
 
 #ifdef CMD_MKDIR
-	"mkdir",	"dirname ...",		do_mkdir,
-	2,		MAXARGS,
+    { "mkdir",  "dirname ...",          do_mkdir, 2, MAXARGS },
 #endif
 
 #ifdef CMD_MKNOD
-	"mknod",	"filename type major minor",	do_mknod,
-	5,		5,
+    { "mknod",  "filename type major minor", do_mknod, 5, 5 },
 #endif
 
 #ifdef CMD_MORE
-	"more",	"filename ...",		do_more,
-	2,		MAXARGS,
+    { "more",   "filename ...",         do_more,   2, MAXARGS },
 #endif
 
 #ifdef CMD_MOUNT
-	"mount",	"[-t type] devname dirname",	do_mount,
-	3,		MAXARGS,
+    { "mount",  "[-t type] devname dirname", do_mount, 3, MAXARGS },
 #endif
 
 #ifdef CMD_MV
-	"mv",		"srcname ... destname",	do_mv,
-	3,		MAXARGS,
+    { "mv",     "srcname ... destname",  do_mv,    3, MAXARGS },
 #endif
 
 #ifdef CMD_PRINTENV
-	"printenv",	"[name]",		do_printenv,
-	1,		2,
+    { "printenv",   "[name]",           do_printenv, 1, 2 },
 #endif
 
 #ifdef CMD_PROMPT
-	"prompt",	"string",		do_prompt,
-	2,		MAXARGS,
+    { "prompt", "string",               do_prompt, 2, MAXARGS },
 #endif
 
 #ifdef CMD_PWD
-	"pwd",		"",			do_pwd,
-	1,		1,
+    { "pwd",        "",                 do_pwd,    1, 1 },
 #endif
 
-	"quit",		"",			do_exit,
-	1,		1,
+    { "quit",       "",                 do_exit,   1, 1 },
 
 #ifdef CMD_RM
-	"rm",		"filename ...",		do_rm,
-	2,		MAXARGS,
+    { "rm",     "filename ...",         do_rm,     2, MAXARGS },
 #endif
 
 #ifdef CMD_RMDIR
-	"rmdir",	"dirname ...",		do_rmdir,
-	2,		MAXARGS,
+    { "rmdir",  "dirname ...",          do_rmdir,  2, MAXARGS },
 #endif
 
 #ifdef CMD_SETENV
-	"setenv",	"name value",		do_setenv,
-	2,		3,
+    { "setenv", "name value",           do_setenv, 2, 3 },
 #endif
 
 #ifdef CMD_SOURCE
-	"source",	"filename",		do_source,
-	2,		2,
+    { "source", "filename",             do_source, 2, 2 },
 #endif
 
 #ifdef CMD_SYNC
-	"sync",	"",			do_sync,
-	1,		1,
+    { "sync",   "",                     do_sync,   1, 1 },
 #endif
 
 #ifdef CMD_TAR
-	"tar",		"[xtv]f devname filename ...",	do_tar,
-	2,		MAXARGS,
+    { "tar",    "[xtv]f devname filename ...",  do_tar, 2, MAXARGS },
 #endif
 
 #ifdef CMD_TOUCH
-	"touch",	"filename ...",		do_touch,
-	2,		MAXARGS,
+    { "touch",  "filename ...",         do_touch,  2, MAXARGS },
 #endif
 
 #ifdef CMD_UMASK
-	"umask",	"[mask]",		do_umask,
-	1,		2,
+    { "umask",  "[mask]",               do_umask,  1, 2 },
 #endif
 
 #ifdef CMD_MOUNT
-	"umount",	"filename",		do_umount,
-	2,		2,
+    { "umount", "filename",             do_umount, 2, 2 },
 #endif
 
 #ifdef CMD_ALIAS
-	"unalias",	"name",			do_unalias,
-	2,		2,
+    { "unalias",    "name",             do_unalias, 2, 2 },
 #endif
-	NULL,		0,			0,
-	0,		0
+    { NULL,     0,          0,          0,      0 }
 };
-
 
 #ifdef CMD_ALIAS
 typedef struct {

--- a/elkscmd/sys_utils/mouse.c
+++ b/elkscmd/sys_utils/mouse.c
@@ -66,8 +66,8 @@ static int		(*parse)();	/* parse routine */
 
 /* local routines*/
 static int  	read_mouse(int *dx, int *dy, int *dz, int *bptr);
-static int  	parsePC(int);		/* routine to interpret PC mouse */
-static int  	parseMS(int);		/* routine to interpret MS mouse */
+int  	        parsePC(int);		/* routine to interpret PC mouse */
+int  	        parseMS(int);		/* routine to interpret MS mouse */
 
 /*
  * Open up the mouse device.

--- a/elkscmd/test/signal/test_signal.c
+++ b/elkscmd/test/signal/test_signal.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
-static int _signo = 0;
+static int _signo;
 
 void sigint (int signo)
 {
@@ -13,12 +13,10 @@ extern sighandler_t _sigtable [15];
 
 int main (int argc, char ** argv)
 {
-	sighandler_t sigold;
-
 	puts ("before signal()");
 	printf ("SIGINT=%p\n", _sigtable [1]);
 
-	sigold = signal (SIGINT, sigint);
+	signal (SIGINT, sigint);
 	puts ("after signal()");
 	printf ("SIGINT=%p\n", _sigtable [1]);
 	printf ("sigint=%p\n", sigint);


### PR DESCRIPTION
Removes a bunch more warnings from the compilation of elkscmd/. No change to behavior; next pass requires more thought as to possible program bugs and harder-to-cleanup issues.

Removes pwdauth, prems and mtools from compilation, unused and lots of warnings.
