### PR TITLE
Fix ash crash checking TERM from linenoise

### DIFF
--- a/elkscmd/ash/linenoise_elks.c
+++ b/elkscmd/ash/linenoise_elks.c
@@ -257,8 +257,7 @@ void linenoiseSetMultiLine(int ml) {
 /* Return true if the terminal name is in the list of terminals we know are
  * not able to understand basic escape sequences. */
 static int isUnsupportedTerm(void) {
-    //char *term = getenv("TERM");
-    char *term = bltinlookup("TERM", 1);    /* getenv won't work here for ELKS*/
+    char *term = termval();
     int j;
 
     if (term == NULL) return 0;

--- a/elkscmd/ash/mkbuiltins
+++ b/elkscmd/ash/mkbuiltins
@@ -89,11 +89,11 @@ do
 	shift
 	for fun
 	do
-		echo "	\"$fun\", $i,"
+		echo "	{ \"$fun\", $i },"
 	done
 	i=`expr $i + 1`
 done < $temp
-echo '	NULL, 0
+echo '	{ NULL, 0 }
 };'
 
 exec > builtins.h

--- a/elkscmd/ash/options.c
+++ b/elkscmd/ash/options.c
@@ -175,10 +175,8 @@ options(cmdline) {
 
 
 STATIC void
-setoption(flag, val)
-	char flag;
-	int val;
-	{
+setoption(int flag, int val)
+{
 	register char *p;
 
 	if ((p = strchr(optchar, flag)) == NULL)

--- a/elkscmd/ash/parser.c
+++ b/elkscmd/ash/parser.c
@@ -684,7 +684,7 @@ STATIC int readtoken(void) {
 #define RETURN(token)	return lasttoken = token
 
 STATIC int xxreadtoken(void) {
-	register c;
+	int c;
 
 	if (tokpushback) {
 		tokpushback = 0;

--- a/elkscmd/ash/parser.c
+++ b/elkscmd/ash/parser.c
@@ -104,7 +104,9 @@ STATIC void parsefname __P((void));
 STATIC void parseheredoc __P((void));
 STATIC int readtoken __P((void));
 STATIC int readtoken1 __P((int, char const *, char *, int));
-void attyline __P((void));
+#if ATTY
+STATIC void attyline __P((void));
+#endif
 STATIC int noexpand __P((char *));
 STATIC void synexpect __P((int));
 STATIC void synerror __P((char *));

--- a/elkscmd/ash/show.c
+++ b/elkscmd/ash/show.c
@@ -268,9 +268,8 @@ trace(fmt, a1, a2, a3, a4, a5, a6, a7, a8)
 }
 
 
-trputs(s)
-	char *s;
-	{
+void trputs(char *s)
+{
 	if (tracefile == NULL)
 		return;
 	fputs(s, tracefile);
@@ -279,10 +278,9 @@ trputs(s)
 }
 
 
-trstring(s)
-	char *s;
-	{
-	register char *p;
+void trstring(char *s)
+{
+	char *p;
 	char c;
 
 	if (tracefile == NULL)

--- a/elkscmd/ash/var.c
+++ b/elkscmd/ash/var.c
@@ -79,9 +79,7 @@ struct var vps1;
 struct var vps2;
 struct var vpse;
 struct var vvers;
-#if ATTY
 struct var vterm;
-#endif
 
 const struct varinit varinit[] = {
 #if ATTY
@@ -96,9 +94,7 @@ const struct varinit varinit[] = {
 	 */
 	{&vps2,	VSTRFIXED|VTEXTFIXED,		"PS2=> "},
 	{&vpse,	VSTRFIXED|VTEXTFIXED|VUNSET,	"PSE="},
-#if ATTY
 	{&vterm,	VSTRFIXED|VTEXTFIXED|VUNSET,	"TERM="},
-#endif
 	{NULL,	0,				NULL}
 };
 

--- a/elkscmd/ash/var.h
+++ b/elkscmd/ash/var.h
@@ -76,9 +76,7 @@ extern struct var vpath;
 extern struct var vps1;
 extern struct var vps2;
 extern struct var vpse;
-#if ATTY
 extern struct var vterm;
-#endif
 
 /*
  * The following macros access the values of the above variables.
@@ -93,9 +91,7 @@ extern struct var vterm;
 #define ps1val()	(vps1.text + 4)
 #define ps2val()	(vps2.text + 4)
 #define pseval()	(vpse.text + 4)
-#if ATTY
 #define termval()	(vterm.text + 5)
-#endif
 
 #if ATTY
 #define attyset()	((vatty.flags & VUNSET) == 0)


### PR DESCRIPTION
When running ash natively on x64 Linux, I can trigger a crash in the `bltinlookup` function due to an overwritten pointer.  16-bit code may or may not crash, but it would be dereferencing freed memory and therefore behave non-deterministically.

Commit 8da6aec933dc1b8e071364b11661c04141f4a85b included this change:
```
 static int isUnsupportedTerm(void) {
-    char *term = getenv("TERM");
+    //char *term = getenv("TERM");
+    char *term = bltinlookup("TERM", 1);    /* getenv won't work here for ELKS*/
     int j;
```

I read "won't work" as "check the shell's current environment, not the one it was started from".  Makes sense, except it appears that `bltinlookup` is only valid to be called in particular contexts.

These environment variables are stored on a stack-like data structure, and by using a hardware watchpoint, I can see that shortly before the crash, this memory location is re-used by the "stack" for some other purpose.  I only loosely understand the code at this point, but I suspect that the allocations are popped off the "stack" during an error, and therefore `bltinlookup()` is not guaranteed valid in all contexts.  For comparison, the rest of ash only calls it from within a builtin command.

And in fact, this theory seems even more likely, since I can only reproduce the crash when I dereference a variable in an error context.

```
$ A=1
$ ecoh $A
ecoh: not found

Program received signal SIGSEGV, Segmentation fault.
varequal (p=p@entry=0x1 <error: Cannot access memory at address 0x1>, q=q@entry=0x55555556825c "TERM") at var.c:649
649		while (*p == *q++) {
(gdb) bt
#0  varequal (p=p@entry=0x1 <error: Cannot access memory at address 0x1>, q=q@entry=0x55555556825c "TERM") at var.c:649
#1  0x0000555555563006 in bltinlookup (name=name@entry=0x55555556825c "TERM", doall=doall@entry=1) at var.c:312
#2  0x000055555556400b in isUnsupportedTerm () at linenoise_elks.c:261
#3  linenoise (prompt=0x5555555681b5 "$ ") at linenoise_elks.c:1218
#4  0x000055555555bf78 in preadbuffer () at input.c:225
#5  0x0000555555560ebc in xxreadtoken () at parser.c:697
#6  0x00005555555610a4 in readtoken () at parser.c:625
#7  0x0000555555561379 in parsecmd (interact=interact@entry=1) at parser.c:143
#8  0x000055555555d7f7 in cmdloop (top=top@entry=1) at main.c:235
#9  0x000055555555da4a in main (argc=1, argv=0x7fffffffe168) at main.c:199
(gdb) up
(gdb) print cmdenviron[0]
$2 = {next = 0x0, text = 0x1 <error: Cannot access memory at address 0x1>}
```