### PR TITLE
[kernel] Cleanup inode code and fix inode count on execve

### DIFF
--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -494,25 +494,24 @@ int sys_execve(const char *filename, char *sptr, size_t slen)
 	} while (++i < NR_OPEN);
     }
 
-    {
+    iput(currentp->t_inode);
+    currentp->t_inode = inode;
+
     /* this could be a good place to set the effective user identifier
      * in case the suid bit of the executable had been set */
 
-	currentp->t_inode = inode;
-
     /* can I trust the following fields?  */
-	if (inode->i_mode & S_ISUID)
-	    currentp->euid = inode->i_uid;
-	if (inode->i_mode & S_ISGID)
-	    currentp->egid = inode->i_gid;
-    }
+    if (inode->i_mode & S_ISUID)
+        currentp->euid = inode->i_uid;
+    if (inode->i_mode & S_ISGID)
+        currentp->egid = inode->i_gid;
 
     currentp->t_enddata = (__pptr) ((__u16)mh.dseg + (__u16)mh.bseg + base_data);
     currentp->t_endbrk =  currentp->t_enddata;
 
-	/* ease libc memory allocations by setting even break address*/
-	if ((int)currentp->t_endbrk & 1)
-		currentp->t_endbrk++;
+    /* ease libc memory allocations by setting even break address*/
+    if ((int)currentp->t_endbrk & 1)
+        currentp->t_endbrk++;
 
     /*
      *      Arrange our return to be to CS:entry

--- a/elks/fs/minix/namei.c
+++ b/elks/fs/minix/namei.c
@@ -125,8 +125,7 @@ int minix_lookup(register struct inode *dir, const char *name, size_t len,
 	if (S_ISDIR(dir->i_mode)) {
 	    debug("minix_lookup: Entering minix_find_entry\n");
 	    bh = minix_find_entry(dir, name, len, &de);
-	    debug("minix_lookup: minix_find_entry returned %x %d\n", bh,
-		   bh->b_mapcount);
+	    debug("minix_lookup: minix_find_entry returned %x %d\n", bh, bh->b_mapcount);
 	    if (bh) {
 		*result = iget(dir->i_sb, (ino_t) de->inode);
 		unmap_brelse(bh);

--- a/elks/fs/read_write.c
+++ b/elks/fs/read_write.c
@@ -63,8 +63,7 @@ int sys_lseek(unsigned int fd, loff_t * p_offset, unsigned int origin)
  *    EFAULT: buf is outside your accessible address space.
  */
 
-int fd_check(unsigned int fd, char *buf, size_t count, int rw,
-	     struct file **file)
+int fd_check(unsigned int fd, char *buf, size_t count, int rw, struct file **file)
 {
     register struct file *tfil;
 

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -177,8 +177,6 @@ typedef struct buffer_head	ext_buffer_head;
 #define BLOCK_READ	0
 #define BLOCK_WRITE	1
 
-#define iget(_a, _b) __iget(_a, _b)
-
 void brelse(struct buffer_head *);
 void bforget(struct buffer_head *);
 void wait_on_buffer (struct buffer_head *);
@@ -206,7 +204,6 @@ struct inode {
     struct inode		*i_next;
     struct inode		*i_prev;
     struct inode		*i_mount;
-    struct wait_queue		i_wait;
     unsigned short		i_count;
     unsigned short		i_flags;
     unsigned char		i_lock;
@@ -411,7 +408,7 @@ extern int sys_close(unsigned int);	/* yes, it's really unsigned */
 
 extern void _close_allfiles(void);
 
-extern struct inode *__iget(struct super_block *,ino_t);
+extern struct inode *iget(struct super_block *,ino_t);
 
 /*@+namechecks@*/
 

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -168,7 +168,7 @@ static void vprintk(const char *fmt, va_list p)
 	    switch (c) {
 	    case 'i':
 	    case 'd':
-		c = 'd'-('X' - 'P');
+		c = 'd';
 		n = 18;
 	    case 'o':
 		n -= 2;

--- a/elks/net/socket.c
+++ b/elks/net/socket.c
@@ -112,7 +112,7 @@ static struct socket *sock_alloc(void)
 
     *sock = ini_sock;
 
-    sock->wait = &inode->i_wait;
+    sock->wait = (struct wait_queue *)inode; /* sockets wait on same wq as inodes locks */
     sock->inode = inode;	/* "backlink" use pointer arithmetic instead */
 
     return sock;


### PR DESCRIPTION
Adds ability to display in-use inode table using ^P with DEBUG_FREE_INODES_COUNT set.

Fixes unmatched `iput` in sys_execve resulting in current program inode not released after every exec system call, slowly eating away inode entries from the 96 inode table.

Cleans up inode-related source code; removes `struct wait_queue i_wait` from inode structure, uses address of inode instead to save kernel RAM (x 96 bytes).

Fixes small problem in `printk` using %d from last commit.

