### PR TITLE
[console] Add DisplayCursor On/Off to AnsiCmd

### DIFF
--- a/elks/arch/i86/drivers/char/console-bios.c
+++ b/elks/arch/i86/drivers/char/console-bios.c
@@ -99,6 +99,10 @@ static void PositionCursorGet (int * x, int * y)
 	*y = row;
 }
 
+static void DisplayCursor(int onoff)
+{
+}
+
 static void VideoWrite(register Console * C, char c)
 {
     int a, p;

--- a/elks/arch/i86/drivers/char/console-direct-pc98.c
+++ b/elks/arch/i86/drivers/char/console-direct-pc98.c
@@ -102,6 +102,14 @@ static void PositionCursor(register Console * C)
     cursor_set(Pos * 2);
 }
 
+static void DisplayCursor(int onoff)
+{
+    if (onoff)
+	cursor_on();
+    else
+	cursor_off();
+}
+
 static word_t conv_pcattr(word_t attr)
 {
     static unsigned char grb[8] = {0x00, 0x20, 0x80, 0xA0, 0x40, 0x60, 0xC0, 0xE0};

--- a/elks/arch/i86/drivers/char/console-direct.c
+++ b/elks/arch/i86/drivers/char/console-direct.c
@@ -100,6 +100,10 @@ static void PositionCursor(register Console * C)
     outb(Pos & 255, CCBasep + 1);
 }
 
+static void DisplayCursor(int onoff)
+{
+}
+
 static void VideoWrite(register Console * C, int c)
 {
     pokew((C->cx + C->cy * Width) << 1, (seg_t) C->vseg,

--- a/elks/arch/i86/drivers/char/console.c
+++ b/elks/arch/i86/drivers/char/console.c
@@ -217,6 +217,23 @@ static void AnsiCmd(register Console * C, int c)
 	    Console_conin('R');
 	}
 	break;
+    case 'h':			/* cursor on */
+    case 'l':			/* cursor off */
+      {
+	char *p = (char *)C->params;
+	if (*p == '?')
+	    p++;
+	else
+	    break;
+	n = atoi(p);
+	if (n == 25) {
+	    if (c == 'h')
+	        DisplayCursor(1);
+	    else
+	        DisplayCursor(0);
+	}
+      }
+      break;
     }
     C->fsm = std_char;
 }


### PR DESCRIPTION
This PR is adding Cursor On/Off by AnsiCmd as we discussed on https://github.com/jbruchon/elks/discussions/1618#discussioncomment-6406993

I checked with PC-9801BX and it worked.

I also added empty function in console-bios.c and console-direct.c for IBM.

Thank you.
 