### PR TITLE
[kernel] Rewrite FAT filesystem file read/write to not use L1 buffers

### DIFF
--- a/elks/fs/msdos/file.c
+++ b/elks/fs/msdos/file.c
@@ -62,10 +62,9 @@ static size_t msdos_file_read(register struct inode *inode,register struct file 
 	char *buf,size_t count)
 {
 	char *start;
-	size_t left,offset,size;
+	size_t left, offset, secoff, size;
 	sector_t sector;
 	struct buffer_head *bh;
-	void *data;
 
 	//debug_fat("file_read cnt %u\n", count);
 	if (!inode) {
@@ -82,11 +81,12 @@ static size_t msdos_file_read(register struct inode *inode,register struct file 
 		if (!(sector = msdos_smap(inode,filp->f_pos >> SECTOR_BITS(inode))))
 			break;
 		offset = (int)filp->f_pos & (SECTOR_SIZE(inode)-1);
-		if (!(bh = msdos_sread(inode->i_sb,sector,&data))) break;
+		if (!(bh = msdos_sread_nomap(inode->i_sb,sector, &secoff))) break;
 		filp->f_pos += (size = MIN(SECTOR_SIZE(inode)-offset,left));
-		memcpy_tofs(buf,(char *)data+offset,size);
+		xms_fmemcpyb(buf, current->t_regs.ds,
+			buffer_data(bh) + offset + secoff, buffer_seg(bh), size);
 		buf += size;
-		unmap_brelse(bh);
+		brelse(bh);
 	}
 	if (start == buf) return -EIO;
 	return buf-start;
@@ -97,11 +97,10 @@ static size_t msdos_file_write(register struct inode *inode,register struct file
     size_t count)
 {
 	sector_t sector;
-	int offset,size,written;
+	size_t offset, secoff, size, written;
 	int error;
 	char *start;
 	struct buffer_head *bh;
-	void *data;
 
 	debug_fat("file_write\n");
 	if (!inode) {
@@ -125,12 +124,12 @@ static size_t msdos_file_write(register struct inode *inode,register struct file
 		if (error) break;
 		offset = (int)filp->f_pos & (SECTOR_SIZE(inode)-1);
 		size = MIN(SECTOR_SIZE(inode)-offset,count);
-		if (!(bh = msdos_sread(inode->i_sb,sector,&data))) {
+		if (!(bh = msdos_sread_nomap(inode->i_sb,sector, &secoff))) {
 			error = -EIO;
 			break;
 		}
-		memcpy_fromfs((char *)data+((int)filp->f_pos & (SECTOR_SIZE(inode)-1)),
-			    buf,written = size);
+		xms_fmemcpyb(buffer_data(bh) + offset + secoff, buffer_seg(bh),
+			buf, current->t_regs.ds, written = size);
 		buf += size;
 		filp->f_pos += written;
 		if (filp->f_pos > inode->i_size) {
@@ -139,7 +138,7 @@ static size_t msdos_file_write(register struct inode *inode,register struct file
 		}
 		debug_fat("file block write %lu\n", buffer_blocknr(bh));
 		mark_buffer_dirty(bh);
-		unmap_brelse(bh);
+		brelse(bh);
 	}
 	inode->i_mtime = CURRENT_TIME;
 	inode->u.msdos_i.i_attrs |= ATTR_ARCH;

--- a/elks/include/linuxmt/limits.h
+++ b/elks/include/linuxmt/limits.h
@@ -5,10 +5,15 @@
 #define MAX_TASKS	16	/* Max # processes */
 
 #ifdef CONFIG_ARCH_PC98
-#define KSTACK_BYTES	740	/* Size of kernel stacks */
+#define KSTACK_BYTES	740	/* Size of kernel stacks for PC-98 */
 #else
-#define KSTACK_BYTES	640	/* Size of kernel stacks */
+#ifdef CONFIG_ASYNCIO
+#define KSTACK_BYTES	700	/* Size of kernel stacks w/async I/O */
+#else
+#define KSTACK_BYTES	640	/* Size of kernel stacks w/sync I/O */
 #endif
+#endif
+
 #define ISTACK_BYTES    512     /* Size of interrupt stack */
 
 #define KSTACK_GUARD    100     /* bytes before CHECK_KSTACK overflow warning */

--- a/elks/include/linuxmt/msdos_fs.h
+++ b/elks/include/linuxmt/msdos_fs.h
@@ -117,6 +117,7 @@ struct fat_cache {
 
 /* misc.c */
 
+struct buffer_head * FATPROC msdos_sread_nomap(struct super_block *s, sector_t sector, size_t *offset);
 struct buffer_head * FATPROC msdos_sread(struct super_block *s, sector_t sector, void **start);
 void FATPROC lock_creation(void);
 void FATPROC unlock_creation(void);

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -14,6 +14,6 @@ wd0=10,0x300,0xCC00,0x80
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.sys
 #init=/bin/sh		# singleuser sh
 #root=hda1 ro		# root hd partition 1 read-only
-#kstack
+kstack
 #strace
 #console=ttyS0,19200 3


### PR DESCRIPTION
The previous FAT filesystem code was 'mapping` all file read/write (and exec) data through system L1 buffers, for really no good reason. This rewrites that code to copy directly to/from application buffers and L2 buffers. On older systems, this could increase percieved FAT file I/O speed, since an unneeded extra copy of every disk block (two sectors) into an L1 buffer is not performed.

It is also possible that the extra 4 L1 buffers required (from the existing 12) when FAT is compiled in may be able to be reduced... more testing needed before that change is made.

It was also discovered using the new kernel stack tracing code that the kernel stack was immediately overflowing when running /bin/sh using KSTACK_BYTES of 640 with CONFIG_ASYNCIO set. This is increased to 700 after the stack tracing showed 668 bytes are currently required. This is pretty close, more testing may require an increased kernel stack. Kernel stack tracing using `kstack` is defaulted back to ON for future development.

