### PR TITLE
[build] Fix menuconfig build on macOS

### DIFF
--- a/config/lxdialog/Makefile
+++ b/config/lxdialog/Makefile
@@ -61,7 +61,7 @@ $(PGM): $(OBJS)
 # Write a custom header for curses.
 
 local-curses.h:
-	@x=`find /lib/ /lib64/ /usr/lib/ /usr/lib64/ /usr/local/lib/ /usr/local/lib64/ /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/lib -maxdepth 2 -name 'libncurses.*'` ;\
+	@x=`find /lib/ /lib64/ /usr/lib/ /usr/lib64/ /usr/local/lib/ /usr/local/lib64/ /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/lib/ -maxdepth 2 -name 'libncurses.*'` ;\
 	if [ ! "$$x" ]; then \
 		echo -e "\007" ;\
 		echo ">> Unable to find the Ncurses libraries." ;\

--- a/config/lxdialog/Makefile
+++ b/config/lxdialog/Makefile
@@ -61,7 +61,7 @@ $(PGM): $(OBJS)
 # Write a custom header for curses.
 
 local-curses.h:
-	@x=`find /lib/ /lib64/ /usr/lib/ /usr/lib64/ /usr/local/lib/ /usr/local/lib64/ -maxdepth 2 -name 'libncurses.*'` ;\
+	@x=`find /lib/ /lib64/ /usr/lib/ /usr/lib64/ /usr/local/lib/ /usr/local/lib64/ /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/lib -maxdepth 2 -name 'libncurses.*'` ;\
 	if [ ! "$$x" ]; then \
 		echo -e "\007" ;\
 		echo ">> Unable to find the Ncurses libraries." ;\


### PR DESCRIPTION
Fixes `lxdialog` build failing to find ncurses library on macOS, discussed in https://github.com/jbruchon/elks/issues/1630#issuecomment-1659135138.
