### PR TITLE
[cmds] Fix curses (0,0) origin in fm

### DIFF
--- a/elkscmd/tui/curses.c
+++ b/elkscmd/tui/curses.c
@@ -84,12 +84,12 @@ void refresh()
 
 void mvcur(int oy, int ox, int y, int x)
 {
-    printf("\e[%d;%dH", y, x);
+    move(y, x);
 }
 
 int mvaddch(int y, int x, int ch)
 {
-    printf("\e[%d;%dH%c", y, x, ch);
+    printf("\e[%d;%dH%c", y+1, x+1, ch);
     return OK;
 }
 
@@ -107,7 +107,7 @@ void erase()
 
 void move(int y, int x)
 {
-    printf("\e[%d;%dH", y, x);
+    printf("\e[%d;%dH", y+1, x+1);
 }
 
 void clrnl(void)

--- a/elkscmd/tui/fm.c
+++ b/elkscmd/tui/fm.c
@@ -363,7 +363,7 @@ void
 exitcurses(void)
 {
 	endwin(); /* Restore terminal */
-    move(LINES-1, 0);
+    move(LINES - 2, 0);
     clrtoeol();
 }
 
@@ -377,7 +377,7 @@ info(char *fmt, ...)
 	va_start(ap, fmt);
 	vsnprintf(buf, sizeof(buf), fmt, ap);
 	va_end(ap);
-	move(LINES - 1, 0);
+	move(LINES - 2, 0);
     clrtoeol();
 	printw("%s", buf);
 }
@@ -392,7 +392,7 @@ warn(char *fmt, ...)
 	va_start(ap, fmt);
 	vsnprintf(buf, sizeof(buf), fmt, ap);
 	va_end(ap);
-	move(LINES - 1, 0);
+	move(LINES - 2, 0);
 	printw("%s: %s\n", buf, strerror(errno));
 }
 
@@ -414,7 +414,7 @@ fatal(char *fmt, ...)
 void
 clearprompt(void)
 {
-	move(LINES - 1, 0);
+	move(LINES - 2, 0);
     clrtoeol();
 }
 

--- a/libc/system/opendir.c
+++ b/libc/system/opendir.c
@@ -8,9 +8,9 @@
 DIR *
 opendir(const char *dname)
 {
-    struct stat st;
     int fd;
     DIR *p;
+    struct stat st;
 
     if ((fd = open(dname, O_RDONLY)) < 0)
         return NULL;
@@ -28,7 +28,7 @@ opendir(const char *dname)
         return NULL;
     }
 
-    p->dd_buf = (char *)p + sizeof(DIR);
+    p->dd_buf = (struct dirent *)((char *)p + sizeof(DIR));
     p->dd_fd = fd;
     p->dd_loc = p->dd_size = 0;
 


### PR DESCRIPTION
Fixes issue described in https://github.com/jbruchon/elks/discussions/1505#discussioncomment-4788701.

Also removes compiler warning from @ccoffing's last commit.