### PR TITLE
fgets boundary bug

### DIFF
--- a/elkscmd/test/libc/main.c
+++ b/elkscmd/test/libc/main.c
@@ -22,6 +22,7 @@ void test_misc_dirname();
 void test_misc_getcwd();
 void test_misc_strtol();
 void test_regex_regcomp();
+void test_stdio_fgets_boundary();
 void test_stdio_init();
 void test_stdio_seek();
 void test_string_memchr();
@@ -70,7 +71,7 @@ int main(int argc, char **argv)
 			usage(argv);
 	}
 
-	testfn_t tests[36];
+	testfn_t tests[37];
 	i = 0;
 	tests[i++] = test_error_strerror;
 	tests[i++] = test_inet_aton_ntoa;
@@ -89,6 +90,7 @@ int main(int argc, char **argv)
 	tests[i++] = test_misc_getcwd;
 	tests[i++] = test_misc_strtol;
 	tests[i++] = test_regex_regcomp;
+	tests[i++] = test_stdio_fgets_boundary;
 	tests[i++] = test_stdio_init;
 	tests[i++] = test_stdio_seek;
 	tests[i++] = test_string_memchr;

--- a/libc/stdio/fgets.c
+++ b/libc/stdio/fgets.c
@@ -3,27 +3,25 @@
 char *
 fgets(char *s, size_t count, FILE *f)
 {
-   char *ret;
-   register size_t i;
-   register int ch;
+    char *ret;
+    register size_t i;
+    register int ch;
 
-   ret = s;
-   for (i = count-1; i > 0; i--)
-   {
-      ch = getc(f);
-      if (ch == EOF)
-      {
-	 if (s == ret)
-	    return 0;
-	 break;
-      }
-      *s++ = (char) ch;
-      if (ch == '\n')
-	 break;
-   }
-   *s = 0;
+    ret = s;
+    for (i = count-1; i > 0; i--) {
+        ch = getc(f);
+        if (ch == EOF) {
+            if (s == ret)
+                return 0;
+            break;
+        }
+        *s++ = (char) ch;
+        if (ch == '\n')
+            break;
+    }
+    *s = 0;
 
-   if (ferror(f))
-      return 0;
-   return ret;
+    if (ferror(f))
+        return 0;
+    return ret;
 }

--- a/libc/stdio/fgets.c
+++ b/libc/stdio/fgets.c
@@ -7,6 +7,8 @@ fgets(char *s, size_t count, FILE *f)
     register size_t i;
     register int ch;
 
+    if (count == 0)
+        return 0;
     ret = s;
     for (i = count-1; i > 0; i--) {
         ch = getc(f);


### PR DESCRIPTION
If fgets were passed a size of 0, it would read without bound and overflow the buffer.  I did a quick search of the codebase but didn't see a potential case of this bug (such as fgets in a loop with a dynamic size).

The behavior when size<=1 is poorly specified (see https://en.cppreference.com/w/c/io/fgets ) but elks now matches what glibc does.