### PR TITLE
[disk] Calc cylinders with unsigned for PC-98 16bits cylinder

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -294,7 +294,7 @@ static unsigned short int INITPROC bioshd_gethdinfo(void) {
 #endif
 	    drivep->fdtype = -1;
 	    drivep->sector_size = 512;
-	    printk("bioshd: hd%c BIOS CHS %d,%d,%d\n", 'a'+drive, drivep->cylinders,
+	    printk("bioshd: hd%c BIOS CHS %u,%d,%d\n", 'a'+drive, drivep->cylinders,
 		drivep->heads, drivep->sectors);
 	}
 #ifdef CONFIG_IDE_PROBE
@@ -802,7 +802,7 @@ int INITPROC bioshd_init(void)
 		    unit++;
 		}
 		debug("DBG: Size = %lu (%X/%X)\n",size,*unit,unit[1]);
-		printk("/dev/%cd%c: %d cylinders, %d heads, %d sectors = %lu.%u %cb\n",
+		printk("/dev/%cd%c: %u cylinders, %d heads, %d sectors = %lu.%u %cb\n",
 		    (count < 4 ? 'h' : 'f'), (count & 3) + (count < 4 ? 'a' : '0'),
 		    drivep->cylinders, drivep->heads, drivep->sectors,
 		    (size/10), (int) (size%10), *unit);

--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -55,7 +55,7 @@ struct blk_dev_struct {
 
 /* For bioshd.c, idequery.c */
 struct drive_infot {            /* CHS per drive*/
-    int cylinders;
+    unsigned int cylinders;
     int sectors;
     int heads;
     int sector_size;

--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -32,9 +32,9 @@
 #define NR_SECTS(p)	p->nr_sects
 #define START_SECT(p)	p->start_sect
 #ifdef CONFIG_ARCH_PC98
-#define NR_SECTS_PC98(p98)	END_SECT_PC98(p98) - START_SECT_PC98(p98) + 1
-#define START_SECT_PC98(p98)	(sector_t) (p98->cyl * last_drive->heads + p98->head) * last_drive->sectors + p98->sector
-#define END_SECT_PC98(p98)	(sector_t) (p98->end_cyl * last_drive->heads + p98->end_head) * last_drive->sectors + p98->end_sector
+#define NR_SECTS_PC98(p98)	(sector_t) END_SECT_PC98(p98) - START_SECT_PC98(p98) + 1
+#define START_SECT_PC98(p98)	(sector_t) p98->cyl * last_drive->heads * last_drive->sectors + p98->head * last_drive->sectors + p98->sector
+#define END_SECT_PC98(p98)	(sector_t) p98->end_cyl * last_drive->heads * last_drive->sectors + p98->end_head * last_drive->sectors + p98->end_sector
 #endif
 
 struct gendisk *gendisk_head = NULL;


### PR DESCRIPTION
This PR is a bug fix that the cylinder gets negative value when PC-98 16bits cylinder are used as mentioned in
https://github.com/jbruchon/elks/issues/1545#issuecomment-1546176192

