### PR TITLE
[kernel] Release .fartext.init code section to free memory after init

### DIFF
--- a/elks/include/linuxmt/init.h
+++ b/elks/include/linuxmt/init.h
@@ -7,6 +7,9 @@
 
 #if defined(CONFIG_FARTEXT_KERNEL) && !defined(__STRICT_ANSI__)
 #define INITPROC __far __attribute__ ((far_section, noinline, section (".fartext.init")))
+/* these symbols defined in elks-small.ld linker script */
+extern void INITPROC __start_fartext_init(void);
+extern void INITPROC __end_fartext_init(void);
 #else
 #define INITPROC
 #endif

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -12,6 +12,7 @@
 #include <linuxmt/utsname.h>
 #include <linuxmt/netstat.h>
 #include <linuxmt/trace.h>
+#include <linuxmt/debug.h>
 #include <arch/system.h>
 #include <arch/segment.h>
 #include <arch/ports.h>
@@ -77,7 +78,7 @@ static char * INITPROC option(char *s);
 #endif
 
 static void init_task(void);
-static void INITPROC kernel_banner(seg_t start, seg_t end);
+static void INITPROC kernel_banner(seg_t start, seg_t end, seg_t init, seg_t extra);
 
 
 void start_kernel(void)
@@ -148,10 +149,21 @@ void INITPROC kernel_init(void)
     if (!opts) printk("/bootopts ignored: header not ## or size > %d\n", OPTSEGSZ-1);
 #endif
 
-    kernel_banner(base, end);
+#ifdef CONFIG_FARTEXT_KERNEL
+    /* add .farinit.init section to main memory free list */
+    seg_t     init_seg = ((unsigned long)(void __far *)__start_fartext_init) >> 16;
+    seg_t s = init_seg + (((word_t)(void *)__start_fartext_init + 15) >> 4);
+    seg_t e = init_seg + (((word_t)(void *)  __end_fartext_init + 15) >> 4);
+    debug("extra %04x to %04x size %04x (%d)\n", s, e, (e - s) << 4, (e - s) << 4);
+    seg_add(s, e);
+#else
+    seg_t s = 0, e = 0;
+#endif
+
+    kernel_banner(base, end, s, e - s);
 }
 
-static void INITPROC kernel_banner(seg_t start, seg_t end)
+static void INITPROC kernel_banner(seg_t start, seg_t end, seg_t init, seg_t extra)
 {
 #ifdef CONFIG_ARCH_IBMPC
     printk("PC/%cT class machine, ", (sys_caps & CAP_PC_AT) ? 'A' : 'X');
@@ -170,12 +182,12 @@ static void INITPROC kernel_banner(seg_t start, seg_t end)
            system_utsname.release,
            (unsigned)_endtext, (unsigned)_endftext, (unsigned)_enddata,
            (unsigned)_endbss - (unsigned)_enddata, heapsize);
-    printk("Kernel text at %x:0000, ", kernel_cs);
+    printk("Kernel text %x:0, ", kernel_cs);
 #ifdef CONFIG_FARTEXT_KERNEL
-    printk("ftext %x:0000, ", (unsigned)((long)kernel_init >> 16));
+    printk("ftext %x:0, init %x:0, ", (unsigned)((long)kernel_init >> 16), init);
 #endif
-    printk("data %x:0000, top %x:0, %uK free\n",
-           kernel_ds, end, (int) ((end - start) >> 6));
+    printk("data %x:0, top %x:0, %uK free\n",
+           kernel_ds, end, (int) ((end - start + extra) >> 6));
 }
 
 static void try_exec_process(const char *path)


### PR DESCRIPTION
Final implementation of creating more usable main memory for applications by discarding the kernel's `.fartext.init` code section after kernel initialization, and adding it to the free list. Discussed in #1644 and #1645. Thanks to @tkchia for help in adding this feature.

The current savings is about 5K, here's the updated boot screen showing the `init` section at `13a6` (which always extends to the start of the `data` segment, here at `14dd`). The reported free memory is about 5K higher than previously:
<img width="832" alt="boot" src="https://github.com/jbruchon/elks/assets/11985637/77e33eaa-af91-45d3-8ccc-c26652611594">

After boot, running `meminfo` shows it's 3856 byte code segment having been allocated in this newly available memory, with the remaining 1120 bytes free:
<img width="832" alt="meminfo" src="https://github.com/jbruchon/elks/assets/11985637/49e1920f-a24d-42a6-9517-78f4756f2f44">

It was noticed that when running multiuser mode, `/bin/getty` ended up being allocated in this spot, which is kind of nice :)