### PR TITLE
[libc] Separate syscall wrappers into categories to reduce executable size

### DIFF
--- a/libc/system/out.mk
+++ b/libc/system/out.mk
@@ -43,7 +43,10 @@ OBJS = \
 	setpgrp.o \
 	signal.o \
 	sleep.o \
-	syscall0.o \
+	syscall01.o \
+	syscall23.o \
+	syscall4.o \
+	syscall5.o \
 	signalcb.o \
 	telldir.o \
 	time.o \

--- a/libc/system/syscall0.inc
+++ b/libc/system/syscall0.inc
@@ -8,18 +8,13 @@
 
 	.text
 
-	.global _syscall_0
-	.global _syscall_1
-	.global _syscall_2
-	.global _syscall_2p
-	.global _syscall_3
-	.global _syscall_4
-	.global _syscall_5
-
 #ifndef __IA16_CALLCVT_REGPARMCALL
+#ifdef L_sys01
+	.global _syscall_0
 _syscall_0:
 	int    $0x80
 
+	.global _syscall_test
 _syscall_test:
 	test   %ax,%ax
 	jns    _syscall_ok
@@ -30,19 +25,27 @@ _syscall_test:
 _syscall_ok:
 	RET_(0)
 #endif
+#endif
 
 #if defined __IA16_CALLCVT_CDECL
+#ifdef L_sys01
+	.global _syscall_1
 _syscall_1:
 	mov    %sp,%bx
 	mov    2+FAR_ADJ_(%bx),%bx
 	jmp    _syscall_0
+#endif
 
+#ifdef L_sys23
+	.global _syscall_2
 _syscall_2:
 	mov    %sp,%bx
 	mov    4+FAR_ADJ_(%bx),%cx
 	mov    2+FAR_ADJ_(%bx),%bx
 	jmp    _syscall_0
 
+	.global _syscall_2p
+	.global _syscall_3
 _syscall_3:
 _syscall_2p:
 	mov    %sp,%bx
@@ -50,7 +53,11 @@ _syscall_2p:
 	mov    4+FAR_ADJ_(%bx),%cx
 	mov    2+FAR_ADJ_(%bx),%bx
 	jmp    _syscall_0
+#endif
 
+#ifdef L_sys4
+	.global _syscall_4
+	.global _syscall_test
 _syscall_4:
 	mov    %sp,%bx
 	push   %di
@@ -61,7 +68,11 @@ _syscall_4:
 	int    $0x80
 	pop    %di
 	jmp    _syscall_test
+#endif
 
+#ifdef L_sys5
+	.global _syscall_5
+	.global _syscall_test
 _syscall_5:
 	mov    %sp,%bx
 	push   %si
@@ -75,7 +86,12 @@ _syscall_5:
 	pop    %di
 	pop    %si
 	jmp    _syscall_test
+#endif
+
 #elif defined __IA16_CALLCVT_STDCALL
+
+#ifdef L_sys01
+	.global _syscall_1
 _syscall_1:
 # ifdef __IA16_CMODEL_IS_FAR_TEXT
 	pop %dx
@@ -89,7 +105,10 @@ _syscall_1:
 	push %dx
 # endif
 	jmp _syscall_0
+#endif
 
+#ifdef L_sys23
+	.global _syscall_2
 _syscall_2:
 # ifdef __IA16_CMODEL_IS_FAR_TEXT
 	mov %sp,%bx
@@ -106,6 +125,7 @@ _syscall_2:
 	jmp _syscall_0
 # endif
 
+	.global _syscall_2p
 _syscall_2p:
 	/* variadic function, callee must not pop any arguments */
 	mov %sp,%bx
@@ -114,6 +134,7 @@ _syscall_2p:
 	mov 2+FAR_ADJ_(%bx),%bx
 	jmp _syscall_0
 
+	.global _syscall_3
 _syscall_3:
 	mov %sp,%bx
 	mov 6+FAR_ADJ_(%bx),%dx
@@ -121,7 +142,10 @@ _syscall_3:
 	mov 2+FAR_ADJ_(%bx),%bx
 	CALL_N_(_syscall_0)
 	RET_(6)
+#endif
 
+#ifdef L_sys4
+	.global _syscall_4
 _syscall_4:
 	mov %sp,%bx
 	push %di
@@ -132,7 +156,10 @@ _syscall_4:
 	CALL_N_(_syscall_0)
 	pop %di
 	RET_(8)
+#endif
 
+#ifdef L_sys5
+	.global _syscall_5
 _syscall_5:
 	mov %sp,%bx
 	push %si
@@ -146,22 +173,38 @@ _syscall_5:
 	pop %di
 	pop %si
 	RET_(10)
+#endif
+
 #elif defined __IA16_CALLCVT_REGPARMCALL
+
+#ifdef L_sys23
+	.global _syscall_2p
 _syscall_2p:
 	push %bp
 	mov %sp,%bp
 	mov 4+FAR_ADJ_(%bp),%cx
 	pop %bp
+
+	.global _syscall_2
+	.global _syscall_3
 _syscall_2:
 _syscall_3:
 	xchg %cx,%dx
+	jmp _syscall_0
+#endif
+
+#ifdef L_sys01
+	.global _syscall_0
+	.global _syscall_1
 _syscall_1:
 _syscall_0:
 	xchg %ax,%bx
 
+	.global _syscall
 _syscall:
 	int    $0x80
 
+	.global _syscall_test
 _syscall_test:
 	test   %ax,%ax
 	jns    _syscall_ok
@@ -171,7 +214,11 @@ _syscall_test:
 
 _syscall_ok:
 	RET_(0)
+#endif
 
+#ifdef L_sys4
+	.global _syscall_4
+	.global _syscall
 _syscall_4:
 	push %di
 	mov %sp,%di
@@ -181,7 +228,11 @@ _syscall_4:
 	CALL_N_(_syscall)
 	pop %di
 	RET_(8)
+#endif
 
+#ifdef L_sys5
+	.global _syscall_5
+	.global _syscall
 _syscall_5:
 	push %di
 	mov %sp,%di
@@ -194,6 +245,8 @@ _syscall_5:
 	pop %si
 	pop %di
 	RET_(10)
+#endif
+
 #else
 # error "unknown calling convention"
 #endif

--- a/libc/system/syscall01.S
+++ b/libc/system/syscall01.S
@@ -1,0 +1,2 @@
+#define L_sys01
+#include "syscall0.inc"

--- a/libc/system/syscall23.S
+++ b/libc/system/syscall23.S
@@ -1,0 +1,2 @@
+#define L_sys23
+#include "syscall0.inc"

--- a/libc/system/syscall4.S
+++ b/libc/system/syscall4.S
@@ -1,0 +1,2 @@
+#define L_sys4
+#include "syscall0.inc"

--- a/libc/system/syscall5.S
+++ b/libc/system/syscall5.S
@@ -1,0 +1,2 @@
+#define L_sys5
+#include "syscall0.inc"


### PR DESCRIPTION
Unbundles `_syscall*` wrapper code in libc/system/syscall0.S (renamed to syscall0.inc) so that executables are as small as possible.

The system call wrapper code is handled somewhat like the recent `execl` etc changes, where `L_sys*` ifdefs are used to control included code. Since crt0.S requires `_exit` which takes 1 argument, that's bundled with syscall 0. Same for syscall 2, 2p and 3 arguments, since stdio programs will use `ioctl` and `open` (2p), along with `write` (3) etc. Syscall 4 and 5 arguments are completely unbundled.

The net result of this enhancement is pretty nice: the minimum size executable (`sync`) is now down to 96 bytes of code and 144 bytes on disk. The change resulted in 4k extra space on a 1440k floppy.

Table of unbundled sizes for cdecl:
```
   text	   data	    bss	    dec	    hex	filename
     22	      0	      0	     22	     16	syscall01.o
     25	      0	      0	     25	     19	syscall23.o
     21	      0	      0	     21	     15	syscall4.o
     26	      0	      0	     26	     1a	syscall5.o
```

Adding this enhancement with the other recent PRs reducing code size, we now have an amazing reduction in floppy disk space used, resulting in the following:
```
Disk            Free space
Size        cdecl     regparmcall
360k         41k              53k
1440k        49k             124k!
```

