### PR TITLE
[kernel] Update linker script to place INITPROC sections at highest addresses

### DIFF
--- a/elks/elks-small.ld
+++ b/elks/elks-small.ld
@@ -47,14 +47,16 @@ SECTIONS {
 		 * IA-16 segment start markers.
 		 */
 		*(".fartext!*" ".fartext.*!")
+		"__start_fartext_init!" = .;
+		"__end_fartext_init!" = .;
 
 		/* Actual segment contents. */
 		/* *(.fartext .fartext$* ".fartext.*[^&]") */
 
 		*(.fartext .fartext.
 		".fartext.[^i]*" ".fartext.i[^n]*" ".fartext.in[^i]*" ".fartext.ini[^t]*")
-		__start_fartext_init = .;
-		*(.fartext .fartext.init ".fartext.init")
+		 __start_fartext_init = .;
+		*(.fartext .fartext.init)
 		__end_fartext_init = .;
 
 		/* IA-16 segment end markers. */

--- a/elks/elks-small.ld
+++ b/elks/elks-small.ld
@@ -53,9 +53,9 @@ SECTIONS {
 
 		*(.fartext .fartext.
 		".fartext.[^i]*" ".fartext.i[^n]*" ".fartext.in[^i]*" ".fartext.ini[^t]*")
-		__start_fartext = .;
+		__start_fartext_init = .;
 		*(.fartext .fartext.init ".fartext.init")
-		__end_fartext = .;
+		__end_fartext_init = .;
 
 		/* IA-16 segment end markers. */
 		*(".fartext&*" ".fartext.*&")

--- a/elks/elks-small.ld
+++ b/elks/elks-small.ld
@@ -49,7 +49,13 @@ SECTIONS {
 		*(".fartext!*" ".fartext.*!")
 
 		/* Actual segment contents. */
-		*(.fartext .fartext$* ".fartext.*[^&]")
+		/* *(.fartext .fartext$* ".fartext.*[^&]") */
+
+		*(.fartext .fartext.
+		".fartext.[^i]*" ".fartext.i[^n]*" ".fartext.in[^i]*" ".fartext.ini[^t]*")
+		__start_fartext = .;
+		*(.fartext .fartext.init ".fartext.init")
+		__end_fartext = .;
 
 		/* IA-16 segment end markers. */
 		*(".fartext&*" ".fartext.*&")


### PR DESCRIPTION
First step in allowing for the kernel INIT segment to be discarded after initialization, providing more memory for application programs, or perhaps other system resources.

Using suggestions provided by @tkchia in #1644.

(Also, I was incorrect in the statement that the kernel code segment comes after the data segment: this was reversed some time ago to allow for the kernel data segment size to by dynamically allocated at startup using `SETUP_HEAPSIZE`.) Quick testing shows that the benefit of discarding the kernel INIT code segment is only going to be 5K bytes.