### PR TITLE
[libc] Fix fd leak: Close even if flush fails

### DIFF
--- a/libc/stdio/fclose.c
+++ b/libc/stdio/fclose.c
@@ -7,48 +7,48 @@
 int
 fclose (FILE *fp)
 {
-   int   rv = 0;
+    int   rv = 0;
 
-   if (fp == 0)
-   {
-      errno = EINVAL;
-      return EOF;
-   }
-   if (fp->fd != -1)
-   {
-      if (fflush(fp))
-	 return EOF;
+    if (fp == 0)
+    {
+        errno = EINVAL;
+        return EOF;
+    }
+    if (fp->fd != -1)
+    {
+        if (fflush(fp))
+            rv = EOF;
 
-      if (close(fp->fd))
-	 rv = EOF;
-      fp->fd = -1;
-   }
+        if (close(fp->fd))
+            rv = EOF;
+        fp->fd = -1;
+    }
 
-   if (fp->mode & __MODE_FREEBUF)
-   {
-      free(fp->bufstart);
-      fp->mode &= ~__MODE_FREEBUF;
-      fp->bufstart = fp->bufend = 0;
-   }
+    if (fp->mode & __MODE_FREEBUF)
+    {
+        free(fp->bufstart);
+        fp->mode &= ~__MODE_FREEBUF;
+        fp->bufstart = fp->bufend = 0;
+    }
 
-   if (fp->mode & __MODE_FREEFIL)
-   {
-      FILE *prev = 0, *ptr;
-      fp->mode = 0;
+    if (fp->mode & __MODE_FREEFIL)
+    {
+        FILE *prev = 0, *ptr;
+        fp->mode = 0;
 
-      for (ptr = __IO_list; ptr && ptr != fp; ptr = ptr->next)
-	 ;
-      if (ptr == fp)
-      {
-	 if (prev == 0)
-	    __IO_list = fp->next;
-	 else
-	    prev->next = fp->next;
-      }
-      free(fp);
-   }
-   else
-      fp->mode = 0;
+        for (ptr = __IO_list; ptr && ptr != fp; ptr = ptr->next)
+            ;
+        if (ptr == fp)
+        {
+            if (prev == 0)
+                __IO_list = fp->next;
+            else
+                prev->next = fp->next;
+        }
+        free(fp);
+    }
+    else
+        fp->mode = 0;
 
-   return rv;
+    return rv;
 }


### PR DESCRIPTION
POSIX says that if fclose fails, the state of the handle is undefined, so the app is not allowed to try again to close it.  And it's widely known that if you really care about data integrity, you must manually flush and error check first, before closing.  So no matter what, fclose should close.