### PR TITLE
[tools] Update gcc-ia16 toolchain for instrumentation and debug lib

### DIFF
--- a/elkscmd/Make.defs
+++ b/elkscmd/Make.defs
@@ -78,6 +78,7 @@ ifeq ($(PLATFORM),i86-ELKS)
 	CC=ia16-elf-gcc
 	CFLBASE=-fno-inline -melks-libc -mcmodel=small -mno-segment-relocation-stuff -mtune=i8086 -Wall -Os
 	#CFLBASE += -mregparmcall
+	#CFLBASE += -finstrument-functions-simple
 	LD=ia16-elf-gcc
 	LDFLAGS=$(CFLBASE)
 	CHECK=gcc -c -o .null.o -Wall -pedantic

--- a/elkscmd/basic/Makefile
+++ b/elkscmd/basic/Makefile
@@ -17,6 +17,7 @@ HOST_CFLAGS = -O3
 
 PRGS = basic
 OBJS = basic.o host.o
+#MAPFILE = -Wl,-Map=basic.map
 
 ifeq ($(CONFIG_ARCH_IBMPC), y)
 OBJS += host-stubs.o
@@ -33,7 +34,7 @@ endif
 all: $(PRGS)
 
 basic: $(OBJS) basic.h host.h
-	$(LD) $(LDFLAGS) -o basic $(OBJS) $(LDLIBS)
+	$(LD) $(LDFLAGS) $(MAPFILE) -o basic $(OBJS) $(LDLIBS)
 
 HOSTSRC = basic.c host.c host-stubs.c
 HOSTSRC += ../../libc/misc/ecvt.c

--- a/elkscmd/debug/Makefile
+++ b/elkscmd/debug/Makefile
@@ -15,10 +15,14 @@ HOSTCFLAGS = -O3
 
 PRGS = testsym disasm opcodes
 LIBOBJS += syms.o stacktrace.o printreg.o
-#OBJS += ulltostr.o
+
+# disable tail call optimization for better stack traces
 CFLAGS += -fno-optimize-sibling-calls
+# always push BP in function prologue for better stack traces
 CFLAGS += -fno-omit-frame-pointer
-#CFLAGS += -finstrument-functions
+# optional instrumentation for function tracing
+CFLAGS += -finstrument-functions-simple
+
 #LDFLAGS += -maout-heap=12000
 
 all: nm86 $(PRGS)
@@ -44,9 +48,6 @@ opcodes: opcodes.o
 	cp $@ $(TOPDIR)/elkscmd/rootfs_template/root
 
 disasm.o: disasm.c
-	$(CC) $(CFLAGS) -fno-instrument-functions -c -o $*.o $<
-
-ulltostr.o: ulltostr.c
 	$(CC) $(CFLAGS) -fno-instrument-functions -c -o $*.o $<
 
 install: $(PRGS)

--- a/elkscmd/debug/printreg.S
+++ b/elkscmd/debug/printreg.S
@@ -48,7 +48,7 @@ print_regs:
 	push %sp
 	push %bp
 	mov  %sp,%bp
-	add  $4,2(%bp)	// adjust SP to before call here
+	addw $4,2(%bp)	// adjust SP to before call here
 
 	push %di
 	push %si

--- a/elkscmd/debug/stacktrace.h
+++ b/elkscmd/debug/stacktrace.h
@@ -5,9 +5,9 @@
 /* stacktrace.c */
 void noinstrument print_stack(int arg1);
 
-/* instrumentation functions called when -finstrument-functions set */
-void noinstrument __cyg_profile_func_enter(void *, void *);
-void noinstrument __cyg_profile_func_exit(void *, void *);
+/* instrumentation functions called when -finstrument-functions-simple set */
+void noinstrument __cyg_profile_func_enter_simple(void);
+void noinstrument __cyg_profile_func_exit_simple(void);
 void print_times(void);
 
 /* printreg.S */

--- a/libc/misc/Makefile
+++ b/libc/misc/Makefile
@@ -38,6 +38,8 @@ OBJS = \
 	wildcard.o \
 	# end of list
 
+#OBJS += instrument.o
+
 all: $(LIB)
 
 $(LIB): $(OBJS)

--- a/libc/misc/instrument.c
+++ b/libc/misc/instrument.c
@@ -1,0 +1,30 @@
+/* test -finstrument-functions-simple */
+#include <stdio.h>
+#define noinstrument    __attribute__((no_instrument_function))
+
+static int count;
+static int **start_sp;
+static unsigned int max_stack;
+
+/* every function this function calls must also be noinstrument!! */
+void noinstrument __cyg_profile_func_enter_simple(void)
+{
+    int **bp = __builtin_frame_address(0);  /* find BP on stack: BP, DI, SI, ret, arg1 */
+    int *calling_fn = __builtin_return_address(0);  /* return address */
+    int i;
+
+    /* calc stack used */
+    if (count == 0) start_sp = bp;
+    unsigned int stack_used = start_sp - bp;
+    if (stack_used > max_stack) max_stack = stack_used;
+
+    for (i=0; i<count; i++)
+        putchar('|');
+    printf(">%x, stack %u/%u\n", (int)calling_fn, stack_used, max_stack);
+    ++count;
+}
+
+void noinstrument __cyg_profile_func_exit_simple(void)
+{
+    --count;
+}

--- a/libc/stdio/__io_init.c
+++ b/libc/stdio/__io_init.c
@@ -3,6 +3,7 @@
 
 #include "_stdio.h"
 
+#pragma GCC diagnostic ignored "-Wprio-ctor-dtor"
 __attribute__((destructor(99))) static void
 __stdio_close_all(void)
 {
@@ -19,6 +20,7 @@ __stdio_close_all(void)
    }
 }
 
+#pragma GCC diagnostic ignored "-Wprio-ctor-dtor"
 __attribute__((constructor(99))) void
 __io_init_vars(void)
 {

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -97,7 +97,7 @@ $(DISTDIR)/$(MPC_DIST).tar.gz:
 
 # GCC for IA16
 
-GCC_VER=70c4679fb560cbca27e15cb3dc4cef1b877eae88
+GCC_VER=ae4111f13b5dc6dea6344249f8df5f769607329f
 GCC_DIST=gcc-ia16-$(GCC_VER)
 
 $(DISTDIR)/$(GCC_DIST).tar.gz:


### PR DESCRIPTION
Adds support for new compiler option `-finstrument-functions-simple`, discussed in https://github.com/tkchia/gcc-ia16/issues/111 and https://github.com/tkchia/gcc-ia16/pull/130.

Updates `gcc-ia16` toolchain to latest version, built with `tools/build.sh`.

ELKS developers do not have to update their toolchain at this time, as the instrumentation capabilities are only included in the elkscmd/debug directory, which is not yet built by default.