### PR TITLE
[kernel] Rewrite block requests to use start sector and count rather than block number

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -848,7 +848,7 @@ static int bioshd_ioctl(struct inode *inode,
     int dev, err;
 
     /* get sector size called with NULL inode and arg = superblock s_dev */
-    if (cmd == HDIO_GET_SECTOR_SIZE)
+    if (cmd == IOCTL_BLK_GET_SECTOR_SIZE)
 	return drive_info[DEVICE_NR(arg)].sector_size;
 
     if (!inode || !inode->i_rdev)

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -1062,9 +1062,9 @@ static void do_bioshd_request(void)
 	    continue;
 	}
 
-	/* all ELKS requests are 1K blocks*/
-	count = BLOCK_SIZE / drivep->sector_size;
-	start = req->rq_blocknr * count;
+	/* get request start sector and sector count */
+	count = req->rq_nr_sectors;
+	start = req->rq_sector;
 
 	if (hd[minor].start_sect == -1U || start >= hd[minor].nr_sects) {
 	    printk("bioshd: bad partition start=%ld sect=%ld nr_sects=%ld.\n",

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -835,7 +835,7 @@ int INITPROC bioshd_init(void)
 	}
 	bioshd_initialized = 1;
     } else {
-	printk("bioshd: unable to register %d\n", MAJOR_NR);
+	printk("bioshd: init error\n");
     }
     return count;
 }

--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -9,15 +9,15 @@
 #include <linuxmt/trace.h>
 
 struct request {
-    kdev_t rq_dev;
+    kdev_t rq_dev;              /* block device */
     unsigned char rq_cmd;       /* READ or WRITE */
     unsigned char rq_status;    /* RQ_INACTIVE or RQ_ACTIVE */
-    sector_t rq_sector;         /* start sector # */
+    sector_t rq_sector;         /* start device logical sector # */
     unsigned int rq_nr_sectors; /* multi-sector I/O # sectors */
-    char *rq_buffer;
-    ramdesc_t rq_seg;           /* L2 main/xms buffer segment */
-    struct buffer_head *rq_bh;
-    struct request *rq_next;
+    char *rq_buffer;            /* I/O buffer address */
+    ramdesc_t rq_seg;           /* L1 or L2 ext/xms buffer segment */
+    struct buffer_head *rq_bh;  /* system buffer head for notifications and locking */
+    struct request *rq_next;    /* next request, used when async I/O */
 };
 
 #define RQ_INACTIVE	0

--- a/elks/arch/i86/drivers/block/directhd.c
+++ b/elks/arch/i86/drivers/block/directhd.c
@@ -480,8 +480,8 @@ void do_directhd_request(void)
 	    continue;
 	}
 
-	count = BLOCK_SIZE / 512;
-	start = req->rq_blocknr * count;
+	count = req->rq_nr_sectors;
+	start = req->rq_sector;
 	buff = req->rq_buffer;
 
 	/* safety check should be here */

--- a/elks/arch/i86/drivers/block/ll_rw_blk.c
+++ b/elks/arch/i86/drivers/block/ll_rw_blk.c
@@ -71,7 +71,6 @@ int get_sector_size(kdev_t dev)
     if (!fops || !fops->ioctl ||
         (size = fops->ioctl(NULL, NULL, IOCTL_BLK_GET_SECTOR_SIZE, dev)) <= 0)
             size = 512;
-    printk("Sector size %d!!\n", size);
     return size;
 }
 
@@ -245,7 +244,8 @@ static void make_request(unsigned short major, int rw, struct buffer_head *bh)
 
     /* fill up the request-info, and add it to the queue */
     req->rq_cmd = rw;
-    req->rq_blocknr = buffer_blocknr(bh);
+    req->rq_nr_sectors = BLOCK_SIZE / get_sector_size(req->rq_dev);
+    req->rq_sector = buffer_blocknr(bh) * req->rq_nr_sectors;
     req->rq_seg = buffer_seg(bh);
     req->rq_buffer = buffer_data(bh);
     req->rq_bh = bh;

--- a/elks/arch/i86/drivers/block/rd.c
+++ b/elks/arch/i86/drivers/block/rd.c
@@ -301,5 +301,5 @@ void rd_init(void)
 #endif
 #endif /* CONFIG_RAMDISK_SEGMENT*/
     } else
-	printk("rd: unable to register %d\n", MAJOR_NR);
+	printk("rd: init error\n");
 }

--- a/elks/arch/i86/drivers/block/ssd-sd.c
+++ b/elks/arch/i86/drivers/block/ssd-sd.c
@@ -590,51 +590,31 @@ int ssddev_ioctl(struct inode *inode, struct file *file,
 }
 
 /**
- * SSD API: Writes one 1K block (two sectors) to the SD card.
+ * SSD API: Writes one sector to the SD card.
  * 
- * returns: 0 on error, 1 if just one sector was written, 2 on success.
+ * returns: # sectors written.
  */
-int ssddev_write_blk(sector_t start, char *buf, ramdesc_t seg)
+int ssddev_write(sector_t start, char *buf, ramdesc_t seg)
 {
     int ret;
 
     ret = sd_write(buf, seg, start);
-    if (ret != 0) {
-        /* no sectors were written */
+    if (ret != 0)       /* error, no sectors were written */
         return 0;
-    }
-
-    ret = sd_write(buf + SD_FIXED_SECTOR_SIZE, seg, start + 1);
-    if (ret != 0) {
-        /* just one sector was written */
-        return 1;
-    }
-
-    /* both sectors were written */
-    return 2;
+    return 1;
 }
 
 /**
- * SSD API: Reads one 1K block (two sectors) to the SD card.
+ * SSD API: Reads one sector from the SD card.
  * 
- * returns: 0 on error, 1 if just one sector was read, 2 on success.
+ * returns: # sectors read.
  */
-int ssddev_read_blk(sector_t start, char *buf, ramdesc_t seg)
+int ssddev_read(sector_t start, char *buf, ramdesc_t seg)
 {
     int ret;
 
     ret = sd_read(buf, seg, start);
-    if (ret != 0) {
-        /* no sectors were read */
+    if (ret != 0)       /* error, no sectors were read */
         return 0;
-    }
-
-    ret = sd_read(buf + SD_FIXED_SECTOR_SIZE, seg, start + 1);
-    if (ret != 0) {
-        /* just one sector was read */
-        return 1;
-    }
-
-    /* both sectors were read */
-    return 2;
+    return 1;
 }

--- a/elks/arch/i86/drivers/block/ssd-test.c
+++ b/elks/arch/i86/drivers/block/ssd-test.c
@@ -74,20 +74,22 @@ int ssddev_ioctl(struct inode *inode, struct file *file,
     return -EINVAL;
 }
 
-/* write one 1K block (two sectors) to SSD */
-int ssddev_write_blk(sector_t start, char *buf, ramdesc_t seg)
+/* write one sector to SSD */
+int ssddev_write(sector_t start, char *buf, ramdesc_t seg)
 {
     unsigned long offset = start << 9;
 
-    xms_fmemcpyw(0, ssd_seg->base + (unsigned int)(offset >> 4), buf, seg, 1024/2);
-    return 2;	/* # sectors written */
+    xms_fmemcpyw(0, ssd_seg->base + (unsigned int)(offset >> 4), buf, seg,
+        SD_FIXED_SECTOR_SIZE/2);
+    return 1;	/* # sectors written */
 }
 
-/* read one 1K block (two sectors) from SSD */
-int ssddev_read_blk(sector_t start, char *buf, ramdesc_t seg)
+/* read one sector from SSD */
+int ssddev_read(sector_t start, char *buf, ramdesc_t seg)
 {
     unsigned long offset = start << 9;
 
-    xms_fmemcpyw(buf, seg, 0, ssd_seg->base + (unsigned int)(offset >> 4), 1024/2);
-    return 2;	/* # sectors read */
+    xms_fmemcpyw(buf, seg, 0, ssd_seg->base + (unsigned int)(offset >> 4),
+        SD_FIXED_SECTOR_SIZE/2);
+    return 1;	/* # sectors read */
 }

--- a/elks/arch/i86/drivers/block/ssd.c
+++ b/elks/arch/i86/drivers/block/ssd.c
@@ -93,30 +93,33 @@ void ssd_io_complete(void)
            panic("SSD: ADDR CHANGED req seg:buf %04x:%04x bh seg:buf %04x:%04x\n",
                 req->rq_seg, req->rq_buffer, buffer_seg(bh), buffer_data(bh));
         }
-        if (req->rq_blocknr != buffer_blocknr(bh)) {
-            panic("SSD: BLOCKNR CHANGED req %ld bh %ld\n",
-                req->rq_blocknr, buffer_blocknr(bh));
+        // FIXME driver can't handle count != 2 sectors nor non-buffer head I/O
+        if (req->rq_sector != buffer_blocknr(bh) * (BLOCK_SIZE / SD_FIXED_SECTOR_SIZE)) {
+            panic("SSD: SECTOR/BLOCKNR CHANGED req %ld bh %ld\n",
+                req->rq_sector, buffer_blocknr(bh));
         }
 #endif
 
         buf = req->rq_buffer;
         seg = req->rq_seg;
-        start = req->rq_blocknr * (BLOCK_SIZE / SD_FIXED_SECTOR_SIZE);
+        start = req->rq_sector;
 
-        /* all ELKS requests are 1K blocks = 2 sectors */
-        if (start >= NUM_SECTS-1) { // FIXME move to ll_rw_blk level
-            printk("SSD: bad request block %lu cmd %d\n", start/2, req->rq_cmd);
+        // FIXME driver can't handle count != 2 sectors
+        // FIXME move max sector check to to ll_rw_blk level
+        if (start >= (NUM_SECTS-1) || req->rq_nr_sectors != 2) {
+            printk("SSD: bad request sector %lu count %d cmd %d\n", start,
+                req->rq_nr_sectors, req->rq_cmd);
             end_request(0);
             continue;
         }
         if (req->rq_cmd == WRITE) {
-            debug_blk("SSD: writing block %lu\n", start/2);
+            debug_blk("SSD: writing sector %lu\n", start);
             ret = ssddev_write_blk(start, buf, seg);
         } else {
-            debug_blk("SSD: reading block %lu\n", start/2);
+            debug_blk("SSD: reading sector %lu\n", start);
             ret = ssddev_read_blk(start, buf, seg);
         }
-        if (ret != 2) {
+        if (ret != req->rq_nr_sectors) {
             end_request(0);         /* I/O error */
             continue;
         }

--- a/elks/arch/i86/drivers/block/ssd.c
+++ b/elks/arch/i86/drivers/block/ssd.c
@@ -44,7 +44,7 @@ void ssd_init(void)
     }
     if (NUM_SECTS)
         printk("ssd: %ldK disk\n", NUM_SECTS/2UL);
-    else printk("ssd: initialization error\n");
+    else printk("ssd: init error\n");
 }
 
 static int ssd_open(struct inode *inode, struct file *filp)
@@ -93,7 +93,6 @@ void ssd_io_complete(void)
            panic("SSD: ADDR CHANGED req seg:buf %04x:%04x bh seg:buf %04x:%04x\n",
                 req->rq_seg, req->rq_buffer, buffer_seg(bh), buffer_data(bh));
         }
-        // FIXME driver can't handle count != 2 sectors nor non-buffer head I/O
         if (req->rq_sector != buffer_blocknr(bh) * (BLOCK_SIZE / SD_FIXED_SECTOR_SIZE)) {
             panic("SSD: SECTOR/BLOCKNR CHANGED req %ld bh %ld\n",
                 req->rq_sector, buffer_blocknr(bh));

--- a/elks/arch/i86/drivers/block/ssd.c
+++ b/elks/arch/i86/drivers/block/ssd.c
@@ -80,7 +80,6 @@ void ssd_io_complete(void)
     for (;;) {
         char *buf;
         int count;
-        ramdesc_t seg;
         sector_t start;
 
         req = CURRENT;
@@ -102,7 +101,6 @@ void ssd_io_complete(void)
 #endif
 
         buf = req->rq_buffer;
-        seg = req->rq_seg;
         start = req->rq_sector;
 
         // FIXME move max sector check to to ll_rw_blk level
@@ -115,10 +113,10 @@ void ssd_io_complete(void)
         for (count = 0; count < req->rq_nr_sectors; count++) {
             if (req->rq_cmd == WRITE) {
                 debug_blk("SSD: writing sector %lu\n", start);
-                ret = ssddev_write(start, buf, seg);
+                ret = ssddev_write(start, buf, req->rq_seg);
             } else {
                 debug_blk("SSD: reading sector %lu\n", start);
-                ret = ssddev_read(start, buf, seg);
+                ret = ssddev_read(start, buf, req->rq_seg);
             }
             if (ret != 1)           /* I/O error */
                 break;

--- a/elks/arch/i86/drivers/block/ssd.h
+++ b/elks/arch/i86/drivers/block/ssd.h
@@ -1,6 +1,7 @@
 #ifndef _SSD_H
 #define _SSD_H
 
+/* if sector size not 512, must implement IOCTL_BLK_GET_SECTOR_SIZE */
 #define SD_FIXED_SECTOR_SIZE 512
 
 sector_t ssddev_init(void);

--- a/elks/arch/i86/drivers/block/ssd.h
+++ b/elks/arch/i86/drivers/block/ssd.h
@@ -7,7 +7,7 @@
 sector_t ssddev_init(void);
 int ssddev_ioctl(struct inode *inode, struct file *file,
             unsigned int cmd, unsigned int arg);
-int ssddev_write_blk(sector_t start, char *buf, ramdesc_t seg);
-int ssddev_read_blk(sector_t start, char *buf, ramdesc_t seg);
+int ssddev_write(sector_t start, char *buf, ramdesc_t seg);
+int ssddev_read(sector_t start, char *buf, ramdesc_t seg);
 
 #endif /* !_SSD_H */

--- a/elks/arch/i86/drivers/char/console-serial-8018x.c
+++ b/elks/arch/i86/drivers/char/console-serial-8018x.c
@@ -167,7 +167,7 @@ void bell(void)
     serial_putc(&ports[0], 7);	/* send ^G to the Serial 0 */
 }
 
-static void sercon_conout(dev_t dev, char Ch)
+static void sercon_conout(dev_t dev, int Ch)
 {
     struct serial_info *sp = &ports[0]; /* TODO: add support for Serial 1 */
 

--- a/elks/arch/i86/drivers/char/meta.c
+++ b/elks/arch/i86/drivers/char/meta.c
@@ -90,7 +90,7 @@ static void do_meta_request(void)
 	    return;
 	udr = new_request();
 	udr->udr_type = UDR_BLK + req->rq_cmd;
-	udr->udr_ptr = req->rq_blocknr;
+	udr->udr_ptr = req->rq_sector;
 	udr->udr_minor = MINOR(req->rq_dev);
 	post_request(driver, udr);
 

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -161,8 +161,8 @@ static void list_buffer_status(void)
                     }
                 }
             }
-            printk("#%3d: buf %3d dev %D block %5ld %c%c%c mapped L%02d %d count %d\n",
-                i, buf_num(bh), ebh->b_dev, ebh->b_blocknr,
+            printk("#%3d: buf %3d blk/dev %5ld/%p %c%c%c mapped L%02d %d count %d\n",
+                i, buf_num(bh), ebh->b_blocknr, ebh->b_dev,
                 ebh->b_locked?  'L': ' ',
                 ebh->b_dirty?   'D': ' ',
                 ebh->b_uptodate?'U': ' ',

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -252,8 +252,8 @@ int INITPROC buffer_init(void)
 
 void wait_on_buffer(struct buffer_head *bh)
 {
-    ext_buffer_head *ebh = EBH(bh);
 #ifdef CONFIG_ASYNCIO
+    ext_buffer_head *ebh = EBH(bh);
     ebh->b_count++;
     wait_set((struct wait_queue *)bh);       /* use bh as wait address */
     for (;;) {
@@ -267,7 +267,7 @@ void wait_on_buffer(struct buffer_head *bh)
     ebh->b_count--;
 #endif
 #ifdef CHECK_BLOCKIO
-    if (ebh->b_locked) panic("wait_on_buffer");
+    if (EBH(bh)->b_locked) panic("wait_on_buffer");
 #endif
 }
 

--- a/elks/fs/devices.c
+++ b/elks/fs/devices.c
@@ -16,9 +16,6 @@
 #include <linuxmt/errno.h>
 
 struct device_struct {
-#ifdef CONFIG_DEV_NAMES
-    char *ds_name;
-#endif
     struct file_operations *ds_fops;
 };
 
@@ -40,11 +37,6 @@ int register_chrdev(unsigned int major, const char *name, struct file_operations
     if (major >= MAX_CHRDEV) return -EINVAL;
     if (dev->ds_fops && (dev->ds_fops != fops)) return -EBUSY;
     dev->ds_fops = fops;
-
-#ifdef CONFIG_DEV_NAMES
-    dev->ds_name = name;
-#endif
-
     return 0;
 }
 
@@ -55,16 +47,10 @@ int register_blkdev(unsigned int major, const char *name, struct file_operations
     if (major >= MAX_BLKDEV) return -EINVAL;
     if (dev->ds_fops && dev->ds_fops != fops) return -EBUSY;
     dev->ds_fops = fops;
-
-#ifdef CONFIG_DEV_NAMES
-    dev->ds_name = name;
-#endif
-
     return 0;
 }
 
 #ifdef BLOAT_FS
-
 /*
  * This routine checks whether a removable media has been changed,
  * and invalidates all buffer-cache-entries in that case. This
@@ -94,7 +80,6 @@ int check_disk_change(kdev_t dev)
 	fops->revalidate(dev);
     return 1;
 }
-
 #endif
 
 /*

--- a/elks/fs/inode.c
+++ b/elks/fs/inode.c
@@ -245,7 +245,7 @@ void iput(register struct inode *inode)
 
 static void set_ops(register struct inode *inode)
 {
-    static unsigned char tabc[] = {     //FIXME change when major nums change
+    static unsigned char tabc[] = {
 	0, 1, 2, 0, 0, 0, 3, 0,
 	0, 0, 0, 0, 4, 0, 0, 0,
     };

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -121,7 +121,7 @@ static struct super_block *msdos_read_super(struct super_block *s, char *data,
 	}
 
 #ifdef CONFIG_VAR_SECTOR_SIZE
-sb->sector_size = get_sector_size(s->s_dev);
+        sb->sector_size = get_sector_size(s->s_dev);
 	switch (sb->sector_size) {
 	case 512:
 		sb->sector_bits = 9;	/* log2(sector_size) */

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -121,12 +121,7 @@ static struct super_block *msdos_read_super(struct super_block *s, char *data,
 	}
 
 #ifdef CONFIG_VAR_SECTOR_SIZE
-	/* get disk sector size using block device ioctl */
-	struct file_operations *fops = get_blkfops(MAJOR(s->s_dev));
-
-	if (!fops || !fops->ioctl ||
-		(sb->sector_size = fops->ioctl(NULL, NULL, HDIO_GET_SECTOR_SIZE, s->s_dev)) <= 0)
-			sb->sector_size = 512;
+sb->sector_size = get_sector_size(s->s_dev);
 	switch (sb->sector_size) {
 	case 512:
 		sb->sector_bits = 9;	/* log2(sector_size) */

--- a/elks/fs/romfs/romfs.c
+++ b/elks/fs/romfs/romfs.c
@@ -90,7 +90,7 @@ static int romfs_readdir (struct inode * i, struct file * f,
 }
 
 
-static int romfs_lookup (struct inode * dir, char * name, size_t len1,
+static int romfs_lookup (struct inode * dir, const char * name, size_t len1,
 	struct inode ** result)
 {
 	int res;
@@ -113,7 +113,7 @@ static int romfs_lookup (struct inode * dir, char * name, size_t len1,
 			/* ELKS trick: the name is in the current task data segment */
 			/* TODO: remove that trick with explicit segment in call */
 			if (len2 == len1) {
-				if (!fmemcmpb ((char *)offset + 3, seg_i, name, current->t_regs.ds, len2)) {
+				if (!fmemcmpb ((char *)offset + 3, seg_i, (void *)name, current->t_regs.ds, len2)) {
 					ino = peekw (offset, seg_i);
 					break;
 				}
@@ -323,7 +323,8 @@ static struct super_block * romfs_read_super (struct super_block * s, void * dat
 	while (1) {
 		lock_super (s);
 
-		if (fmemcmpw (ROMFS_MAGIC_STR, kernel_ds, 0, CONFIG_ROMFS_BASE, ROMFS_MAGIC_LEN >> 1)) {
+		if (fmemcmpw ((void *)ROMFS_MAGIC_STR, kernel_ds, 0, CONFIG_ROMFS_BASE,
+          ROMFS_MAGIC_LEN >> 1)) {
 			printk ("romfs: no superblock at %x:0h\n", CONFIG_ROMFS_BASE);
 			res = NULL;
 			break;

--- a/elks/include/linuxmt/bioshd.h
+++ b/elks/include/linuxmt/bioshd.h
@@ -48,6 +48,4 @@
 
 #define MAX_ERRS		5
 
-#define HDIO_GET_SECTOR_SIZE    0x0330  /* ioctl get drive sector size */
-
 #endif

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -448,9 +448,7 @@ extern int open_namei(const char *,int,int,struct inode **,struct inode *);
 extern int do_mknod(char *,int,int,dev_t);
 extern void iput(struct inode *);
 
-/*extern struct inode *get_empty_inode(void); */
 extern struct inode *new_inode(struct inode *dir, __u16 mode);
-extern void insert_inode_hash(struct inode *);
 extern void clear_inode(struct inode *);
 extern int open_filp(unsigned short, struct inode *, struct file **);
 extern void close_filp(struct inode *, struct file *);
@@ -461,17 +459,12 @@ extern struct buffer_head *getblk32(kdev_t,block32_t);
 extern struct buffer_head *readbuf(struct buffer_head *);
 
 extern void ll_rw_blk(int,struct buffer_head *);
-extern void ll_rw_page(void);
-
-extern void print_bufmap_status(void);
+extern int get_sector_size(kdev_t dev);
 
 extern void put_super(kdev_t);
 extern kdev_t ROOT_DEV;
 
-extern void show_buffers(void);
 extern void mount_root(void);
-
-extern int char_read(struct inode *,struct file *,char *,int);
 
 extern int fd_check(unsigned int,char *,size_t,int,struct file **);
 

--- a/elks/include/linuxmt/ioctl.h
+++ b/elks/include/linuxmt/ioctl.h
@@ -1,17 +1,17 @@
 #ifndef __LINUXMT_IOCTL_H
 #define __LINUXMT_IOCTL_H
 
-// Use MAJOR as high-level byte for numbering
-// to avoid mixing operations
+/* Use MAJOR as high-level byte for numbering to avoid mixing operations */
 
+/* Block device generic driver operations */
+#define IOCTL_BLK_GET_SECTOR_SIZE 0x0330    /* ioctl get drive sector size */
 
-// Ethernet generic driver operations
-
-#define IOCTL_ETH_ADDR_GET	0x0901
-#define IOCTL_ETH_ADDR_SET	0x0902
-#define IOCTL_ETH_HWADDR_GET	0x0903  // get physical HW address from NIC
-#define IOCTL_ETH_GETSTAT	0x0904  // get error stats from NIC
-#define IOCTL_ETH_OFWSKIP_SET	0x0906  // Set # of packets to skip in case of buffer overflow
-#define IOCTL_ETH_OFWSKIP_GET	0x0905  // get current overrflow skip value
+/* Ethernet generic driver operations */
+#define IOCTL_ETH_ADDR_GET      0x0901
+#define IOCTL_ETH_ADDR_SET      0x0902
+#define IOCTL_ETH_HWADDR_GET    0x0903  /* get physical HW address from NIC */
+#define IOCTL_ETH_GETSTAT       0x0904  /* get error stats from NIC */
+#define IOCTL_ETH_OFWSKIP_SET   0x0906  /* Set # of packets to skip on buffer overflow */
+#define IOCTL_ETH_OFWSKIP_GET   0x0905  /* get current overrflow skip value */
 
 #endif

--- a/elks/include/linuxmt/kdev_t.h
+++ b/elks/include/linuxmt/kdev_t.h
@@ -6,9 +6,8 @@
 
 #ifdef __KERNEL__
 
-#define MAJOR(dev)	((unsigned short int) ((dev) >> MINORBITS))
-#define MINOR(dev)	((unsigned short int) ((dev) & MINORMASK))
-#define HASHDEV(dev)	(dev)
+#define MAJOR(dev)	((unsigned short) ((dev) >> MINORBITS))
+#define MINOR(dev)	((unsigned short) ((dev) & MINORMASK))
 #define MKDEV(ma,mi)	((kdev_t) (((ma) << MINORBITS) | (mi)))
 #define NODEV		MKDEV(0,0)
 

--- a/elkscmd/sys_utils/mount.c
+++ b/elkscmd/sys_utils/mount.c
@@ -34,7 +34,8 @@ static struct dev_name_struct {
         { "fd0",     0x0380 },
         { "fd1",     0x03a0 },
         { "ssd",     0x0200 },
-        { "rd",      0x0100 },
+        { "rd0",     0x0100 },
+        { "rd1",     0x0101 },
         { NULL,           0 }
 };
 


### PR DESCRIPTION
Work in preparation to move track caching code out of bioshd driver, for use by other drivers. 

All block drivers changed to receive requests in terms of sectors, allowing eventual use of a multi-sector I/O request for track caching or raw device I/O (without system buffers) with any block device driver.

Adds `get_sector_size` function allowing `ll_rw_blk` level to learn sector size based on device number. This is implemented using the renamed HDIO_GET_SECTOR_SIZE -> IOCTL_BLK_GET_SECTOR_SIZE ioctl on block drivers that support hardware sector sizes != 512.

Tested on SSD (/dev/ssd), ramdisk (/dev/rd0) and bios (/dev/fd0, /dev/hd) drivers.