### PR TITLE
[kernel] Rewrite memcpy in ASM for speed

### DIFF
--- a/elks/arch/i86/lib/string.S
+++ b/elks/arch/i86/lib/string.S
@@ -108,7 +108,7 @@ memset:
 	shr     $1,%cx         	// copy words
 	rep			// while (cx) cx--, [es:di++] = al
 	stosw
-	rcl	$1,%cx		// then possibly final byute
+	rcl	$1,%cx		// then possibly final byte
 	rep
 	stosb
 	mov	ARG0(%bx),%ax	// return value = start addr of block

--- a/elks/arch/i86/lib/string.S
+++ b/elks/arch/i86/lib/string.S
@@ -105,8 +105,12 @@ memset:
 	mov	ARG1(%bx),%ax	// byte to write
 	mov	ARG2(%bx),%cx	// loop count
 	cld
-	rep			// while (cx)
-	stosb			// 	cx--, [es:di++] = al
+	shr     $1,%cx         	// copy words
+	rep			// while (cx) cx--, [es:di++] = al
+	stosw
+	rcl	$1,%cx		// then possibly final byute
+	rep
+	stosb
 	mov	ARG0(%bx),%ax	// return value = start addr of block
 	pop	%di
 	mov	%dx,%es

--- a/elks/arch/i86/lib/string.S
+++ b/elks/arch/i86/lib/string.S
@@ -15,6 +15,7 @@
 	.global strcpy
 	.global strcmp
 	.global memset
+	.global memcpy
 
 // int strlen(char *str)
 // returns the length of string
@@ -110,3 +111,34 @@ memset:
 	pop	%di
 	mov	%dx,%es
 	ret
+
+// char *memcpy(void *dest, void *src, size_t count)
+
+memcpy:
+        mov    %si,%ax
+        mov    %es,%bx
+        mov    %ds,%cx
+        mov    %cx,%es
+        mov    %di,%dx
+
+        mov    %sp,%si
+        mov    ARG2(%si),%cx  // byte count
+        mov    ARG0(%si),%di  // destination pointer
+        mov    ARG1(%si),%si  // source pointer
+        push   %di            // save dest return value
+        cld
+        shr    $1,%cx         // copy words
+        rep
+        movsw
+        rcl    $1,%cx         // then possibly final byte
+        rep
+        movsb
+
+        mov    %dx,%di
+        mov    %bx,%es
+        mov    %ax,%si
+        mov    %ss,%ax
+        mov    %ax,%ds
+        pop    %ax            // return dst
+
+        ret

--- a/elks/include/arch/string.h
+++ b/elks/include/arch/string.h
@@ -11,6 +11,7 @@
 #define __HAVE_ARCH_STRCPY
 #define __HAVE_ARCH_STRCMP
 #define __HAVE_ARCH_MEMSET
+#define __HAVE_ARCH_MEMCPY
 
 /*@+namechecks@*/
 


### PR DESCRIPTION
Using the recently added P)rofile command in [blink16](https://github.com/ghaerr/blink16), it was found that a significant amount of early time was spent in the kernel `memcpy` routine. Rewriting in ASM for speed. I have not tested the real instruction timings on various x86 processors, but think using `rep movsw` will be faster than the prior C language version.

Here's a screenshot showing `blink16`s profiling of a portion of the kernel boot sequence:

<img width="1585" alt="ELKS blink16 memcpy" src="https://user-images.githubusercontent.com/11985637/222978301-8e9d2b19-5c63-497a-98b5-4d9750a48add.png">
This fix brings down `memcpy` to less than 0.43% (although `blink16` is not counting `rep movsw` instruction cycles, which means it's still likely quite inaccurate).