### PR TITLE
[kernel] Rewrite wait_on_buffer for async I/O, trace fixes

### DIFF
--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -6,6 +6,7 @@
 #include <linuxmt/kdev_t.h>
 #include <linuxmt/genhd.h>
 #include <linuxmt/config.h>
+#include <linuxmt/trace.h>
 
 struct request {
     kdev_t rq_dev;		/* -1 if no request */

--- a/elks/arch/i86/kernel/strace.c
+++ b/elks/arch/i86/kernel/strace.c
@@ -123,11 +123,13 @@ static void check_kstack(int n)
         currentp->kstack_max = n;
         if (n > max)
             max = n;
-        printk("KSTACK(%d) sys_%7s max %3d prevmax %3d sysmax %3d%s",
-            currentp->pid, s->s_name,
-            currentp->kstack_max, currentp->kstack_prevmax, max, warning);
-        if (n == max) printk("*");
-        printk("\n");
+        if (currentp->kstack_prevmax != 0) {
+            printk("KSTACK(%d) sys_%7s max %3d prevmax %3d sysmax %3d%s",
+                currentp->pid, s->s_name,
+                currentp->kstack_max, currentp->kstack_prevmax, max, warning);
+            if (n == max) printk("*");
+            printk("\n");
+        }
     }
 }
 #endif

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -84,7 +84,7 @@ static int nr_free_bh;
 #define INR_COUNT(bh) if(!(bh->b_count++))nr_free_bh--
 #define CLR_COUNT(bh) if(bh->b_count)nr_free_bh++
 #define SET_COUNT(bh) if(--nr_free_bh < 0) { \
-                          panic("get_free_buffer: bad free buffer head count"); \
+                          panic("get_free_buffer: bad free buffer_head count"); \
                           nr_free_bh = 0; }
 #else
 #define DCR_COUNT(bh) (bh->b_count--)
@@ -230,10 +230,10 @@ void wait_on_buffer(struct buffer_head *bh)
     }
     wait_clear((struct wait_queue *)bh);
     current->state = TASK_RUNNING;
-	DCR_COUNT(ebh);
+    DCR_COUNT(ebh);
 #elif defined(CHECK_BLOCKIO)
     if (ebh->b_locked)
-        panic("wait_on_buffer: block %ld\n", ebh->b_blocknr);
+        panic("wait_on_buffer: block %ld locked\n", ebh->b_blocknr);
 #endif
 }
 
@@ -337,7 +337,9 @@ void brelse(struct buffer_head *bh)
     if (!bh) return;
     wait_on_buffer(bh);
     ebh = EBH(bh);
-    if (ebh->b_count == 0) panic("brelse");
+#ifdef CHECK_BLOCKIO
+    if (ebh->b_count == 0) panic("brelse: count 0");
+#endif
     DCR_COUNT(ebh);
 #ifdef BLOAT_FS
     if (!ebh->b_count)

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -1,9 +1,11 @@
 #include <linuxmt/config.h>
-#include <linuxmt/debug.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/kernel.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/sched.h>
+#include <linuxmt/trace.h>
+#include <linuxmt/debug.h>
+
 #include <arch/segment.h>
 
 int task_slots_unused = MAX_TASKS;

--- a/elks/kernel/sched.c
+++ b/elks/kernel/sched.c
@@ -10,6 +10,7 @@
 #include <linuxmt/init.h>
 #include <linuxmt/timer.h>
 #include <linuxmt/string.h>
+#include <linuxmt/trace.h>
 #include <linuxmt/debug.h>
 
 #include <arch/irq.h>

--- a/elks/kernel/sleepwake.c
+++ b/elks/kernel/sleepwake.c
@@ -1,12 +1,13 @@
-#include <arch/irq.h>
-#include <arch/segment.h>
-
 #include <linuxmt/kernel.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/sched.h>
 #include <linuxmt/types.h>
 #include <linuxmt/wait.h>
+#include <linuxmt/trace.h>
 #include <linuxmt/debug.h>
+
+#include <arch/irq.h>
+#include <arch/segment.h>
 
 /*
  *	Wait queue functionality for Linux ELKS. Taken from sched.c/h of


### PR DESCRIPTION
The `wait_on_buffer` routine was noticed to be buggy for async I/O, and was rewritten, even though async I/O isn't currently in use.

Also fixes some consistency settings that may not have been set properly via the trace.h file.