### PR TITLE
[setup] Get total memory from PC-98 system

### DIFF
--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -1081,7 +1081,24 @@ putc:	push %bx
 
 // Return total memory in Kbytes
 arch_get_mem:
-	mov $SETUP_MEM_KBYTES,%ax
+#if SETUP_MEM_KBYTES_ASM
+	mov $SETUP_MEM_KBYTES_ASM,%ax  // force available memory (usually for testing)
+#else
+	push %es
+	push %cx
+	push %bx
+	xor %ax,%ax
+	mov %ax,%es
+	mov $0x501,%bx
+	mov %es:(%bx),%cl
+	and $7,%cl
+	inc %cl
+	mov $128,%al
+	mul %cl
+	pop %bx
+	pop %cx
+	pop %es
+#endif
 	ret
 
 // Set INITSEG values for PC98 architecture

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -48,7 +48,7 @@
 #define SETUP_VID_COLS		80	/* video # columns */
 #define SETUP_VID_LINES		25	/* video # lines */
 #define SETUP_CPU_TYPE		1	/* processor type = 8086 */
-#define SETUP_MEM_KBYTES	640	/* base memory in 1K bytes */
+#define SETUP_MEM_KBYTES	setupw(0x2a)	/* base memory in 1K bytes */
 #define SETUP_ROOT_DEV		setupw(0x1fc)	/* root device, kdev_t or BIOS dev */
 #define SETUP_ELKS_FLAGS	setupb(0x1f6)	/* flags for root device type */
 #define SETUP_PART_OFFSETLO	setupw(0x1e2)	/* partition offset low word */
@@ -57,7 +57,11 @@
 #define UTS_MACHINE		"pc-98 i8086"
 
 #define CONFIG_VAR_SECTOR_SIZE	/* sector size may vary across disks */
-#endif
+//#undef SETUP_MEM_KBYTES
+//#define SETUP_MEM_KBYTES        640     /* force available memory in 1K bytes */
+//#define SETUP_MEM_KBYTES_ASM    SETUP_MEM_KBYTES
+
+#endif /* CONFIG_ARCH_PC98 */
 
 #ifdef CONFIG_ARCH_8018X
 #define MAX_SERIAL		2	/* max number of serial tty devices*/


### PR DESCRIPTION
This PR adds a feature to get total memory from PC-98 system as mentioned in https://github.com/jbruchon/elks/issues/1545#issuecomment-1546176192