### PR TITLE
[kernel] Fix compile/link with CONFIG_HW_COMPAQFAST

### DIFF
--- a/elks/arch/i86/kernel/system.c
+++ b/elks/arch/i86/kernel/system.c
@@ -9,6 +9,7 @@
 #include <linuxmt/debug.h>
 
 #include <arch/segment.h>
+#include <arch/io.h>
 
 
 byte_t sys_caps;		/* system capabilities bits */


### PR DESCRIPTION
Fixes a problem found in https://github.com/jbruchon/elks/issues/1563#issuecomment-1468969902.