### PR TITLE
[cmds] Build 'hostdisasm` for host-based ELKS disassembler

### DIFF
--- a/elkscmd/debug/Makefile
+++ b/elkscmd/debug/Makefile
@@ -12,7 +12,7 @@ include $(BASEDIR)/Make.rules
 
 PRGS = testsym disasm opcodes
 INSTRUMENTOBJS = instrument.o syms.o shared.o shared-asm.o
-DISASMOBJS = dis.o disasm.o syms.o shared-asm.o
+DISASMOBJS = dis.o disasm.o syms.o
 TESTOBJS   = testsym.o stacktrace.o printreg.o $(INSTRUMENTOBJS)
 
 # disable tail call optimization for better stack traces
@@ -27,12 +27,9 @@ LDFLAGS += -maout-symtab -maout-heap=12000
 # added after CFLAGS for non-instrumented .c files in this directory
 NOINSTFLAGS = -fno-instrument-functions -fno-instrument-functions-simple
 
-HOSTPRGS = nm86
+HOSTPRGS = nm86 hostdisasm
 
 all: $(HOSTPRGS) $(PRGS)
-
-nm86: nm86.c syms.c
-	$(HOSTCC) $(HOSTCFLAGS) -o $@ $^
 
 testsym: $(TESTOBJS)
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
@@ -54,6 +51,12 @@ disasm.o: disasm.c
 
 dis.o: dis.c
 	$(CC) $(CFLAGS) $(NOINSTFLAGS) -c -o $*.o $<
+
+nm86: nm86.c syms.c
+	$(HOSTCC) $(HOSTCFLAGS) -o $@ $^
+
+hostdisasm: dis.c disasm.c syms.c
+	$(HOSTCC) $(HOSTCFLAGS) -D__far= -Wno-int-to-void-pointer-cast -Wno-format -o $@ $^
 
 install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin

--- a/elkscmd/debug/dis.c
+++ b/elkscmd/debug/dis.c
@@ -11,10 +11,12 @@
 #include <getopt.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
-#include <linuxmt/mem.h>
 #include "syms.h"
 #include "instrument.h"
 #include "disasm.h"
+#if __ia16__
+#include <linuxmt/mem.h>
+#endif
 
 #define KSYMTAB         "/lib/system.sym"
 
@@ -170,6 +172,8 @@ int main(int ac, char **av)
         printf("Can't open %s\n", symfile);
         exit(1);
     }
+
+#if __ia16__
     if (f_ksyms) {
         fd = open("/dev/kmem", O_RDONLY);
         if (fd < 0
@@ -181,6 +185,7 @@ int main(int ac, char **av)
         }
         close(fd);
     }
+#endif
 
     if (strchr(*av, ':')) {
         sscanf(*av, "%lx:%lx#%ld", &seg, &off, &count);

--- a/elkscmd/debug/syms.c
+++ b/elkscmd/debug/syms.c
@@ -117,7 +117,7 @@ static char * noinstrument sym_string(void *addr, int exact,
     int (*istype)(unsigned char *p))
 {
     unsigned char *p, *lastp;
-    static char buf[32];
+    static char buf[64];
 
     if (!syms && !sym_read_exe_symbols(__program_filename)) {
 hex:


### PR DESCRIPTION
`hostdisasm` is now built in elkscmd/debug to provide host-based disassembler for ELKS binaries. If symbol table is present in the binary, symbolic disassembly will be displayed. `hostdisasm` is basically the same as the ELKS `disasm` except memory-based disassembly isn't implemented.

To test, `cd elkscmd/debug; make`, then `./hostdisasm testsym` for an example with symbolic disassembly.