### PR TITLE
[nano-x] Cleanup extra printf after failed GrOpen

### DIFF
--- a/elkscmd/nano-X/demos/ntetris.c
+++ b/elkscmd/nano-X/demos/ntetris.c
@@ -744,12 +744,9 @@ void new_game(nstate *state)
 void init_game(nstate *state)
 {
 	GR_SCREEN_INFO si;
-	//GR_WM_PROPERTIES props;
 
-	if(GrOpen() < 0) {
-		printf("Can't open graphics\n");
+	if(GrOpen() < 0)
 		exit(1);
-	}
 
 	GrGetScreenInfo(&si);
 	GrMoveCursor(si.cols - 16, 0);
@@ -761,6 +758,7 @@ void init_game(nstate *state)
 					MAIN_WINDOW_BACKGROUND_COLOUR, 0);
 #if 0
 	/* set title */
+	GR_WM_PROPERTIES props;
 	props.flags = GR_WM_FLAGS_TITLE | GR_WM_FLAGS_PROPS;
 	props.props = GR_WM_PROPS_BORDER | GR_WM_PROPS_CAPTION |
 			GR_WM_PROPS_CLOSEBOX;

--- a/elkscmd/nano-X/demos/nxtest.c
+++ b/elkscmd/nano-X/demos/nxtest.c
@@ -34,8 +34,6 @@ GdDelay(unsigned long msecs)
 int main(int argc, char ** argv)
 {
     if (GrOpen() < 0) {
-        GrClose();
-        printf("Can't open graphics\n");
         exit(1);
     }
     


### PR DESCRIPTION
Removes display of "Can't open graphics" when `nxtetris` is opened without MOUSE_PORT=none set on system without mouse.

@toncho11, I think everything should be fixed now with regards to using `export MOUSE_PORT=` as discussed previously. 