### PR TITLE
[nano-X] Adding PC-98 mouse driver and XOR function in video driver.

### DIFF
--- a/elkscmd/nano-X/Makefile
+++ b/elkscmd/nano-X/Makefile
@@ -24,7 +24,8 @@ NANOXDEMOS += bin/nxdemo
 # SLOW_CPU discards unprocessed mouse input for slow systems
 LOCALFLAGS += -DSLOW_CPU=1
 ifeq ($(CONFIG_ARCH_PC98), y)
-DRIVERS += drivers/mou_null.o
+#DRIVERS += drivers/mou_null.o
+DRIVERS += drivers/mou_pc98.o
 else
 DRIVERS += drivers/mou_ser.o
 endif

--- a/elkscmd/nano-X/drivers/mou_pc98.c
+++ b/elkscmd/nano-X/drivers/mou_pc98.c
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 1999 Greg Haerr <greg@censoft.com>
+ * Portions Copyright (c) 1991 David I. Bell
+ * Permission is granted to use, distribute, or modify this source,
+ * provided that this copyright notice remains intact.
+ *
+ * PC-98 Bus Mouse Driver
+ * This driver is created and modified, based on mou_ser.c
+ * T. Yamada 2023
+ * 
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include "../device.h"
+
+extern int  inportb(int port);
+extern void outportb(int port,unsigned char data);
+
+#define SCALE       3   /* default scaling factor for acceleration */
+#define THRESH      5   /* default threshhold for acceleration */
+
+/* default settings*/
+#define MOUSE_PORT  "use"   /* default */
+
+/* values in the bytes returned by the mouse for the buttons*/
+#define PC98_LEFT_BUTTON    0x80
+#define PC98_RIGHT_BUTTON   0x20
+
+/* I/O address */
+#define PC98_MOUSE_I_ADDR        0x7FD9
+#define PC98_MOUSE_O_ADDR        0x7FDD
+#define PC98_MOUSE_CONTROL_ADDR  0x7FDF
+
+/* I/O bits */
+#define PC98_O_HC   0x80 /* counter is hold and cleared */
+#define PC98_O_X_L  0x00 /* X LSB 4bits are selected */
+#define PC98_O_X_M  0x20 /* X MSB 4bits are selected */
+#define PC98_O_Y_L  0x40 /* Y LSB 4bits are selected */
+#define PC98_O_Y_M  0x60 /* Y MSB 4bits are selected */
+#define PC98_O_C    0x93 /* countrol register value */
+
+/* local data*/
+static BUTTON       buttons;        /* current mouse buttons pressed */
+static BUTTON       buttons_before; /* previous mouse buttons pressed */
+static BUTTON       availbuttons;   /* which buttons are available */
+static COORD        x_now;          /* current x counter value */
+static COORD        y_now;          /* current y counter value */
+
+static int      left;       /* because the button values change */
+static int      right;      /* between mice, the buttons are redefined */
+
+/* local routines*/
+static int      MOU_Open(MOUSEDEVICE *pmd);
+static void     MOU_Close(void);
+static BUTTON   MOU_GetButtonInfo(void);
+static void     MOU_GetDefaultAccel(int *pscale,int *pthresh);
+static int      MOU_Read(COORD *dx, COORD *dy, COORD *dz, BUTTON *bptr);
+static int      MOU_Poll(void);
+
+MOUSEDEVICE mousedev = {
+    MOU_Open,
+    MOU_Close,
+    MOU_GetButtonInfo,
+    MOU_GetDefaultAccel,
+    MOU_Read,
+    MOU_Poll
+};
+
+/*
+ * Open up the mouse device.
+ */
+static int
+MOU_Open(MOUSEDEVICE *pmd)
+{
+    char    *port;
+
+    /* Control Register for 8255A */
+    /* Port A input, Port B input, Port C MSB output, Port C LSB input */
+    outportb(PC98_MOUSE_CONTROL_ADDR, PC98_O_C);
+
+    if (!(port = getenv("MOUSE_PORT")))
+        port = MOUSE_PORT;
+
+    if (!strcmp(port, "none"))
+        return -2;      /* no mouse */
+
+    /* set button bits and parse procedure*/
+    left = PC98_LEFT_BUTTON;
+    right = PC98_RIGHT_BUTTON;
+
+    /* initialize data*/
+    availbuttons = LBUTTON | RBUTTON;
+    buttons = 0;
+    buttons_before = 0;
+
+    return -3;
+}
+
+/*
+ * Close the mouse device.
+ */
+static void
+MOU_Close(void)
+{
+}
+
+/*
+ * Get mouse buttons supported
+ */
+static BUTTON
+MOU_GetButtonInfo(void)
+{
+    return availbuttons;
+}
+
+/*
+ * Get default mouse acceleration settings
+ */
+static void
+MOU_GetDefaultAccel(int *pscale,int *pthresh)
+{
+    *pscale = SCALE;
+    *pthresh = THRESH;
+}
+
+/*
+ * Attempt to read bytes from the mouse and interpret them.
+ * When a new state is read, the current buttons and x and y deltas
+ * are returned. This routine does not block.
+ */
+static int
+MOU_Read(COORD *dx, COORD *dy, COORD *dz, BUTTON *bptr)
+{
+    int b;
+
+    /*
+     * If the X, Y values are greater than 127,
+     * then the delta would be negative.
+     */
+    if (x_now > 127)
+        *dx = x_now - 256;
+    else
+        *dx = x_now;
+
+    if (y_now > 127)
+        *dy = y_now - 256;
+    else
+        *dy = y_now;
+
+    *dz = 0;
+
+    /* Read button again in case Poll is not called */
+    buttons = (inportb(PC98_MOUSE_I_ADDR) & 0xE0) ^ 0xE0;
+    buttons_before = buttons;
+
+    b = 0;
+    if (buttons & left)
+        b |= LBUTTON;
+    if (buttons & right)
+        b |= RBUTTON;
+    *bptr = b;
+
+    return 1;
+}
+
+static int
+MOU_Poll(void)
+{
+    /*
+     * The counter for x, y values are cleared every time.
+     * If the x, y values are not equal to zero or
+     * button states have changed then return 1.
+     */
+    outportb(PC98_MOUSE_O_ADDR, (PC98_O_HC | PC98_O_X_L)); // X LSB 4bits
+    x_now = inportb(PC98_MOUSE_I_ADDR) & 0xF;
+
+    outportb(PC98_MOUSE_O_ADDR, (PC98_O_HC | PC98_O_X_M)); // X MSB 4bits
+    x_now += (inportb(PC98_MOUSE_I_ADDR) & 0xF) << 4;
+
+    outportb(PC98_MOUSE_O_ADDR, (PC98_O_HC | PC98_O_Y_L)); // Y LSB 4bits
+    y_now = inportb(PC98_MOUSE_I_ADDR) & 0xF;
+
+    outportb(PC98_MOUSE_O_ADDR, (PC98_O_HC | PC98_O_Y_M)); // Y MSB 4bits
+    y_now += (inportb(PC98_MOUSE_I_ADDR) & 0xF) << 4;
+
+    buttons = (inportb(PC98_MOUSE_I_ADDR) & 0xE0) ^ 0xE0;
+
+    outportb(PC98_MOUSE_O_ADDR, 0x00); // Clear HC
+
+    if (x_now || y_now || (buttons != buttons_before)) {
+        buttons_before = buttons;
+        return 1;
+    }
+    else {
+        return 0;
+    }
+}

--- a/elkscmd/nano-X/drivers/vgaplan4_pc98.c
+++ b/elkscmd/nano-X/drivers/vgaplan4_pc98.c
@@ -46,10 +46,9 @@ static unsigned char mask[8] = {
 int
 ega_init(PSD psd)
 {
-	psd->addr = SCREENBASE0;		/* long ptr -> short on 16bit sys*/
+	psd->addr = (char *)SCREENBASE0;		/* long ptr -> short on 16bit sys*/
 	psd->linelen = BYTESPERLINE;
-	/* framebuffer mmap size*/
-	psd->size = 0x10000;
+	psd->size = 65535;
 
 	return 1;
 }
@@ -58,18 +57,29 @@ ega_init(PSD psd)
 void
 ega_drawpixel(PSD psd,unsigned int x, unsigned int y, PIXELVAL c)
 {
+	FARADDR dst;
 	int		plane;
 	assert (x >= 0 && x < psd->xres);
 	assert (y >= 0 && y < psd->yres);
 	assert (c >= 0 && c < psd->ncolors);
 
 	DRAWON;
-	for(plane=0; plane<4; ++plane) {
-		if  (c & (1 << plane)) {
-			ORBYTE_FP (screenbase_table[plane] + x / 8 + y * BYTESPERLINE,mask[x&7]);
+	if(gr_mode == MODE_XOR) {
+		for(plane=0; plane<4; ++plane) {
+			dst = screenbase_table[plane] + x / 8 + y * BYTESPERLINE;
+			if  (c & (1 << plane)) {
+				PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x&7]));
+			}
 		}
-		else {
-			ANDBYTE_FP (screenbase_table[plane] + x / 8 + y * BYTESPERLINE,~mask[x&7]);
+	} else {
+		for(plane=0; plane<4; ++plane) {
+			dst = screenbase_table[plane] + x / 8 + y * BYTESPERLINE;
+			if  (c & (1 << plane)) {
+				ORBYTE_FP (dst,mask[x&7]);
+			}
+			else {
+				ANDBYTE_FP (dst,~mask[x&7]);
+			}
 		}
 	}
 	DRAWOFF;
@@ -114,7 +124,7 @@ ega_drawhorzline(PSD psd, unsigned int x1, unsigned int x2, unsigned int y,
 	assert (c >= 0 && c < psd->ncolors);
 
 	DRAWON;
-	/* XOR/OR/AND mode is not supported for PC-98 for now */
+	/* OR/AND mode is not supported for PC-98 for now */
 	if(gr_mode == MODE_SET) {
 		for(plane=0; plane<4; ++plane) {
 			x1 = x1_ini;
@@ -165,6 +175,45 @@ ega_drawhorzline(PSD psd, unsigned int x1, unsigned int x2, unsigned int y,
 				}
 			}
 		}
+	} else if(gr_mode == MODE_XOR) {
+		for(plane=0; plane<4; ++plane) {
+			x1 = x1_ini;
+			dst = screenbase_table[plane] + x1 / 8 + y * BYTESPERLINE;
+			if (x1 / 8 == x2 / 8) {
+				while(x1 < x2) {
+					if  (c & (1 << plane)) {
+						PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x1&7]));
+					}
+					x1++;
+				}
+			} else {
+
+				while (x1 % 8) {
+					if  (c & (1 << plane)) {
+						PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x1&7]));
+					}
+					x1++;
+				}
+				if (x1_ini % 8)
+					dst++;
+
+				last = screenbase_table[plane] + x2 / 8 + y * BYTESPERLINE;
+				while (dst < last) {
+					if  (c & (1 << plane)) {
+						PUTBYTE_FP(dst,~GETBYTE_FP(dst));
+						dst++;
+					}
+				}
+
+				x1 = ((x2 >> 3) << 3);
+				while (x1 < x2) {
+					if  (c & (1 << plane)) {
+						PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x1&7]));
+					}
+					x1++;
+				}
+			}
+		}
 	} else {
 		/* slower method, draw pixel by pixel*/
 		while(x1 < x2) {
@@ -197,17 +246,30 @@ ega_drawvertline(PSD psd,unsigned int x, unsigned int y1, unsigned int y2,
 	assert (c >= 0 && c < psd->ncolors);
 
 	DRAWON;
-	for(plane=0; plane<4; ++plane) {
-		dst = screenbase_table[plane] + x / 8 + y1 * BYTESPERLINE;
-		last = screenbase_table[plane] + x / 8 + y2 * BYTESPERLINE;
-		while (dst < last) {
-			if  (c & (1 << plane)) {
-				ORBYTE_FP (dst,mask[x&7]);
+	if(gr_mode == MODE_XOR) {
+		for(plane=0; plane<4; ++plane) {
+			dst = screenbase_table[plane] + x / 8 + y1 * BYTESPERLINE;
+			last = screenbase_table[plane] + x / 8 + y2 * BYTESPERLINE;
+			while (dst < last) {
+				if  (c & (1 << plane)) {
+					PUTBYTE_FP(dst,(GETBYTE_FP(dst) ^ mask[x&7]));
+				}
+				dst += BYTESPERLINE;
 			}
-			else {
-				ANDBYTE_FP (dst,~mask[x&7]);
+		}
+	} else {
+		for(plane=0; plane<4; ++plane) {
+			dst = screenbase_table[plane] + x / 8 + y1 * BYTESPERLINE;
+			last = screenbase_table[plane] + x / 8 + y2 * BYTESPERLINE;
+			while (dst < last) {
+				if  (c & (1 << plane)) {
+					ORBYTE_FP (dst,mask[x&7]);
+				}
+				else {
+					ANDBYTE_FP (dst,~mask[x&7]);
+				}
+				dst += BYTESPERLINE;
 			}
-			dst += BYTESPERLINE;
 		}
 	}
 	DRAWOFF;

--- a/elkscmd/nano-X/nanox/srvmain.c
+++ b/elkscmd/nano-X/nanox/srvmain.c
@@ -6,6 +6,7 @@
  *
  * Main module of graphics server.
  */
+#include <autoconf.h>           /* for CONFIG_ options */
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -173,6 +174,13 @@ GsSelect(GR_TIMEOUT timeout)
 	int	setsize = 0;
 	struct timeval to;
 
+#if CONFIG_ARCH_PC98
+	if (mousedev.Poll()) {
+		GsCheckMouseEvent();
+		return;
+	}
+#endif
+
 	/* Set up the FDs for use in the main select(): */
 	FD_ZERO(&rfds);
 	if (mouse_fd >= 0) FD_SET(mouse_fd, &rfds);
@@ -204,6 +212,10 @@ GsSelect(GR_TIMEOUT timeout)
 	++setsize;
 
     /* convert wait timeout to timeval struct*/
+#if CONFIG_ARCH_PC98
+    if (timeout == GR_TIMEOUT_BLOCK)
+        timeout = 10;
+#endif
     if (timeout == GR_TIMEOUT_POLL) {
         to.tv_sec = 0;
         to.tv_usec = 0;


### PR DESCRIPTION
This PR adds PC-98 mouse driver for Nano-X that has been created in the discussion starting from https://github.com/jbruchon/elks/issues/1545#issuecomment-1445045441

srvmain is modified to add polling function when CONFIG_ARCH_PC98 is defined.

Also this adds XOR function to the video driver.

Thank you.