### PR TITLE
[kernel] Allow multiple signals pending per process, enhance abort(), write test_sigfail test case

### DIFF
--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -67,6 +67,8 @@ int tty_intcheck(register struct tty *ttyp, unsigned char key)
     if ((ttyp->termios.c_lflag & ISIG) && ttyp->pgrp) {
 	if (key == ttyp->termios.c_cc[VINTR])
 	    sig = SIGINT;
+	if (key == ttyp->termios.c_cc[VQUIT])
+	    sig = SIGQUIT;
 	if (key == ttyp->termios.c_cc[VSUSP])
 	    sig = SIGTSTP;
 #if DEBUG_EVENT

--- a/elks/arch/i86/kernel/signal.c
+++ b/elks/arch/i86/kernel/signal.c
@@ -58,7 +58,7 @@ int do_signal(void)
 		      (SM_SIGQUIT|SM_SIGILL|SM_SIGABRT|SM_SIGFPE|SM_SIGSEGV|SM_SIGTRAP))
 		    dump_core();
 #endif
-		printk("SIGNAL terminating pid %d\n", currentp->pid);
+		debug_sig("SIGNAL terminating pid %d\n", currentp->pid);
 		do_exit(signr);				/* Default Terminate */
 	    }
 	}

--- a/elks/arch/i86/kernel/signal.c
+++ b/elks/arch/i86/kernel/signal.c
@@ -68,10 +68,11 @@ int do_signal(void)
 	    arch_setup_sighandler_stack(currentp, sah, signr);
 	    *sd = SIGDISP_DFL;
 	    debug_sig("SIGNAL reset pending signals\n");
+	    clr_irq();		/* stop race between reset signal and return to user */
+	    currentp->signal &= ~mask;
 	    if (currentp->signal)
-		printk("SIGNAL(%d) processing mask %04x, ignoring signal w/mask %04x\n",
+		printk("SIGNAL(%d) processing mask %04x, additional signal w/mask %04x\n",
 		    currentp->pid, mask, currentp->signal);
-	    currentp->signal = 0;
 
 	    return 1;
 	}

--- a/elks/arch/i86/kernel/signal.c
+++ b/elks/arch/i86/kernel/signal.c
@@ -65,14 +65,12 @@ int do_signal(void)
 	else if (*sd != SIGDISP_IGN) {			/* Set handler */
 	    debug_sig("SIGNAL setup return stack for handler %x:%x\n",
 		      _FP_SEG(sah), _FP_OFF(sah));
-	    //debug_sig("Stack at %x\n", currentp->t_regs.sp);
 	    arch_setup_sighandler_stack(currentp, sah, signr);
-	    //debug_sig("Stack at %x\n", currentp->t_regs.sp);
 	    *sd = SIGDISP_DFL;
 	    debug_sig("SIGNAL reset pending signals\n");
 	    if (currentp->signal)
-		printk("SIGNAL(%d) ignoring signal (mask=%s)\n",
-		    currentp->pid, currentp->signal);
+		printk("SIGNAL(%d) processing mask %04x, ignoring signal w/mask %04x\n",
+		    currentp->pid, mask, currentp->signal);
 	    currentp->signal = 0;
 
 	    return 1;

--- a/elks/arch/i86/kernel/signal.c
+++ b/elks/arch/i86/kernel/signal.c
@@ -58,7 +58,7 @@ int do_signal(void)
 		      (SM_SIGQUIT|SM_SIGILL|SM_SIGABRT|SM_SIGFPE|SM_SIGSEGV|SM_SIGTRAP))
 		    dump_core();
 #endif
-		debug_sig("SIGNAL terminating pid %d\n", currentp->pid);
+		printk("SIGNAL terminating pid %d\n", currentp->pid);
 		do_exit(signr);				/* Default Terminate */
 	    }
 	}

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -13,4 +13,4 @@ wd0=10,0x300,0xCC00,0x80
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.sys
 #init=/bin/sh		# singleuser shell
 #root=hda1 ro		# root hd partition 1, read-only
-#console=ttyS0,19200 3	# serial console
+console=ttyS0,19200 3	# serial console

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -13,4 +13,4 @@ wd0=10,0x300,0xCC00,0x80
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.sys
 #init=/bin/sh		# singleuser shell
 #root=hda1 ro		# root hd partition 1, read-only
-console=ttyS0,19200 3	# serial console
+#console=ttyS0,19200 3	# serial console

--- a/elkscmd/test/.gitignore
+++ b/elkscmd/test/.gitignore
@@ -4,3 +4,4 @@ other/test_eth
 other/test_pty
 other/test_select
 other/test_signal
+other/test_sigfail

--- a/elkscmd/test/other/Makefile
+++ b/elkscmd/test/other/Makefile
@@ -16,6 +16,7 @@ PRGS = \
     test_pty \
     test_select \
     test_signal \
+    test_sigfail \
     # EOL
 
 all: $(PRGS)
@@ -33,6 +34,9 @@ test_select: test_select.o
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 test_signal: test_signal.o
+	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+
+test_sigfail: test_sigfail.o
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 install: $(PRGS)

--- a/elkscmd/test/other/test_sigfail.c
+++ b/elkscmd/test/other/test_sigfail.c
@@ -1,0 +1,44 @@
+/*
+ * Confirm signal loss from kernel clearing signal mask
+ * before calling any registered signal handler.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <signal.h>
+
+#define ABORT   1
+#define INT     2
+volatile int status;
+
+void sigabort(int signo)
+{
+    status |= ABORT;
+    signal(SIGABRT, sigabort);  // must reregister handler each time
+}
+
+void sigint(int signo)
+{
+    status |= INT;
+    signal(SIGINT, sigint);     // must reregister handler each time
+}
+
+int main(int argc, char **argv)
+{
+    signal(SIGINT, sigint);
+    signal(SIGABRT, sigabort);
+    if (fork() == 0) {
+        for (;;) {
+            status &= ~ABORT;
+            kill(getpid(), SIGABRT);
+            if (!(status & ABORT)) printf("ABORT failed\n");
+            if (getppid() == 1) exit(1);
+        }
+    }
+    for(;;) {
+        status &= ~INT;
+        kill(getpid(), SIGINT);
+        if (!(status & INT)) printf("INT failed\n");
+    }
+    return 0;
+}

--- a/elkscmd/test/other/test_sigfail.c
+++ b/elkscmd/test/other/test_sigfail.c
@@ -44,6 +44,7 @@ int main(int argc, char **argv)
         status &= ~INT;
         kill(pid, SIGINT);
         if (!(status & INT)) printf("INT failed\n");
+        if (getppid() == 1) exit(1);
     }
     return 0;
 }

--- a/elkscmd/test/other/test_sigfail.c
+++ b/elkscmd/test/other/test_sigfail.c
@@ -6,6 +6,8 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <signal.h>
+#include <time.h>
+#include <sys/select.h>
 
 #define ABORT   1
 #define INT     2
@@ -25,26 +27,35 @@ void sigint(int signo)
     signal(SIGINT, sigint);     // must reregister handler each time
 }
 
+void delay(long msecs)
+{
+    struct timeval tv;
+
+    tv.tv_sec = 0;
+    tv.tv_usec = msecs * 1000;
+    select(0, NULL, NULL, NULL, &tv);
+}
+
 int main(int argc, char **argv)
 {
     signal(SIGINT, sigint);
     signal(SIGABRT, sigabort);
     pid = getpid();
-    if (fork() == 0) {
+    if (vfork() == 0) {
         signal(SIGINT, SIG_IGN);
         signal(SIGABRT, SIG_IGN);
         for (;;) {
             status &= ~ABORT;
             kill(pid, SIGABRT);
             if (!(status & ABORT)) printf("ABORT failed\n");
-            if (getppid() == 1) exit(1);
+            if (getppid() == 1) _exit(1);
         }
     }
     for(;;) {
         status &= ~INT;
         kill(pid, SIGINT);
         if (!(status & INT)) printf("INT failed\n");
-        if (getppid() == 1) exit(1);
+        if (getppid() == 1) _exit(1);
     }
     return 0;
 }

--- a/elkscmd/test/other/test_sigfail.c
+++ b/elkscmd/test/other/test_sigfail.c
@@ -11,6 +11,8 @@
 #define INT     2
 volatile int status;
 
+static int pid;
+
 void sigabort(int signo)
 {
     status |= ABORT;
@@ -27,17 +29,20 @@ int main(int argc, char **argv)
 {
     signal(SIGINT, sigint);
     signal(SIGABRT, sigabort);
+    pid = getpid();
     if (fork() == 0) {
+        signal(SIGINT, SIG_IGN);
+        signal(SIGABRT, SIG_IGN);
         for (;;) {
             status &= ~ABORT;
-            kill(getpid(), SIGABRT);
+            kill(pid, SIGABRT);
             if (!(status & ABORT)) printf("ABORT failed\n");
             if (getppid() == 1) exit(1);
         }
     }
     for(;;) {
         status &= ~INT;
-        kill(getpid(), SIGINT);
+        kill(pid, SIGINT);
         if (!(status & INT)) printf("INT failed\n");
     }
     return 0;

--- a/libc/system/abort.c
+++ b/libc/system/abort.c
@@ -5,10 +5,13 @@
 void
 abort(void)
 {
-   signal (SIGABRT, SIG_DFL);
-   kill (getpid (), SIGABRT);  // first try
-   pause ();  // system may just schedule
-   signal (SIGKILL, SIG_DFL);
-   kill (getpid (), SIGKILL);  // second try
-   _exit (255);  // third try
+    /* call registered handler if any, or die if none */
+    kill (getpid(), SIGABRT);
+
+    /* no registered handler, die on SIGABRT */
+    signal (SIGABRT, SIG_DFL);
+    kill (getpid(), SIGABRT);
+
+    /* should not be needed */
+    _exit(255);
 }


### PR DESCRIPTION
Pursuant to discussion in https://github.com/jbruchon/elks/pull/1555#issuecomment-1460397198, this PR adds `test_sigfail` (available on 2880k+ images) which demonstrates how the ELKS kernel always clears the current process signal mask when calling a registered handler.

To demonstrate, run `test_sigfail`, which registers signal handlers for SIGINT and SIGABRT, then forks, with each process sending SIGINT or SIGABRT to only the first process as fast as possible. One can then type ^C multiple times, producing another SIGINT, which on occasion will either 1) terminate the program, or 2) cause the following kernel message to be displayed:
```
SIGNAL(pid) processing mask 0002, ignoring signal w/mask 0020 // 0002=SIGINT, 0020=SIGABRT
```
(Note the program will display "ABORT failed" continually - this is because `vfork()` doesn't actually share parent and child address space in the current ELKS implementation).

In the first case, the program terminates because ELKS requires re-registration of signal handlers each time a signal is received, and if a SIGINT is received between the time the handler callback is scheduled and the handler is executed, the second SIGINT will cause the kernel to terminate the program.

In the second more rare case, the program has received both SIGINT and SIGABRT signals before being scheduled, and the kernel displays the above message before clearing the remaining signal (in line 74 of signal.c).

In some cases, the kernel will display the following message:
```
SIGNAL(pid) processing mask 0002, ignoring signal w/mask 0002
```
This seems to indicate that the task has received a SIGINT while processing the SIGINT message but before returning to the modified user stack frame, thus indicating that the same signal remains to be processed. This may be why the kernel signal dispatch routine was written to originally clear the signal mask. I have also seen, but now cannot repeat, process STACK OVERFLOW messages when I changed the kernel to _not_ clear the signal mask. So the system needs more testing before changing signal mask processing.

Ctrl-\ (QUIT) can be pressed to terminate the program, sending a SIGQUIT.

The above testing varies radically depending on how many tasks are being scheduled by ELKS, e.g. whether or not an additional terminal may be logged in. It is recommended to run `test_sigfail` using serial console set in /bootopts, so that kernel messages can be seen outside of the ABORT fail messages.

The point of this was to confirm the conclusion in https://github.com/jbruchon/elks/pull/1555#issuecomment-1460397198 that 1) the kernel can't guarantee a registered SIGABRT handler to be called, and that 2) the suggested changes should be made in libc `abort`.

