### PR TITLE
[basic] Add CGA compatible color for PC-98

### DIFF
--- a/elkscmd/basic/host-pc98.c
+++ b/elkscmd/basic/host-pc98.c
@@ -31,6 +31,8 @@ typedef struct {
 } xyc_t;
 
 static xyc_t gxyc = {0, 0, 7, 0, 1};
+static unsigned char cga[16] = {0x0, 0x1, 0x4, 0x5, 0x2, 0x3, 0x6, 0x7,
+                                0x8, 0x9, 0xC, 0xD, 0xA, 0xB, 0xE, 0xF};
 
 void int_A0(unsigned int l_seg)
 {
@@ -262,9 +264,13 @@ void host_cls() {
 
 void host_color(int fgc, int bgc) {
 
-    if (gmode) {
+    if (gmode == 1) {
         gxyc.fgc = fgc;
         gxyc.bgc = bgc;
+    }
+    else if (gmode == 2) {
+        gxyc.fgc = cga[fgc];
+        gxyc.bgc = cga[bgc];
     }
 }
 


### PR DESCRIPTION
Hello @ghaerr ,

I am making mini game with basic and I noticed color number is still different from CGA.

I made MODE 2 as CGA mode that convert the number as we did on console.
(Although 8 colors, no brown)

I will make data in cga code so that it can work in IBM PC when it supports graphic mode without much modification. 

MODE 1 (pc-98 mode)
![basic_col_98](https://user-images.githubusercontent.com/61556504/234338889-89b3373b-0601-45a5-8fac-a762c5e09642.png)

MODE 2 (CGA compatible mode)
![basic_col_cga](https://user-images.githubusercontent.com/61556504/234338909-08f8386b-08e9-41b7-9786-2d49645e3745.png)

Thank you.