### PR TITLE
[libc] Optimize libc's opendir more like ash's

### DIFF
--- a/elkscmd/test/libc/system.c
+++ b/elkscmd/test/libc/system.c
@@ -49,25 +49,25 @@ TEST_CASE(system_sleep)
 
 TEST_CASE(system_dirent)
 {
-	DIR *d;
-	struct dirent *de;
+    DIR *d;
+    struct dirent *de;
 
-	d = opendir("doesnotexist");
-	EXPECT_EQ(errno, ENOENT);
-	ASSERT_EQ_P(d, NULL);
+    d = opendir("doesnotexist");
+    EXPECT_EQ(errno, ENOENT);
+    ASSERT_EQ_P(d, NULL);
 
-	d = opendir("/");
-	ASSERT_NE_P(d, NULL);
-	for (de = NULL; de; ) {
-		errno = 0;
-		de = readdir(d);
-		if (de == NULL) {
-			ASSERT_NE(errno, 0);
-			break;
-		}
-	}
-	/* TODO rewinddir, seekdir, telldir */
-	ASSERT_SYS(closedir(d), 0, 0);
+    d = opendir("/");
+    ASSERT_NE_P(d, NULL);
+    for (de = NULL; de; ) {
+        errno = 0;
+        de = readdir(d);
+        if (de == NULL) {
+            ASSERT_NE(errno, 0);
+            break;
+        }
+    }
+    /* TODO rewinddir, seekdir, telldir */
+    ASSERT_SYS(closedir(d), 0, 0);
 }
 
 TEST_CASE(system_scandir)

--- a/elkscmd/test/libc/system.c
+++ b/elkscmd/test/libc/system.c
@@ -56,7 +56,11 @@ TEST_CASE(system_dirent)
     EXPECT_EQ(errno, ENOENT);
     ASSERT_EQ_P(d, NULL);
 
-    d = opendir("/");
+    d = opendir("/bin/sh");
+    EXPECT_EQ(errno, ENOTDIR);
+    ASSERT_EQ_P(d, NULL);
+
+    d = opendir("/bin");
     ASSERT_NE_P(d, NULL);
     for (de = NULL; de; ) {
         errno = 0;

--- a/libc/system/closedir.c
+++ b/libc/system/closedir.c
@@ -7,7 +7,6 @@ closedir(DIR *dirp)
 {
     int fd;
     fd = dirp->dd_fd;
-    free(dirp->dd_buf);
     free(dirp);
     return close(fd);
 }

--- a/libc/system/closedir.c
+++ b/libc/system/closedir.c
@@ -5,9 +5,9 @@
 int
 closedir(DIR *dirp)
 {
-   int   fd;
-   fd = dirp->dd_fd;
-   free(dirp->dd_buf);
-   free(dirp);
-   return close(fd);
+    int fd;
+    fd = dirp->dd_fd;
+    free(dirp->dd_buf);
+    free(dirp);
+    return close(fd);
 }

--- a/libc/system/opendir.c
+++ b/libc/system/opendir.c
@@ -5,40 +5,40 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-DIR  *
+DIR *
 opendir(const char *dname)
 {
-   struct stat st;
-   int   fd;
-   DIR  *p;
+    struct stat st;
+    int fd;
+    DIR *p;
 
-   if (stat(dname, &st) < 0)
-      return 0;
+    if (stat(dname, &st) < 0)
+        return 0;
 
-   if (!S_ISDIR(st.st_mode))
-   {
-      errno = ENOTDIR;
-      return 0;
-   }
-   if ((fd = open(dname, O_RDONLY)) < 0)
-      return 0;
+    if (!S_ISDIR(st.st_mode))
+    {
+        errno = ENOTDIR;
+        return 0;
+    }
+    if ((fd = open(dname, O_RDONLY)) < 0)
+        return 0;
 
-   p = malloc(sizeof(DIR));
-   if (p == 0)
-   {
-      close(fd);
-      return 0;
-   }
+    p = malloc(sizeof(DIR));
+    if (p == 0)
+    {
+        close(fd);
+        return 0;
+    }
 
-   p->dd_buf = malloc(sizeof(struct dirent));
-   if (p->dd_buf == 0)
-   {
-      free(p);
-      close(fd);
-      return 0;
-   }
-   p->dd_fd = fd;
-   p->dd_loc = p->dd_size = 0;
+    p->dd_buf = malloc(sizeof(struct dirent));
+    if (p->dd_buf == 0)
+    {
+        free(p);
+        close(fd);
+        return 0;
+    }
+    p->dd_fd = fd;
+    p->dd_loc = p->dd_size = 0;
 
-   return p;
+    return p;
 }


### PR DESCRIPTION
Optimize for the common case and do the open first.  This avoids a namei() call; verifying that it is a directory is just a flag check. This also closes the race of interpreting the name twice and possibly getting inconsistent results.

Use a single allocation; avoids a malloc/free.