### PR TITLE
[kernel] Refactor debug events, add display inode table with ^N

### DIFF
--- a/elks/arch/i86/drivers/block/ssd.c
+++ b/elks/arch/i86/drivers/block/ssd.c
@@ -151,6 +151,7 @@ static void do_ssd_request(void)
         return;
 #else
         ssd_io_complete();                  /* synchronous I/O */
+        return;
 #endif
     }
 }

--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -72,8 +72,8 @@ int tty_intcheck(register struct tty *ttyp, unsigned char key)
 	if (key == ttyp->termios.c_cc[VSUSP])
 	    sig = SIGTSTP;
 #if DEBUG_EVENT
-	if (key == ('P' & 0x1f)) {	/* ctrl-P*/
-	    debug_event();
+	if (key >= ('N' & 0x1f) && key <= ('P' & 0x1f)) {       /* CTRLN-CTRLP */
+	    debug_event((key - 'N') & 0x1f);
 	    return 1;
 	}
 #endif

--- a/elks/fs/file_table.c
+++ b/elks/fs/file_table.c
@@ -7,6 +7,7 @@
 #include <linuxmt/types.h>
 #include <linuxmt/config.h>
 #include <linuxmt/fs.h>
+#include <linuxmt/limits.h>
 #include <linuxmt/fcntl.h>
 #include <linuxmt/stat.h>
 #include <linuxmt/string.h>

--- a/elks/fs/namei.c
+++ b/elks/fs/namei.c
@@ -48,11 +48,6 @@ int permission(register struct inode *inode, int mask)
         !S_ISCHR(inode->i_mode) && !S_ISBLK(inode->i_mode)) /* allow writable devices*/
 	error = -EROFS;
 
-#ifdef BLOAT_FS
-    else if (inode->i_op && inode->i_op->permission)
-	error = inode->i_op->permission(inode, mask);
-#endif
-
 #ifdef HAVE_IMMUTABLE
     else if ((mask & S_IWOTH) && IS_IMMUTABLE(inode))
 	/* Nobody gets write access to an immutable file */

--- a/elks/include/linuxmt/debug.h
+++ b/elks/include/linuxmt/debug.h
@@ -3,31 +3,16 @@
 
 /* linuxmt/include/linuxmt/debug.h for ELKS v. >=0.0.47
  * (C) 1997 Chad Page
+ * Al Riddoch <ajr@ecs.soton.ac.uk> 14th Oct. 1997
  * 
  * This file contains the #defines to turn on and off various printk()-related
  * functions...
  */
 
-/* Found that strings were still included if debugging disabled so
- * re-organised so that each has a different macro depending on the number
- * of paramaters such that the parameters are not compiled in.
- *
- * Al Riddoch <ajr@ecs.soton.ac.uk> 14th Oct. 1997
- */
-
-/* This switches which version of the kstack-tracker gets used */
-
-/* Replaced by the 'true' kernel-strace */
-#ifdef DEBUG
-#define pstrace printk
-#else
-#define pstrace(_a)
-#endif
-
 /*
  * Kernel debug options, set =1 to turn on. Works across multiple files.
  */
-#define DEBUG_EVENT	1		/* generate debug events on CTRLP*/
+#define DEBUG_EVENT     1               /* generate debug events on CTRLN-CTRLP*/
 #define DEBUG_STARTDEF	1		/* default startup debug display*/
 #define DEBUG_BIOS	0		/* BIOS driver*/
 #define DEBUG_BLK	0		/* block i/o*/
@@ -45,14 +30,14 @@
 
 #if DEBUG_EVENT
 void dprintk(const char *, ...);        /* printk when debugging on*/
-void debug_event(void);			/* generate debug event*/
-void debug_setcallback(void (*cbfunc)()); /* callback on debug event*/
+void debug_event(int evnum);            /* generate debug event*/
+void debug_setcallback(int evnum, void (*cbfunc)()); /* callback on debug event*/
 #define PRINTK		dprintk
 #else
 #define PRINTK		printk
 #define dprintk(...)
-#define debug_callback(...)
-#define debug_event(...)
+#define debug_event(evnum)
+#define debug_setcallback(evnum,cbfunc)
 #endif
 
 #if DEBUG_BIOS

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -47,10 +47,6 @@
 
 #define NR_OPEN 	20
 
-#define NR_INODE	96	/* this should be bigger than NR_FILE */
-#define NR_FILE 	64	/* this can well be larger on a larger system */
-#define NR_SUPER	6
-
 #define BLOCK_SIZE	1024
 #define BLOCK_SIZE_BITS 10
 

--- a/elks/include/linuxmt/limits.h
+++ b/elks/include/linuxmt/limits.h
@@ -1,16 +1,18 @@
 #ifndef __LINUXMT_LIMITS_H
 #define __LINUXMT_LIMITS_H
 
-/* tunable parameters */
-#define MAX_TASKS	16	/* Max # processes */
+/* tunable parameters - changing these can have a large effect on kernel data size */
+
+/* kernel */
+#define MAX_TASKS       16      /* Max # processes */
 
 #ifdef CONFIG_ARCH_PC98
-#define KSTACK_BYTES	740	/* Size of kernel stacks for PC-98 */
+#define KSTACK_BYTES    740     /* Size of kernel stacks for PC-98 */
 #else
 #ifdef CONFIG_ASYNCIO
-#define KSTACK_BYTES	700	/* Size of kernel stacks w/async I/O */
+#define KSTACK_BYTES    700     /* Size of kernel stacks w/async I/O */
 #else
-#define KSTACK_BYTES	640	/* Size of kernel stacks w/sync I/O */
+#define KSTACK_BYTES    640     /* Size of kernel stacks w/sync I/O */
 #endif
 #endif
 
@@ -18,13 +20,18 @@
 
 #define KSTACK_GUARD    100     /* bytes before CHECK_KSTACK overflow warning */
 
-#define POLL_MAX	6	/* Maximum number of polled queues per process */
+#define POLL_MAX        6       /* Maximum number of polled queues per process */
 
-#define NR_ALARMS	5	/* Max number of simultaneous alarms system-wide */
-#define NGROUPS		13	/* Supplementary groups */
+/* filesystem */
+#define NR_INODE        96      /* this should be bigger than NR_FILE */
+#define NR_FILE         64      /* this can well be larger on a larger system */
+#define NR_SUPER        6       /* max mounts */
 
-#define PIPE_BUFSIZ	80	/* doesn't have to be power of two */
+#define PIPE_BUFSIZ     80      /* doesn't have to be power of two */
 
-#define MAX_PACKET_ETH 1536	/* Max packet size, 6 blocks of 256 bytes */
+#define NR_ALARMS       5       /* Max number of simultaneous alarms system-wide */
+#define NGROUPS         13      /* Supplementary groups */
+
+#define MAX_PACKET_ETH 1536     /* Max packet size, 6 blocks of 256 bytes */
 
 #endif /* !__LINUXMT_LIMITS_H */

--- a/elks/include/linuxmt/minix_fs.h
+++ b/elks/include/linuxmt/minix_fs.h
@@ -11,7 +11,6 @@
 
 #define MINIX_ROOT_INO 1
 
-/* Not the same as the bogus LINK_MAX in <linux/limits.h>. Oh well. */
 #define MINIX_LINK_MAX	250
 
 /* MINIX V1 buffers for inode and zone bitmaps*/

--- a/elks/include/linuxmt/trace.h
+++ b/elks/include/linuxmt/trace.h
@@ -32,6 +32,9 @@
 /* integrity check application SS on interrupts from user mode */
 #define CHECK_SS
 
+/* check buffer and inode free counts, list inodes w/^N and buffers w/^O */
+#define CHECK_FREECNTS
+
 #endif /* CONFIG_TRACE */
 
 

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -275,19 +275,22 @@ void panic(const char *error, ...)
 
 int dprintk_on = DEBUG_STARTDEF;	/* toggled by debug events*/
 #if DEBUG_EVENT
-static void (*dprintk_cb)();		/* debug event callback function*/
+static void (*debug_cbfuncs[3])();  /* debug event callback function*/
 
-void debug_setcallback(void (*cbfunc)())
+void debug_setcallback(int evnum, void (*cbfunc)())
 {
-    dprintk_cb = cbfunc;
+    if ((unsigned)evnum < 3)
+        debug_cbfuncs[evnum] = cbfunc;
 }
 
-void debug_event(void)
+void debug_event(int evnum)
 {
-    dprintk_on = !dprintk_on;
-    if (dprintk_cb)
-	dprintk_cb();
-    kill_all(SIGURG);
+    if (evnum == 2) {           /* CTRLP toggles dprintk*/
+        dprintk_on = !dprintk_on;
+        kill_all(SIGURG);
+    }
+    if (debug_cbfuncs[evnum])
+	debug_cbfuncs[evnum]();
 }
 
 void dprintk(const char *fmt, ...)

--- a/elkscmd/file_utils/df.c
+++ b/elkscmd/file_utils/df.c
@@ -25,6 +25,7 @@
 #include <sys/mount.h>
 #include <linuxmt/minix_fs.h>
 #include <linuxmt/fs.h>
+#include <linuxmt/limits.h>
 
 #define BLOCK_SIZE	1024
 

--- a/elkscmd/sys_utils/mount.c
+++ b/elkscmd/sys_utils/mount.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <sys/mount.h>
 #include <linuxmt/fs.h>
+#include <linuxmt/limits.h>
 
 #define errmsg(str) write(STDERR_FILENO, str, sizeof(str) - 1)
 


### PR DESCRIPTION
Adds the ability to display active inode table using Ctrl-N.
System buffer status displayed using Ctrl-O.
The associated display routines can be called at interrupt time or through keystroke.
The above options enabled using `CHECK_FREECNTS` and `DEBUG_EVENTS`.

Adds `CHECK_FREECNTS` to trace.h to add freelist size checking code for nodes and buffers.

Moves `NR_INODES`, `NR_FILES` and `NR_SUPER` to limits.h.
Cleans up more inode.c filesystem bloat and if 0 code.

Refactored debug callback events, there are now three possible, using Ctrl-N, Ctrl-O and Ctrl-P. Ctrl-P is still used to toggle display of debug_xxx options set in debug.h.

