### PR TITLE
Fix libc warnings

### DIFF
--- a/elkscmd/test/libc/misc.c
+++ b/elkscmd/test/libc/misc.c
@@ -142,7 +142,7 @@ static void validateCrypt(const char *s)
     EXPECT_LT(len, 64);
     for (size_t i = 0; i < len; ++i) {
         char c = s[i];
-        if (c < 32 || c > 127 || strpbrk(s, "\\:;*!")) {
+        if (c < 32 || strpbrk(s, "\\:;*!")) {
             ASSERT_FAIL("Invalid character 0x%02x\n", c);
         }
     }

--- a/elkscmd/test/libc/misc.c
+++ b/elkscmd/test/libc/misc.c
@@ -10,179 +10,179 @@
 
 TEST_CASE(misc_basename)
 {
-	struct {
-		const char *path;
-		const char *base;
-	} tests[] = {
-		{ "", "." },
-		{ "/usr/lib", "lib" },
-		{ "/usr/", "usr" },
-		{ "usr/", "usr" },
-		{ "/", "/" },
-		{ "///", "/" },
-		{ "//usr//lib//", "lib" },
-		{ ".", "." },
-		{ "..", ".." },
-		{ NULL, NULL }
-	};
+    struct {
+        const char *path;
+        const char *base;
+    } tests[] = {
+        { "", "." },
+        { "/usr/lib", "lib" },
+        { "/usr/", "usr" },
+        { "usr/", "usr" },
+        { "/", "/" },
+        { "///", "/" },
+        { "//usr//lib//", "lib" },
+        { ".", "." },
+        { "..", ".." },
+        { NULL, NULL }
+    };
 
-	for (int i = 0; tests[i].path; ++i) {
-		char *path = strdup(tests[i].path);
-		char *base = basename(path);
-		ASSERT_STREQ(base, tests[i].base);
-		free(path);
-	}
+    for (int i = 0; tests[i].path; ++i) {
+        char *path = strdup(tests[i].path);
+        char *base = basename(path);
+        ASSERT_STREQ(base, tests[i].base);
+        free(path);
+    }
 }
 
 TEST_CASE(misc_dirname)
 {
-	struct {
-		const char *path;
-		const char *dir;
-	} tests[] = {
-		{ "", "." },
-		{ "/usr/lib/", "/usr" },
-		{ "/usr/lib", "/usr" },
-		{ "/usr/", "/" },
-		{ "usr/", "." },
-		{ "/", "/" },
-		{ "///", "/" },
-		/* TODO does not yet clean up slashes */
-		{ "//usr//lib//", "//usr" },
-		{ ".", "." },
-		{ "..", "." },
-		{ NULL, NULL }
-	};
+    struct {
+        const char *path;
+        const char *dir;
+    } tests[] = {
+        { "", "." },
+        { "/usr/lib/", "/usr" },
+        { "/usr/lib", "/usr" },
+        { "/usr/", "/" },
+        { "usr/", "." },
+        { "/", "/" },
+        { "///", "/" },
+        /* TODO does not yet clean up slashes */
+        { "//usr//lib//", "//usr" },
+        { ".", "." },
+        { "..", "." },
+        { NULL, NULL }
+    };
 
-	for (int i = 0; tests[i].path; ++i) {
-		char *path = strdup(tests[i].path);
-		char *dir = dirname(path);
-		ASSERT_STREQ(dir, tests[i].dir);
-		free(path);
-	}
+    for (int i = 0; tests[i].path; ++i) {
+        char *path = strdup(tests[i].path);
+        char *dir = dirname(path);
+        ASSERT_STREQ(dir, tests[i].dir);
+        free(path);
+    }
 }
 
 #define TEST(r, f, x, m) \
-	do { \
-		errno = 0; \
-		msg = #f; \
-		if (((r) = (f)) != (x)) \
-			ASSERT_FAIL("%s failed (" m ")\n", #f, r, x); \
-	} while (0)
+    do { \
+        errno = 0; \
+        msg = #f; \
+        if (((r) = (f)) != (x)) \
+            ASSERT_FAIL("%s failed (" m ")\n", #f, r, x); \
+    } while (0)
 
 #define TEST2(r, f, x, m) \
-	if (((r) = (f)) != (x)) ASSERT_FAIL("%s failed (" m ")\n", msg, r, x)
+    if (((r) = (f)) != (x)) ASSERT_FAIL("%s failed (" m ")\n", msg, r, x)
 
 TEST_CASE(misc_strtol)
 {
-	int i;
-	long l;
-	unsigned long ul;
-	char *msg = "";
-	char *s, *c;
+    int i;
+    long l;
+    unsigned long ul;
+    char *msg = "";
+    char *s, *c;
 
-	assert(sizeof(long) == 4);
+    assert(sizeof(long) == 4);
 
-	/* test cases adapted from musl's libc-test */
-	TEST(l, strtol(s="2147483648", &c, 0), 2147483647L, "uncaught overflow %ld != %ld");
-	TEST2(i, c-s, 10, "wrong final position %d != %d");
-	TEST2(i, errno, ERANGE, "missing errno %d != %d");
-	TEST(l, strtol(s="-2147483649", &c, 0), -2147483647L-1, "uncaught overflow %ld != %ld");
-	TEST2(i, c-s, 11, "wrong final position %d != %d");
-	TEST2(i, errno, ERANGE, "missing errno %d != %d");
-	TEST(ul, strtoul(s="4294967296", &c, 0), 4294967295UL, "uncaught overflow %lu != %lu");
-	TEST2(i, c-s, 10, "wrong final position %d != %d");
-	TEST2(i, errno, ERANGE, "missing errno %d != %d");
-	TEST(ul, strtoul(s="-1", &c, 0), -1UL, "rejected negative %lu != %lu");
-	TEST2(i, c-s, 2, "wrong final position %d != %d");
-	TEST2(i, errno, 0, "spurious errno %d != %d");
-	TEST(ul, strtoul(s="-2", &c, 0), -2UL, "rejected negative %lu != %lu");
-	TEST2(i, c-s, 2, "wrong final position %d != %d");
-	TEST2(i, errno, 0, "spurious errno %d != %d");
-	TEST(ul, strtoul(s="-2147483648", &c, 0), -2147483648UL, "rejected negative %lu != %lu");
-	TEST2(i, c-s, 11, "wrong final position %d != %d");
-	TEST2(i, errno, 0, "spurious errno %d != %d");
-	TEST(ul, strtoul(s="-2147483649", &c, 0), -2147483649UL, "rejected negative %lu != %lu");
-	TEST2(i, c-s, 11, "wrong final position %d != %d");
-	TEST2(i, errno, 0, "spurious errno %d != %d");
-	TEST(ul, strtoul(s="-4294967296", &c, 0), 4294967295UL, "uncaught negative overflow %lu != %lu");
-	TEST2(i, c-s, 11, "wrong final position %d != %d");
-	TEST2(i, errno, ERANGE, "spurious errno %d != %d");
+    /* test cases adapted from musl's libc-test */
+    TEST(l, strtol(s="2147483648", &c, 0), 2147483647L, "uncaught overflow %ld != %ld");
+    TEST2(i, c-s, 10, "wrong final position %d != %d");
+    TEST2(i, errno, ERANGE, "missing errno %d != %d");
+    TEST(l, strtol(s="-2147483649", &c, 0), -2147483647L-1, "uncaught overflow %ld != %ld");
+    TEST2(i, c-s, 11, "wrong final position %d != %d");
+    TEST2(i, errno, ERANGE, "missing errno %d != %d");
+    TEST(ul, strtoul(s="4294967296", &c, 0), 4294967295UL, "uncaught overflow %lu != %lu");
+    TEST2(i, c-s, 10, "wrong final position %d != %d");
+    TEST2(i, errno, ERANGE, "missing errno %d != %d");
+    TEST(ul, strtoul(s="-1", &c, 0), -1UL, "rejected negative %lu != %lu");
+    TEST2(i, c-s, 2, "wrong final position %d != %d");
+    TEST2(i, errno, 0, "spurious errno %d != %d");
+    TEST(ul, strtoul(s="-2", &c, 0), -2UL, "rejected negative %lu != %lu");
+    TEST2(i, c-s, 2, "wrong final position %d != %d");
+    TEST2(i, errno, 0, "spurious errno %d != %d");
+    TEST(ul, strtoul(s="-2147483648", &c, 0), -2147483648UL, "rejected negative %lu != %lu");
+    TEST2(i, c-s, 11, "wrong final position %d != %d");
+    TEST2(i, errno, 0, "spurious errno %d != %d");
+    TEST(ul, strtoul(s="-2147483649", &c, 0), -2147483649UL, "rejected negative %lu != %lu");
+    TEST2(i, c-s, 11, "wrong final position %d != %d");
+    TEST2(i, errno, 0, "spurious errno %d != %d");
+    TEST(ul, strtoul(s="-4294967296", &c, 0), 4294967295UL, "uncaught negative overflow %lu != %lu");
+    TEST2(i, c-s, 11, "wrong final position %d != %d");
+    TEST2(i, errno, ERANGE, "spurious errno %d != %d");
 }
 
 TEST_CASE(misc_getopt)
 {
-	/* TODO */
+    /* TODO */
 }
 
 TEST_CASE(misc_getcwd)
 {
-	char buf[256];
-	char *p;
+    char buf[256];
+    char *p;
 
-	p = getcwd(buf, 1);
-	EXPECT_EQ(errno, ERANGE);
-	EXPECT_EQ_P(p, NULL);
+    p = getcwd(buf, 1);
+    EXPECT_EQ(errno, ERANGE);
+    EXPECT_EQ_P(p, NULL);
 
-	/* TODO:BUG hangs or crashes elksemu but not real ELKS */
+    /* TODO:BUG hangs or crashes elksemu but not real ELKS */
 #if 0
-	memset(buf, 'X', sizeof(buf));
-	p = getcwd(buf, sizeof(buf));
-	EXPECT_EQ_P(p, buf);
-	EXPECT_EQ(buf[0], '/');
-	EXPECT_LT(strlen(buf), sizeof(buf)); /* is NULL terminated */
+    memset(buf, 'X', sizeof(buf));
+    p = getcwd(buf, sizeof(buf));
+    EXPECT_EQ_P(p, buf);
+    EXPECT_EQ(buf[0], '/');
+    EXPECT_LT(strlen(buf), sizeof(buf)); /* is NULL terminated */
 #endif
 }
 
 static void validateCrypt(const char *s)
 {
-	/* NULL terminated, "sane" length, printable ASCII, no \ : ; * ! */
-	size_t len = strlen(s);
-	EXPECT_GT(len, 10);
-	EXPECT_LT(len, 64);
-	for (size_t i = 0; i < len; ++i) {
-		char c = s[i];
-		if (c < 32 || c > 127 || strpbrk(s, "\\:;*!")) {
-			ASSERT_FAIL("Invalid character 0x%02x\n", c);
-		}
-	}
+    /* NULL terminated, "sane" length, printable ASCII, no \ : ; * ! */
+    size_t len = strlen(s);
+    EXPECT_GT(len, 10);
+    EXPECT_LT(len, 64);
+    for (size_t i = 0; i < len; ++i) {
+        char c = s[i];
+        if (c < 32 || c > 127 || strpbrk(s, "\\:;*!")) {
+            ASSERT_FAIL("Invalid character 0x%02x\n", c);
+        }
+    }
 }
 
 TEST_CASE(misc_crypt)
 {
-	/* Implements TEA (tiny encryption algorithm) as documented here
-	 * http://www.ftp.cl.cam.ac.uk/ftp/papers/djw-rmn/djw-rmn-tea.html
-	 *
-	 * Hardcoded to require 2 bytes of salt, no error checking
-	 *
-	 * Can consume long passwords: current getpass() can return 128 chars
-	 */
-	char salt[2];
+    /* Implements TEA (tiny encryption algorithm) as documented here
+     * http://www.ftp.cl.cam.ac.uk/ftp/papers/djw-rmn/djw-rmn-tea.html
+     *
+     * Hardcoded to require 2 bytes of salt, no error checking
+     *
+     * Can consume long passwords: current getpass() can return 128 chars
+     */
+    char salt[2];
 
-	/* TODO crypt does not encode the salt which limits valid values;
-	 * does no error checking of valid values; verify this is correct
-	 */
+    /* TODO crypt does not encode the salt which limits valid values;
+     * does no error checking of valid values; verify this is correct
+     */
 
-	/* vary salt */
-	salt[0] = 'a';
-	salt[1] = 'b';
-	char *p = crypt("secret", salt);
-	char *p1 = testlib_strdup(p);
-	validateCrypt(p1);
-	salt[1] = 'c';
-	p = crypt("secret", salt);
-	validateCrypt(p);
-	EXPECT_STRNE(p, p1);
+    /* vary salt */
+    salt[0] = 'a';
+    salt[1] = 'b';
+    char *p = crypt("secret", salt);
+    char *p1 = testlib_strdup(p);
+    validateCrypt(p1);
+    salt[1] = 'c';
+    p = crypt("secret", salt);
+    validateCrypt(p);
+    EXPECT_STRNE(p, p1);
 
-	/* long password */
-	char *secret = testlib_malloc(128);
-	memset(secret, 'X', 127);
-	secret[127] = 0;
-	p = crypt(secret, salt);
-	p1 = testlib_strdup(p);
-	validateCrypt(p1);
-	secret[126] = 'Y';
-	p = crypt(secret, salt);
-	validateCrypt(p);
-	EXPECT_STRNE(p, p1);
+    /* long password */
+    char *secret = testlib_malloc(128);
+    memset(secret, 'X', 127);
+    secret[127] = 0;
+    p = crypt(secret, salt);
+    p1 = testlib_strdup(p);
+    validateCrypt(p1);
+    secret[126] = 'Y';
+    p = crypt(secret, salt);
+    validateCrypt(p);
+    EXPECT_STRNE(p, p1);
 }

--- a/elkscmd/test/libc/stdio.c
+++ b/elkscmd/test/libc/stdio.c
@@ -124,28 +124,28 @@ TEST_CASE(stdio_fgets_boundary)
     /* size <= 0 is a domain error; returns NULL */
     buf[0] = CANARY_BYTE;
     p = fgets(buf, 0, fp);
-    ASSERT_EQ(p, NULL);
+    ASSERT_EQ_P(p, NULL);
     ASSERT_FALSE(feof(fp));
     ASSERT_EQ(buf[0], CANARY_BYTE);
 
     /* no room for data, only terminator */
     buf[1] = CANARY_BYTE;
     p = fgets(buf, 1, fp);
-    ASSERT_EQ(p, buf);
+    ASSERT_EQ_P(p, buf);
     ASSERT_EQ(buf[0], 0);
     ASSERT_EQ(buf[1], CANARY_BYTE);
 
     /* first data byte + terminator */
     buf[2] = CANARY_BYTE;
     p = fgets(buf, 2, fp);
-    ASSERT_EQ(p, buf);
+    ASSERT_EQ_P(p, buf);
     ASSERT_EQ(buf[0], data[0]);
     ASSERT_EQ(buf[1], 0);
     ASSERT_EQ(buf[2], CANARY_BYTE);
 
     /* 2 remaining bytes + terminator */
     p = fgets(buf, 4, fp);
-    ASSERT_EQ(p, buf);
+    ASSERT_EQ_P(p, buf);
     ASSERT_TRUE(feof(fp));
     ASSERT_EQ(buf[0], data[1]);
     ASSERT_EQ(buf[1], data[2]);
@@ -154,7 +154,7 @@ TEST_CASE(stdio_fgets_boundary)
     /* EOF after no data */
     buf[0] = CANARY_BYTE;
     p = fgets(buf, 4, fp);
-    ASSERT_EQ(p, NULL);
+    ASSERT_EQ_P(p, NULL);
     ASSERT_TRUE(feof(fp));
     ASSERT_EQ(buf[0], CANARY_BYTE);
 

--- a/elkscmd/test/libc/stdio.c
+++ b/elkscmd/test/libc/stdio.c
@@ -52,8 +52,7 @@ TEST_CASE(stdio_seek)
     char wbuf[256];
     char rbuf[256];
     size_t n;
-    FILE* fp;
-    int i;
+    FILE *fp;
 
     fp = fopen("/tmp/libcseek.txt", "w+");
     ASSERT_EQ(!fp, 0);
@@ -71,9 +70,9 @@ TEST_CASE(stdio_seek)
     ASSERT_EQ(n, 0);
 
     /* random-access write */
-    for (i = 0; i < sizeof(wbuf); ++i)
+    for (size_t i = 0; i < sizeof(wbuf); ++i)
         wbuf[i] = i;
-    for (i = sizeof(wbuf) - 1; i >= 0; --i) {
+    for (ssize_t i = sizeof(wbuf) - 1; i >= 0; --i) {
         n = fseek(fp, i, SEEK_SET);
         ASSERT_EQ(n, 0);
         n = ftell(fp);

--- a/elkscmd/test/libc/testlib.c
+++ b/elkscmd/test/libc/testlib.c
@@ -29,26 +29,26 @@ static const char *captureValue;
 
 int testlib_getErrno()
 {
-	return errno;
+    return errno;
 }
 
 void testlib_setErrno(int e)
 {
-	errno = e;
+    errno = e;
 }
 
 const char* testlib_strerror()
 {
-	return strerror(errno);
+    return strerror(errno);
 }
 
 int testlib_strequals(const void *s1, const void *s2)
 {
-	if (s1 == s2)
-		return 1;
-	if (!s1 || !s2)
-		return 0;
-	return strcmp(s1, s2) == 0;
+    if (s1 == s2)
+        return 1;
+    if (!s1 || !s2)
+        return 0;
+    return strcmp(s1, s2) == 0;
 }
 
 int testlib_strnequals(const void *s1, const void *s2, int n)
@@ -62,75 +62,75 @@ int testlib_strnequals(const void *s1, const void *s2, int n)
 
 int testlib_tvEq(struct timeval *a, struct timeval *b)
 {
-	if (a->tv_sec == b->tv_sec && a->tv_usec == b->tv_usec)
-		return 0;
-	if (a->tv_sec > b->tv_sec ||
-		(a->tv_sec == b->tv_sec && a->tv_usec > b->tv_usec))
-		return 1;
-	return -1;
+    if (a->tv_sec == b->tv_sec && a->tv_usec == b->tv_usec)
+        return 0;
+    if (a->tv_sec > b->tv_sec ||
+            (a->tv_sec == b->tv_sec && a->tv_usec > b->tv_usec))
+        return 1;
+    return -1;
 }
 
 void testlib_tvAdd(struct timeval *a, struct timeval *b)
 {
-	a->tv_sec += b->tv_sec;
-	a->tv_usec += b->tv_usec;
-	testlib_tvNormalize(a);
+    a->tv_sec += b->tv_sec;
+    a->tv_usec += b->tv_usec;
+    testlib_tvNormalize(a);
 }
 
 int testlib_tvSub(struct timeval *a, struct timeval *b, struct timeval *diff)
 {
-	if (a->tv_usec < b->tv_usec) {
-		long sec = (b->tv_usec - a->tv_usec) / 1000000L + 1;
-		b->tv_usec -= 1000000L * sec;
-		b->tv_sec += sec;
-	}
-	if (a->tv_usec - b->tv_usec > 1000000L) {
-		long sec = (a->tv_usec - b->tv_usec) / 1000000L;
-		b->tv_usec += 1000000L * sec;
-		b->tv_sec -= sec;
-	}
+    if (a->tv_usec < b->tv_usec) {
+        long sec = (b->tv_usec - a->tv_usec) / 1000000L + 1;
+        b->tv_usec -= 1000000L * sec;
+        b->tv_sec += sec;
+    }
+    if (a->tv_usec - b->tv_usec > 1000000L) {
+        long sec = (a->tv_usec - b->tv_usec) / 1000000L;
+        b->tv_usec += 1000000L * sec;
+        b->tv_sec -= sec;
+    }
 
-	diff->tv_sec = a->tv_sec - b->tv_sec;
-	diff->tv_usec = a->tv_usec - b->tv_usec;
+    diff->tv_sec = a->tv_sec - b->tv_sec;
+    diff->tv_usec = a->tv_usec - b->tv_usec;
 
-	return a->tv_sec < b->tv_sec;
+    return a->tv_sec < b->tv_sec;
 }
 
 void testlib_tvNormalize(struct timeval *a)
 {
-	while (a->tv_usec > 1000000L) {
-		a->tv_sec++;
-		a->tv_usec -= 1000000L;
-	}
+    while (a->tv_usec > 1000000L) {
+        a->tv_sec++;
+        a->tv_usec -= 1000000L;
+    }
 }
 
 void testlib_abort(const char *fmt, ...)
 {
-	va_list ap;
-	va_start(ap, fmt);
-	vfprintf(stderr, fmt, ap);
-	va_end(ap);
-	abort();
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+    abort();
 }
 
 void *testlib_malloc(unsigned int size)
 {
-	char *p = malloc(sizeof(void*) + size);
-	if (p == NULL)
-		testlib_abort("%s failed: %s\n", "malloc", strerror(errno));
-	*(void **)p = autoFree;
-	autoFree = p;
-	return p + sizeof(void*);
+    char *p = malloc(sizeof(void*) + size);
+    if (p == NULL)
+        testlib_abort("%s failed: %s\n", "malloc", strerror(errno));
+    *(void **)p = autoFree;
+    autoFree = p;
+    return p + sizeof(void*);
 }
 
 char *testlib_strdup(const char *s)
 {
-	char *p = strdup(s);
-	if (p == NULL)
-		testlib_abort("%s failed: %s\n", "strdup", strerror(errno));
-	*(void **)p = autoFree;
-	autoFree = p;
-	return p + sizeof(void*);
+    char *p = strdup(s);
+    if (p == NULL)
+        testlib_abort("%s failed: %s\n", "strdup", strerror(errno));
+    *(void **)p = autoFree;
+    autoFree = p;
+    return p + sizeof(void*);
 }
 
 void testlib_capture(const char *file, int line, const char *key, const char *value)
@@ -141,41 +141,41 @@ void testlib_capture(const char *file, int line, const char *key, const char *va
 
 void testlib_showInfo(const char *file, int line, const char *fmt, ...)
 {
-	if (!testlib_verbose)
-		return;
-	va_list ap;
-	va_start(ap, fmt);
-	fprintf(stdout, "%s:%d: ", file, line);
-	vfprintf(stdout, fmt, ap);
-	va_end(ap);
+    if (!testlib_verbose)
+        return;
+    va_list ap;
+    va_start(ap, fmt);
+    fprintf(stdout, "%s:%d: ", file, line);
+    vfprintf(stdout, fmt, ap);
+    va_end(ap);
 }
 
 void testlist_showErrorFmt(const char *file, int line, const char* func,
-	const char *fmt, ...)
+        const char *fmt, ...)
 {
-	va_list ap;
-	va_start(ap, fmt);
-	fprintf(stderr, "Test '%s' failed in %s() %s:%d:\n", test_name,
-		func, file, line);
-	vfprintf(stdout, fmt, ap);
-	va_end(ap);
+    va_list ap;
+    va_start(ap, fmt);
+    fprintf(stderr, "Test '%s' failed in %s() %s:%d:\n", test_name,
+            func, file, line);
+    vfprintf(stdout, fmt, ap);
+    va_end(ap);
 }
 
 void testlib_showError(const char *file, int line, const char* func,
-	const char* kind, const char* expr, const char* v1, const char* sym,
-	const char* v2)
+        const char* kind, const char* expr, const char* v1, const char* sym,
+        const char* v2)
 {
-	fprintf(stderr, "Test '%s' failed %s in %s() %s:%d:\n"
-		"\texpr %s\n"
-		"\tgot  \"%s\"\n"
-		"\tneed %s \"%s\"\n",
-		test_name, kind, func, file, line,
-		expr, v1 ? v1 : "(null)", sym, v2 ? v2 : "null");
+    fprintf(stderr, "Test '%s' failed %s in %s() %s:%d:\n"
+            "\texpr %s\n"
+            "\tgot  \"%s\"\n"
+            "\tneed %s \"%s\"\n",
+            test_name, kind, func, file, line,
+            expr, v1 ? v1 : "(null)", sym, v2 ? v2 : "null");
 }
 
 void testlib_debugTrap()
 {
-	asm("int3");
+    asm("int3");
 }
 
 void testlib_onFail(int isFatal)
@@ -200,66 +200,66 @@ static void testlib_initEnv()
 
 static void testlib_deinitEnv()
 {
-	while (autoFree) {
-		void *p = autoFree;
-		autoFree = *(void **)autoFree;
-		free(p);
-	}
+    while (autoFree) {
+        void *p = autoFree;
+        autoFree = *(void **)autoFree;
+        free(p);
+    }
 }
 
 void testlib_runTestCases(testfn_t *start, testfn_t *end)
 {
-	for (testfn_t *fn = start; fn != end; ++fn) {
-		pid_t pid = -1;
-		int failed = 0;
+    for (testfn_t *fn = start; fn != end; ++fn) {
+        pid_t pid = -1;
+        int failed = 0;
 
-		if (testlib_forkTest) {
-			pid = fork();
-			if (pid == (pid_t)-1) {
-				testlib_abort("%s failed: %s\n", "fork", strerror(errno));
-			}
-		}
+        if (testlib_forkTest) {
+            pid = fork();
+            if (pid == (pid_t)-1) {
+                testlib_abort("%s failed: %s\n", "fork", strerror(errno));
+            }
+        }
 
-		++testlib_tests;
-		if (pid == 0 || pid == (pid_t)-1) {
-			unsigned int startAsserts = testlib_assertionFails;
+        ++testlib_tests;
+        if (pid == 0 || pid == (pid_t)-1) {
+            unsigned int startAsserts = testlib_assertionFails;
 
-			testlib_initEnv();
+            testlib_initEnv();
 
-			if (setjmp(env) == 0) {
-				(*fn)();
+            if (setjmp(env) == 0) {
+                (*fn)();
 
-				if (testlib_assertionFails > startAsserts)
-					failed = 1;
-			} else {
-				failed = 1;
-			}
+                if (testlib_assertionFails > startAsserts)
+                    failed = 1;
+            } else {
+                failed = 1;
+            }
 
-			testlib_deinitEnv();
+            testlib_deinitEnv();
 
-			if (pid == 0)
-				exit(failed);
-		}
+            if (pid == 0)
+                exit(failed);
+        }
 
-		if (pid != 0 && pid != (pid_t)-1) {
-			/* TODO update assertion count in parent process */
-			if (waitpid(pid, &failed, 0) < 0) {
-				testlib_abort("%s failed: %s\n", "waitpid", strerror(errno));
-			}
-		}
+        if (pid != 0 && pid != (pid_t)-1) {
+            /* TODO update assertion count in parent process */
+            if (waitpid(pid, &failed, 0) < 0) {
+                testlib_abort("%s failed: %s\n", "waitpid", strerror(errno));
+            }
+        }
 
-		if (failed) {
-			++testlib_testFails;
-			if (testlib_abortOnFail)
-				break;
-		}
-	}
+        if (failed) {
+            ++testlib_testFails;
+            if (testlib_abortOnFail)
+                break;
+        }
+    }
 }
 
 int testlib_report()
 {
-	fprintf(stderr, "\n%u / %u %s\n%u / %u %s\n",
-		testlib_assertionFails, testlib_assertions, "assertions failed",
-		testlib_testFails, testlib_tests, "tests failed");
-	return !!testlib_assertionFails;
+    fprintf(stderr, "\n%u / %u %s\n%u / %u %s\n",
+            testlib_assertionFails, testlib_assertions, "assertions failed",
+            testlib_testFails, testlib_tests, "tests failed");
+    return !!testlib_assertionFails;
 }

--- a/elkscmd/test/libc/testlib.c
+++ b/elkscmd/test/libc/testlib.c
@@ -243,7 +243,7 @@ void testlib_runTestCases(testfn_t *start, testfn_t *end)
 
         if (pid != 0 && pid != (pid_t)-1) {
             /* TODO update assertion count in parent process */
-            if (waitpid(pid, &failed, 0) < 0) {
+            if (waitpid(pid, &failed, 0) == (pid_t)-1) {
                 testlib_abort("%s failed: %s\n", "waitpid", strerror(errno));
             }
         }

--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -115,8 +115,8 @@ ssize_t getline(char **__restrict lineptr, size_t *__restrict n,
 		FILE *__restrict stream);
 
 FILE *fopen(const char*, const char*);
-FILE *fdopen(int, char*);
-FILE *freopen(char*, char*, FILE*);
+FILE *fdopen(int, const char*);
+FILE *freopen(const char*, const char*, FILE*);
 
 #ifdef __LIBC__
 FILE *__fopen(const char*, int, FILE*, const char*);
@@ -129,7 +129,7 @@ size_t fread(void *, size_t, size_t, FILE *);
 int fseek(FILE *fp, long offset, int ref);
 long ftell(FILE *fp);
 void rewind(FILE *fp);
-int fwrite(char *buf, int size, int nelm, FILE *fp);
+int fwrite(const char *buf, int size, int nelm, FILE *fp);
 char * gets(char *str);	/* BAD function; DON'T use it! */
 
 int fscanf(FILE * fp, const char * fmt, ...);
@@ -164,7 +164,7 @@ int vfscanf(register FILE *fp, register char *fmt, va_list ap);
 int vscanf(const char *fmt, va_list ap);
 int vsscanf(char *sp, const char *fmt, va_list ap);
 
-FILE *popen(char *, char *);
+FILE *popen(const char *, const char *);
 int pclose(FILE *);
 
 #endif /* __STDIO_H */

--- a/libc/misc/atoi.c
+++ b/libc/misc/atoi.c
@@ -3,16 +3,16 @@
 
 int atoi(const char *s)
 {
-	int n = 0;
-	int neg = 0;
+    int n = 0;
+    int neg = 0;
 
-	while (*s == ' ' || *s == '\t')
-		s++;
-	switch (*s) {
-	case '-': neg = 1;
-	case '+': s++;
-	}
-	while ((unsigned) (*s - '0') <= 9u)
-		n = n * 10 + *s++ - '0';
-	return neg ? 0u - n : n;
+    while (*s == ' ' || *s == '\t')
+        s++;
+    switch (*s) {
+        case '-': neg = 1;
+        case '+': s++;
+    }
+    while ((unsigned) (*s - '0') <= 9u)
+        n = n * 10 + *s++ - '0';
+    return neg ? 0u - n : n;
 }

--- a/libc/misc/instrument.c
+++ b/libc/misc/instrument.c
@@ -7,8 +7,8 @@
 
 static char ftrace;
 static int count;
-static unsigned int start_sp;
-static unsigned int max_stack;
+static size_t start_sp;
+static size_t max_stack;
 
 /* runs before main and rewrites argc/argv on stack if --ftrace found */
 __attribute__((no_instrument_function,constructor(120)))
@@ -35,8 +35,8 @@ void noinstrument __cyg_profile_func_enter_simple(void)
     int *calling_fn = __builtin_return_address(0);  /* return address */
     int i;
 
-    if (count == 0) start_sp = (unsigned int)bp;
-    unsigned int stack_used = start_sp - (unsigned int)bp;
+    if (count == 0) start_sp = (size_t)bp;
+    size_t stack_used = start_sp - (size_t)bp;
     if (stack_used > max_stack) max_stack = stack_used;
 
     for (i=0; i<count; i++)

--- a/libc/misc/popen.c
+++ b/libc/misc/popen.c
@@ -3,7 +3,7 @@
 #include <sys/wait.h>
 #include <paths.h>
 
-FILE *popen(char *command, char *rw)
+FILE *popen(const char *command, const char *rw)
 {
     int pipe_fd[2];
     int pid, reading;

--- a/libc/misc/popen.c
+++ b/libc/misc/popen.c
@@ -3,39 +3,42 @@
 #include <sys/wait.h>
 #include <paths.h>
 
-FILE * popen(char *command, char *rw)
+FILE *popen(char *command, char *rw)
 {
-   int pipe_fd[2];
-   int pid, reading;
+    int pipe_fd[2];
+    int pid, reading;
 
-   if( command == NULL || pipe(pipe_fd) < 0 ) return NULL;
-   reading = (rw[0] == 'r');
+    if (command == NULL || pipe(pipe_fd) < 0)
+        return NULL;
+    reading = (rw[0] == 'r');
 
-   pid = vfork();
-   if( pid < 0 ) { close(pipe_fd[0]); close(pipe_fd[1]); return NULL; }
-   if( pid == 0 )
-   {
-      close(pipe_fd[!reading]);
-      close(reading);
-      if( pipe_fd[reading] != reading )
-      {
-	 dup2(pipe_fd[reading], reading);
-         close(pipe_fd[reading]);
-      }
+    pid = vfork();
+    if (pid < 0) {
+        close(pipe_fd[0]);
+        close(pipe_fd[1]);
+        return NULL;
+    }
+    if (pid == 0) {
+        close(pipe_fd[!reading]);
+        close(reading);
+        if (pipe_fd[reading] != reading) {
+            dup2(pipe_fd[reading], reading);
+            close(pipe_fd[reading]);
+        }
 
-      execl(_PATH_BSHELL, "sh", "-c", command, (char*)0);
-      _exit(255);
-   }
+        execl(_PATH_BSHELL, "sh", "-c", command, (char*)0);
+        _exit(255);
+    }
 
-   close(pipe_fd[reading]);
-   return fdopen(pipe_fd[!reading], rw);
+    close(pipe_fd[reading]);
+    return fdopen(pipe_fd[!reading], rw);
 }
 
-int pclose(fd)
-FILE *fd;
+int pclose(FILE *fd)
 {
-   int waitstat;
-   if( fclose(fd) != 0 ) return EOF;
-   return wait(&waitstat);
+    int waitstat;
+    if (fclose(fd) != 0)
+        return EOF;
+    return wait(&waitstat);
 }
 

--- a/libc/stdio/fdopen.c
+++ b/libc/stdio/fdopen.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 
 FILE *
-fdopen(int file, char *mode)
+fdopen(int file, const char *mode)
 {
-   return __fopen((char*)0, file, (FILE*)0, mode);
+    return __fopen((char*)0, file, (FILE*)0, mode);
 }

--- a/libc/stdio/fread.c
+++ b/libc/stdio/fread.c
@@ -13,7 +13,8 @@
  */
 size_t fread(void *buf, size_t size, size_t nelm, FILE *fp)
 {
-    int len, v;
+    int v;
+    ssize_t len;
     size_t bytes, got = 0;
     __LINK_SYMBOL(__stdio_init);
 
@@ -31,7 +32,7 @@ size_t fread(void *buf, size_t size, size_t nelm, FILE *fp)
     bytes = size * nelm;
 
     len = fp->bufread - fp->bufpos;
-    if (len >= bytes) {
+    if ((size_t)len >= bytes) {
         /* Enough buffered */
         memcpy(buf, fp->bufpos, bytes);
         fp->bufpos += bytes;

--- a/libc/stdio/fread.c
+++ b/libc/stdio/fread.c
@@ -13,47 +13,44 @@
  */
 size_t fread(void *buf, size_t size, size_t nelm, FILE *fp)
 {
-   int len, v;
-   size_t bytes, got = 0;
-   __LINK_SYMBOL(__stdio_init);
+    int len, v;
+    size_t bytes, got = 0;
+    __LINK_SYMBOL(__stdio_init);
 
-   v = fp->mode;
+    v = fp->mode;
 
-   /* Want to do this to bring the file pointer up to date */
-   if (v & __MODE_WRITING)
-      fflush(fp);
+    /* Want to do this to bring the file pointer up to date */
+    if (v & __MODE_WRITING)
+        fflush(fp);
 
-   /* Can't read or there's been an EOF or error then return zero */
-   if ((v & (__MODE_READ | __MODE_EOF | __MODE_ERR)) != __MODE_READ)
-      return 0;
+    /* Can't read or there's been an EOF or error then return zero */
+    if ((v & (__MODE_READ | __MODE_EOF | __MODE_ERR)) != __MODE_READ)
+        return 0;
 
-   /* This could be long, doesn't seem much point tho */
-   bytes = size * nelm;
+    /* This could be long, doesn't seem much point tho */
+    bytes = size * nelm;
 
-   len = fp->bufread - fp->bufpos;
-   if (len >= bytes)		/* Enough buffered */
-   {
-      memcpy(buf, fp->bufpos, bytes);
-      fp->bufpos += bytes;
-      return nelm;
-   }
-   else if (len > 0)		/* Some buffered */
-   {
-      memcpy(buf, fp->bufpos, len);
-      fp->bufpos += len;
-      got = len;
-   }
+    len = fp->bufread - fp->bufpos;
+    if (len >= bytes) {
+        /* Enough buffered */
+        memcpy(buf, fp->bufpos, bytes);
+        fp->bufpos += bytes;
+        return nelm;
+    } else if (len > 0) {
+        /* Some buffered */
+        memcpy(buf, fp->bufpos, len);
+        fp->bufpos += len;
+        got = len;
+    }
 
-   /* Need more; do it with a direct read */
-   len = read(fp->fd, (char *)buf + got, bytes - got);
-   /* Possibly for now _or_ later */
-   if (len < 0)
-   {
-      fp->mode |= __MODE_ERR;
-      len = 0;
-   }
-   else if (len == 0)
-      fp->mode |= __MODE_EOF;
+    /* Need more; do it with a direct read */
+    len = read(fp->fd, (char *)buf + got, bytes - got);
+    /* Possibly for now _or_ later */
+    if (len < 0) {
+        fp->mode |= __MODE_ERR;
+        len = 0;
+    } else if (len == 0)
+        fp->mode |= __MODE_EOF;
 
-   return (got + len) / size;
+    return (got + len) / size;
 }

--- a/libc/stdio/freopen.c
+++ b/libc/stdio/freopen.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 
 FILE *
-freopen(char *file, char *mode, FILE *fp)
+freopen(const char *file, const char *mode, FILE *fp)
 {
    return __fopen(file, -1, fp, mode);
 }

--- a/libc/stdio/fwrite.c
+++ b/libc/stdio/fwrite.c
@@ -14,67 +14,62 @@
 int
 fwrite(char *buf, int size, int nelm, FILE *fp)
 {
-   register int v;
-   int   len;
-   unsigned bytes, put;
+    register int v;
+    int len;
+    unsigned bytes, put;
 
-   /* If last op was a read ... note fflush may change fp->mode and ret OK */
-   if ((fp->mode & __MODE_READING) && fflush(fp))
-      return 0;
+    /* If last op was a read ... note fflush may change fp->mode and ret OK */
+    if ((fp->mode & __MODE_READING) && fflush(fp))
+        return 0;
 
-   v = fp->mode;
-   /* Can't write or there's been an EOF or error then return 0 */
-   if ((v & (__MODE_WRITE | __MODE_EOF | __MODE_ERR)) != __MODE_WRITE)
-      return 0;
+    v = fp->mode;
+    /* Can't write or there's been an EOF or error then return 0 */
+    if ((v & (__MODE_WRITE | __MODE_EOF | __MODE_ERR)) != __MODE_WRITE)
+        return 0;
 
-   /* This could be long, doesn't seem much point tho */
-   bytes = size * nelm;
+    /* This could be long, doesn't seem much point tho */
+    bytes = size * nelm;
 
-   len = fp->bufend - fp->bufpos;
+    len = fp->bufend - fp->bufpos;
 
-   /* Flush the buffer if not enough room */
-   if (bytes > len)
-      if (fflush(fp))
-	 return 0;
+    /* Flush the buffer if not enough room */
+    if (bytes > len)
+        if (fflush(fp))
+            return 0;
 
-   len = fp->bufend - fp->bufpos;
-   if (bytes <= len)		/* It'll fit in the buffer ? */
-   {
-      register int do_flush=0;
-      fp->mode |= __MODE_WRITING;
-      memcpy(fp->bufpos, buf, bytes);
-      if (v & _IOLBF)
-      {
-         if(memchr(fp->bufpos, '\n', bytes))
-	    do_flush=1;
-      }
-      fp->bufpos += bytes;
+    len = fp->bufend - fp->bufpos;
+    /* It'll fit in the buffer ? */
+    if (bytes <= len) {
+        register int do_flush=0;
+        fp->mode |= __MODE_WRITING;
+        memcpy(fp->bufpos, buf, bytes);
+        if (v & _IOLBF) {
+            if (memchr(fp->bufpos, '\n', bytes))
+                do_flush=1;
+        }
+        fp->bufpos += bytes;
 
-      /* If we're unbuffered or line buffered and have seen nl */
-      if (do_flush || (v & _IONBF) != 0)
-	 fflush(fp);
+        /* If we're unbuffered or line buffered and have seen nl */
+        if (do_flush || (v & _IONBF) != 0)
+            fflush(fp);
 
-      return nelm;
-   }
-   else
-      /* Too big for the buffer */
-   {
-      put = bytes;
-      do
-      {
-         len = write(fp->fd, buf, bytes);
-	 if( len > 0 )
-	 {
-	    buf+=len; bytes-=len;
-	 }
-      }
-      while (len > 0 || (len == -1 && errno == EINTR));
+        return nelm;
+    } else {
+        /* Too big for the buffer */
+        put = bytes;
+        do {
+            len = write(fp->fd, buf, bytes);
+            if ( len > 0 ) {
+                buf+=len; bytes-=len;
+            }
+        }
+        while (len > 0 || (len == -1 && errno == EINTR));
 
-      if (len < 0)
-	 fp->mode |= __MODE_ERR;
+        if (len < 0)
+            fp->mode |= __MODE_ERR;
 
-      put -= bytes;
-   }
+        put -= bytes;
+    }
 
-   return put / size;
+    return put / size;
 }

--- a/libc/stdio/fwrite.c
+++ b/libc/stdio/fwrite.c
@@ -15,7 +15,7 @@ int
 fwrite(char *buf, int size, int nelm, FILE *fp)
 {
     register int v;
-    int len;
+    ssize_t len;
     unsigned bytes, put;
 
     /* If last op was a read ... note fflush may change fp->mode and ret OK */
@@ -33,13 +33,13 @@ fwrite(char *buf, int size, int nelm, FILE *fp)
     len = fp->bufend - fp->bufpos;
 
     /* Flush the buffer if not enough room */
-    if (bytes > len)
+    if (bytes > (size_t)len)
         if (fflush(fp))
             return 0;
 
     len = fp->bufend - fp->bufpos;
     /* It'll fit in the buffer ? */
-    if (bytes <= len) {
+    if (bytes <= (size_t)len) {
         register int do_flush=0;
         fp->mode |= __MODE_WRITING;
         memcpy(fp->bufpos, buf, bytes);

--- a/libc/stdio/fwrite.c
+++ b/libc/stdio/fwrite.c
@@ -12,7 +12,7 @@
  * Again this ignores __MODE__IOTRAN.
  */
 int
-fwrite(char *buf, int size, int nelm, FILE *fp)
+fwrite(const char *buf, int size, int nelm, FILE *fp)
 {
     register int v;
     ssize_t len;

--- a/libc/stdio/getdelim.c
+++ b/libc/stdio/getdelim.c
@@ -45,7 +45,7 @@ ssize_t getdelim(char **__restrict lineptr, size_t *__restrict n,
 		pos = 1;
 
 		do {
-			if (pos >= *n) {
+			if ((size_t)pos >= *n) {
 				if (!(buf = realloc(buf, *n + GETDELIM_GROWBY))) {
 					pos = -1;
 					break;


### PR DESCRIPTION
Fixing warnings as pointed out by https://github.com/jbruchon/elks/pull/1558#issuecomment-1465241879

I was using the wrong test macro (ASSERT_EQ is for integers; ASSERT_EQ_P is for pointers).

Also added const to some stdio functions, and some other minor warning fixes along the way.