### PR TITLE
UMB memory support

### DIFF
--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -141,31 +141,26 @@ void seg_free (segment_s * seg)
 	list_s * i = &_seg_free;
 
 	// Try to merge with previous segment if free
-
 	list_s * p = seg->all.prev;
-	if (&_seg_all != p) {
-		segment_s * prev = structof (p, segment_s, all);
-		if (prev->flags == SEG_FLAG_FREE && prev->base + prev->size == seg->base) {
-			list_remove (&(prev->free));
-			seg_merge (prev, seg);
-			i = _seg_free.prev;
-			seg = prev;
-		} else {
-			seg->flags = SEG_FLAG_FREE;
-			seg->pid = 0;
-		}
+	segment_s * prev = structof (p, segment_s, all);
+	if ((prev->flags == SEG_FLAG_FREE) && (prev->base + prev->size == seg->base)) {
+		list_remove (&(prev->free));
+		seg_merge (prev, seg);
+		i = _seg_free.prev;
+		seg = prev;
+	} else {
+		seg->flags = SEG_FLAG_FREE;
+		seg->pid = 0;
 	}
 
 	// Try to merge with next segment if free
 
 	list_s * n = seg->all.next;
-	if (n != &_seg_all) {
-		segment_s * next = structof (n, segment_s, all);
-		if (next->flags == SEG_FLAG_FREE && seg->base + seg->size == next->base) {
-			list_remove (&(next->free));
-			seg_merge (seg, next);
-			i = _seg_free.prev;
-		}
+	segment_s * next = structof (n, segment_s, all);
+	if ((next->flags == SEG_FLAG_FREE) && (seg->base + seg->size == next->base)) {
+		list_remove (&(next->free));
+		seg_merge (seg, next);
+		i = _seg_free.prev;
 	}
 
 	// Insert to free list head or tail
@@ -343,11 +338,6 @@ void INITPROC mm_init(seg_t start, seg_t end)
 {
 	list_init (&_seg_all);
 	list_init (&_seg_free);
-
-	//temporary
-	seg_add(0xC000, 0xC800);
-	seg_add(0xD000, 0xF000);
-	//!temporary
 
 	seg_add(start, end);
 }

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -145,7 +145,7 @@ void seg_free (segment_s * seg)
 	list_s * p = seg->all.prev;
 	if (&_seg_all != p) {
 		segment_s * prev = structof (p, segment_s, all);
-		if (prev->flags == SEG_FLAG_FREE) {
+		if (prev->flags == SEG_FLAG_FREE && prev->base + prev->size == seg->base) {
 			list_remove (&(prev->free));
 			seg_merge (prev, seg);
 			i = _seg_free.prev;
@@ -161,7 +161,7 @@ void seg_free (segment_s * seg)
 	list_s * n = seg->all.next;
 	if (n != &_seg_all) {
 		segment_s * next = structof (n, segment_s, all);
-		if (next->flags == SEG_FLAG_FREE) {
+		if (next->flags == SEG_FLAG_FREE && seg->base + seg->size == next->base) {
 			list_remove (&(next->free));
 			seg_merge (seg, next);
 			i = _seg_free.prev;
@@ -322,16 +322,10 @@ again:
 	}
 }
 
-
-// Initialize the memory manager.
-
-void INITPROC mm_init(seg_t start, seg_t end)
+void INITPROC seg_add(seg_t start, seg_t end)
 {
-	list_init (&_seg_all);
-	list_init (&_seg_free);
-
 	segment_s * seg = (segment_s *) heap_alloc (sizeof (segment_s), HEAP_TAG_SEG);
-	if (seg) {
+	if(seg) {
 		seg->base = start;
 		seg->size = end - start;
 		seg->flags = SEG_FLAG_FREE;
@@ -341,4 +335,19 @@ void INITPROC mm_init(seg_t start, seg_t end)
 		list_insert_before (&_seg_all, &(seg->all));  // add tail
 		list_insert_before (&_seg_free, &(seg->free));  // add tail
 	}
+}
+
+// Initialize the memory manager.
+
+void INITPROC mm_init(seg_t start, seg_t end)
+{
+	list_init (&_seg_all);
+	list_init (&_seg_free);
+
+	//temporary
+	seg_add(0xC000, 0xC800);
+	seg_add(0xD000, 0xF000);
+	//!temporary
+
+	seg_add(start, end);
 }

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -139,28 +139,31 @@ void seg_free (segment_s * seg)
 	//     chance on next allocation of same size
 
 	list_s * i = &_seg_free;
+	seg->flags = SEG_FLAG_FREE;
+	seg->pid = 0;
 
 	// Try to merge with previous segment if free
 	list_s * p = seg->all.prev;
-	segment_s * prev = structof (p, segment_s, all);
-	if ((prev->flags == SEG_FLAG_FREE) && (prev->base + prev->size == seg->base)) {
-		list_remove (&(prev->free));
-		seg_merge (prev, seg);
-		i = _seg_free.prev;
-		seg = prev;
-	} else {
-		seg->flags = SEG_FLAG_FREE;
-		seg->pid = 0;
+	if (&_seg_all != p) {
+		segment_s * prev = structof (p, segment_s, all);
+		if ((prev->flags == SEG_FLAG_FREE) && (prev->base + prev->size == seg->base)) {
+			list_remove (&(prev->free));
+			seg_merge (prev, seg);
+			i = _seg_free.prev;
+			seg = prev;
+		}
 	}
 
 	// Try to merge with next segment if free
 
 	list_s * n = seg->all.next;
-	segment_s * next = structof (n, segment_s, all);
-	if ((next->flags == SEG_FLAG_FREE) && (seg->base + seg->size == next->base)) {
-		list_remove (&(next->free));
-		seg_merge (seg, next);
-		i = _seg_free.prev;
+	if (n != &_seg_all) {
+		segment_s * next = structof (n, segment_s, all);
+		if ((next->flags == SEG_FLAG_FREE) && (seg->base + seg->size == next->base)) {
+			list_remove (&(next->free));
+			seg_merge (seg, next);
+			i = _seg_free.prev;
+		}
 	}
 
 	// Insert to free list head or tail

--- a/elks/include/linuxmt/init.h
+++ b/elks/include/linuxmt/init.h
@@ -24,6 +24,7 @@ extern void INITPROC inode_init(void);
 extern void INITPROC irq_init(void);
 extern void save_timer_irq(void);
 extern void INITPROC mm_init(seg_t,seg_t);
+extern void INITPROC seg_add(seg_t start, seg_t end);
 extern void INITPROC sched_init(void);
 extern void INITPROC serial_init(void);
 extern void INITPROC rs_setbaud(dev_t dev, unsigned long baud);

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -331,6 +331,25 @@ static void parse_nic(char *line, struct netif_parms *parms)
     }
 }
 
+static void parse_umb(char *line)
+{
+	char *p = line-1; /* because we start reading at p+1 */
+	seg_t base, end;
+	segext_t len;
+
+	do {
+		base = (seg_t)simple_strtol(p+1, 16);
+		if((p = strchr(p+1, ':'))) {
+			len = (segext_t)simple_strtol(p+1, 16);
+			end = base + len;
+#if DEBUG
+			printk("umb segment from %x to %x\n", base, end);
+#endif
+			seg_add(base, end);
+		}
+	}while((p = strchr(p+1, ',')));
+}
+
 /*
  * This is a simple kernel command line parsing function: it parses
  * the command line from /bootopts, and fills in the arguments/environment
@@ -433,6 +452,10 @@ static int parse_options(void)
 		}
 		if (!strncmp(line,"comirq=",7)) {
 			comirq(line+7);
+			continue;
+		}
+		if (!strncmp(line,"umb=",4)) {
+			parse_umb(line+4);
 			continue;
 		}
 		if (!strncmp(line,"TZ=",3)) {


### PR DESCRIPTION
This pull request adds support for UMB memory in the form of a new line in /bootopts :
```umb=0xC000:0x800,0xD000:0x1000``` for example will allow ELKS to use memory situated from 0xC0000 to 0xC8000 and from 0xD0000 to 0xE0000. 
The usual limitations of UMB still applies : memory needs to actually be here and must not conflict with anything else like bios or video memory.
This should also work to add conventional memory that the bios can't see (if the bios is hard-coded for the specific amount of memory the computer comes with)

This PR also fixes a bug revealed when using the UMB memory (see #1589) 