### PR TITLE
[kernel] Release L1 buffers in get_free_buf on second pass

### DIFF
--- a/elks/fs/inode.c
+++ b/elks/fs/inode.c
@@ -89,7 +89,7 @@ static void list_inode_status(void)
         i++;
         if (inode->i_count) inuse++;
     } while ((inode = inode->i_prev) != NULL);
-    printk("Total inodes inuse %d/%d\n", inuse, NR_INODE);
+    printk("Total inodes inuse %d/%d (%d free)\n", inuse, NR_INODE, nr_free_inodes);
 }
 #endif
 


### PR DESCRIPTION
This is a first, rough pass at scavenging more buffers in `get_free_buffer`. Previously, any buffers mapped into L1, even when b_mapcount == 0 would not be considered for reuse. Now, all are freed if no buffers found in the first pass. This has the net effect of allowing ELKS to run with much fewer buffers (as low as 10 in testing).

Later on, more testing is needed to determine a more optimzal strategy for finding/releasing buffers under heavy system load, including possibly limiting the number of buffers written per sync cycle between `get_free_buffer` and `sync_buffers`.

Also corrects total and free buffer count displayed during ^O buffer display.