### PR TITLE
[cmds] Fix clock on PC-98 and ps based on config options

### DIFF
--- a/elkscmd/debug/disasm.c
+++ b/elkscmd/debug/disasm.c
@@ -125,6 +125,7 @@ void out_bw(int flags)
     /* discard register operands */
     if (flags & REGOP)
         return;
+    f_outcol++;
     putchar(wordSize? 'w': 'b');
 }
 static void outs(const char *str, int flags)
@@ -159,9 +160,12 @@ static void outs(const char *str, int flags)
         printf(".byte 0x%02x\n", opcode);
         return;
     }
+    f_outcol = strlen(str);
     printf("%s", str);
     if (flags & BW) out_bw(flags);
-    if (flags != 0) putchar('\t');
+    if (flags != 0) {
+        while (f_outcol++ & 7) putchar(' ');
+    }
 #if 0
     if (segOver != -1) {
         printf("%s", segregs[segOver]);
@@ -286,10 +290,12 @@ nextopcode:
                 goto nextopcode;
 #endif
                 }
-            case 0x27: case 0x2f:  // DA
+            case 0x27:              // DAA
+            case 0x2f:              // DAS
                 outs(opcode == 0x27? "daa": "das", 0);
                 break;
-            case 0x37: case 0x3f:  // AA
+            case 0x37:              // AAA
+            case 0x3f:              // AAS
                 outs(opcode == 0x37? "aaa": "aas", 0);
                 break;
             case 0x40: case 0x41: case 0x42: case 0x43:

--- a/elkscmd/sys_utils/clock.c
+++ b/elkscmd/sys_utils/clock.c
@@ -1,3 +1,4 @@
+#include <autoconf.h>           /* for CONFIG_ options */
 #include <stdio.h>
 #include <stdlib.h>
 #include <getopt.h>

--- a/elkscmd/sys_utils/ps.c
+++ b/elkscmd/sys_utils/ps.c
@@ -13,6 +13,7 @@
 #include <linuxmt/ntty.h>
 #undef __KERNEL__
 
+#include <autoconf.h>           /* for CONFIG_ options */
 #include <linuxmt/mm.h>
 #include <linuxmt/mem.h>
 #include <linuxmt/major.h>


### PR DESCRIPTION
Fixes `clock` and `ps` on PC-98 build CONFIG options based on conversation in https://github.com/jbruchon/elks/issues/1482#issuecomment-1416698919. 

Also updates `disasm` source code from 86sim project.