### PR TITLE
[kernel] Add optional display of kernel buffer status

### DIFF
--- a/elks/include/linuxmt/debug.h
+++ b/elks/include/linuxmt/debug.h
@@ -27,7 +27,7 @@
 /*
  * Kernel debug options, set =1 to turn on. Works across multiple files.
  */
-#define DEBUG_EVENT	0		/* generate debug events on CTRLP*/
+#define DEBUG_EVENT	1		/* generate debug events on CTRLP*/
 #define DEBUG_STARTDEF	1		/* default startup debug display*/
 #define DEBUG_BIOS	0		/* BIOS driver*/
 #define DEBUG_BLK	0		/* block i/o*/

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -14,6 +14,6 @@ wd0=10,0x300,0xCC00,0x80
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.sys
 #init=/bin/sh		# singleuser sh
 #root=hda1 ro		# root hd partition 1 read-only
-kstack
+#kstack
 #strace
 #console=ttyS0,19200 3


### PR DESCRIPTION
When enabled, typing ^P will display the status of all kernel system buffers, for help in debugging async I/O and block driver development. 

Following is a display showing various buffers with `L`ocked, `D`irty and `U`ptodate bits, along with L1 buffer usage (labeled L1-L12):
```
#  1: buf   7 dev 0x0200 block    44   U mapped L12 0 count 0
#  2: buf  17 dev 0x0200 block     5   U mapped L10 0 count 0
#  3: buf  10 dev 0x0380 block    27   U mapped L08 0 count 0
#  4: buf  18 dev 0x0380 block    29   U mapped L09 0 count 0
#  5: buf   3 dev 0x0200 block    43   U mapped L06 0 count 0
#  6: buf  19 dev 0x0200 block    42   U mapped L05 0 count 0
#  7: buf   6 dev 0x0200 block    41 LDU mapped L03 0 count 1
#  8: buf  16 dev 0x0200 block     4   U mapped L07 0 count 0
#  9: buf  15 dev 0x0200 block    40   U mapped L01 0 count 0
# 10: buf  12 dev 0x0200 block    39 L U mapped L00 0 count 0
# 11: buf   4 dev 0x0200 block    38 L U mapped L00 0 count 0
# 12: buf  14 dev 0x0200 block    37 LDU mapped L00 0 count 1
# 13: buf   5 dev 0x0200 block    34  DU mapped L00 0 count 0
# 14: buf  13 dev 0x0200 block    32   U mapped L02 0 count 0
# 15: buf   8 dev 0x0200 block     3  DU mapped L04 0 count 1
# 16: buf  11 dev 0x0200 block     2  DU mapped L11 0 count 1
# 17: buf   9 dev 0x0200 block     1   U mapped L00 0 count 1
# 18: buf   2 dev 0x0380 block     3   U mapped L00 0 count 1
# 19: buf   1 dev 0x0380 block     2   U mapped L00 0 count 1
# 20: buf   0 dev 0x0380 block     1   U mapped L00 0 count 1
Total buffers inuse 11/20
```
Interestingly, not as many buffers are marked inuse than I had suspected.
