### PR TITLE
Fix incorrect usage of readlink

### DIFF
--- a/elkscmd/file_utils/cp.c
+++ b/elkscmd/file_utils/cp.c
@@ -349,7 +349,7 @@ static int do_copies(void)
 		} else if (flags == S_IFLNK) {
 			char lnkname[256];
 
-			int cnt = readlink(inode_build->path, lnkname, sizeof(lnkname));
+			int cnt = readlink(inode_build->path, lnkname, sizeof(lnkname) - 1);
 			if (cnt < 0) {
 				fprintf(stderr, "Can't read symlink "); fflush(stderr);
 				perror(inode_build->path);

--- a/elkscmd/minix2/remsync.c
+++ b/elkscmd/minix2/remsync.c
@@ -189,7 +189,7 @@ char *rdlink(const char *link, off_t size)
 	if (len <= size) {
 		path= allocate(path, (len= size * 2) * sizeof(path[0]));
 	}
-	if ((n= readlink(link, path, len)) == -1) return nil;
+	if ((n= readlink(link, path, len - 1)) == -1) return nil;
 	path[n]= 0;
 	return path;
 }

--- a/elkscmd/tui/realpath.c
+++ b/elkscmd/tui/realpath.c
@@ -39,7 +39,9 @@ static int resolve_path(char *path,char *result,char *pos)
 	    if (lstat(result,&st) < 0) return -1;
 	    if (S_ISLNK(st.st_mode)) {
 		char buf[PATH_MAX];
-		if (readlink(result,buf,sizeof(buf)) < 0) return -1;
+		int n;
+		if ((n = readlink(result,buf,sizeof(buf) - 1)) < 0) return -1;
+		buf[n] = 0;
 		*pos = 0;
 		if (slash) {
 		    *slash = '/';


### PR DESCRIPTION
@ghaerr the file in fm still has potential buffer overflows as you noted in the file, but at least the output from the readlink is now guaranteed to be properly terminated.