### PR TITLE
[libc] limits.h with PATH_MAX

### DIFF
--- a/elkscmd/ash/autocomplete.c
+++ b/elkscmd/ash/autocomplete.c
@@ -11,6 +11,7 @@
 #include <sys/stat.h>
 #include <stdio.h>
 #include <string.h>
+#include <limits.h>
 #include "linenoise.h"
 #include "output.h"
 
@@ -20,7 +21,7 @@ void completion(const char *buf, linenoiseCompletions *lc)
 	DIR *fp;
 	struct dirent *dp;
 	int count;
-	char dir[128];
+	char dir[PATH_MAX];  /* larger than NAME_MAX since this is user-supplied */
 	char line[LINENOISE_MAX_LINE];
 	char result[LINENOISE_MAX_LINE];
 	char lastentry[LINENOISE_MAX_LINE];
@@ -69,7 +70,7 @@ void completion(const char *buf, linenoiseCompletions *lc)
 		return;
 	if (count == 1) {
 		struct stat st;
-		char path[128];
+		char path[PATH_MAX];
 
 		fmtstr(path, sizeof(path), "%s/%s", dir, lastentry);
 		if (!stat(path, &st)) {
@@ -89,7 +90,7 @@ void completion(const char *buf, linenoiseCompletions *lc)
 	while ((dp = readdir(fp)) != NULL) {
 		if (!strncmp(file, dp->d_name, strlen(file))) {
 			struct stat st;
-			char path[128];
+			char path[PATH_MAX];
 
 			if ((file[0] == '.') || (strcmp(dp->d_name, ".") && strcmp(dp->d_name, ".."))) {
 				strcpy(result, buf);

--- a/elkscmd/ash/cd.c
+++ b/elkscmd/ash/cd.c
@@ -326,11 +326,9 @@ pwdcmd(argc, argv)  char **argv; {
  * directory, this routine returns immediately.
  */
 
-#define MAXPWD 256
-
 STATIC void
 getpwd() {
-	char buf[MAXPWD];
+	char buf[PATH_MAX];
 	char *p;
 	int i;
 	int status;
@@ -356,7 +354,7 @@ getpwd() {
 	close(pip[1]);
 	pip[1] = -1;
 	p = buf;
-	while ((i = read(pip[0], p, buf + MAXPWD - p)) > 0
+	while ((i = read(pip[0], p, buf + PATH_MAX - p)) > 0
 	     || i == -1 && errno == EINTR) {
 		if (i > 0)
 			p += i;

--- a/elkscmd/ash/redir.c
+++ b/elkscmd/ash/redir.c
@@ -62,7 +62,6 @@ static char sccsid[] = "@(#)redir.c	5.1 (Berkeley) 3/7/91";
 
 
 #define EMPTY -2		/* marks an unused slot in redirtab */
-#define PIPESIZE 4096		/* amount of buffering in a pipe */
 
 
 MKINIT
@@ -232,7 +231,7 @@ openhere(redir)
 		error("Pipe call failed");
 	if (redir->type == NHERE) {
 		len = strlen(redir->nhere.doc->narg.text);
-		if (len <= PIPESIZE) {
+		if (len <= PIPE_BUF) {
 			xwrite(pip[1], redir->nhere.doc->narg.text, len);
 			goto out;
 		}

--- a/elkscmd/busyelks/cmd/fdisk.c
+++ b/elkscmd/busyelks/cmd/fdisk.c
@@ -8,6 +8,7 @@
  */
 
 #include <fcntl.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -24,7 +25,7 @@
 #define die { printf("Usage %s [-l] <device-name>\n",argv[0]); fflush(stdout); exit(1); }
 #define spc ((unsigned long)(geometry.heads*geometry.sectors))
 
-static char dev[256]; /* FIXME - should be a #define'd number from header file */
+static char dev[PATH_MAX];
 static int pFd;
 static unsigned char partitiontable[512];
 static struct hd_geometry geometry;
@@ -402,7 +403,7 @@ fdisk_main(int argc, char * argv[])
 		printf("Can only specify one device on the command line.\n");
 		return 1;
 	    } else
-		strncpy(dev,argv[i],256); /* FIXME - Should be some value from a header */
+		strncpy(dev,argv[i],sizeof(dev));
 	} else
 	    if (*argv[i]=='-')
 		switch(*(argv[i]+1)) {
@@ -419,7 +420,7 @@ fdisk_main(int argc, char * argv[])
 
     if(argc==1)
 #ifdef DEFAULT_DEV
-	strncpy(dev,DEFAULT_DEV,256);
+	strncpy(dev,DEFAULT_DEV,sizeof(dev));
 #else
 	die;
 #endif

--- a/elkscmd/busyelks/cmd/l.c
+++ b/elkscmd/busyelks/cmd/l.c
@@ -17,7 +17,6 @@
 
 
 #define	LISTSIZE	256
-#define PATHLEN		256
 
 
 #ifndef __P
@@ -55,7 +54,7 @@ l_main(argc, argv)
 	int		endslash;
 	char		**newlist;
 	struct	dirent	*dp;
-	char		fullname[PATHLEN];
+	char		fullname[PATH_MAX];
 	struct	stat	statbuf;
 	static		char *def[2] = {"-ls", "."};
 

--- a/elkscmd/busyelks/cmd/login.c
+++ b/elkscmd/busyelks/cmd/login.c
@@ -29,8 +29,7 @@
 /*#define USE_UTMP*/	/* Disabled until we fix the "utmp file currupt" */
 			/* issue. 17/4/2002 Harry Kalogirou */
 			
-#define PATHLEN 256
-#define STR_SIZE (PATHLEN + 7)
+#define STR_SIZE (PATH_MAX + 7)
 
 char ** environ;
 

--- a/elkscmd/busyelks/cmd/ls.c
+++ b/elkscmd/busyelks/cmd/ls.c
@@ -114,7 +114,7 @@ static void getfiles(char *name, struct stack *pstack, int flags)
     int endslash, valid;
     DIR *dirp;
     struct dirent *dp;
-    char fullname[PATHLEN];
+    char fullname[PATH_MAX];
 
     endslash = name[strlen(name)-1] == '/';
 
@@ -157,7 +157,7 @@ static void lsfile(char *name, struct stat *statbuf, int flags)
     struct passwd	*pwd;
     struct group	*grp;
     long		len;
-    char		buf[PATHLEN];
+    char		buf[PATH_MAX];
     static char		username[12];
     static int		userid;
     static int		useridknown;
@@ -248,7 +248,7 @@ static void lsfile(char *name, struct stat *statbuf, int flags)
 
 #ifdef S_ISLNK
     if ((flags & LSF_LONG) && S_ISLNK(statbuf->st_mode)) {
-	len = readlink(name, buf, PATHLEN - 1);
+	len = readlink(name, buf, PATH_MAX - 1);
 	if (len >= 0) {
 	    buf[len] = '\0';
 	    printf(" -> %s", buf);

--- a/elkscmd/busyelks/cmd/sh.c
+++ b/elkscmd/busyelks/cmd/sh.c
@@ -129,7 +129,7 @@ sh_main(argc, argv)
 	char	**argv;
 {
 	char	*cp;
-	char	buf[PATHLEN];
+	char	buf[PATH_MAX];
 
 	printf("Stand-alone shell (version %s)\n", version);
 	fflush(stdout);

--- a/elkscmd/busyelks/defs.h
+++ b/elkscmd/busyelks/defs.h
@@ -1,6 +1,2 @@
 
-#define PATH_MAX 256
-#define NAME_MAX 256
-#define OPEN_MAX 16
-
 #define _PROTOTYPE(x,y) x y;

--- a/elkscmd/busyelks/lib/buildname.c
+++ b/elkscmd/busyelks/lib/buildname.c
@@ -22,7 +22,7 @@
 char *buildname(char *dirname, char *filename)
 {
 	char *cp;
-	static char buf[PATHLEN];
+	static char buf[PATH_MAX];
 
 	if ((dirname == NULL) || (*dirname == '\0')) return filename;
 

--- a/elkscmd/busyelks/lib/wildcards.c
+++ b/elkscmd/busyelks/lib/wildcards.c
@@ -33,7 +33,7 @@ int expandwildcards(char *name, int maxargc, char **retargv)
 	struct	dirent	*dp;
 	int	dirlen;
 	int	matches;
-	char	dirname[PATHLEN];
+	char	dirname[PATH_MAX];
 
 	last = strrchr(name, '/');
 	if (last) last++;

--- a/elkscmd/busyelks/sash.h
+++ b/elkscmd/busyelks/sash.h
@@ -12,7 +12,6 @@
 #include <malloc.h>
 #include <ctype.h>
 
-#define	PATHLEN		256	
 #define	CMDLEN		512	
 #define	MAXARGS		500	
 #define	ALIASALLOC	20

--- a/elkscmd/debug/syms.c
+++ b/elkscmd/debug/syms.c
@@ -30,7 +30,7 @@ unsigned char * noinstrument sym_read_exe_symbols(char *path)
 {
     int fd;
     unsigned char *s;
-    char fullpath[128];
+    char fullpath[PATH_MAX];
 
     if (syms) return syms;
     if ((fd = open(path, O_RDONLY)) < 0) {

--- a/elkscmd/file_utils/cp.c
+++ b/elkscmd/file_utils/cp.c
@@ -21,6 +21,7 @@
 #include <utime.h>
 #include <errno.h>
 #include <dirent.h>
+#include <limits.h>
 
 #define BUF_SIZE	BUFSIZ		/* use disk block size for stack limit and efficiency*/
 
@@ -347,7 +348,7 @@ static int do_copies(void)
 			err |= do_mknod(inode_build->path, destdir(inode_build->path), flags,
 				inode_build->dev >> MAJOR_SHIFT, inode_build->dev & 0xff);
 		} else if (flags == S_IFLNK) {
-			char lnkname[256];
+			char lnkname[PATH_MAX];
 
 			int cnt = readlink(inode_build->path, lnkname, sizeof(lnkname) - 1);
 			if (cnt < 0) {
@@ -366,7 +367,7 @@ static int do_copies(void)
 
 char *destdir(char *file)
 {
-	static char dir[256];
+	static char dir[PATH_MAX];
 
 	strcpy(dir, destination_dir);
 	if (file[prefix] != '/')
@@ -499,7 +500,7 @@ int copy_directory(char *source_dir, char *dest_dir)
 char *buildname(char *dirname, char *filename)
 {
 	char		*cp;
-	static	char	buf[256];
+	static	char	buf[PATH_MAX];
 
 	if ((dirname == NULL) || (*dirname == '\0'))
 		return filename;

--- a/elkscmd/file_utils/futils.h
+++ b/elkscmd/file_utils/futils.h
@@ -7,8 +7,6 @@
  * Stripped down and inlined for ELKS file_utils
  */
 
-#define	PATHLEN		256	
-
 #define	isdecimal(ch)	(((ch) >= '0') && ((ch) <= '9'))
 #define isoctal(ch)     (((ch) >= '0') && ((ch) <= '7'))
 

--- a/elkscmd/file_utils/l.c
+++ b/elkscmd/file_utils/l.c
@@ -17,7 +17,6 @@
 
 
 #define	LISTSIZE	256
-#define PATHLEN		256
 
 
 #ifndef __P
@@ -59,7 +58,7 @@ void lsfile(char *cp)
 char *buildname(char *dirname, char *filename)
 {
 	char		*cp;
-	static	char	buf[PATHLEN];
+	static	char	buf[PATH_MAX];
 
 	if ((dirname == NULL) || (*dirname == '\0'))
 		return filename;
@@ -95,7 +94,7 @@ int main(int argc, char **argv)
 	int		endslash;
 	char		**newlist;
 	struct	dirent	*dp;
-	char		fullname[PATHLEN];
+	char		fullname[PATH_MAX];
 	struct	stat	statbuf;
 	static		char *def[2] = {"-ls", "."};
 

--- a/elkscmd/file_utils/ln.c
+++ b/elkscmd/file_utils/ln.c
@@ -18,6 +18,7 @@
 #include <grp.h>
 #include <utime.h>
 #include <errno.h>
+#include <limits.h>
 #include "futils.h"
 
 /*
@@ -42,8 +43,7 @@ int isadir(const char *name)
 char *buildname(const char * const dirname, char *filename)
 {
 	char *cp;
-	static char buf[PATHLEN];
-
+	static char buf[PATH_MAX];
 
 	if ((dirname == NULL) || (*dirname == '\0')) return filename;
 

--- a/elkscmd/file_utils/ls.c
+++ b/elkscmd/file_utils/ls.c
@@ -46,6 +46,7 @@
 #include <string.h>
 #include <grp.h>
 #include <time.h>
+#include <limits.h>
 
 /* klugde */
 #define COLS 80
@@ -144,7 +145,7 @@ static int getfiles(char *name, struct stack *pstack, int flags)
     int addslash;
     DIR *dirp;
     struct dirent *dp;
-    char fullname[PATHLEN];
+    char fullname[PATH_MAX];
     int pathlen = strlen(name);
 
     addslash = name[pathlen - 1] != '/';
@@ -211,7 +212,7 @@ static void lsfile(char *name, struct stat *statbuf, int flags)
     char		*pp;
     static char		username[12];
     static char		groupname[12];
-    char		buf[PATHLEN];
+    char		buf[PATH_MAX];
     struct stat		sbuf;
 
     cp = buf;
@@ -306,7 +307,7 @@ static void lsfile(char *name, struct stat *statbuf, int flags)
 
 #ifdef S_ISLNK
     if ((flags & LSF_LONG) && S_ISLNK(statbuf->st_mode)) {
-        len = readlink(name, buf, PATHLEN - 1);
+        len = readlink(name, buf, PATH_MAX - 1);
         if (len >= 0) {
             buf[len] = '\0';
             printf(" -> %s", buf);

--- a/elkscmd/file_utils/mkdir.c
+++ b/elkscmd/file_utils/mkdir.c
@@ -3,6 +3,7 @@
 #include <sys/stat.h>
 #include <stdio.h>
 #include <string.h>
+#include <limits.h>
 #include "futils.h"
 
 static unsigned short newmode;
@@ -10,7 +11,7 @@ static unsigned short newmode;
 static int make_dir(char *name, int f)
 {
 	char *line;
-	char iname[80];
+	char iname[PATH_MAX];
 	
 	strcpy(iname, name);
 	if (((line = rindex(iname,'/')) != NULL) && f) {

--- a/elkscmd/file_utils/mv.c
+++ b/elkscmd/file_utils/mv.c
@@ -17,6 +17,7 @@
 #include <utime.h>
 #include <errno.h>
 #include <dirent.h>
+#include <limits.h>
 #include "futils.h"
 
 #define BUF_SIZE 1024 
@@ -44,7 +45,7 @@ int isadir(char *name)
 char *buildname(char *dirname, char *filename)
 {
 	char		*cp;
-	static	char	buf[PATHLEN];
+	static	char	buf[PATH_MAX];
 
 	if ((dirname == NULL) || (*dirname == '\0'))
 		return filename;
@@ -69,7 +70,7 @@ int linkfiles(char *srcdir, char *destdir)
 	DIR *dirp;
 	struct dirent *dp;
 	char *newsrc;
-	char newdest[PATHLEN];
+	char newdest[PATH_MAX];
 
 	dirp = opendir(srcdir);
 	if (!dirp) {
@@ -239,8 +240,8 @@ int main(int argc, char **argv)
 
 		/* handle renaming symlinks*/
 		if (lstat(srcname, &sbuf) >= 0 && S_ISLNK(sbuf.st_mode)) {
-			char buf[PATHLEN];
-			int len = readlink(srcname, buf, PATHLEN - 1);
+			char buf[PATH_MAX];
+			int len = readlink(srcname, buf, PATH_MAX - 1);
 			if (len < 0) {
 				perror(srcname);
 				continue;
@@ -280,7 +281,7 @@ int main(int argc, char **argv)
 
 			/* handle broken kernel directory rename (issue #583)*/
 			/*if (isadir(srcname)) {*/
-			char destdir[PATHLEN];
+			char destdir[PATH_MAX];
 
 			if (mkdir(destname, 0777 & ~umask(0))) {
 				perror(destname);

--- a/elkscmd/file_utils/rm.c
+++ b/elkscmd/file_utils/rm.c
@@ -5,6 +5,7 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <fcntl.h>
+#include <limits.h>
 
 static 	int	errcode;
 
@@ -40,7 +41,7 @@ void rm(char *arg, int fflg, int rflg, int iflg, int level) {
         struct stat buf;
         struct dirent *dp;
         DIR *dirp;
-        char name[128];
+        char name[PATH_MAX];
 
         if(lstat(arg, &buf)) {
                 if (fflg==0) {

--- a/elkscmd/man/man2/intro.2
+++ b/elkscmd/man/man2/intro.2
@@ -233,7 +233,7 @@ would have resulted in a deadlock situation.
 A component of a path name exceeded 
 .Pq Dv NAME_MAX
 characters, or an entire
-path name exceeded 255
+path name exceeded
 .Pq Dv PATH_MAX 
 characters.
 .It Er 37 ENOLCK Em "No locks available" .
@@ -488,7 +488,7 @@ optional slash
 .Ql \&/ ,
 followed by zero or more directory names separated
 by slashes, optionally followed by a file name.
-The total length of a path name must be less than 255
+The total length of a path name must be less than
 .Pq Dv PATH_MAX
 characters.
 .Pp

--- a/elkscmd/man/man2/pipe.2
+++ b/elkscmd/man/man2/pipe.2
@@ -25,13 +25,13 @@ The file descriptors returned can
 be used in read and write operations.
 When the pipe is written using the descriptor
 .IR fildes [1]
-up to PIPE_MAX bytes of data are buffered
+up to PIPE_BUF bytes of data are buffered
 before the writing process is suspended.
 A read using the descriptor
 .IR fildes [0]
 will pick up the data.
 .PP
-PIPE_MAX equals 7168 under MINIX 3, but note that most systems use 4096.
+PIPE_BUF equals 80 under ELKS, but note that most systems use 4096.
 .PP
 It is assumed that after the
 pipe has been set up,
@@ -85,5 +85,5 @@ space.
 Writes may return ENOSPC errors if no pipe data can be buffered, because
 the pipe file system is full.
 .SH BUGS
-Should more than PIPE_MAX bytes be necessary in any
+Should more than PIPE_BUF bytes be necessary in any
 pipe among a loop of processes, deadlock will occur.

--- a/elkscmd/minix2/lp.c
+++ b/elkscmd/minix2/lp.c
@@ -45,7 +45,7 @@ void lp(char *file)
 	if (status != 0) exit(1);
 }
 
-char path[257];
+char path[PATH_MAX];
 int cwdsize;
 
 int main(int argc, char **argp)

--- a/elkscmd/minix2/lpd.c
+++ b/elkscmd/minix2/lpd.c
@@ -272,7 +272,7 @@ void work(void) {
 
 /* Print all the jobs in the job list. */
 
-    char file[257], *pf=file;
+    char file[PATH_MAX], *pf=file;
     struct job *job;
     FILE *j, *f;
     int c;

--- a/elkscmd/minix3/defs.h
+++ b/elkscmd/minix3/defs.h
@@ -1,6 +1,2 @@
 
-#define PATH_MAX 256
-#define NAME_MAX 256
-#define OPEN_MAX 16
-
 #define _PROTOTYPE(x,y) x y;

--- a/elkscmd/minix3/mail.c
+++ b/elkscmd/minix3/mail.c
@@ -64,7 +64,7 @@ int needupdate = 0;		/* need to update mailbox */
 int msgstatus = 0;		/* return the mail status */
 int distlist = 0;		/* include distribution list */
 char mailbox[PATHLEN];		/* user's mailbox/maildrop */
-char tempname[PATHLEN] = "/tmp/mailXXXXXX";	/* temporary file */
+char tempname[] = "/tmp/mailXXXXXX";	/* temporary file */
 char *subject = NULL;
 FILE *boxfp = NULL;		/* mailbox file */
 jmp_buf printjump;		/* for quitting out of letters */

--- a/elkscmd/misc_utils/compress.c
+++ b/elkscmd/misc_utils/compress.c
@@ -158,6 +158,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <errno.h>
+#include <limits.h>
 #ifdef __GNUC__
 #include <string.h>
 #include <stdlib.h>
@@ -209,8 +210,7 @@ static char ident[] = "(N)compress 4.2.4";
 #  define OBUFSIZ BUFSIZ	/* Default output buffer size	*/
 #endif
 
-/* [ELKS] CM: use PATHLEN from mutils.h */
-#define MAXPATHLEN PATHLEN	/* MAXPATHLEN - maximum length of a	*/
+#define MAXPATHLEN PATH_MAX	/* MAXPATHLEN - maximum length of a	*/
 				/*  pathname we allow 			*/
 #define	SIZE_INNER_LOOP	256	/* Size of the inter (fast) compress loop */
 

--- a/elkscmd/misc_utils/mined.h
+++ b/elkscmd/misc_utils/mined.h
@@ -37,7 +37,6 @@ extern char *pos_string;	/* Absolute cursor positioning */
 #define SHIFT_SIZE	25		/* Number of chars to shift */
 #define SHIFT_MARK	'!'		/* Char indicating line continues */
 #define MAX_CHARS	1024		/* Maximum chars on one line */
-#define NAME_MAX	128
 
 /* LINE_START must be rounded up to the lowest SHIFT_SIZE */
 #define LINE_START	(((-MAX_CHARS - 1) / SHIFT_SIZE) * SHIFT_SIZE \

--- a/elkscmd/misc_utils/mined1.c
+++ b/elkscmd/misc_utils/mined1.c
@@ -1808,7 +1808,7 @@ int input(char *inbuf, FLAG clearfl)
 
 /*
  * Get_file() reads a filename from the terminal. Filenames longer than 
- * FILE_LENGHT chars are truncated.
+ * NAME_MAX chars are truncated.
  */
 int get_file(char *message, char *file)
 {

--- a/elkscmd/misc_utils/mutils.h
+++ b/elkscmd/misc_utils/mutils.h
@@ -14,7 +14,6 @@
 #include <time.h>
 #include <ctype.h>
 
-#define	PATHLEN		256	
 #define	CMDLEN		512	
 #define	MAXARGS		500	
 #define	ALIASALLOC	20

--- a/elkscmd/misc_utils/uudecode.c
+++ b/elkscmd/misc_utils/uudecode.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <limits.h>
 
 /* single character decode */
 #define DEC(c)	(((c) - ' ') & 077)
@@ -95,7 +96,7 @@ char **argv;
 {
 	FILE *in, *out;
 	int mode;
-	char dest[128];
+	char dest[PATH_MAX];
 	char buf[80];
 
 	/* optional input arg */

--- a/elkscmd/screen/screen.c
+++ b/elkscmd/screen/screen.c
@@ -30,13 +30,13 @@ static char ScreenVersion[] = "screen 2.0a.2 (ELKS) 30-Apr-2020";
 #include <signal.h>
 #include <errno.h>
 #include <termcap.h>
+#include <limits.h>
 
 #ifdef ELKS 
 #include <termios.h>
 #include <linuxmt/un.h>
 #include <string.h>
 #include <unistd.h>
-#define OPEN_MAX	20      /* NR_OPEN from include/fs.h */
 #define	SIGTTOU         27	/* background tty write attempted */
 #else
 #include <sgtty.h>

--- a/elkscmd/sh_utils/shutils.h
+++ b/elkscmd/sh_utils/shutils.h
@@ -12,7 +12,6 @@
 #include <malloc.h>
 #include <ctype.h>
 
-#define	PATHLEN		256	
 #define	CMDLEN		512	
 #define	MAXARGS		500	
 #define	ALIASALLOC	20

--- a/elkscmd/sys_utils/init.c
+++ b/elkscmd/sys_utils/init.c
@@ -35,12 +35,13 @@
 #include <errno.h>
 #include <time.h>
 #include <paths.h>
+#include <limits.h>
 
 #define USE_UTMP	0	/* =1 to use /var/run/utmp*/
 #define DEBUG		0	/* =1 for debug messages*/
 
 /* debug and sysinit/respawn sh -e output goes here*/
-#define CONSOLE       "/dev/console"
+#define CONSOLE       _PATH_CONSOLE
 
 #if !DEBUG
 #define debug(...)
@@ -267,7 +268,7 @@ void removeChild(struct tabentry *pos)
 pid_t respawn(const char **a)
 {
     int pid;
-    char *argv[5], buf[128];
+    char *argv[5], buf[PATH_MAX];
     int fd;
     char *devtty;
 

--- a/elkscmd/sys_utils/login.c
+++ b/elkscmd/sys_utils/login.c
@@ -28,8 +28,7 @@
 /*#define USE_UTMP*/	/* Disabled until we fix the "utmp file corrupt" */
 			/* issue. 17/4/2002 Harry Kalogirou */
 
-#define PATHLEN 256
-#define STR_SIZE (PATHLEN + 7)
+#define STR_SIZE (PATH_MAX + 7)
 
 void login(register struct passwd *pwd, struct utmp *ut_ent)
 {

--- a/elkscmd/sys_utils/man.c
+++ b/elkscmd/sys_utils/man.c
@@ -32,9 +32,10 @@
 #endif
 #include <ctype.h>
 #include <string.h>
+#include <limits.h>
 
-#ifdef __ia16__			/* ELKS */
 #include <paths.h>
+#ifdef __ia16__			/* ELKS */
 #define MORE			"more"
 #else					/* Host */
 #define MORE			"less -R"
@@ -86,7 +87,7 @@ char line_header[256] = "";	/* Page header line */
 char line_footer[256] = "";	/* Page footer line */
 char little_header[256] = "";	/* Mini header for tty mode */
 
-char man_file[256] = "";
+char man_file[PATH_MAX] = "";
 
 int flg_w = 0;
 int verbose = 1;
@@ -117,7 +118,7 @@ static char defsect[] = "1:2:3:4:5:6:7:8:9";
 static char defsuff[] = ":.Z";
 static char manorcat[] = "man:cat";
 
-   char fbuf[256];
+   char fbuf[PATH_MAX];
    char *manpath;
    char *mansect = sect;
    char *mansuff;
@@ -194,7 +195,7 @@ void step(char **pcurr, char **pnext)
 int open_page(char * name)
 {
    char *p, *command = 0;
-   char buf[256];
+   char buf[PATH_MAX];
 
    if (access(name, 0) < 0) return -1;
 

--- a/elkscmd/xvi/xvi.c
+++ b/elkscmd/xvi/xvi.c
@@ -557,7 +557,7 @@ static int hnum;		/* start value for column numbering	*/
 static int inpfd = -1;		/* descriptor of the input file		*/
 static int tmpfd = -1;		/* descriptor of the temporary file	*/
 static int auxfd = -1;		/* descriptor of the auxiliary file	*/
-static char inpfname[256];	/* path name of the input file		*/
+static char inpfname[PATH_MAX];	/* path name of the input file		*/
 static char tmpfname[19];	/* path name of the temporary file	*/
 static char auxfname[19];	/* path name of the auxiliary file	*/
 static int x,y;			/* physical cursor coordinates		*/

--- a/libc/include/limits.h
+++ b/libc/include/limits.h
@@ -5,10 +5,13 @@
 #define PATH_MAX 128
 
 /* Maximum number of bytes in a filename, not including terminating null. */
-#define NAME_MAX 14
+/* copied from MAXNAMLEN in linuxmt/dirent.h */
+#define NAME_MAX 26
 
+/* copied from PIPE_BUFSIZ in linuxmt/config.h */
 #define PIPE_BUF 80
 
+/* copied from NR_OPEN in linuxmt/fs.h */
 #define OPEN_MAX 20
 
 #include_next <limits.h>

--- a/libc/include/limits.h
+++ b/libc/include/limits.h
@@ -1,0 +1,16 @@
+#ifndef __LIMITS_H
+#define __LIMITS_H
+
+/* Maximum number of bytes in a pathname, including the terminating null. */
+#define PATH_MAX 128
+
+/* Maximum number of bytes in a filename, not including terminating null. */
+#define NAME_MAX 14
+
+#define PIPE_BUF 80
+
+#define OPEN_MAX 20
+
+#include_next <limits.h>
+
+#endif


### PR DESCRIPTION
Added PATH_MAX to a new libc limits.h.  The build logs before and after this change have the same warnings.

Grepping for PATH_MAX or NAME_MAX is now a map to a goldmine of buffer overflows, for better or worse.

Is it acceptable to include linuxmt/config.h from limits.h to get some kernel values, or should these just be hardcoded and kept in sync manually?  I could also include linuxmt/fs.h to automatically set OPEN_MAX.  But I suppose there is the risk of namespace pollution.  For the moment, I have not done this due to possible pollution.

Notes on some specific changes:
- I did not update elks/tools/mfs/ and elks/tools/mfsck/ which have NAME_MAX set to 255.  Seems excessive but maybe there is a reason.
- mined claims to truncate the filename, which I changed to proper NAME_MAX, but I think the truncation is buggy anyway.
- mail builds its own short paths, so I left it with its own smaller buffer size.


