### PR TITLE
[cmds] Add MOUSE_PORT=none for no mouse on Nano-X demos

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -196,8 +196,8 @@ test/libc/test_libc				:other
 #mtools/mwrite					:other
 #m4/m4							:other
 #prems/pres/pres				:other
-#nano-X/bin/nxclock				:nanox					:1440k
-#nano-X/bin/nxdemo				:nanox					:1440k
+nano-X/bin/nxclock				:other
+nano-X/bin/nxdemo				:other
 nano-X/bin/nxlandmine			:nanox				:1200k
 nano-X/bin/nxterm				:nanox
 nano-X/bin/nxworld				:nanox

--- a/elkscmd/nano-X/demos/demo.c
+++ b/elkscmd/nano-X/demos/demo.c
@@ -59,7 +59,6 @@ main(int argc,char **argv)
 	GR_BITMAP	bitmap2bg[7];
 
 	if (GrOpen() < 0) {
-		fprintf(stderr, "cannot open graphics\n");
 		exit(1);
 	}
 	

--- a/elkscmd/nano-X/demos/demo2.c
+++ b/elkscmd/nano-X/demos/demo2.c
@@ -8,7 +8,6 @@ int main()
 	GR_EVENT 	event;
 
 	if (GrOpen() < 0) {
-		fprintf(stderr, "cannot open graphics\n");
 		exit(1);
 	}
 

--- a/elkscmd/nano-X/demos/landmine.c
+++ b/elkscmd/nano-X/demos/landmine.c
@@ -392,7 +392,6 @@ main(argc,argv)
 	 * Now open the graphics and play the game.
 	 */
 	if (GrOpen() < 0) {
-		fprintf(stderr, "Cannot open graphics\n");
 		exit(1);
 	}
 

--- a/elkscmd/nano-X/demos/nclock.c
+++ b/elkscmd/nano-X/demos/nclock.c
@@ -59,7 +59,6 @@ main(int argc,char **argv)
 	GR_BITMAP	bitmap1bg[7];
 
 	if (GrOpen() < 0) {
-		fprintf(stderr, "cannot open graphics\n");
 		exit(1);
 	}
 	

--- a/elkscmd/nano-X/demos/nterm.c
+++ b/elkscmd/nano-X/demos/nterm.c
@@ -49,7 +49,6 @@ int main(int argc, char ** argv)
 	GR_BITMAP	bitmap1bg[7];
 
 	if (GrOpen() < 0) {
-		fprintf(stderr, "cannot open graphics\n");
 		exit(1);
 	}
 	

--- a/elkscmd/nano-X/demos/world.c
+++ b/elkscmd/nano-X/demos/world.c
@@ -159,7 +159,6 @@ main(argc, argv)
 		return 1;
 	}
 	if (GrOpen() < 0) {
-		fprintf(stderr, "Cannot open graphics\n");
 		return 1;
 	}
 	GrGetScreenInfo(&si);

--- a/elkscmd/nano-X/nanox/srvmain.c
+++ b/elkscmd/nano-X/nanox/srvmain.c
@@ -297,7 +297,7 @@ GsInitialize(void)
 	}
 
 	if ((mouse_fd = GdOpenMouse()) == -1) { /* -2 == mou_nul.c */
-		perror("Cannot initialise mouse");
+		/*perror("Cannot initialise mouse");*/
 		/*GsCloseSocket();*/
 		GdCloseKeyboard();
 		free(wp);


### PR DESCRIPTION
Requested in #1502. 

Use `export MOUSE_PORT=none` to run any Nano-X programs with no mouse.
Updates error messages for better understandability.
Adds `nxclock` and `nxdemo` to CONFIG_APP_OTHER distribution (2880k+ and HD).