### PR TITLE
[kernel] Determine kernel stack usage when allowing async I/O

### DIFF
--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -46,11 +46,6 @@
 
 #include <arch/segment.h>
 
-static struct minix_exec_hdr mh;
-#ifdef CONFIG_EXEC_MMODEL
-static struct elks_supl_hdr esuph;
-#endif
-
 #ifndef __GNUC__
 /* FIXME: evaluates some operands twice */
 #   define add_overflow(a, b, res) \
@@ -74,7 +69,7 @@ static struct elks_supl_hdr esuph;
  * Only IA-16 segment relocations are accepted
  */
 static int relocate(seg_t place_base, lsize_t rsize, segment_s *seg_code,
-		    segment_s *seg_data, struct inode *inode, struct file *filp)
+               segment_s *seg_data, struct inode *inode, struct file *filp, size_t tseg)
 {
     int retval = 0;
     __u16 save_ds = current->t_regs.ds;
@@ -96,7 +91,7 @@ static int relocate(seg_t place_base, lsize_t rsize, segment_s *seg_code,
 	    case S_TEXT:
 		val = seg_code->base; break;
 	    case S_FTEXT:
-		val = seg_code->base + bytes_to_paras((size_t)mh.tseg); break;
+		val = seg_code->base + bytes_to_paras(tseg); break;
 	    case S_DATA:
 		val = seg_data->base; break;
 	    default:
@@ -138,7 +133,9 @@ int sys_execve(const char *filename, char *sptr, size_t slen)
     size_t len, min_len, heap, stack = 0;
     size_t bytes;
     segext_t paras;
+    ASYNCIO_REENTRANT struct minix_exec_hdr mh;         /* 32 bytes */
 #ifdef CONFIG_EXEC_MMODEL
+    ASYNCIO_REENTRANT struct elks_supl_hdr esuph;       /* 24 bytes */
     int need_reloc_code = 1;
 #endif
 
@@ -417,13 +414,13 @@ int sys_execve(const char *filename, char *sptr, size_t slen)
     if (need_reloc_code) {
 	/* Read and apply text segment relocations */
 	retval = relocate(seg_code->base, esuph.msh_trsize, seg_code, seg_data,
-			  inode, filp);
+			  inode, filp, mh.tseg);
 	if (retval != 0)
 	    goto error_exec5;
 	/* Read and apply far text segment relocations */
 	retval = relocate(seg_code->base + bytes_to_paras((size_t)mh.tseg),
 			  esuph.esh_ftrsize, seg_code, seg_data,
-			  inode, filp);
+			  inode, filp, mh.tseg);
 	if (retval != 0)
 	    goto error_exec5;
     } else {
@@ -433,7 +430,7 @@ int sys_execve(const char *filename, char *sptr, size_t slen)
     }
     /* Read and apply data relocations */
     retval = relocate(seg_data->base, esuph.msh_drsize, seg_code, seg_data,
-		      inode, filp);
+		      inode, filp, mh.tseg);
     if (retval != 0)
 	goto error_exec5;
 #endif

--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -94,8 +94,7 @@ int FATPROC msdos_get_entry_long(
 	off_t oldpos = *pos;	/* location of next directory entry start*/
 	int is_long;
 	unsigned char alias_checksum = 0;
-	/* static not reentrant: conserve stack usage*/
-	static unsigned short unicodename[26+1];	/* Limited to two long entries */
+	ASYNCIO_REENTRANT unsigned short unicodename[26+1];	/* Limited to two long entries */
 
 	if ((int)*pos & (sizeof(struct msdos_dir_entry) - 1)) return -ENOENT;
 	is_long = 0;
@@ -153,7 +152,7 @@ int FATPROC msdos_get_entry_long(
 			int i,i2,last;
 			int long_len = 0;
 			unsigned char c;
-			static char longname[14]; /* static not reentrant: conserve stack usage*/
+			ASYNCIO_REENTRANT char longname[14];
 
 			if (is_long) {
 				unsigned char sum;
@@ -230,8 +229,7 @@ static int msdos_readdir(struct inode *dir, struct file *filp, char *dirbuf,
 	ino_t ino;
 	off_t dirpos;
 	int res, namelen;
-	/* static not reentrant: conserve stack usage*/
-	static char name[14];
+	ASYNCIO_REENTRANT char name[14];
 
 	if (!dir || !S_ISDIR(dir->i_mode)) return -EBADF;
 	if (dir->i_ino == MSDOS_ROOT_INO) {

--- a/elks/fs/msdos/namei.c
+++ b/elks/fs/msdos/namei.c
@@ -68,8 +68,7 @@ static int FATPROC msdos_find(struct inode *dir,const char *name,int len,
     struct buffer_head **bh,struct msdos_dir_entry **de,ino_t *ino)
 {
 	int res;
-	/* static not reentrant: conserve stack usage*/
-	static char msdos_name[MSDOS_NAME+1];
+	ASYNCIO_REENTRANT char msdos_name[MSDOS_NAME+1];
 
 	if ((res = msdos_format_name(name,len, msdos_name)) < 0) return res;
 	res = msdos_scan(dir,msdos_name,bh,de,ino);
@@ -96,9 +95,8 @@ static int FATPROC msdos_find_long(struct inode *dir, const char *name, int len,
 	int i, entry_len, res;
 	off_t dirpos, pos = 0;
 	int nocase = 0;
-	/* static not reentrant: conserve stack usage*/
-	static char entry_name[14];
-	static char msdos_name[14];
+	ASYNCIO_REENTRANT char entry_name[14];
+	ASYNCIO_REENTRANT char msdos_name[14];
 
 	for (i=0; i<len; i++)
 		msdos_name[i] = get_fs_byte(name++);
@@ -209,8 +207,7 @@ int msdos_create(register struct inode *dir,const char *name,int len,int mode,
 	struct msdos_dir_entry *de;
 	ino_t ino;
 	int res;
-	/* static not reentrant: conserve stack usage*/
-	static char msdos_name[MSDOS_NAME];
+	ASYNCIO_REENTRANT char msdos_name[MSDOS_NAME];
 
 	if ((res = msdos_format_name(name,len, msdos_name)) < 0) {
 		iput(dir);
@@ -238,8 +235,7 @@ int msdos_mkdir(struct inode *dir,const char *name,int len,int mode)
 	struct inode *inode,*dot;
 	ino_t ino;
 	int res;
-	/* static not reentrant: conserve stack usage*/
-	static char msdos_name[MSDOS_NAME];
+	ASYNCIO_REENTRANT char msdos_name[MSDOS_NAME];
 
 	if ((res = msdos_format_name(name,len, msdos_name)) < 0) {
 		iput(dir);

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -352,6 +352,17 @@ struct file_system_type {
     int				type;
 };
 
+/*
+ * fs/exec.c and the FAT filesystem can save kernel stack space for their
+ * larger stack declarations when block I/O is always synchronous, thus
+ * reducing the required size of each task struct.
+ */
+#ifdef CONFIG_ASYNCIO
+#define ASYNCIO_REENTRANT
+#else
+#define ASYNCIO_REENTRANT     static
+#endif
+
 #ifdef BLOAT_FS
 /*
  * Attribute flags.  These should be or-ed together to figure out what

--- a/elkscmd/file_utils/rmdir.c
+++ b/elkscmd/file_utils/rmdir.c
@@ -24,29 +24,34 @@ static int remove_dir(char *name, int f)
 
 int main(int argc, char **argv)
 {
-	int i, parent = 0, er = 0;
+	int i, parent = 0, force = 0, er = 0;
 	
 	if (argc < 2) goto usage;
 
-	if ((argv[1][0] == '-') && (argv[1][1] == 'p'))	
-		parent = 1;
+        while (argv[1][0] == '-') {
+                switch (argv[1][1]) {
+                case 'p': parent = 1; break;
+                case 'f': force = 1; break;
+                default: goto usage;
+                }
+                argv++;
+                argc--;
+        }
 	
 	newmode = 0666 & ~umask(0);
 
 	for (i = parent + 1; i < argc; i++) {
-		if (argv[i][0] != '-') {
 			while (argv[i][strlen(argv[i])-1] == '/')
 				argv[i][strlen(argv[i])-1] = '\0';
 			if (remove_dir(argv[i],parent)) {
 				errstr(argv[i]);
-				errmsg(": cannot remove directory\n");
+				errmsg(": no or can't remove directory\n");
 				er = 1;
 			}
-		} else goto usage;
 	}
-	return er;
+	return force? 0: er;
 
 usage:
-	errmsg("usage: rmdir directory [...]\n");
+	errmsg("usage: rmdir [-pf] directory [...]\n");
 	return 1;
 }


### PR DESCRIPTION
The current ELKS kernel tries to save kernel stack space by declaring some of its relatively larger stack variables and buffers as `static`, taking advantage of the fact that when block I/O is guaranteed synchronous, kernel functions that call filesystem code won't block, and thus won't be reentered by another process/system call.

This PR sets up a test capability (setting CONFIG_ASYNCIO) to allocate these stack variables as non-static declarations, and then measure the resulting increased kernel stack usage as a result, using the recently-introduced `kstack` tracing. A shell script is run producing heavy filesystem activity on MINIX and FAT filesystems (the MINIX filesystem doesn't use any larger stack variables/buffers).

The preliminary maximum kernel stack usage results found using static vs non-static for MINIX and FAT are:
```
       static reentrant  filesystem
kstack 386 -> 410        MINIX
kstack 500 -> 598        FAT
```
The largest kernel stack was reported during a `stat` system call:
```
KSTACK(149) sys_stat    max 598 prevmax 382 sysmax 598 (OVERFLOW AT 640)*
```
The preliminary conclusion is that an extra 100 bytes of stack are required to support async I/O, when FAT is used.
Trying to understand the actual maximum kernel stack required per task is tricky, and timing dependent. The current kernel stack allocation is 640 bytes on IBM PC, and 740 on PC-98. The PC-98 seems to require more stack during BIOS calls, and all BIOS calls are made from the kernel stack.

This PR also adds a `-f` option (force no error result) to `rmdir`, as was needed for a test shell script.