### PR TITLE
[libc] Add --ftrace option to all commands for function tracing

### DIFF
--- a/elkscmd/basic/Makefile
+++ b/elkscmd/basic/Makefile
@@ -18,6 +18,7 @@ HOST_CFLAGS = -O3
 PRGS = basic
 OBJS = basic.o host.o
 #MAPFILE = -Wl,-Map=basic.map
+#CFLAGS += -finstrument-functions-simple
 
 ifeq ($(CONFIG_ARCH_IBMPC), y)
 OBJS += host-stubs.o

--- a/elkscmd/debug/Makefile
+++ b/elkscmd/debug/Makefile
@@ -14,7 +14,8 @@ HOSTCFLAGS = -O3
 ###############################################################################
 
 PRGS = testsym disasm opcodes
-LIBOBJS += syms.o stacktrace.o printreg.o
+LIBOBJS += instrument.o syms.o
+LIBOBJS += stacktrace.o printreg.o
 
 # disable tail call optimization for better stack traces
 CFLAGS += -fno-optimize-sibling-calls

--- a/elkscmd/debug/instrument.c
+++ b/elkscmd/debug/instrument.c
@@ -1,0 +1,106 @@
+/*
+ * ELKS instrumentation functions for ia16-elf-gcc
+ *
+ * June 2022 Greg Haerr
+ */
+#include <stdio.h>
+#include <string.h>
+#include "stacktrace.h"
+#include "syms.h"
+
+/* turn on for microcycle (CPU cycle/1000) timing info */
+#define HAS_RDTSC       1   /* has RDTSC instruction: requires 386+ CPU */
+
+static char ftrace;
+static int count;
+static unsigned int start_sp;
+static unsigned int max_stack;
+
+/* runs before main and rewrites argc/argv on stack if --ftrace found */
+__attribute__((no_instrument_function,cdecl,constructor(101)))
+static void checkargs(volatile int ac, char **av)
+{
+    char **avp = av + 1;
+
+    if (*avp && !strcmp(*avp, "--ftrace")) {
+        while (*avp) {
+            *avp = *(avp + 1);
+            avp++;
+        }
+        ftrace = 1;
+        ac--;
+    }
+    get_micro_count();      /* init timer base */
+}
+
+/* every function this function calls must also be noinstrument!! */
+void noinstrument __cyg_profile_func_enter_simple(void)
+{
+    if (!ftrace) return;
+
+#if 1
+    int **bp = __builtin_frame_address(0);  /* find BP on stack: BP, DI, SI, ret, arg1 */
+    int *calling_fn = __builtin_return_address(0);  /* return address */
+#else
+    int **bp = (int **)&arg1 - 4;   /* find BP on stack: BP, DI, SI, ret, arg1 */
+    int *calling_fn = bp[3];        /* return address */
+    assert(bp == __builtin_frame_address(0));
+    assert(calling_fn == __builtin_return_address(0));
+#endif
+    int i;
+    char callsite[32];
+
+    /* calc stack used */
+    if (count == 0) start_sp = (unsigned int)bp;
+    unsigned int stack_used = start_sp - (unsigned int)bp;
+    if (stack_used > max_stack) max_stack = stack_used;
+
+    //print_regs();
+    //print_stack(0xDEAD);
+
+    /* calc caller address */
+    i = calc_push_count(calling_fn);
+    if (i & BP_PUSHED) {            /* caller pushed BP */
+        bp = (int **)bp[0];         /* one level down to get caller BP */
+        i &= COUNT_MASK;
+    } else bp += 4;                 /* caller didn't push BP, skip past our ret addr */
+    if (i >= 0)
+        strcpy(callsite, sym_text_symbol(bp[i], 1));   /* return address of caller */
+    else
+        strcpy(callsite, "<unknown>");
+    for (i=0; i<count; i++)
+        putchar('|');
+    printf(">%s, from %s, stack %u/%u %lu ucycles\n",
+        sym_text_symbol(calling_fn, 0), callsite, stack_used, max_stack,
+        get_micro_count());
+    ++count;
+}
+
+void noinstrument __cyg_profile_func_exit_simple(void)
+{
+    if (ftrace)
+        --count;
+}
+
+/* return CPU cycles / 1000 via RDTSC instruction */
+unsigned long noinstrument get_micro_count(void)
+{
+#if HAS_RDTSC
+    static unsigned long long last_ts;
+
+    unsigned long long ts = rdtsc();    /* REQUIRES 386 CPU! */
+    unsigned long diff = (ts - last_ts) / 1000;
+    last_ts = ts;
+    return diff;
+#else
+    return 0;
+#endif
+}
+
+/***static char * noinstrument lltohexstr(unsigned long long val)
+{
+    static char buf[17];
+
+    sprintf(buf,"%08lx%08lx", (long)(val >> 32), (long)val);
+    return buf;
+}***/

--- a/elkscmd/debug/instrument.c
+++ b/elkscmd/debug/instrument.c
@@ -4,6 +4,7 @@
  * June 2022 Greg Haerr
  */
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "stacktrace.h"
 #include "syms.h"
@@ -22,7 +23,7 @@ static void checkargs(volatile int ac, char **av)
 {
     char **avp = av + 1;
 
-    if (*avp && !strcmp(*avp, "--ftrace")) {
+    if ((*avp && !strcmp(*avp, "--ftrace")) || getenv("FTRACE")) {
         while (*avp) {
             *avp = *(avp + 1);
             avp++;

--- a/elkscmd/debug/opcodes.s
+++ b/elkscmd/debug/opcodes.s
@@ -237,7 +237,15 @@ main:
  cld
  std
  call   *0x9090(%bx)
+ push   0x0000
+ push   0x7fff
+ push   0x8000
+ push   0x8001
 
+ push   $0x0000
+ push   $0x7fff
+ push   $0x8000
+ push   $0x8001
  add    %dx,0x9090(%bx)
  add    0x9090(%bx),%dx
  add    $0x9090,%ax

--- a/elkscmd/debug/stacktrace.c
+++ b/elkscmd/debug/stacktrace.c
@@ -1,19 +1,12 @@
 /*
- * ELKS stack trace and instrumentation functions library for ia16-elf-gcc
+ * ELKS stack trace functions for ia16-elf-gcc
  *
  * June 2022 Greg Haerr
  */
 #include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <sys/stat.h>
-#include <assert.h>
 #include "stacktrace.h"
 #include "syms.h"
 
-#define PROFILING   1   /* =1 to include instrumentation functions */
 #define STACKCOLS   8   /* # of stack address columns */
 
 /* ia-16 C function stack layout (hi to low):
@@ -32,16 +25,11 @@
 +--------------+
 */
 
-#define BP_PUSHED   0x0100
-#define DI_PUSHED   0x0200
-#define SI_PUSHED   0x0400
-#define COUNT_MASK  0x0007
-
 /*
  * Return pushed word count and register bitmask by function at passed address,
  * used to traverse BP chain and display registers.
  */
-static int noinstrument calc_push_count(int *addr)
+int noinstrument calc_push_count(int *addr)
 {
     int *fn = sym_fn_start_address(addr);   /* get fn start from address */
     char *fp = (char *)fn;
@@ -102,69 +90,3 @@ void noinstrument print_stack(int arg1)
         }
     } while (++i < 15 && fn != 0 && addr != 0);
 }
-
-#if PROFILING
-static int count;
-static unsigned int start_sp;
-static unsigned int max_stack;
-
-/* every function this function calls must also be noinstrument!! */
-void noinstrument __cyg_profile_func_enter_simple(void)
-{
-#if 1
-    int **bp = __builtin_frame_address(0);  /* find BP on stack: BP, DI, SI, ret, arg1 */
-    int *calling_fn = __builtin_return_address(0);  /* return address */
-#else
-    int **bp = (int **)&arg1 - 4;   /* find BP on stack: BP, DI, SI, ret, arg1 */
-    int *calling_fn = bp[3];        /* return address */
-    assert(bp == __builtin_frame_address(0));
-    assert(calling_fn == __builtin_return_address(0));
-#endif
-    int i;
-    char callsite[32];
-
-    /* calc stack used */
-    if (count == 0) start_sp = (unsigned int)bp;
-    unsigned int stack_used = start_sp - (unsigned int)bp;
-    if (stack_used > max_stack) max_stack = stack_used;
-
-    //print_times();
-    //print_regs();
-    //print_stack(0xDEAD);
-
-    /* calc caller address */
-    i = calc_push_count(calling_fn);
-    if (i & BP_PUSHED) {            /* caller pushed BP */
-        bp = (int **)bp[0];         /* one level down to get caller BP */
-        i &= COUNT_MASK;
-    } else bp += 4;                 /* caller didn't push BP, skip past our ret addr */
-    if (i >= 0)
-        strcpy(callsite, sym_text_symbol(bp[i], 1));   /* return address of caller */
-    else
-        strcpy(callsite, "<unknown>");
-    for (i=0; i<count; i++)
-        putchar('|');
-    printf(">%s, from %s, stack %u/%u\n", sym_text_symbol(calling_fn, 0), callsite,
-        stack_used, max_stack);
-    ++count;
-}
-
-void noinstrument __cyg_profile_func_exit_simple(void)
-{
-    --count;
-}
-#endif /* PROFILING */
-
-#if LATER
-long long ts, last_ts, diff;
-
-void noinstrument print_times(void)
-{
-    ts = rdtsc();       /* REQUIRES 386 CPU! */
-    //diff = ts - last_ts;
-    diff = ts;
-    printf("time = %08lx%08lx, (%s),", (long)(diff >> 32), (long)diff, lltohexstr(diff));
-    printf("%s\n", ulltostr(diff, 16));
-    last_ts = ts;
-}
-#endif

--- a/elkscmd/debug/stacktrace.c
+++ b/elkscmd/debug/stacktrace.c
@@ -105,7 +105,7 @@ void noinstrument print_stack(int arg1)
 
 #if PROFILING
 static int count;
-static int **start_sp;
+static unsigned int start_sp;
 static unsigned int max_stack;
 
 /* every function this function calls must also be noinstrument!! */
@@ -124,8 +124,8 @@ void noinstrument __cyg_profile_func_enter_simple(void)
     char callsite[32];
 
     /* calc stack used */
-    if (count == 0) start_sp = bp;
-    unsigned int stack_used = start_sp - bp;
+    if (count == 0) start_sp = (unsigned int)bp;
+    unsigned int stack_used = start_sp - (unsigned int)bp;
     if (stack_used > max_stack) max_stack = stack_used;
 
     //print_times();

--- a/elkscmd/debug/stacktrace.h
+++ b/elkscmd/debug/stacktrace.h
@@ -2,21 +2,24 @@
 
 #define noinstrument    __attribute__((no_instrument_function))
 
+/* calc_push_count returns */
+#define BP_PUSHED   0x0100
+#define DI_PUSHED   0x0200
+#define SI_PUSHED   0x0400
+#define COUNT_MASK  0x0007
+
 /* stacktrace.c */
 void noinstrument print_stack(int arg1);
+int noinstrument calc_push_count(int *addr);
 
 /* instrumentation functions called when -finstrument-functions-simple set */
 void noinstrument __cyg_profile_func_enter_simple(void);
 void noinstrument __cyg_profile_func_exit_simple(void);
-void print_times(void);
+unsigned long noinstrument get_micro_count(void);
+void noinstrument print_times(void);
 
 /* printreg.S */
 void noinstrument print_regs(void);
 void noinstrument print_sreg(void);
 int noinstrument getcsbyte(char *addr);
 unsigned long long noinstrument rdtsc(void);
-
-/* ulltostr.c */
-char * noinstrument lltostr(long long val, int radix);
-char * noinstrument ulltostr(unsigned long long val, int radix);
-char * noinstrument lltohexstr(unsigned long long val);

--- a/elkscmd/debug/testsym.c
+++ b/elkscmd/debug/testsym.c
@@ -1,11 +1,13 @@
 /* testsym - example program built with ELKS symbol table */
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
 #include "syms.h"
 #include "stacktrace.h"
 
 void z()
 {
+    print_regs();
     printf("Stack backtrace of z:\n");
     print_stack(0xDEAD);
 }
@@ -17,15 +19,14 @@ void y(int a)
 
 void x()
 {
-    extern int errno;
     extern long lseek();
 
-    printf("x = %s\n", sym_text_symbol(x, 1));
-    printf("strlen+3 = %s\n", sym_text_symbol(strlen+3, 1));
-    printf("strlen = %s\n", sym_text_symbol(sym_fn_start_address(strlen+3), 1));
-    printf("lseek+20 = %s\n", sym_text_symbol(lseek+32, 1));
+    //printf("x = %s\n", sym_text_symbol(x, 1));
+    //printf("strlen+3 = %s\n", sym_text_symbol(strlen+3, 1));
+    //printf("strlen = %s\n", sym_text_symbol(sym_fn_start_address(strlen+3), 1));
+    //printf("lseek+20 = %s\n", sym_text_symbol(lseek+32, 1));
     //printf(".shift_loop = %s\n", sym_text_symbol((void *)0x0C71, 1));
-    printf("errno = %s\n", sym_data_symbol(&errno, 1));
+    //printf("errno = %s\n", sym_data_symbol(&errno, 1));
     y(1);
 }
 

--- a/libc/crt0.S
+++ b/libc/crt0.S
@@ -36,9 +36,9 @@ _start:
 	inc %ax
 	shl $1,%ax
 	add %bx,%ax	// envp [0]
-	push %ax
-	push %bx
-	push %cx
+	push %ax        // push for any cdecl constructors and main
+	push %bx        // argv
+	push %cx        // argc
 
 // ...Code fragments from .preinit & .preinit.* sections will go here...
 //    NOTE: these assume ax = envp, bx = argv, & may clobber dx
@@ -55,9 +55,9 @@ _start:
 #endif
 	CALL_(main)
 #ifndef __IA16_CALLCVT_REGPARMCALL
-	push %ax  // main return value
+	push %ax        // main return value
 #endif
-	CALL_N_(exit)  // no return
+	CALL_N_(exit)   // no return
 
 	.section .finihead,"ax",@progbits
 
@@ -65,7 +65,7 @@ _start:
 
 exit:
 #ifdef __IA16_CALLCVT_REGPARMCALL
-	xchg %ax,%di
+	xchg %ax,%di    // save exit arg in DI
 #endif
 
 // ...Code fragments from .fini & .fini.* sections will go here...
@@ -74,9 +74,9 @@ exit:
 	.section .finitail,"ax",@progbits
 
 #ifdef __IA16_CALLCVT_REGPARMCALL
-	xchg %ax,%di
+	xchg %ax,%di    // retrieve exit arg
 #endif
-	JMP_(_exit)  // kernel one - no return
+	JMP_(_exit)     // no return
 
 	.data
 

--- a/libc/misc/Makefile
+++ b/libc/misc/Makefile
@@ -38,7 +38,7 @@ OBJS = \
 	wildcard.o \
 	# end of list
 
-#OBJS += instrument.o
+OBJS += instrument.o
 
 all: $(LIB)
 

--- a/libc/misc/instrument.c
+++ b/libc/misc/instrument.c
@@ -1,30 +1,50 @@
 /* test -finstrument-functions-simple */
 #include <stdio.h>
+#include <string.h>
 #define noinstrument    __attribute__((no_instrument_function))
 
+static char ftrace;
 static int count;
-static int **start_sp;
+static unsigned int start_sp;
 static unsigned int max_stack;
+
+/* runs before main and rewrites argc/argv on stack if --ftrace found */
+__attribute__((no_instrument_function,cdecl,constructor(101)))
+static void checkargs(volatile int ac, char **av)
+{
+    char **avp = av + 1;
+
+    if (*avp && !strcmp(*avp, "--ftrace")) {
+        while (*avp) {
+            *avp = *(avp + 1);
+            avp++;
+        }
+        ftrace = 1;
+        ac--;
+    }
+}
 
 /* every function this function calls must also be noinstrument!! */
 void noinstrument __cyg_profile_func_enter_simple(void)
 {
+    if (!ftrace) return;
+
     int **bp = __builtin_frame_address(0);  /* find BP on stack: BP, DI, SI, ret, arg1 */
     int *calling_fn = __builtin_return_address(0);  /* return address */
     int i;
 
-    /* calc stack used */
-    if (count == 0) start_sp = bp;
-    unsigned int stack_used = start_sp - bp;
+    if (count == 0) start_sp = (unsigned int)bp;
+    unsigned int stack_used = start_sp - (unsigned int)bp;
     if (stack_used > max_stack) max_stack = stack_used;
 
     for (i=0; i<count; i++)
         putchar('|');
-    printf(">%x, stack %u/%u\n", (int)calling_fn, stack_used, max_stack);
+    printf("@%04x stack %u/%u\n", (int)calling_fn, stack_used, max_stack);
     ++count;
 }
 
 void noinstrument __cyg_profile_func_exit_simple(void)
 {
-    --count;
+    if (ftrace)
+        --count;
 }

--- a/libc/misc/instrument.c
+++ b/libc/misc/instrument.c
@@ -14,7 +14,7 @@ static void checkargs(volatile int ac, char **av)
 {
     char **avp = av + 1;
 
-    if (*avp && !strcmp(*avp, "--ftrace")) {
+    if ((*avp && !strcmp(*avp, "--ftrace")) || getenv("FTRACE")) {
         while (*avp) {
             *avp = *(avp + 1);
             avp++;


### PR DESCRIPTION
Demonstration of some new instrumentation and debugging capabilities recently added to ELKS. 

When enabled, this automatically adds an `--ftrace` command line option to all ELKS programs which displays each function call made with nesting level, and the current stack and max stack used. Currently only displays function address (symbolic display coming shortly).

This option is enabled and can be compiled in to the entire ELKS elkscmd/ build by uncommenting the `CFLBASE += -finstrument-functions-simple` line in elkscmd/Make.defs. It also requires running the latest toolchain, which can be built by running `tools/build.sh`.

The process works by using the new `gcc-ia16` constructor function capability, along with instrumentation calls compiled into every function by the new toolchain. When `-finstrument-functions-simple` is added to the compiler command line, the linker will automatically include from the C library a default version of a constructor routine that is run before `main` that checks the argc/argv command line for `--ftrace` as the first argument, and turns on function tracing while rewriting the remaining argc/argv array if found. The default instrumentation just displays the function address being called and the stack depth. This is immediately useful to determine the maximum stack an application requires, as well get a feel for the nested procedure call depth.

Of course, this capability will be much more useful when function names are taken from a symbol table included in the application binary, which will be the next step.
