### PR TITLE
[libc] Cleanup C library header files

### DIFF
--- a/elkscmd/minix1/grep.c
+++ b/elkscmd/minix1/grep.c
@@ -173,7 +173,7 @@ char *filename;
   if (FLAG('s') || FLAG('l')) {
 	while ((line = get_line(input)) != NULL) {
 		testline = FLAG('i') ? map_nocase(line) : line;
-		if (regexec(expression, testline, 1)) {
+		if (regexec(expression, testline)) {
 			status = MATCH;
 			break;
 		}
@@ -188,7 +188,7 @@ char *filename;
   while ((line = get_line(input)) != NULL) {
 	++lineno;
 	testline = FLAG('i') ? map_nocase(line) : line;
-	if (regexec(expression, testline, 1)) {
+	if (regexec(expression, testline)) {
 		status = MATCH;
 		if (!FLAG('v')) {
 			if (label != NULL)

--- a/libc/include/assert.h
+++ b/libc/include/assert.h
@@ -11,12 +11,11 @@
 
 #else /* Not NDEBUG.  */
 
-extern void __assert __P((const char *, const char *, int));
+void __assert(const char *, const char *, int);
 
 #define	assert(expr)							      \
   ((void) ((expr) ||							      \
-	   (__assert (__STRING(expr),				      \
-			   __FILE__, __LINE__), 0)))
+	   (__assert (__STRING(expr), __FILE__, __LINE__), 0)))
 
 #endif /* NDEBUG.  */
 

--- a/libc/include/fcntl.h
+++ b/libc/include/fcntl.h
@@ -11,9 +11,9 @@
 
 __BEGIN_DECLS
 
-extern int creat __P ((__const char * __filename, mode_t __mode));
-extern int fcntl __P ((int __fildes,int __cmd, ...));
-extern int open __P ((__const char * __filename, int __flags, ...));
+int creat(const char * __filename, mode_t __mode);
+int fcntl(int __fildes,int __cmd, ...);
+int open(const char * __filename, int __flags, ...);
 
 __END_DECLS
 

--- a/libc/include/features.h
+++ b/libc/include/features.h
@@ -7,12 +7,6 @@
 #define __P(x) x
 #define __const const
 
-/* Not really ansi */
-#ifdef __BCC__
-#define const
-#define volatile
-#endif
-
 #else /* K&R */
 
 #define __P(x) ()
@@ -31,10 +25,6 @@
 /* No C++ */
 #define __BEGIN_DECLS
 #define __END_DECLS
-
-/* GNUish things */
-#define __CONSTVALUE
-#define __CONSTVALUE2
 
 #include <sys/cdefs.h>
 

--- a/libc/include/getopt.h
+++ b/libc/include/getopt.h
@@ -12,6 +12,6 @@ extern char *optarg;
 extern int opterr;
 extern int optind;
 
-extern int getopt __P((int argc, char *const *argv, const char *shortopts));
+int getopt(int argc, char *const *argv, const char *shortopts);
 
 #endif /* __GETOPT_H */

--- a/libc/include/grp.h
+++ b/libc/include/grp.h
@@ -14,21 +14,21 @@ struct group
   char **gr_mem;		/* Member list.	*/
 };
 
-extern void setgrent __P ((void));
-extern void endgrent __P ((void));
-extern struct group * getgrent __P ((void));
+void setgrent(void);
+void endgrent(void);
+struct group * getgrent(void);
 
-extern struct group * getgrgid __P ((__const gid_t gid));
-extern struct group * getgrnam __P ((__const char * name));
+struct group * getgrgid(const gid_t gid);
+struct group * getgrnam(const char * name);
 
-extern struct group * fgetgrent __P ((FILE * file));
+struct group * fgetgrent(FILE * file);
 
-extern int setgroups __P ((size_t n, __const gid_t * groups));
-extern int initgroups __P ((__const char * user, gid_t gid));
+int setgroups(size_t n, const gid_t * groups);
+int initgroups(const char * user, gid_t gid);
 
 
 #ifdef __LIBC__
-extern struct group * __getgrent __P ((int grp_fd));
+struct group * __getgrent(int grp_fd);
 #endif
 
 #endif /* _GRP_H */

--- a/libc/include/libgen.h
+++ b/libc/include/libgen.h
@@ -1,8 +1,7 @@
 #ifndef __LIBGEN_H
 #define __LIBGEN_H
 
-extern char *dirname (char *path);
-
-extern char *basename (char *path);
+char *dirname(char *path);
+char *basename(char *path);
 
 #endif /* __LIBGEN_H */

--- a/libc/include/malloc.h
+++ b/libc/include/malloc.h
@@ -11,21 +11,21 @@
  * 
  */
 
-extern void free __P((void *));
-extern void *calloc(unsigned int elm, unsigned int sz);
-extern void *malloc __P((size_t));
-extern void *realloc __P((void *, size_t));
-extern void *alloca __P((size_t));
+void free(void *);
+void *calloc(unsigned int elm, unsigned int sz);
+void *malloc(size_t);
+void *realloc(void *, size_t);
+void *alloca(size_t);
 
 #ifdef __LIBC__
 /* remove __MINI_MALLOC__ and always use real malloc for libc routines*/
 //#define __MINI_MALLOC__
 
-extern void *__mini_malloc(size_t size);
+void *__mini_malloc(size_t size);
 #endif
 
 #ifdef __MINI_MALLOC__
-extern void *(*__alloca_alloc) __P((size_t));
+extern void *(*__alloca_alloc)(size_t);
 #define malloc(x) ((*__alloca_alloc)(x))
 #endif
 

--- a/libc/include/pwd.h
+++ b/libc/include/pwd.h
@@ -18,23 +18,23 @@ struct passwd
 };
 
 
-extern void setpwent __P ((void));
-extern void endpwent __P ((void));
-extern struct passwd * getpwent __P ((void));
+void setpwent(void);
+void endpwent(void);
+struct passwd * getpwent(void);
 
 int putpwent (const struct passwd * p, FILE * stream);
-extern int getpw __P ((uid_t uid, char *buf));
+int getpw(uid_t uid, char *buf);
 
-extern struct passwd * fgetpwent __P ((FILE * file));
+struct passwd * fgetpwent(FILE * file);
 
-extern struct passwd * getpwuid __P ((__const uid_t));
-extern struct passwd * getpwnam __P ((__const char *));
+struct passwd * getpwuid(const uid_t);
+struct passwd * getpwnam(const char *);
 
 #ifdef __LIBC__
-extern struct passwd * __getpwent __P ((__const int passwd_fd));
+struct passwd * __getpwent(const int passwd_fd);
 #endif
 
-extern char *getpass(char *prompt);
+char *getpass(char *prompt);
 
 #endif /* pwd.h  */
 

--- a/libc/include/regex.h
+++ b/libc/include/regex.h
@@ -15,10 +15,9 @@ typedef struct regexp {
 	char program[1];	/* Unwarranted chumminess with compiler. */
 } regexp;
 
-extern regexp *regcomp();
-extern int regexec();
-extern void regsub();
-extern void regerror();
+regexp *regcomp(char *exp);
+int regexec(regexp *prog, char *string);
+void regerror();
 
-extern int expandwildcards(char *name, int maxargc, char **retargv);
-extern void freewildcards(void);
+int expandwildcards(char *name, int maxargc, char **retargv);
+void freewildcards(void);

--- a/libc/include/setjmp.h
+++ b/libc/include/setjmp.h
@@ -1,4 +1,3 @@
-
 #ifndef __SETJMP_H
 #define __SETJMP_H
 
@@ -21,14 +20,14 @@ typedef struct
    unsigned int es;
 } jmp_buf[1];
 
-int _setjmp __P((jmp_buf env));
-void _longjmp __P((jmp_buf env, int rv));
+int _setjmp(jmp_buf env);
+void _longjmp(jmp_buf env, int rv);
 
 /* LATER: Seems GNU beat me to it, must be OK then :-)
  *        Humm, what's this about setjmp being a macro !?
- *	  Ok, use the BSD names as normal use the ANSI as macros
+ *        Ok, use the BSD names as normal use the ANSI as macros
  */
 
-#define setjmp(a_env)		_setjmp(a_env)
+#define setjmp(a_env)           _setjmp(a_env)
 #define longjmp(a_env, a_rv)	_longjmp(a_env, a_rv)
 #endif

--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -96,36 +96,36 @@ extern FILE stderr[1];
 
 /* These two call malloc */
 #define setlinebuf(__fp)             setvbuf((__fp), (char*)0, _IOLBF, 0)
-extern int setvbuf __P((FILE*, char*, int, size_t));
+int setvbuf(FILE*, char*, int, size_t);
 
 /* These don't */
 #define setbuf(__fp, __buf) setbuffer((__fp), (__buf), BUFSIZ)
-extern void setbuffer __P((FILE*, char*, int));
+void setbuffer(FILE*, char*, int);
 
-extern int fgetc __P((FILE*));
-extern int fputc __P((int, FILE*));
+int fgetc(FILE*);
+int fputc(int, FILE*);
 
-extern int fclose __P((FILE*));
-extern int fflush __P((FILE*));
-extern char *fgets __P((char*, size_t, FILE*));
+int fclose(FILE*);
+int fflush(FILE*);
+char *fgets(char*, size_t, FILE*);
 
 ssize_t getdelim(char **__restrict lineptr, size_t *__restrict n,
 		int delimiter, register FILE *__restrict stream);
 ssize_t getline(char **__restrict lineptr, size_t *__restrict n,
 		FILE *__restrict stream);
 
-extern FILE *fopen __P((const char*, const char*));
-extern FILE *fdopen __P((int, char*));
-extern FILE *freopen  __P((char*, char*, FILE*));
+FILE *fopen(const char*, const char*);
+FILE *fdopen(int, char*);
+FILE *freopen(char*, char*, FILE*);
 
 #ifdef __LIBC__
-extern FILE *__fopen __P((const char*, int, FILE*, const char*));
+FILE *__fopen(const char*, int, FILE*, const char*);
 #endif
 
-extern int fputs __P((const char*, FILE*));
+int fputs(const char*, FILE*);
 int puts (const char * s);
 
-size_t fread __P ((void *, size_t, size_t, FILE *));
+size_t fread(void *, size_t, size_t, FILE *);
 int fseek(FILE *fp, long offset, int ref);
 long ftell(FILE *fp);
 int fwrite(char *buf, int size, int nelm, FILE *fp);
@@ -133,10 +133,10 @@ char * gets(char *str);	/* BAD function; DON'T use it! */
 
 int fscanf(FILE * fp, const char * fmt, ...);
 
-extern int printf __P ((__const char*, ...));
-extern int fprintf __P ((FILE*, __const char*, ...));
-extern int sprintf __P ((char*, __const char*, ...));
-extern int snprintf __P ((char*, size_t, __const char*, ...));
+int printf(const char*, ...);
+int fprintf(FILE*, const char*, ...);
+int sprintf(char*, const char*, ...);
+int snprintf(char*, size_t, const char*, ...);
 
 int vfprintf (FILE * stream, const char * format, va_list ap);
 int vsprintf (char * sp, const char * format, va_list ap);
@@ -161,10 +161,10 @@ int sscanf (const char * str, const char * format, ...);
 
 int ungetc (int c, FILE *stream);
 int vfscanf(register FILE *fp, register char *fmt, va_list ap);
-int vscanf(__const char *fmt, va_list ap);
-int vsscanf(char *sp, __const char *fmt, va_list ap);
+int vscanf(const char *fmt, va_list ap);
+int vsscanf(char *sp, const char *fmt, va_list ap);
 
-extern FILE *popen(char *, char *);
-extern int pclose(FILE *);
+FILE *popen(char *, char *);
+int pclose(FILE *);
 
 #endif /* __STDIO_H */

--- a/libc/include/sys/cdefs.h
+++ b/libc/include/sys/cdefs.h
@@ -31,8 +31,4 @@ typedef double __long_double_t;
 #define __BEGIN_DECLS
 #define __END_DECLS
 
-/* GNUish things */
-#define __CONSTVALUE
-#define __CONSTVALUE2
-
 #endif

--- a/libc/include/sys/ioctl.h
+++ b/libc/include/sys/ioctl.h
@@ -1,9 +1,8 @@
-
 #ifndef _SYS_IOCTL_H
 #define _SYS_IOCTL_H
 #include <features.h>
 #include __SYSINC__(ioctl.h)
 
-extern int ioctl __P((int __fildes, int __cmd, ...));
+int ioctl(int __fildes, int __cmd, ...);
 
 #endif

--- a/libc/include/sys/stat.h
+++ b/libc/include/sys/stat.h
@@ -5,14 +5,13 @@
 #include <sys/types.h>
 #include __SYSINC__(stat.h)
 
-int lstat __P((__const char * __path, struct stat * __statbuf));
-int fstat __P((int __fd, struct stat * __statbuf));
-
 /* hysterical raisins */
 #define S_IREAD		S_IRUSR /* read permission, owner */
 #define S_IWRITE	S_IWUSR /* write permission, owner */
 #define S_IEXEC		S_IXUSR /* execute/search permission, owner */
 
+int lstat(const char * __path, struct stat * __statbuf);
+int fstat(int __fd, struct stat * __statbuf);
 int stat (const char * restrict path, struct stat * restrict buf);
 int mkdir(const char *pathm, mode_t mode);
 int mknod(const char *path, mode_t mode, dev_t dev);

--- a/libc/include/sys/wait.h
+++ b/libc/include/sys/wait.h
@@ -55,8 +55,7 @@ extern pid_t wait (int * stat_loc);
    Return (pid_t) -1 for errors.  If the WUNTRACED bit is
    set in OPTIONS, return status for stopped children; otherwise don't.  */
 
-extern pid_t waitpid __P ((pid_t __pid, int *__stat_loc,
-			     int __options));
+pid_t waitpid(pid_t __pid, int *__stat_loc, int __options);
 
 /* This being here makes the prototypes valid whether or not
    we have already included <sys/resource.h> to define `struct rusage'.  */
@@ -67,11 +66,9 @@ struct rusage;
    nil, store information about the child's resource usage there.  If the
    WUNTRACED bit is set in OPTIONS, return status for stopped children;
    otherwise don't.  */
-extern pid_t wait3 __P ((int * __stat_loc,
-			   int __options, struct rusage * __usage));
+pid_t wait3(int * __stat_loc, int __options, struct rusage * __usage);
 
 /* PID is like waitpid.  Other args are like wait3.  */
-extern pid_t wait4 __P ((pid_t __pid, int * __stat_loc,
-			   int __options, struct rusage *__usage));
+pid_t wait4(pid_t __pid, int * __stat_loc, int __options, struct rusage *__usage);
 
 #endif /* sys/wait.h  */

--- a/libc/include/termcap.h
+++ b/libc/include/termcap.h
@@ -1,4 +1,3 @@
-
 #ifndef _TERMCAP_H
 #define _TERMCAP_H
 
@@ -10,12 +9,12 @@ extern char *UP;
 extern char *BC;
 extern int ospeed;
 
-extern int tgetent __P((char *, const char *));
-extern int tgetflag __P((const char *));
-extern int tgetnum __P((const char *));
-extern char *tgetstr __P((const char *, char **));
+int tgetent(char *, const char *);
+int tgetflag(const char *);
+int tgetnum(const char *);
+char *tgetstr(const char *, char **);
 
-extern int tputs __P((const char *, int, int (*)(int)));
-extern char *tgoto __P((const char *, int, int));
+int tputs(const char *, int, int (*)(int));
+char *tgoto(const char *, int, int);
 
 #endif /* _TERMCAP_H */

--- a/libc/include/termios.h
+++ b/libc/include/termios.h
@@ -5,21 +5,21 @@
 #include <sys/types.h>
 #include __SYSINC__(termios.h)
 
-extern speed_t cfgetispeed __P ((struct termios *__termios_p));
-extern speed_t cfgetospeed __P ((struct termios *__termios_p));
-extern int cfsetispeed __P ((struct termios *__termios_p, speed_t __speed));
-extern int cfsetospeed __P ((struct termios *__termios_p, speed_t __speed));
+speed_t cfgetispeed(struct termios *__termios_p);
+speed_t cfgetospeed(struct termios *__termios_p);
+int cfsetispeed(struct termios *__termios_p, speed_t __speed);
+int cfsetospeed(struct termios *__termios_p, speed_t __speed);
 
-extern void cfmakeraw  __P ((struct termios *__t));
+void cfmakeraw (struct termios *__t);
 
 int tcgetattr (int fd, struct termios * termios_p);
 int tcsetattr (int fd, int optional_actions, const struct termios * termios_p);
 
-extern int tcdrain __P ((int __fildes));
-extern int tcflow __P ((int __fildes, int __action));
-extern int tcflush __P ((int __fildes, int __queue_selector));
-extern int tcsendbreak __P ((int __fildes, int __duration));
-extern pid_t tcgetpgrp __P ((int __fildes));
-extern int tcsetpgrp __P ((int __fildes, pid_t __pgrp_id));
+int tcdrain(int __fildes);
+int tcflow(int __fildes, int __action);
+int tcflush(int __fildes, int __queue_selector);
+int tcsendbreak(int __fildes, int __duration);
+pid_t tcgetpgrp(int __fildes);
+int tcsetpgrp(int __fildes, pid_t __pgrp_id);
 
 #endif

--- a/libc/include/time.h
+++ b/libc/include/time.h
@@ -44,24 +44,21 @@ extern long timezone;
 
 __BEGIN_DECLS
 
-extern int	stime __P ((time_t* __tptr));
+int	stime (time_t* __tptr);
 
-extern clock_t	clock __P ((void));
-extern time_t	time __P ((time_t * __tp));
+clock_t	clock(void);
+time_t	time(time_t * __tp);
 #ifndef __HAS_NO_FLOATS__
-extern __CONSTVALUE double difftime __P ((time_t __time2,
-					  time_t __time1)) __CONSTVALUE2;
+double  difftime(time_t __time2, time_t __time1);
 #endif
-extern time_t	mktime __P ((struct tm * __tp));
+time_t	mktime(struct tm * __tp);
+char *	asctime(const struct tm * __tp);
+char *	ctime(const time_t * __tp);
+size_t	strftime(char * __s, size_t __smax, const char * __fmt, const struct tm * __tp);
+void	tzset(void);
 
-extern char *	asctime __P ((__const struct tm * __tp));
-extern char *	ctime __P ((__const time_t * __tp));
-extern size_t	strftime __P ((char * __s, size_t __smax,
-			__const char * __fmt, __const struct tm * __tp));
-extern void	tzset __P ((void));
-
-extern struct tm*	gmtime __P ((__const time_t *__tp));
-extern struct tm*	localtime __P ((__const time_t * __tp));
+struct tm*	gmtime(const time_t *__tp);
+struct tm*	localtime(const time_t * __tp);
 
 __END_DECLS
 

--- a/libc/include/unistd.h
+++ b/libc/include/unistd.h
@@ -9,13 +9,13 @@
 #define STDOUT_FILENO 1
 #define STDERR_FILENO 2
 
-extern ssize_t read __P ((int __fd, void * __buf, size_t __nbytes));
-extern ssize_t write __P ((int __fd, __const void * __buf, size_t __n));
-extern int pipe __P ((int __pipedes[2]));
-extern unsigned int alarm __P ((unsigned int __seconds));
-extern unsigned int sleep __P ((unsigned int __seconds));
-extern int pause __P ((void));
-extern char*    crypt __P((__const char *__key, __const char *__salt));
+ssize_t read(int __fd, void * __buf, size_t __nbytes);
+ssize_t write(int __fd, const void * __buf, size_t __n);
+int     pipe(int __pipedes[2]);
+unsigned int alarm(unsigned int __seconds);
+unsigned int sleep(unsigned int __seconds);
+int     pause(void);
+char*   crypt(const char *__key, const char *__salt);
 
 #ifndef SEEK_SET
 #define SEEK_SET 0

--- a/libc/include/utmp.h
+++ b/libc/include/utmp.h
@@ -36,16 +36,16 @@ struct utmp
 
 };
 
-extern void             setutent __P ((void));
-extern void             utmpname __P ((__const char *));
-extern struct utmp *    getutent __P ((void));
-extern struct utmp *    getutid __P ((__const struct utmp *));
-extern struct utmp *    getutline __P ((__const struct utmp *));
-extern struct utmp *    pututline __P ((__const struct utmp *));
-extern void             endutent __P ((void));
+void             setutent(void);
+void             utmpname(const char *);
+struct utmp *    getutent(void);
+struct utmp *    getutid(const struct utmp *);
+struct utmp *    getutline(const struct utmp *);
+struct utmp *    pututline(const struct utmp *);
+void             endutent(void);
 
 #ifdef __LIBC__
-struct utmp *           __getutent __P ((int));
+struct utmp *    __getutent(int);
 #endif
 
 #endif /* __UTMP_H */

--- a/libc/malloc/__alloca_alloc.c
+++ b/libc/malloc/__alloca_alloc.c
@@ -1,5 +1,5 @@
 #include <malloc.h>
 
 #ifdef __MINI_MALLOC__
-void *(*__alloca_alloc) __P ((size_t)) = __mini_malloc;
+void *(*__alloca_alloc)(size_t) = __mini_malloc;
 #endif

--- a/libc/misc/qsort-bsd.c
+++ b/libc/misc/qsort-bsd.c
@@ -56,8 +56,8 @@
 #include <sys/types.h>
 #include <stdlib.h>
 
-static inline char	*med3 __P((char *, char *, char *, int (*)()));
-static inline void	 swapfunc __P((char *, char *, int, int));
+static inline char	*med3(char *, char *, char *, int (*)());
+static inline void	 swapfunc(char *, char *, int, int);
 
 #define min(a, b)	(a) < (b) ? a : b
 


### PR DESCRIPTION
Cleans up K&R style declarations in C library header files.

Removes `__P` and `extern`, changes `__const` to `const`.

Fixes `regex.h` errors in grep.c, which would crash when moving to REGPARMCALL calling convention.

