### PR TITLE
[disasm] Disassemble ELKS binaries and display .data symbols

### DIFF
--- a/elkscmd/debug/dis.c
+++ b/elkscmd/debug/dis.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <fcntl.h>
+#include <getopt.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
 #include <linuxmt/mem.h>
@@ -16,7 +17,11 @@
 #include "disasm.h"
 
 #define KSYMTAB         "/lib/system.sym"
+
+#define MAGIC       0x0301  /* magic number for executable progs */
+
 char f_ksyms;
+char f_syms;
 unsigned short textseg, ftextseg, dataseg;
 
 char * noinstrument getsymbol(int seg, int offset)
@@ -30,6 +35,11 @@ char * noinstrument getsymbol(int seg, int offset)
             return sym_ftext_symbol((void *)offset, 1);
         if (seg == dataseg)
             return sym_data_symbol((void *)offset, 1);
+    }
+    if (f_syms) {
+        if (seg == dataseg)
+            return sym_data_symbol((void *)offset, 1);
+        return sym_text_symbol((void *)offset, 1);
     }
     sprintf(buf, f_asmout? "0x%04x": "%04x", offset);
     return buf;
@@ -46,6 +56,11 @@ char * noinstrument getsegsymbol(int seg)
             return ".fartext";
         if (seg == dataseg)
             return ".data";
+    }
+    if (f_syms) {
+        if (seg == dataseg)
+            return ".data";
+        return ".text";
     }
     sprintf(buf, f_asmout? "0x%04x": "%04x", seg);
     return buf;
@@ -70,7 +85,7 @@ void disasm_mem(int cs, int ip, int opcount)
     if (!f_asmout) printf("Disassembly of %s:\n", getsymbol(cs, (int)ip));
     for (n=0; n<opcount; n++) {
         if (!f_asmout) printf("%04hx:%04hx  ", cs, ip);
-        nextip = disasm(cs, ip, nextbyte_mem);
+        nextip = disasm(cs, ip, nextbyte_mem, dataseg);
         if (opcount == 32767 && peekb(cs, ip) == 0xc3)  /* RET */
             break;
         ip = nextip;
@@ -94,17 +109,22 @@ int disasm_file(char *filename)
     long filesize;
     struct stat sbuf;
 
-    if ((infp = fopen(filename, "r")) == NULL) {
+    if (stat(filename, &sbuf) < 0 || (infp = fopen(filename, "r")) == NULL) {
         printf("Can't open %s\n", filename);
         return 1;
     }
-    if (stat(filename, &sbuf) < 0)
-        filesize = 0;
-    else filesize = sbuf.st_size;
+    filesize = sbuf.st_size;
+    f_syms = sym_read_exe_symbols(filename)? 1: 0;
+    if (f_syms || (sym_hdr.type & 0xFFFF) == MAGIC) {
+            fseek(infp, sym_hdr.hlen, SEEK_SET);
+            filesize = sym_hdr.tseg;    /* FIXME no .fartext yet */
+            textseg = 0;
+            dataseg = 1;
+    }
 
     while (ip < filesize) {
         if (!f_asmout) printf("%04hx  ", ip);
-        nextip = disasm(0, ip, nextbyte_file);
+        nextip = disasm(textseg, ip, nextbyte_file, dataseg);
         ip = nextip;
     }
     fclose(infp);
@@ -113,33 +133,44 @@ int disasm_file(char *filename)
 
 void usage(void)
 {
-    printf("Usage: disasm [-k] [-a] [[seg:off[#size] | filename]\n");
+    printf("Usage: disasm [-k] [-a] [-s symfile] [[seg:off[#size] | filename]\n");
     exit(1);
 }
 
 int main(int ac, char **av)
 {
     unsigned long seg = 0, off = 0;
-    int fd;
+    int fd, ch;
+    char *symfile = NULL;
     long count = 22;
 
-    while (ac > 1 && av[1][0] == '-') {
-        if (av[1][1] == 'a')
+    while ((ch = getopt(ac, av, "kas:")) != -1) {
+        switch (ch) {
+        case 'a':
             f_asmout = 1;
-        else if (av[1][1] == 'k')
+            break;
+        case 'k':
             f_ksyms = 1;
-        else usage();
-        ac--;
-        av++;
+            symfile = KSYMTAB;
+            break;
+        case 's':
+            f_syms = 1;
+            symfile = optarg;
+            break;
+        default:
+            usage();
+        }
     }
-    if (ac != 2)
+    ac -= optind;
+    av += optind;
+    if (ac < 1)
         usage();
 
+    if (symfile && !sym_read_symbols(symfile)) {
+        printf("Can't open %s\n", symfile);
+        exit(1);
+    }
     if (f_ksyms) {
-        if (!sym_read_symbols(KSYMTAB)) {
-            printf("Can't open %s\n", KSYMTAB);
-            exit(1);
-        }
         fd = open("/dev/kmem", O_RDONLY);
         if (fd < 0
             || ioctl(fd, MEM_GETCS, &textseg) < 0
@@ -151,14 +182,14 @@ int main(int ac, char **av)
         close(fd);
     }
 
-    if (strchr(av[1], ':')) {
-        sscanf(av[1], "%lx:%lx#%ld", &seg, &off, &count);
+    if (strchr(*av, ':')) {
+        sscanf(*av, "%lx:%lx#%ld", &seg, &off, &count);
 
         if (seg > 0xffff || off > 0xffff) {
             printf("Error: segment or offset larger than 0xffff\n");
             return 1;
         }
         disasm_mem((int)seg, (int)off, (int)count);
-    } else return disasm_file(av[1]);
+    } else return disasm_file(*av);
     return 0;
 }

--- a/elkscmd/debug/disasm.h
+++ b/elkscmd/debug/disasm.h
@@ -7,6 +7,6 @@ char * noinstrument getsymbol(int seg, int offset);
 char * noinstrument getsegsymbol(int seg);
 
 /* disasm.c */
-int disasm(int cs, int ip, int (*nextbyte)(int, int));
+int disasm(int cs, int ip, int (*nextbyte)(int, int), int ds);
 extern int f_asmout;    /* =1 for asm output (no addresses or hex values) */
 extern int f_outcol;    /* output column number (if !f_asmout) */

--- a/elkscmd/debug/instrument.c
+++ b/elkscmd/debug/instrument.c
@@ -11,7 +11,7 @@
 #include "syms.h"
 
 /* turn on for microcycle (CPU cycle/1000) timing info */
-#define HAS_RDTSC       1   /* has RDTSC instruction: requires 386+ CPU */
+#define HAS_RDTSC       0   /* has RDTSC instruction: requires 386+ CPU */
 
 static char ftrace;
 static int count;

--- a/elkscmd/debug/syms.h
+++ b/elkscmd/debug/syms.h
@@ -24,4 +24,24 @@ unsigned char * noinstrument sym_read_symbols(char *path);
 char * noinstrument sym_text_symbol(void *addr, int exact);
 char * noinstrument sym_ftext_symbol(void *addr, int exact);
 char * noinstrument sym_data_symbol(void *addr, int exact);
+char * noinstrument sym_symbol(void *addr, int exact);
 void * noinstrument sym_fn_start_address(void *addr);
+
+/* a.out header */
+#include <stdint.h>
+
+struct minix_exec_hdr {
+    uint32_t  type;
+    uint8_t   hlen;       // 0x04
+    uint8_t   reserved1;
+    uint16_t  version;
+    uint32_t  tseg;       // 0x08
+    uint32_t  dseg;       // 0x0c
+    uint32_t  bseg;       // 0x10
+    uint32_t  entry;
+    uint16_t  chmem;
+    uint16_t  minstack;
+    uint32_t  syms;
+};
+
+extern struct minix_exec_hdr sym_hdr;


### PR DESCRIPTION
Updates `disasm` to disassemble ELKS binaries when symbol table present.
Also now displays kernel .data segment symbols.

Things are coming along with the ability to disassemble programs in /bin, as well as the running kernel. This allows for much better understanding of code on an operating ELKS system.

Here's a screenshot of the startup code in /bin/basic when built with debug info, using `disasm /bin/basic | more`:
<img width="832" alt="Screen Shot 2023-01-19 at 12 19 57 PM" src="https://user-images.githubusercontent.com/11985637/213543447-640f2fa8-27ab-4e69-bafc-26b3cea080d6.png">

Here's the startup code for the memory resident kernel being disassembled using the kernel symbol table in /lib/system.sym, using `disasm -k 2d0:0#1024 | more`:
<img width="832" alt="Screen Shot 2023-01-19 at 12 20 06 PM" src="https://user-images.githubusercontent.com/11985637/213543646-f52996c6-4629-48a8-b0ca-533dac57c333.png">
