### PR TITLE
Better guidance to run slattach.sh as root

### DIFF
--- a/slattach.sh
+++ b/slattach.sh
@@ -1,7 +1,13 @@
 # Helper script to setup SLIP connection between Linux and ELKS
 #
-# run "net start slip" on ELKS after running this script
+# run "net start slip" on ELKS after running this script as root
 #
+
+if [[ $(id -u) != 0 ]];
+then
+	echo "Please run me as root."
+	exit 1
+fi
 
 baud=38400
 device=/dev/ttyS0


### PR DESCRIPTION
When run as user, the error messages from slattach & co are almost always missing my eyes, thus this enhancement to enforce the script to be run as root.