### PR TITLE
[build] Update build scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# This build script is called in main.yml by GitHub Continuous Integration
 # Full build (including the cross tool chain)
 
 # Arguments:

--- a/buildimages.sh
+++ b/buildimages.sh
@@ -1,12 +1,15 @@
 #
-# Build all ELKS images
+# This script is used to build all ELKS images outside Github CI
 
 cleanup()
 {
     make kclean
     rm -f bootblocks/*.o
     rm -f elkscmd/sys_utils/clock.o
+    rm -f elkscmd/sys_utils/ps.o
+    rm -f elkscmd/sys_utils/meminfo.o
     rm -f elkscmd/basic/*.o
+    rm -f elkscmd/nano-X/*/*.o
 }
 
 # build PC-98 versions
@@ -21,6 +24,15 @@ build_pc98()
     cp pc98-1440.config .config
     make
     mv image/fd1440.img image/fd1440-pc98.img
+}
+
+# build 8018X image
+build_8018x()
+{
+    cleanup
+    cp 8018x.config .config
+    make
+    mv image/romfs.bin image/romfs-8018x.bin
 }
 
 # build IBM PC versions
@@ -38,6 +50,7 @@ build_ibm()
 make clean
 build_ibm
 build_pc98
+build_8018x
 
 cp ibmpc-1440.config .config
 cleanup


### PR DESCRIPTION
`./buildimages.sh` can be used to build all ELKS release images for IBM PC, PC-98 and 8018X, and will be used to build the upcoming v0.7.0 release images for uploading to GitHub.