### PR TITLE
[cmds] Add 8k heap to tinyirc, add to 2.88M floppy

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -178,7 +178,7 @@ inet/telnetd/telnetd			:net
 inet/httpd/httpd				:net
 inet/ftp/ftp					:net
 inet/ftp/ftpd					:net
-#inet/tinyirc/tinyirc			:net
+inet/tinyirc/tinyirc			:other
 inet/urlget/urlget				:net
 inet/urlget/urlget :::ftpget	:net
 inet/urlget/urlget :::ftpput	:net

--- a/elkscmd/inet/tinyirc/Makefile
+++ b/elkscmd/inet/tinyirc/Makefile
@@ -1,46 +1,34 @@
-# tinyirc makefile
-# by Nathan Laredo
-#
-# I don't wish to assert any rights (copyright) over this makefile
-# but please give me credit if you use my code.
-#
-# chat.freenode.net=
-SERVER = 162.213.39.42
-PORT = 8000
-#
+# Makefile for tinyirc
 
 BASEDIR=../..
+
 include $(BASEDIR)/Make.defs
 
-LOCALFLAGS=-DPOSIX -DELKS
-
+###############################################################################
 #
-# Rules
-#
+# Include standard packaging commands.
 
 include $(BASEDIR)/Make.rules
 
+###############################################################################
+
+# configurable options
+# chat.freenode.net=
+SERVER = 162.213.39.42
+PORT = 8000
+
 all: tinyirc
 
-LOCALDEFS = -DDEFAULTSERVER=\"$(SERVER)\" -DDEFAULTPORT=$(PORT)
+LOCALFLAGS = -DPOSIX -DELKS -DDEFAULTSERVER=\"$(SERVER)\" -DDEFAULTPORT=$(PORT)
 
 tinyirc: tinyirc.o
-	$(LD) $(LDFLAGS) -o tinyirc tinyirc.o $(LDLIBS)
+	$(LD) $(LDFLAGS) -o $@ -maout-heap=8192 $^ $(LDLIBS)
 
 tinyircd: tinyircd.o
-	$(LD) $(LDFLAGS) -o tinyircd tinyircd.o $(LDLIBS)
-
-tinyirccv: tinyirccv.o
-	$(CC) $(LDFLAGS) -o tinyirc tinyirccv.o $(LIBS)
-
-tinyirc.o: tinyirc.c Makefile
-	$(CC) $(CFLAGS) $(LOCALDEFS) -c tinyirc.c -o tinyirc.o
-
-tinyirccv.o: tinyirccv.c Makefile
-	$(CC) $(CFLAGS) $(LOCALDEFS) -c tinyirccv.c -o tinyirccv.o
+	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 install: tinyirc
 	$(INSTALL) tinyirc $(DESTDIR)/bin
 
 clean:
-	rm -f core *.o tinyirc
+	rm -f *.o tinyirc

--- a/elkscmd/inet/tinyirc/tinyirc.c
+++ b/elkscmd/inet/tinyirc/tinyirc.c
@@ -76,7 +76,7 @@ unsigned short IRCPORT = DEFAULTPORT;
 int my_tcp, sok = 1, my_tty, hline, dumb = 0, CO, LI, column;
 char *tmp, *linein, *CM, *CS, *CE, *SO, *SE, *DC, *ptr, *term, *fromhost,
 *TOK[20], IRCNAME[32], IRCLOGIN[64], IRCGECOS[64], inputbuf[512], ib[IB_SIZE],
- serverdata[512], ch, *bp[1024], lineout[512], *hist[HISTLEN], termcap[1024];
+ serverdata[512], ch, bp[1024], lineout[512], *hist[HISTLEN], termcap[1024];
 int cursd = 0, curli = 0, curx = 0, noinput = 0, reconnect = 1;
 fd_set readfs;
 struct timeval timeout;
@@ -246,8 +246,7 @@ static int doerror()
 }
 static int doinvite()
 {
-    printf("*** %s (%s) invites you to join %s.",
-	   TOK[0], fromhost, &TOK[3]);
+    printf("*** %s (%s) invites you to join %s.", TOK[0], fromhost, TOK[3]);
     return 0;
 }
 static int dojoin()


### PR DESCRIPTION
Fixes "sys_brk" problem reported in #1568.

Adds `tinyirc` to 2.88M floppy (or CONFIG_APPS_OTHER). Unfortunately, there is no room left on the 1.44M floppy.

Fixes a couple C coding errors in source. I agree with @DutchComputerKid that tinyirc has more problems than this but at least it'll be part of the standard ELKS distribution now.

@toncho11: Since you're probably testing on a small system, here's a copy of the binary so that you don't have to build it:
[tinyirc.zip](https://github.com/jbruchon/elks/files/11045117/tinyirc.zip)
