### PR TITLE
[cmds] Add mini /bin/init for systems with very little RAM

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -46,6 +46,7 @@
 # 
 # -------------	----------------------------------------------------------
 sys_utils/init			:boot	:sysutil    :128k
+#sys_utils/min_init ::bin/init :boot	:sysutil    :128k
 sys_utils/getty			:boot	:sysutil    :128k
 sys_utils/login			:boot	:sysutil    :128k
 sash/sash	::bin/sh	    	:defsash	# install as /bin/sh

--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -17,6 +17,7 @@ ELKS_LIB=$(ELKS_DIR)/arch/i86/lib
 # exitemu disabled because it calls INT directly to DOSEMU
 PRGS = \
 	init \
+	min_init \
 	getty \
 	login \
 	kill \
@@ -39,8 +40,13 @@ PRGS = \
 	makeboot \
 	# EOL
 
+all: $(PRGS)
+
 init: init.o
 	$(LD) $(LDFLAGS) -maout-heap=4096 -maout-stack=1024 -o init init.o $(LDLIBS)
+
+min_init: min_init.o
+	$(LD) $(LDFLAGS) -maout-heap=256 -maout-stack=256 -o min_init min_init.o $(LDLIBS)
 
 getty: getty.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -maout-heap=1024 -maout-stack=1024 -o getty getty.o $(TINYPRINTF) $(LDLIBS)

--- a/elkscmd/sys_utils/min_init.c
+++ b/elkscmd/sys_utils/min_init.c
@@ -1,5 +1,10 @@
 /*
- * init.c
+ * min_init.c
+ *
+ * This is a small version of init for use in the ELKS project.
+ * It is not fully functional, and may not be the most efficient
+ * implementation for larger systems. It minimises memory usage and
+ * code size.
  *
  * Copyright 1997 Alistair Riddoch
  * ajr@ecs.soton.ac.uk
@@ -7,37 +12,35 @@
  * This file may be distributed under the terms of the GNU General Public
  * License v2, or at your option any later version.
  */
-
-/*
- * This is a small version of init for use in the ELKS project.
- * It is not fully functional, and may not be the most efficient
- * implementation for larger systems. It minimises memory usage and
- * code size.
- */
-
-#include <sys/types.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
-#include <utmp.h>
 #include <fcntl.h>
 #include <string.h>
+#include <sys/wait.h>
+
+#define USE_UTMP	0	/* =1 to use /var/run/utmp*/
+#define DEBUG		0	/* =1 for debug messages*/
+
+#if USE_UTMP
+#include <utmp.h>
+struct utmp entry;
+#endif
 
 struct exec_struct {
-	char tty_name[12];
+	char tty_name[10];
 	pid_t tty_pid;
 };
 
-#define NUM_TTYS 3
-/* #define DEBUG */
-
+#define NUM_TTYS    1
 struct exec_struct tty_list[] = {
 	{"/dev/tty1", 0},
-/*	{"/dev/ttys1", 0},*/
-	{"/dev/tty2", 0},
-	{"/dev/tty3", 0}
+//  {"/dev/tty2", 0},
+//  {"/dev/tty3", 0},
+//	{"/dev/ttyS1", 0},
 };
 
-char *nargv[2] = {"/bin/getty", NULL};
+char *nargv[2] = {"/bin/login", NULL};
 
 int determine_tty(int pid)
 {
@@ -48,24 +51,24 @@ int determine_tty(int pid)
 	return -1;
 }
 
-struct utmp entry;
-
 int spawn_tty(int num)
 {
 	int pid, fd;
 
 	if ((pid = fork()) != 0) {
+#if USE_UTMP
 		strcpy(entry.ut_line, tty_list[num].tty_name + 5);
 		entry.ut_id[0] = tty_list[num].tty_name[8];
 		entry.ut_id[1] = tty_list[num].tty_name[9];
 		entry.ut_pid = pid;
 		setutent();
 		pututline(&entry);
+#endif
 		return pid;
 	}
 	setsid();
 
-#ifdef DEBUG
+#if DEBUG
 	close(0);
 	close(1);
 	close(2);
@@ -79,26 +82,26 @@ int spawn_tty(int num)
 	dup2(fd ,STDERR_FILENO);
 
 	execv(nargv[0], nargv);
-#ifdef DEBUG
-	perror("EXEC:\n");
+#if DEBUG
+	perror("execv");
 #endif
 	exit(1);
 }
 
-void main(int argc,char ** argv)
+int main(int argc,char ** argv)
 {
-	int i, pid, fd;
+	int i;
 	/* FIXME - Should really clean up utmp here */
 
+#if DEBUG
 	argv[0] = "init";
-
-#ifdef DEBUG
-	fd = open("/dev/tty1", 2);
+	int fd = open("/dev/tty1", 2);
 	dup2(fd, 0);
 	dup2(fd, 1);
 	dup2(fd, 2);
 #endif
 
+#if USE_UTMP
 	memset(&entry, 0, sizeof(struct utmp));
 	entry.ut_type = INIT_PROCESS;
 	time(&entry.ut_time);
@@ -110,29 +113,25 @@ void main(int argc,char ** argv)
 
 	entry.ut_type = LOGIN_PROCESS;
 	strcpy(entry.ut_user, "LOGIN");
+#endif
 	for (i = 0; i < NUM_TTYS; i++) {
-		pid = spawn_tty(i);
-		tty_list[i].tty_pid = pid;
+		tty_list[i].tty_pid = spawn_tty(i);
 	}
+#if USE_UTMP
 	endutent();
-
-#ifdef DEBUG
-	printf("PID of init is %d\n",getpid());
-	fflush(stdout);
 #endif
 
 	while (1) {
-		pid = wait(NULL);
+		int pid = wait(NULL);
 		if (-1 == pid)
 			continue;
 		i = determine_tty(pid);
-#ifdef DEBUG
-		printf("TTY %d died %d\n", i, pid);
-		fflush(stdout);
-#endif
-		tty_list[i].tty_pid = 0;
+#if USE_UTMP
 		time(&entry.ut_time);
+#endif
 		tty_list[i].tty_pid = spawn_tty(i);
+#if USE_UTMP
 		endutent();
+#endif
 	}
 }


### PR DESCRIPTION
Smaller than 1K executable and runs in less than 1.5K RAM.

Edit `elkscmd/Applications` to enable. Runs `/bin/login` on compiled-in /dev/tty1 or others.