### PR TITLE
[libc] Fix libc from always being rebuilt when .config changed

### DIFF
--- a/elks/include/linuxmt/types.h
+++ b/elks/include/linuxmt/types.h
@@ -2,8 +2,10 @@
 #define __LINUXMT_TYPES_H
 
 #include <arch/types.h>
-#include <linuxmt/config.h>
 
+#ifdef __KERNEL__
+#include <linuxmt/config.h>
+#endif
 
 typedef __s32			loff_t;
 typedef __s32			off_t;


### PR DESCRIPTION
Finally tracked down the reason libc was being rebuilt every time .config file changed. Discussed earlier in https://github.com/jbruchon/elks/pull/1459#issuecomment-1336605351. 

Now, with the libc `*.d` dependency files added by @tkchia in #1459, one can make changes to libc functions and only the required libc files are rebuilt and installed by using a standard `make` at the top level ELKS repo. Combined with this PR, it is now easy to make changes in the C library functions without having to wait to recompile everything, when used for testing in elkscmd/ applications.

(The linuxmt/types.h has to include config.h because of CONFIG_32BIT_INODES, but only the kernel needs config.h, since the usermode-facing type remains `u_ino_t` regardless for the C library).