### PR TITLE
[kernel] Fix MINIX fs indirect block allocation

### DIFF
--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -189,10 +189,10 @@ static void end_request(int uptodate)
     if (req->rq_status != RQ_ACTIVE \
         || (req->rq_cmd != READ && req->rq_cmd != WRITE) \
         || MAJOR(req->rq_dev) != MAJOR_NR) \
-        panic("%s: bad request dev %x cmd %d active %d", \
-            DEVICE_NAME, req->rq_dev, req->rq_cmd, req->rq_status); \
+        panic(DEVICE_NAME ": bad request dev %x cmd %d active %d", \
+            req->rq_dev, req->rq_cmd, req->rq_status); \
     if (req->rq_bh && !EBH(req->rq_bh)->b_locked) \
-        panic("%s: not locked", DEVICE_NAME);
+        panic(DEVICE_NAME ": not locked");
 #else
 #define CHECK_REQUEST(req)
 #endif

--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -145,8 +145,9 @@ static void end_request(int uptodate)
     req = CURRENT;
 
     if (!uptodate) {
-        printk("%s: I/O error: dev %x, block %lu\n",
-            DEVICE_NAME, req->rq_dev, req->rq_blocknr);
+        printk("%s: I/O %s error: dev %x, block %lu\n",
+            DEVICE_NAME, (req->rq_cmd == WRITE)? "write": "read",
+            req->rq_dev, req->rq_blocknr);
 
 #ifdef MULTI_BH
 #ifdef BLOAT_FS
@@ -185,8 +186,11 @@ static void end_request(int uptodate)
 
 #ifdef CHECK_BLOCKIO
 #define CHECK_REQUEST(req) \
-    if (MAJOR(req->rq_dev) != MAJOR_NR) \
-        panic("%s: bad request %x", DEVICE_NAME, req->rq_dev); \
+    if (req->rq_status != RQ_ACTIVE \
+        || (req->rq_cmd != READ && req->rq_cmd != WRITE) \
+        || MAJOR(req->rq_dev) != MAJOR_NR) \
+        panic("%s: bad request dev %x cmd %d active %d", \
+            DEVICE_NAME, req->rq_dev, req->rq_cmd, req->rq_status); \
     if (req->rq_bh && !EBH(req->rq_bh)->b_locked) \
         panic("%s: not locked", DEVICE_NAME);
 #else

--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -145,8 +145,8 @@ static void end_request(int uptodate)
     req = CURRENT;
 
     if (!uptodate) {
-        printk("%s: I/O %s error: dev %x, block %lu\n",
-            DEVICE_NAME, (req->rq_cmd == WRITE)? "write": "read",
+        printk(DEVICE_NAME ": I/O %s error: dev %x, block %lu\n",
+            (req->rq_cmd == WRITE)? "write": "read",
             req->rq_dev, req->rq_blocknr);
 
 #ifdef MULTI_BH

--- a/elks/arch/i86/drivers/block/ll_rw_blk.c
+++ b/elks/arch/i86/drivers/block/ll_rw_blk.c
@@ -226,8 +226,11 @@ static void make_request(unsigned short major, int rw, struct buffer_head *bh)
 	max_req = (NR_REQUEST * 2) / 3;
 #endif
 #ifdef CHECK_BLOCKIO
-        if (!EBH(bh)->b_dirty)
-                printk("make_request: block %ld not dirty\n", EBH(bh)->b_blocknr);
+        if (!EBH(bh)->b_dirty) {
+            printk("make_request: block %ld not dirty\n", EBH(bh)->b_blocknr);
+            unlock_buffer(bh);
+            return;
+        }
 #endif
 	break;
 

--- a/elks/arch/i86/drivers/block/ssd-test.c
+++ b/elks/arch/i86/drivers/block/ssd-test.c
@@ -17,10 +17,6 @@
  *	fsck -lvf /dev/ssd
  */
 #include <linuxmt/config.h>
-#include <linuxmt/debug.h>
-#if DEBUG_BLK
-#define DEBUG 1
-#endif
 #include <linuxmt/rd.h>
 #include <linuxmt/major.h>
 #include <linuxmt/fs.h>
@@ -28,6 +24,7 @@
 #include <linuxmt/kernel.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/errno.h>
+#include <linuxmt/debug.h>
 #include "ssd.h"
 
 #define NUM_SECTS	192		/* set to max # sectors on SSD device */
@@ -50,7 +47,7 @@ int ssddev_ioctl(struct inode *inode, struct file *file,
 
     switch (cmd) {
     case RDCREATE:
-	debug("SSD: ioctl make %d\n", arg); /* size ignored, always NUM_SECTS */
+	debug_blk("SSD: ioctl make %d\n", arg); /* size ignored, always NUM_SECTS */
 	if (ssd_seg)
 	    return -EBUSY;
 	ssd_seg = seg_alloc((segext_t)NUM_SECTS << 5, SEG_FLAG_RAMDSK);
@@ -64,7 +61,7 @@ int ssddev_ioctl(struct inode *inode, struct file *file,
 	return 0;
 
     case RDDESTROY:
-	debug("SSD: ioctl kill\n");
+	debug_blk("SSD: ioctl kill\n");
 	if (ssd_seg) {
 	    invalidate_inodes(inode->i_rdev);
 	    invalidate_buffers(inode->i_rdev);

--- a/elks/fs/block_dev.c
+++ b/elks/fs/block_dev.c
@@ -64,10 +64,11 @@ size_t block_read(struct inode *inode, register struct file *filp,
 	 *      Read the block in
 	 */
 	chars = (filp->f_pos >> BLOCK_SIZE_BITS);
-	if (inode->i_op->getblk)
+	if (inode->i_op->getblk) {
 	    bh = inode->i_op->getblk(inode, (block_t)chars, 0);
-	else
+	} else {
 	    bh = getblk(inode->i_rdev, (block_t)chars);
+	}
 	/* Offset to block/offset */
 	chars = BLOCK_SIZE - (((size_t)(filp->f_pos)) & (BLOCK_SIZE - 1));
 	if (chars > count) chars = count;
@@ -127,10 +128,11 @@ size_t block_write(struct inode *inode, register struct file *filp,
 	register struct buffer_head *bh;
 
 	chars = (filp->f_pos >> BLOCK_SIZE_BITS);
-	if (inode->i_op->getblk)
+	if (inode->i_op->getblk) {
 	    bh = inode->i_op->getblk(inode, (block_t)chars, 1);
-	else
+	} else {
 	    bh = getblk(inode->i_rdev, (block_t)chars);
+	}
 	if (!bh) {
 	    if (!written) written = -ENOSPC;
 	    break;

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -83,9 +83,7 @@ static int nr_free_bh;
 #define DCR_COUNT(bh) if(!(--bh->b_count))nr_free_bh++
 #define INR_COUNT(bh) if(!(bh->b_count++))nr_free_bh--
 #define CLR_COUNT(bh) if(bh->b_count)nr_free_bh++
-#define SET_COUNT(bh) if(--nr_free_bh < 0) { \
-                          panic("get_free_buffer: bad free count"); \
-                          nr_free_bh = 0; }
+#define SET_COUNT(bh) if(--nr_free_bh < 0) { panic("get_free_buffer: bad free count"); }
 #else
 #define DCR_COUNT(bh) (bh->b_count--)
 #define INR_COUNT(bh) (bh->b_count++)

--- a/elks/fs/minix/bitmap.c
+++ b/elks/fs/minix/bitmap.c
@@ -116,13 +116,14 @@ repeat:
     mark_buffer_dirty(bh);
     unmap_buffer(bh);
     j += i*8192 + sb->u.minix_sb.s_firstdatazone - 1;
-    if (j < sb->u.minix_sb.s_firstdatazone || j >= sb->u.minix_sb.s_nzones)
+    if (j < sb->u.minix_sb.s_firstdatazone || j >= sb->u.minix_sb.s_nzones) {
         return 0;
+    }
     if (!(bh = getblk(sb->s_dev, j))) {
         printk("new_block: bad block %u\n", j);
         return 0;
     }
-    map_buffer(bh);
+    map_buffer(bh);     // FIXME use xms_fmemset and no map_buffer
     memset(bh->b_data, 0, BLOCK_SIZE);
     mark_buffer_uptodate(bh, 1);
     mark_buffer_dirty(bh);

--- a/elks/fs/minix/inode.c
+++ b/elks/fs/minix/inode.c
@@ -269,6 +269,7 @@ static unsigned short map_iblock(struct inode *inode, block_t i,
 {
     register struct buffer_head *bh;
     register block_t *b_zone;
+    block_t b;
 
     if (!(bh = bread(inode->i_dev, i))) {
 	return 0;
@@ -280,8 +281,9 @@ static unsigned short map_iblock(struct inode *inode, block_t i,
 	    mark_buffer_dirty(bh);
 	}
     }
+    b = *b_zone;
     unmap_brelse(bh);
-    return *b_zone;
+    return b;
 }
 
 unsigned short _minix_bmap(register struct inode *inode, block_t block, int create)

--- a/elks/fs/read_write.c
+++ b/elks/fs/read_write.c
@@ -133,7 +133,7 @@ int sys_write(unsigned int fd, char *buf, size_t count)
 
 	    }
 	    written = (int) fop->write(inode, file, buf, count);
-	    schedule();
+	    schedule();         // FIXME should this be here?
 	}
     }
     return written;

--- a/elks/include/linuxmt/debug.h
+++ b/elks/include/linuxmt/debug.h
@@ -27,7 +27,7 @@
 /*
  * Kernel debug options, set =1 to turn on. Works across multiple files.
  */
-#define DEBUG_EVENT	1		/* generate debug events on CTRLP*/
+#define DEBUG_EVENT	0		/* generate debug events on CTRLP*/
 #define DEBUG_STARTDEF	1		/* default startup debug display*/
 #define DEBUG_BIOS	0		/* BIOS driver*/
 #define DEBUG_BLK	0		/* block i/o*/

--- a/elkscmd/disk_utils/fsck.c
+++ b/elkscmd/disk_utils/fsck.c
@@ -745,7 +745,7 @@ void check_file(struct minix_inode * dir, unsigned long offset)
 	printd("\n");
 	if (ino >= INODES) {
 		print_current_name();
-		printf(" contains a bad inode number %d for file '", ino);
+		printf(" contains a bad inode number %u for file '", ino);
 		printf("%.*s'.",14,name); /* FIXME 14 can be integrated */
 		if (ask(" Remove",1)) {
 			*(unsigned short *)(name-2) = 0;


### PR DESCRIPTION
Fixes major MINIX filesystem indirect block allocation problem seen when running with new asynchronous I/O SSD-TEST driver.

Moves `wait_for_buffer` to entry of `map_buffer` to synchronize possible previously requested I/O, required to fix data corruption with simultaneous multiple processes writing MINIX filesystem.

Drops I/O requested through `ll_rw_blk` when buffer not dirty; a kernel message is displayed instead. Should only be seen with remaining possible filesystem problems, such as simultaneously creating and writing to the same file, for which ELKS may show an unallocated inode in a MINIX fs free inode bitmap.

Minor updates to SSD driver to eliminate occasional NULL request problem.
Updates `CHECK_REQUEST` for more request queue checking.