### PR TITLE
[kernel] Invalidate L1 buffers properly, update block drivers to sync

### DIFF
--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -66,7 +66,7 @@ extern void resetup_one_dev(struct gendisk *dev, int drive);
 /* ram disk */
 #define DEVICE_NAME "rd"
 #define DEVICE_REQUEST do_rd_request
-#define DEVICE_NR(device) ((device) & 7)
+#define DEVICE_NR(device) ((device) & 1)
 #define DEVICE_ON(device)
 #define DEVICE_OFF(device)
 
@@ -77,7 +77,7 @@ extern void resetup_one_dev(struct gendisk *dev, int drive);
 /* solid-state disk */
 #define DEVICE_NAME "ssd"
 #define DEVICE_REQUEST do_ssd_request
-#define DEVICE_NR(device) ((device) & 3)
+#define DEVICE_NR(device) ((device) & 0)
 #define DEVICE_ON(device)
 #define DEVICE_OFF(device)
 

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -53,7 +53,7 @@ kdev_t buffer_dev(struct buffer_head *bh)          { return EBH(bh)->b_dev; }
 #endif /* CONFIG_FAR_BUFHEADS */
 
 /* Internal L1 buffers, must be kernel DS addressable */
-#define WORD_ALIGNED    __attribute__((aligned(16)))
+#define WORD_ALIGNED    __attribute__((aligned(2)))
 static char L1buf[NR_MAPBUFS][BLOCK_SIZE] WORD_ALIGNED;
 
 /* Buffer cache */

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -472,11 +472,13 @@ extern int fd_check(unsigned int,char *,size_t,int,struct file **);
 extern void map_buffer(struct buffer_head *);
 extern void unmap_buffer(struct buffer_head *);
 extern void unmap_brelse(struct buffer_head *);
+extern void brelseL1(struct buffer_head *bh, int copyout);
 extern char *buffer_data(struct buffer_head *);
 #else
 #define map_buffer(bh)
 #define unmap_buffer(bh)
 #define unmap_brelse(bh) brelse(bh)
+#define brelseL1(bh)
 #define buffer_data(bh)  ((bh)->b_data)	/* for accessing unmapped buffer data*/
 #endif
 

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -478,7 +478,7 @@ extern char *buffer_data(struct buffer_head *);
 #define map_buffer(bh)
 #define unmap_buffer(bh)
 #define unmap_brelse(bh) brelse(bh)
-#define brelseL1(bh)
+#define brelseL1(bh,copyout)
 #define buffer_data(bh)  ((bh)->b_data)	/* for accessing unmapped buffer data*/
 #endif
 

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -473,11 +473,13 @@ extern void map_buffer(struct buffer_head *);
 extern void unmap_buffer(struct buffer_head *);
 extern void unmap_brelse(struct buffer_head *);
 extern void brelseL1(struct buffer_head *bh, int copyout);
+extern void brelseL1_index(int i, int copyout);
 extern char *buffer_data(struct buffer_head *);
 #else
 #define map_buffer(bh)
 #define unmap_buffer(bh)
 #define unmap_brelse(bh) brelse(bh)
+#define brelseL1_index(i,copyout)
 #define brelseL1(bh,copyout)
 #define buffer_data(bh)  ((bh)->b_data)	/* for accessing unmapped buffer data*/
 #endif

--- a/image/Make.devices
+++ b/image/Make.devices
@@ -36,9 +36,7 @@ devices:
 ##############################################################################
 # Solid state disk
 
-ifneq ($(CONFIG_DEV_BLK_NONE), y)
 	$(MKDEV) /dev/ssd	b 2 0
-endif
 
 ##############################################################################
 # BIOS devices, hard and floppy disks.


### PR DESCRIPTION
The kernel L1 buffers were being left mapped to their corresponding block device past a close or unmount, possibly allowing them to be reused with invalid data should another device (floppy or USB drive) be inserted into the same hardware or the contents changed while unmounted.

Also updates all block drivers (BIOS, SSD and RD) to properly do a forced sync and buffer invalidate on close.

Word-aligns L1 buffers.