### PR TITLE
[cmds] Fix passwd command

### DIFF
--- a/elks/scripts/indent.sh
+++ b/elks/scripts/indent.sh
@@ -1,0 +1,5 @@
+
+#
+# ELKS coding standard indentation rules
+#
+indent -i4 -br -ce -npcs -nsob -bap -psl -l78

--- a/elkscmd/sys_utils/passwd.c
+++ b/elkscmd/sys_utils/passwd.c
@@ -17,6 +17,7 @@
 #include <pwd.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <time.h>
 
 /* maximum errors */
@@ -130,7 +131,9 @@ main(int argc, char **argv)
                 perror("Error removing old password file");
                 return 1;
             }
-            if (rename(tmp_fname, "/etc/passwd") == -1) {
+            /* can't use rename() since unimplemented on FAT fs */
+            sprintf(nbuf1, "mv %s /etc/passwd", tmp_fname);
+            if (system(nbuf1) != 0) {
                 perror("Error installing new password file");
                 return 1;
             }

--- a/elkscmd/sys_utils/passwd.c
+++ b/elkscmd/sys_utils/passwd.c
@@ -43,111 +43,110 @@ char ** argv;
 
     switch (argc) {
         case 1:
-	    pwd = getpwuid(getuid());
-	    if (pwd == NULL) {
-		fprintf(stderr, "%s: Error reading password file\n", argv[0]);
-	        return 1;
-	    }
-	    break;
+            pwd = getpwuid(getuid());
+            if (pwd == NULL) {
+                fprintf(stderr, "%s: Error reading password file\n", argv[0]);
+                return 1;
+            }
+            break;
         case 2:
-	    pwd = getpwnam(argv[1]);
-  	    if (pwd == NULL) {
-		fprintf(stderr, "%s: Unknown user %s\n", argv[0], argv[1]);
-	        return 1;
-	    }
-	    if ((getuid() != 0) && (getuid() != pwd->pw_uid)) {
-		fprintf(stderr, "You may not change the password for %s.\n",
-		     argv[1]);
-		return 1;
-	    }
-	    break;
+            pwd = getpwnam(argv[1]);
+            if (pwd == NULL) {
+                fprintf(stderr, "%s: Unknown user %s\n", argv[0], argv[1]);
+                return 1;
+            }
+            if ((getuid() != 0) && (getuid() != pwd->pw_uid)) {
+                fprintf(stderr, "You may not change the password for %s.\n",
+                     argv[1]);
+                return 1;
+            }
+            break;
         default:
-	    fprintf(stderr, "usage: %s [ name ]\n", argv[0]);
-	    return 1;
+            fprintf(stderr, "usage: %s [ name ]\n", argv[0]);
+            return 1;
     }
 
     printf("Changing password for %s\n", pwd->pw_name);
 
     if ((getuid() != 0) && (pwd->pw_passwd[0] != 0)) {
-	pbuf = getpass("Old password:");
-	putchar('\n');
-	salt[0] = pwd->pw_passwd[0];
-	salt[1] = pwd->pw_passwd[1];
-	salt[2] = 0;
-	if (strcmp(crypt(pbuf,salt),pwd->pw_passwd)) {
-	    fprintf(stderr, "Incorrect password for %s.\n", pwd->pw_name);
-	    return 1;
-	}
-	memset(pbuf, 0, strlen(pbuf));
+        pbuf = getpass("Old password:");
+        putchar('\n');
+        salt[0] = pwd->pw_passwd[0];
+        salt[1] = pwd->pw_passwd[1];
+        salt[2] = 0;
+        if (strcmp(crypt(pbuf,salt),pwd->pw_passwd)) {
+            fprintf(stderr, "Incorrect password for %s.\n", pwd->pw_name);
+            return 1;
+        }
+        memset(pbuf, 0, strlen(pbuf));
     }
 
     failure_cnt = 0;
     for (;;) {
         pbuf = getpass("New password:");
-	putchar('\n');
-	strcpy(nbuf1, pbuf);
-	memset(pbuf, 0, strlen(pbuf));
-	pbuf = getpass("Re-enter new password:");
-	putchar('\n');
-	strcpy(nbuf2, pbuf);
-	memset(pbuf, 0, strlen(pbuf));
-	if (strcmp(nbuf1, nbuf2) == 0) {
-	  /* I'm just going to use the LSB of time for salt */
-	    time(&now);
-	    ch = salt_char[now & 0x3F];
-	    salt[0] = ch;
-	    ch = salt_char[(now >> 6) & 0x3F];
-	    salt[1] = ch;
-	    salt[2] = 0;
+        putchar('\n');
+        strcpy(nbuf1, pbuf);
+        memset(pbuf, 0, strlen(pbuf));
+        pbuf = getpass("Re-enter new password:");
+        putchar('\n');
+        strcpy(nbuf2, pbuf);
+        memset(pbuf, 0, strlen(pbuf));
+        if (strcmp(nbuf1, nbuf2) == 0) {
+          /* I'm just going to use the LSB of time for salt */
+            time(&now);
+            ch = salt_char[now & 0x3F];
+            salt[0] = ch;
+            ch = salt_char[(now >> 6) & 0x3F];
+            salt[1] = ch;
+            salt[2] = 0;
 
-	  /* need to create a temporary file for the new password */
-	    tmp_fname = tmpnam(NULL);
-	    if (tmp_fname == NULL) {
-		perror("Error getting temporary file name");
-		return 1;
-	    }
-	    passwd_fp = fopen(tmp_fname, "w");
-	    if (passwd_fp == NULL) {
-		fprintf(stderr, "Error creating temporary password file\n");
-		return 1;
-	    }
+          /* need to create a temporary file for the new password */
+            tmp_fname = tmpnam(NULL);
+            if (tmp_fname == NULL) {
+                perror("Error getting temporary file name");
+                return 1;
+            }
+            passwd_fp = fopen(tmp_fname, "w");
+            if (passwd_fp == NULL) {
+                fprintf(stderr, "Error creating temporary password file\n");
+                return 1;
+            }
 
           /* save off our UID */
-	    uid = pwd->pw_uid;
+            uid = pwd->pw_uid;
 
-	  /* save entries to the new file */
-	    pwd = getpwent();
-	    while (pwd != NULL) {
-		if (pwd->pw_uid == uid) {
-			pwd->pw_passwd = crypt(nbuf1, salt);
-		}
-	        if (putpwent(pwd, passwd_fp) == -1) {
-		    perror("Error writing password file");
-		    return 1;
-	        }
-	        pwd = getpwent();
-	    }
+          /* save entries to the new file */
+            pwd = getpwent();
+            while (pwd != NULL) {
+                if (pwd->pw_uid == uid) {
+                        pwd->pw_passwd = crypt(nbuf1, salt);
+                }
+                if (putpwent(pwd, passwd_fp) == -1) {
+                    perror("Error writing password file");
+                    return 1;
+                }
+                pwd = getpwent();
+            }
 
-	  /* update the file and move it into position */
-	    fclose(passwd_fp);
-	    if (unlink("/etc/passwd") == -1) {
-		perror("Error removing old password file");
-		return 1;
-	    }
-	    if (rename(tmp_fname, "/etc/passwd") == -1) {
-		perror("Error installing new password file");
-		return 1;
-	    }
+          /* update the file and move it into position */
+            fclose(passwd_fp);
+            if (unlink("/etc/passwd") == -1) {
+                perror("Error removing old password file");
+                return 1;
+            }
+            if (rename(tmp_fname, "/etc/passwd") == -1) {
+                perror("Error installing new password file");
+                return 1;
+            }
 
-	  /* celebrate our success */
-	    printf("Password changed.\n");
-	    return 0;
-	}
-	if (++failure_cnt >= MAX_FAILURE) {
-	    fprintf(stderr, "The password for %s is unchanged.\n",pwd->pw_name);
+          /* celebrate our success */
+            printf("Password changed.\n");
+            return 0;
+        }
+        if (++failure_cnt >= MAX_FAILURE) {
+            fprintf(stderr, "The password for %s is unchanged.\n",pwd->pw_name);
             return 1;
-	}
-	fprintf(stderr, "They don't match; try again.\n");
+        }
+        fprintf(stderr, "They don't match; try again.\n");
     }
 }
-

--- a/elkscmd/sys_utils/passwd.c
+++ b/elkscmd/sys_utils/passwd.c
@@ -1,17 +1,16 @@
 /*
- * file:         passwd.c
- * description:  change user password
- * author:       Shane Kerr <kerr@wizard.net>
- * copyright:    1998 by Shane Kerr <kerr@wizard.net>, under terms of GPL
+ * file:         passwd.c description:  change user password author:
+ * Shane Kerr <kerr@wizard.net> copyright:    1998 by Shane Kerr
+ * <kerr@wizard.net>, under terms of GPL
  */
 
 /* todo:  make executable setuid on execute */
-/*        needs to check setuid bit in fs/exec.c of ELKS kernel */
+/* needs to check setuid bit in fs/exec.c of ELKS kernel */
 /* todo:  add a set of rules to make sure trivial passwords are not used */
 /* todo:  lock password file while updating */
-/*        need file locking first */
+/* need file locking first */
 /* todo:  use rename to do an atomic move of temporary file */
-/*        need rename that overwrites first */
+/* need rename that overwrites first */
 
 #include <unistd.h>
 #include <sys/types.h>
@@ -24,46 +23,45 @@
 #define MAX_FAILURE 5
 
 /* valid characters for a salt value */
-char salt_char[] =
-          "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789./";
+char            salt_char [] =
+"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789./";
 
-int main(argc,argv)
-int argc;
-char ** argv;
+int
+main(int argc, char **argv)
 {
-    struct passwd *pwd;
-    char *pbuf, salt[3];
-    char nbuf1[128], nbuf2[128];
-    time_t now;
-    int ch;
-    int failure_cnt;
-    FILE *passwd_fp;
-    char *tmp_fname;
-    int uid;
+    struct passwd  *pwd;
+    char           *pbuf, salt[3];
+    char            nbuf1  [128], nbuf2[128];
+    time_t          now;
+    int             ch;
+    int             failure_cnt;
+    FILE           *passwd_fp;
+    char           *tmp_fname;
+    int             uid;
 
     switch (argc) {
-        case 1:
-            pwd = getpwuid(getuid());
-            if (pwd == NULL) {
-                fprintf(stderr, "%s: Error reading password file\n", argv[0]);
-                return 1;
-            }
-            break;
-        case 2:
-            pwd = getpwnam(argv[1]);
-            if (pwd == NULL) {
-                fprintf(stderr, "%s: Unknown user %s\n", argv[0], argv[1]);
-                return 1;
-            }
-            if ((getuid() != 0) && (getuid() != pwd->pw_uid)) {
-                fprintf(stderr, "You may not change the password for %s.\n",
-                     argv[1]);
-                return 1;
-            }
-            break;
-        default:
-            fprintf(stderr, "usage: %s [ name ]\n", argv[0]);
+    case 1:
+        pwd = getpwuid(getuid());
+        if (pwd == NULL) {
+            fprintf(stderr, "%s: Error reading password file\n", argv[0]);
             return 1;
+        }
+        break;
+    case 2:
+        pwd = getpwnam(argv[1]);
+        if (pwd == NULL) {
+            fprintf(stderr, "%s: Unknown user %s\n", argv[0], argv[1]);
+            return 1;
+        }
+        if ((getuid() != 0) && (getuid() != pwd->pw_uid)) {
+            fprintf(stderr, "You may not change the password for %s.\n",
+                    argv[1]);
+            return 1;
+        }
+        break;
+    default:
+        fprintf(stderr, "usage: %s [ name ]\n", argv[0]);
+        return 1;
     }
 
     printf("Changing password for %s\n", pwd->pw_name);
@@ -74,13 +72,12 @@ char ** argv;
         salt[0] = pwd->pw_passwd[0];
         salt[1] = pwd->pw_passwd[1];
         salt[2] = 0;
-        if (strcmp(crypt(pbuf,salt),pwd->pw_passwd)) {
+        if (strcmp(crypt(pbuf, salt), pwd->pw_passwd)) {
             fprintf(stderr, "Incorrect password for %s.\n", pwd->pw_name);
             return 1;
         }
         memset(pbuf, 0, strlen(pbuf));
     }
-
     failure_cnt = 0;
     for (;;) {
         pbuf = getpass("New password:");
@@ -92,7 +89,7 @@ char ** argv;
         strcpy(nbuf2, pbuf);
         memset(pbuf, 0, strlen(pbuf));
         if (strcmp(nbuf1, nbuf2) == 0) {
-          /* I'm just going to use the LSB of time for salt */
+            /* I'm just going to use the LSB of time for salt */
             time(&now);
             ch = salt_char[now & 0x3F];
             salt[0] = ch;
@@ -100,7 +97,7 @@ char ** argv;
             salt[1] = ch;
             salt[2] = 0;
 
-          /* need to create a temporary file for the new password */
+            /* need to create a temporary file for the new password */
             tmp_fname = tmpnam(NULL);
             if (tmp_fname == NULL) {
                 perror("Error getting temporary file name");
@@ -111,15 +108,14 @@ char ** argv;
                 fprintf(stderr, "Error creating temporary password file\n");
                 return 1;
             }
-
-          /* save off our UID */
+            /* save off our UID */
             uid = pwd->pw_uid;
 
-          /* save entries to the new file */
+            /* save entries to the new file */
             pwd = getpwent();
             while (pwd != NULL) {
                 if (pwd->pw_uid == uid) {
-                        pwd->pw_passwd = crypt(nbuf1, salt);
+                    pwd->pw_passwd = crypt(nbuf1, salt);
                 }
                 if (putpwent(pwd, passwd_fp) == -1) {
                     perror("Error writing password file");
@@ -128,7 +124,7 @@ char ** argv;
                 pwd = getpwent();
             }
 
-          /* update the file and move it into position */
+            /* update the file and move it into position */
             fclose(passwd_fp);
             if (unlink("/etc/passwd") == -1) {
                 perror("Error removing old password file");
@@ -138,13 +134,12 @@ char ** argv;
                 perror("Error installing new password file");
                 return 1;
             }
-
-          /* celebrate our success */
+            /* celebrate our success */
             printf("Password changed.\n");
             return 0;
         }
         if (++failure_cnt >= MAX_FAILURE) {
-            fprintf(stderr, "The password for %s is unchanged.\n",pwd->pw_name);
+            fprintf(stderr, "The password for %s is unchanged.\n", pwd->pw_name);
             return 1;
         }
         fprintf(stderr, "They don't match; try again.\n");

--- a/libc/getent/__getgrent.c
+++ b/libc/getent/__getgrent.c
@@ -2,20 +2,20 @@
  * __getgrent.c - This file is part of the libc-8086/grp package for ELKS,
  * Copyright (C) 1995, 1996 Nat Friedman <ndf@linux.mit.edu>.
  * 
- *  This library is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Library General Public
- *  License as published by the Free Software Foundation; either
- *  version 2 of the License, or (at your option) any later version.
- *
- *  This library is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- *  Library General Public License for more details.
- *
- *  You should have received a copy of the GNU Library General Public
- *  License along with this library; if not, write to the Free
- *  Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Library General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+ * License for more details.
+ * 
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * 
  */
 
 #include <unistd.h>
@@ -26,143 +26,139 @@
 
 /*
  * This is the core group-file read function.  It behaves exactly like
- * getgrent() except that it is passed a file descriptor.  getgrent()
- * is just a wrapper for this function.
+ * getgrent() except that it is passed a file descriptor.  getgrent() is just
+ * a wrapper for this function.
  */
-struct group *
+struct group   *
 __getgrent(int grp_fd)
 {
-#ifndef GR_SCALE_DYNAMIC  
-  static char line_buff[GR_MAX_LINE_LEN];
-  static char * members[GR_MAX_MEMBERS];
+#ifndef GR_SCALE_DYNAMIC
+    static char     line_buff[GR_MAX_LINE_LEN];
+    static char    *members[GR_MAX_MEMBERS];
 #else
-  static char * line_buff = NULL;
-  static char ** members = NULL;
-  short line_index;
-  short buff_size;
+    static char    *line_buff = NULL;
+    static char   **members = NULL;
+    short           line_index;
+    short           buff_size;
 #endif
-  static struct group group;
-  register char * ptr;
-  char * field_begin;
-  short member_num;
-  char * endptr;
-  int line_len;
+    static struct group group;
+    register char  *ptr;
+    char           *field_begin;
+    short           member_num;
+    char           *endptr;
+    int             line_len;
 
 
-  /* We use the restart label to handle malformatted lines */
+    /* We use the restart label to handle malformatted lines */
 restart:
 #ifdef GR_SCALE_DYNAMIC
-  line_index=0;
-  buff_size=256;
+    line_index = 0;
+    buff_size = 256;
 #endif
 
 #ifndef GR_SCALE_DYNAMIC
-  /* Read the line into the static buffer */
-  if ((line_len=read(grp_fd, line_buff, GR_MAX_LINE_LEN))<=0)
-    return NULL;
-  field_begin=strchr(line_buff, '\n');
-  if (field_begin!=NULL)
-    lseek(grp_fd, (long) (1+field_begin-(line_buff+line_len)), SEEK_CUR);
-  else /* The line is too long - skip it :-\ */
-    {
-      do { if ((line_len=read(grp_fd, line_buff, GR_MAX_LINE_LEN))<=0)
-	return NULL;
-      } while (!(field_begin=strchr(line_buff, '\n')));
-      lseek(grp_fd, (long) ((field_begin-line_buff)-line_len+1), SEEK_CUR);
-      goto restart;
+    /* Read the line into the static buffer */
+    if ((line_len = read(grp_fd, line_buff, GR_MAX_LINE_LEN)) <= 0)
+        return NULL;
+    field_begin = strchr(line_buff, '\n');
+    if (field_begin != NULL)
+        lseek(grp_fd, (long)(1 + field_begin - (line_buff + line_len)), SEEK_CUR);
+    else {                      /* The line is too long - skip it :-\ */
+        do {
+            if ((line_len = read(grp_fd, line_buff, GR_MAX_LINE_LEN)) <= 0)
+                return NULL;
+        } while (!(field_begin = strchr(line_buff, '\n')));
+        lseek(grp_fd, (long)((field_begin - line_buff) - line_len + 1), SEEK_CUR);
+        goto restart;
     }
-  if (*line_buff=='#' || *line_buff==' ' || *line_buff=='\n' ||
-      *line_buff=='\t')
-    goto restart;
-  *field_begin='\0';
+    if (*line_buff == '#' || *line_buff == ' ' || *line_buff == '\n' ||
+        *line_buff == '\t')
+        goto restart;
+    *field_begin = '\0';
 
-#else /* !GR_SCALE_DYNAMIC */
-  line_buff=realloc(line_buff, buff_size);
-  while (1)
-    {
-      if ((line_len=read(grp_fd, line_buff+line_index,
-			 buff_size-line_index))<=0)
-	  return NULL;
-      field_begin=strchr(line_buff, '\n');
-      if (field_begin!=NULL)
-	{
-	  lseek(grp_fd, (long) (1+field_begin-(line_len+line_index+line_buff)),
-		SEEK_CUR);
-	  *field_begin='\0';
-	  if (*line_buff=='#' || *line_buff==' ' || *line_buff=='\n' ||
-	      *line_buff=='\t')
-	    goto restart;
-	  break;
-	}
-      else /* Allocate some more space */
-	{
-	  line_index=buff_size;
-	  buff_size+=256;
-	  line_buff=realloc(line_buff, buff_size);
-	}
+#else                           /* !GR_SCALE_DYNAMIC */
+    line_buff = realloc(line_buff, buff_size);
+    while (1) {
+        if ((line_len = read(grp_fd, line_buff + line_index,
+                             buff_size - line_index)) <= 0)
+            return NULL;
+        field_begin = strchr(line_buff, '\n');
+        if (field_begin != NULL) {
+            lseek(grp_fd, (long)(1 + field_begin - (line_len + line_index + line_buff)),
+                  SEEK_CUR);
+            *field_begin = '\0';
+            if (*line_buff == '#' || *line_buff == ' ' || *line_buff == '\n' ||
+                *line_buff == '\t')
+                goto restart;
+            break;
+        } else {                /* Allocate some more space */
+            line_index = buff_size;
+            buff_size += 256;
+            line_buff = realloc(line_buff, buff_size);
+        }
     }
-#endif /* GR_SCALE_DYNAMIC */
+#endif                          /* GR_SCALE_DYNAMIC */
 
-  /* Now parse the line */
-  group.gr_name=line_buff;
-  ptr=strchr(line_buff, ':');
-  if (ptr==NULL) goto restart;
-  *ptr++='\0';
+    /* Now parse the line */
+    group.gr_name = line_buff;
+    ptr = strchr(line_buff, ':');
+    if (ptr == NULL)
+        goto restart;
+    *ptr++ = '\0';
 
-  group.gr_passwd=ptr;
-  ptr=strchr(ptr, ':');
-  if (ptr==NULL) goto restart;
-  *ptr++='\0';
+    group.gr_passwd = ptr;
+    ptr = strchr(ptr, ':');
+    if (ptr == NULL)
+        goto restart;
+    *ptr++ = '\0';
 
-  field_begin=ptr;
-  ptr=strchr(ptr, ':');
-  if (ptr==NULL) goto restart;
-  *ptr++='\0';
+    field_begin = ptr;
+    ptr = strchr(ptr, ':');
+    if (ptr == NULL)
+        goto restart;
+    *ptr++ = '\0';
 
-  group.gr_gid=(gid_t) strtoul(field_begin, &endptr, 10);
-  if (*endptr!='\0') goto restart;
+    group.gr_gid = (gid_t) strtoul(field_begin, &endptr, 10);
+    if (*endptr != '\0')
+        goto restart;
 
-  member_num=0;
-  field_begin=ptr;
+    member_num = 0;
+    field_begin = ptr;
 
 #ifndef GR_SCALE_DYNAMIC
-  while ((ptr=strchr(ptr, ','))!=NULL)
-    {
-      *ptr='\0';
-      ptr++;
-      members[member_num]=field_begin;
-      field_begin=ptr;
-      member_num++;
+    while ((ptr = strchr(ptr, ',')) != NULL) {
+        *ptr = '\0';
+        ptr++;
+        members[member_num] = field_begin;
+        field_begin = ptr;
+        member_num++;
     }
-  if (*field_begin=='\0')
-    members[member_num]=NULL;
-  else
-    {
-      members[member_num]=field_begin;
-      members[member_num+1]=NULL;
+    if (*field_begin == '\0')
+        members[member_num] = NULL;
+    else {
+        members[member_num] = field_begin;
+        members[member_num + 1] = NULL;
     }
-#else /* !GR_SCALE_DYNAMIC */
-  if (members!=NULL)
-    free (members);
-  members=(char **) malloc(1*sizeof(char *));
-  while ((ptr=strchr(ptr, ','))!=NULL)
-    {
-      *ptr='\0';
-      ptr++;
-      members[member_num]=field_begin;
-      field_begin=ptr;
-      member_num++;
-      members=(char **)realloc((void *)members, (member_num+1)*sizeof(char *));
+#else                           /* !GR_SCALE_DYNAMIC */
+    if (members != NULL)
+        free(members);
+    members = (char **)malloc(1 * sizeof(char *));
+    while ((ptr = strchr(ptr, ',')) != NULL) {
+        *ptr = '\0';
+        ptr++;
+        members[member_num] = field_begin;
+        field_begin = ptr;
+        member_num++;
+        members = (char **)realloc((void *)members, (member_num + 1) * sizeof(char *));
     }
-  if (*field_begin=='\0')
-      members[member_num]=NULL;
-  else
-    {
-      members[member_num]=field_begin;
-      members[member_num+1]=NULL;
+    if (*field_begin == '\0')
+        members[member_num] = NULL;
+    else {
+        members[member_num] = field_begin;
+        members[member_num + 1] = NULL;
     }
-#endif /* GR_SCALE_DYNAMIC */
+#endif                          /* GR_SCALE_DYNAMIC */
 
-  group.gr_mem=members;
-  return &group;
+    group.gr_mem = members;
+    return &group;
 }

--- a/libc/getent/__getpwent.c
+++ b/libc/getent/__getpwent.c
@@ -2,20 +2,20 @@
  * __getpwent.c - This file is part of the libc-8086/pwd package for ELKS,
  * Copyright (C) 1995, 1996 Nat Friedman <ndf@linux.mit.edu>.
  * 
- *  This library is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Library General Public
- *  License as published by the Free Software Foundation; either
- *  version 2 of the License, or (at your option) any later version.
- *
- *  This library is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- *  Library General Public License for more details.
- *
- *  You should have received a copy of the GNU Library General Public
- *  License along with this library; if not, write to the Free
- *  Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Library General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+ * License for more details.
+ * 
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * 
  */
 
 #include <stdlib.h>
@@ -26,75 +26,90 @@
 
 #define PWD_BUFFER_SIZE 256
 
-/* This isn't as flash as my previous version -- it doesn't dynamically
-  scale down the gecos on too-long lines, but it also makes fewer syscalls,
-  so it's probably nicer.  Write me if you want the old version.  Maybe I
-  should include it as a build-time option... ?
-  -Nat <ndf@linux.mit.edu> */
-   
-struct passwd *
+/*
+ * This isn't as flash as my previous version -- it doesn't dynamically scale
+ * down the gecos on too-long lines, but it also makes fewer syscalls, so
+ * it's probably nicer.  Write me if you want the old version.  Maybe I
+ * should include it as a build-time option... ? -Nat <ndf@linux.mit.edu>
+ */
+
+struct passwd  *
 __getpwent(int pwd_fd)
 {
-  static char line_buff[PWD_BUFFER_SIZE];
-  static struct passwd passwd;
-  char * field_begin;
-  char * endptr;
-  char * gid_ptr;
-  char * uid_ptr;
-  int line_len;
-  int i;
+    static char     line_buff[PWD_BUFFER_SIZE];
+    static struct passwd passwd;
+    char           *field_begin;
+    char           *endptr;
+    char           *gid_ptr;
+    char           *uid_ptr;
+    int             line_len;
+    int             i;
 
-  /* We use the restart label to handle malformatted lines */
+    /* We use the restart label to handle malformatted lines */
 restart:
-  /* Read the passwd line into the static buffer using a minimal of
-     syscalls. */
-  if ((line_len=read(pwd_fd, line_buff, PWD_BUFFER_SIZE))<=0)
-    return NULL;
-  field_begin=strchr(line_buff, '\n');
-  if (field_begin!=NULL)
-    lseek(pwd_fd, (long) (1+field_begin-(line_buff+line_len)), SEEK_CUR);
-  else /* The line is too long - skip it. :-\ */
-    {
-      do { if ((line_len=read(pwd_fd, line_buff, PWD_BUFFER_SIZE))<=0)
-	return NULL;
-      } while (!(field_begin=strchr(line_buff, '\n')));
-      lseek(pwd_fd, (long) (field_begin-line_buff)-line_len+1, SEEK_CUR);
-      goto restart;
+    /*
+     * Read the passwd line into the static buffer using a minimal of
+     * syscalls.
+     */
+    if ((line_len = read(pwd_fd, line_buff, PWD_BUFFER_SIZE)) <= 0)
+        return NULL;
+    field_begin = strchr(line_buff, '\n');
+    if (field_begin != NULL)
+        lseek(pwd_fd, (long)(1 + field_begin - (line_buff + line_len)), SEEK_CUR);
+    else {                      /* The line is too long - skip it. :-\ */
+        do {
+            if ((line_len = read(pwd_fd, line_buff, PWD_BUFFER_SIZE)) <= 0)
+                return NULL;
+        } while (!(field_begin = strchr(line_buff, '\n')));
+        lseek(pwd_fd, (long)(field_begin - line_buff) - line_len + 1, SEEK_CUR);
+        goto restart;
     }
-  if (*line_buff=='#' || *line_buff==' ' || *line_buff=='\n' ||
-      *line_buff=='\t')
-      goto restart;
-  *field_begin='\0';
+    if (*line_buff == '#' || *line_buff == ' ' || *line_buff == '\n' ||
+        *line_buff == '\t')
+        goto restart;
+    *field_begin = '\0';
 
-  /* We've read the line; now parse it. */
-  field_begin=line_buff;
-  for (i=0;i<7;i++)
-    {
-      switch(i)
-	{
-	case 0: passwd.pw_name=field_begin; break;
-	case 1: passwd.pw_passwd=field_begin; break;
-	case 2: uid_ptr=field_begin; break;
-	case 3: gid_ptr=field_begin; break;
-	case 4: passwd.pw_gecos=field_begin; break;
-	case 5: passwd.pw_dir=field_begin; break;
-	case 6: passwd.pw_shell=field_begin; break;
-	}
-      if (i<6)
-	{
-	  field_begin=strchr(field_begin, ':');
-	  if (field_begin==NULL) goto restart;
-	  *field_begin++='\0';
-	}
+    /* We've read the line; now parse it. */
+    field_begin = line_buff;
+    for (i = 0; i < 7; i++) {
+        switch (i) {
+        case 0:
+            passwd.pw_name = field_begin;
+            break;
+        case 1:
+            passwd.pw_passwd = field_begin;
+            break;
+        case 2:
+            uid_ptr = field_begin;
+            break;
+        case 3:
+            gid_ptr = field_begin;
+            break;
+        case 4:
+            passwd.pw_gecos = field_begin;
+            break;
+        case 5:
+            passwd.pw_dir = field_begin;
+            break;
+        case 6:
+            passwd.pw_shell = field_begin;
+            break;
+        }
+        if (i < 6) {
+            field_begin = strchr(field_begin, ':');
+            if (field_begin == NULL)
+                goto restart;
+            *field_begin++ = '\0';
+        }
     }
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-  passwd.pw_gid=(gid_t) strtoul(gid_ptr, &endptr, 10);
-  if (*endptr!='\0') goto restart;
-  
-  passwd.pw_uid=(uid_t) strtoul(uid_ptr, &endptr, 10);
-  if (*endptr!='\0') goto restart;
+    passwd.pw_gid = (gid_t) strtoul(gid_ptr, &endptr, 10);
+    if (*endptr != '\0')
+        goto restart;
 
-  return &passwd;
+    passwd.pw_uid = (uid_t) strtoul(uid_ptr, &endptr, 10);
+    if (*endptr != '\0')
+        goto restart;
+
+    return &passwd;
 }
-
-

--- a/libc/getent/pwent.c
+++ b/libc/getent/pwent.c
@@ -57,7 +57,7 @@ getpwent(void)
 {
     if (pw_fd == -1) {
         setpwent();
-        if (pw_fd != -1)
+        if (pw_fd == -1)
             return NULL;
     }
     return __getpwent(pw_fd);


### PR DESCRIPTION
Fixes #1549.

Fixes `getpwent` bug introduced in #1546.

Reformats very ugly source code in libc/getent.

Adds first pass at standardized ELKS C indentation script. (Needs tabs replacement to 4 spaces also).

