### PR TITLE
[kernel] Introduce precision kernel looping timeouts

### DIFF
--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -124,6 +124,9 @@ extern jiff_t xtime_jiffies;
 extern int tz_offset;
 #define CURRENT_TIME (xtime.tv_sec + (jiffies - xtime_jiffies)/HZ)
 
+/* return true if time a is after time b */
+#define time_after(a,b)         (((long)(b) - (long)(a) < 0))
+
 #define for_each_task(p) \
 	for (p = &task[0] ; p!=&task[MAX_TASKS]; p++ )
 


### PR DESCRIPTION
Allows for easy coding of precision kernel timeouts, rather than continuously busy looping or decrementing a variable.

Adds 30ms timeout for IDE Query function, rather than busy looping forever if IDE device not responding (found using blink emulator).
