### PR TITLE
[cmds] Force Nano-X programs to be built using cdecl calling convention

### DIFF
--- a/elks/kernel/time.c
+++ b/elks/kernel/time.c
@@ -48,10 +48,8 @@ int tz_offset;
 
 void tz_init(const char *tzstr)
 {
-    if (strlen(tzstr) > 3) {
+    if (strlen(tzstr) > 3)
         tz_offset = atoi(tzstr+3);
-        printk("TZ=%d\n", tz_offset);
-    }
 }
 
 /* set the time of day */

--- a/elkscmd/nano-X/Makefile
+++ b/elkscmd/nano-X/Makefile
@@ -67,6 +67,9 @@ DEMOLIBS += libnano-X.a
 ALL += libnano-X.a nano-X nxdemos
 endif
 
+# remove any -mregparmcall as ASM files need cdecl calling convention
+CFLAGS := $(filter-out -mregparmcall, $(CFLAGS))
+
 SERVFILES = engine/devdraw.o engine/devmouse.o engine/devkbd.o engine/devclip1.o \
 	engine/devpal1.o engine/devpal2.o engine/devpal4.o
 


### PR DESCRIPTION
Prepare for possible upcoming conversion to REGPARMCALL calling convention for ELKS user applications, forces CDECL convention for all programs using ASM files with arguments, which only includes Nano-X at time time.

Cleanup TZ= display in kernel boot.