### PR TITLE
Fix IRCv3 PING/PONG connection issue

### DIFF
--- a/elkscmd/inet/tinyirc/tinyirc.c
+++ b/elkscmd/inet/tinyirc/tinyirc.c
@@ -511,7 +511,8 @@ int parsedata()
     int i, found = 0;
 
     if (serverdata[0] == 'P') {
-	sprintf(lineout, "PONG :%s\n", IRCNAME);
+	memcpy(lineout, serverdata, sizeof(serverdata));
+	lineout[1] = 'O';
 	return sendline();
     }
     if (!dumb)


### PR DESCRIPTION
IRCv3 specification sends an unique token on each PING which it requires be sent back by replying with PONG.

tested on libera.chat (non IRCv3 PING/PONG) and unrealircd (hybrid, one IRCv3 PING packet followed by original PING packets)

Fixes #1568 