### PR TITLE
[console] Add VideoSeg and AttributeSeg for High Resolution PC-98

### DIFF
--- a/elks/arch/i86/drivers/char/console-direct-pc98.c
+++ b/elks/arch/i86/drivers/char/console-direct-pc98.c
@@ -77,8 +77,8 @@ static int NumConsoles = MAX_CONSOLES;
 
 int Current_VCminor = 0;
 int kraw = 0;
-unsigned VideoSeg = 0xA000;
-unsigned AttributeSeg = 0xA200;
+unsigned VideoSeg;
+unsigned AttributeSeg;
 
 #ifdef CONFIG_EMUL_ANSI
 #define TERM_TYPE " emulating ANSI "
@@ -213,6 +213,14 @@ void console_init(void)
     Console *C;
     int i;
     unsigned PageSizeW;
+
+    VideoSeg = 0xA000;
+    AttributeSeg = 0xA200;
+
+    if (peekb(0x501,0) & 8) { /* High Resolution PC-98 */
+	VideoSeg = 0xE000;
+	AttributeSeg = 0xE200;
+    }
 
     MaxCol = (Width = 80) - 1;
 


### PR DESCRIPTION
This PR adds a feature to support booting console on PC-H98 as mentioned in https://github.com/jbruchon/elks/issues/1545#issuecomment-1546176192