### PR TITLE
[kernel] Don't use map_buffer for memset on new filesystem blocks

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -729,11 +729,11 @@ static int bioshd_open(struct inode *inode, struct file *filp)
 #ifdef CONFIG_BLK_DEV_BFD
         probe_floppy(target, hdp);      /* probe only on initial open */
 #endif
-        inode->i_size = hdp->nr_sects * drive_info[target].sector_size;
-        /* limit inode size to max filesize for CHS >= 4MB (2^22)*/
-        if (hdp->nr_sects >= 0x00400000L)	/* 2^22*/
-            inode->i_size = 0x7ffffffL;         /* 2^31 - 1*/
     }
+    inode->i_size = hdp->nr_sects * drive_info[target].sector_size;
+    /* limit inode size to max filesize for CHS >= 4MB (2^22)*/
+    if (hdp->nr_sects >= 0x00400000L)	/* 2^22*/
+        inode->i_size = 0x7ffffffL;         /* 2^31 - 1*/
     return 0;
 }
 

--- a/elks/arch/i86/drivers/block/rd.c
+++ b/elks/arch/i86/drivers/block/rd.c
@@ -76,10 +76,10 @@ static int rd_open(struct inode *inode, struct file *filp)
 
     debug("RD: open /dev/rd%d\n", target);
     if (!rd_initialised || target >= MAX_DRIVES || !drive_info[target].valid)
-	return -ENXIO;
+        return -ENXIO;
 
-    if (++access_count[target] == 1)
-        inode->i_size = (long)drive_info[target].size << 9;
+    ++access_count[target];
+    inode->i_size = (long)drive_info[target].size << 9;
     return 0;
 }
 

--- a/elks/arch/i86/drivers/block/ssd.c
+++ b/elks/arch/i86/drivers/block/ssd.c
@@ -53,8 +53,8 @@ static int ssd_open(struct inode *inode, struct file *filp)
     debug_blk("SSD: open\n");
     if (!NUM_SECTS)
         return -ENXIO;
-    if (++access_count == 1)
-        inode->i_size = NUM_SECTS << 9;
+    ++access_count;
+    inode->i_size = NUM_SECTS << 9;
     return 0;
 }
 

--- a/elks/arch/i86/lib/unreal.S
+++ b/elks/arch/i86/lib/unreal.S
@@ -40,6 +40,7 @@
 	.global	set_a20
 	.global	linear32_fmemcpyw
 	.global	linear32_fmemcpyb
+	.global	linear32_fmemset
 
 # Check if unreal mode capable. Currently requires 32-bit CPU (386+)
 # Returns 1 if OK, otherwise error code (-1=not 386, -2=in V86 mode).
@@ -402,6 +403,55 @@ linear32_fmemcpyb:
 	mov    %ss,%ax
 	mov    %ax,%ds
 	pop    %es
+	ret
+
+#
+# void linear32_fmemset(void *dst_off, addr_t dst_seg, byte_t val, size_t count)
+# WARNING: Requires 32-bit CPU, with unreal mode and A20 gate enabled!
+#          Trashes EAX, EBX, ECX, ESI and EDI without saving.
+#
+linear32_fmemset:
+	push   %si
+	push   %es
+	mov    %di,%dx
+
+	//pushf               // save interrupt status
+	//cli                 // uncomment if extended registers used in interrupt routines
+	xorl   %esi,%esi
+	mov    %sp,%si
+
+	xorl   %ecx,%ecx
+	mov    14(%si),%cx    // word count -> ECX
+
+	xorl   %ebx,%ebx
+	mov    6(%si),%bx     // word dest offset -> EBX
+	movl   8(%esi),%edi   // long dest address -> EDI
+	addl   %ebx,%edi      // EDI is linear destination
+
+	xorl   %eax,%eax
+	mov    12(%si),%al    // byte val -> EAX
+	mov    %al,%ah
+
+	xor    %bx,%bx        // ES = DS = 0 for 32-bit linear addressing
+	mov    %bx,%es
+	mov    %bx,%ds
+
+	cld
+	shrl   $1,%ecx        // store words
+	addr32 rep stosw      // word [ES:EDI++] <- AX, ECX times
+	addr32 nop            // 80386 B1 step chip bug on address size mixing
+
+	rcll    $1,%ecx       // then possibly final byte
+	addr32 rep stosb      // byte [ES:EDI++] <- AL, ECX times
+	addr32 nop            // 80386 B1 step chip bug on address size mixing
+
+	//popf                // restore interrupt status
+
+	mov    %dx,%di
+	mov    %ss,%ax
+	mov    %ax,%ds
+	pop    %es
+	pop    %si
 	ret
 
 # The GDT contains 8-byte DESCRIPTORS for each protected-mode segment.

--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -153,7 +153,6 @@ void xms_fmemset(void *dst_off, ramdesc_t dst_seg, byte_t val, size_t count)
 
 	if (need_xms_dst) {
 		if (!xms_enabled) panic("xms_fmemset");
-		if (!need_xms_dst) dst_seg <<= 4;
 
 #ifdef CONFIG_FS_XMS_INT15
 		panic("xms_fmemset int15");

--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -146,6 +146,25 @@ void xms_fmemcpyb(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src
 	fmemcpyb(dst_off, (seg_t)dst_seg, src_off, (seg_t)src_seg, count);
 }
 
+/* memset XMS or far memory, INT 15 not yet supported */
+void xms_fmemset(void *dst_off, ramdesc_t dst_seg, byte_t val, size_t count)
+{
+	int	need_xms_dst = dst_seg >> 16;
+
+	if (need_xms_dst) {
+		if (!xms_enabled) panic("xms_fmemset");
+		if (!need_xms_dst) dst_seg <<= 4;
+
+#ifdef CONFIG_FS_XMS_INT15
+		panic("xms_fmemset int15");
+#else
+		linear32_fmemset(dst_off, dst_seg, val, count);
+#endif
+		return;
+	}
+	fmemsetb(dst_off, (seg_t)dst_seg, val, count);
+}
+
 #ifdef CONFIG_FS_XMS_INT15
 struct gdt_table {
 	word_t	limit_15_0;

--- a/elks/fs/block_dev.c
+++ b/elks/fs/block_dev.c
@@ -9,6 +9,7 @@
 #include <linuxmt/sched.h>
 #include <linuxmt/kernel.h>
 #include <linuxmt/fcntl.h>
+#include <linuxmt/debug.h>
 
 size_t block_read(struct inode *inode, struct file *filp, char *buf, size_t count)
 {
@@ -84,6 +85,8 @@ size_t block_write(struct inode *inode, struct file *filp, char *buf, size_t cou
 	    if (!written) written = -ENOSPC;
 	    break;
 	}
+        if (/*bh->b_dev == 0x200 &&*/ EBH(bh)->b_blocknr >= 5)
+                debug_blk("block_write: have block %ld\n", EBH(bh)->b_blocknr);
 	/* Offset to block/offset */
 	offset = ((size_t)filp->f_pos) & (BLOCK_SIZE - 1);
 	chars = BLOCK_SIZE - offset;

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -622,17 +622,17 @@ void zero_buffer(struct buffer_head *bh, size_t offset, int count)
 {
     ext_buffer_head *ebh;
 #if defined(CONFIG_FS_XMS_INT15) || (!defined(CONFIG_FS_EXTERNAL_BUFFER) && !defined(CONFIG_FS_XMS_BUFFER))
-#define DOMAP   1
+#define FORCEMAP 1
 #else
-#define DOMAP   0
+#define FORCEMAP 0
 #endif
     /* xms int15 doesn't support a memset function, so map into L1 */
-    if (bh->b_data || DOMAP) {
+    if (FORCEMAP || bh->b_data) {
         map_buffer(bh);
         memset(bh->b_data + offset, 0, count);
         unmap_buffer(bh);
     }
-#if defined(CONFIG_FS_EXTERNAL_BUFFER) || defined(CONFIG_FS_XMS_BUFFER)
+#if !FORCEMAP
     else {
         ebh = EBH(bh);
         xms_fmemset(ebh->b_L2data + offset, ebh->b_ds, 0, count);

--- a/elks/fs/minix/bitmap.c
+++ b/elks/fs/minix/bitmap.c
@@ -123,11 +123,12 @@ repeat:
         printk("new_block: bad block %u\n", j);
         return 0;
     }
-    map_buffer(bh);     // FIXME use xms_fmemset and no map_buffer
-    memset(bh->b_data, 0, BLOCK_SIZE);
+    debug_blk("minix_new_block: block %ld uptodate %d\n",
+        EBH(bh)->b_blocknr, EBH(bh)->b_uptodate);
+    zero_buffer(bh, 0, BLOCK_SIZE);
     mark_buffer_uptodate(bh, 1);
     mark_buffer_dirty(bh);
-    unmap_brelse(bh);
+    brelse(bh);
     return j;
 }
 

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -43,6 +43,7 @@ struct msdos_devdir_entry devnods[DEVDIR_SIZE] = {
     { "fd2",    S_IFBLK | 0644, MKDEV(3,192)},
     { "fd3",    S_IFBLK | 0644, MKDEV(3,224)},
     { "rd0",	S_IFBLK | 0644, MKDEV(1, 0) },
+    { "ssd",	S_IFBLK | 0644, MKDEV(2, 0) },
     { "kmem",	S_IFCHR | 0644, MKDEV(1, 2) },
     { "null",	S_IFCHR | 0644, MKDEV(1, 3) },
     { "zero",	S_IFCHR | 0644, MKDEV(1, 5) },

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -142,15 +142,14 @@ int FATPROC msdos_add_cluster(register struct inode *inode)
 			if (!(bh = msdos_sread_nomap(inode->i_sb, sector, &offset)))
 				printk("FAT: sread fail\n");
 			else {
-                debug_blk("msdos_add_cluster2: block %ld uptodate %d\n",
-                    EBH(bh)->b_blocknr, EBH(bh)->b_uptodate);
-                zero_buffer(bh, offset, SECTOR_SIZE(inode));
-            }
+				debug_blk("msdos_add_cluster2: block %ld uptodate %d\n",
+					EBH(bh)->b_blocknr, EBH(bh)->b_uptodate);
+				zero_buffer(bh, offset, SECTOR_SIZE(inode));
+			}
 		}
 		if (bh) {
 			debug_fat("add_cluster block write %lu\n", buffer_blocknr(bh));
 			mark_buffer_dirty(bh);
-			//unmap_brelse(bh);
 			brelse(bh);
 		}
 	}

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -468,6 +468,8 @@ extern void mount_root(void);
 
 extern int fd_check(unsigned int,char *,size_t,int,struct file **);
 
+extern void zero_buffer(struct buffer_head *bh, size_t offset, int count);
+
 #ifdef CONFIG_FS_EXTERNAL_BUFFER
 extern void map_buffer(struct buffer_head *);
 extern void unmap_buffer(struct buffer_head *);

--- a/elks/include/linuxmt/memory.h
+++ b/elks/include/linuxmt/memory.h
@@ -50,18 +50,21 @@ void xms_fmemcpyw(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src
 		size_t count);
 void xms_fmemcpyb(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src_seg,
 		size_t count);
+void xms_fmemset(void *dst_off, ramdesc_t dst_seg, byte_t val, size_t count);
 
 /* low level copy - must have 386 CPU and xms_enabled before calling! */
 void linear32_fmemcpyw(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg,
 		size_t count);
 void linear32_fmemcpyb(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg,
 		size_t count);
+void linear32_fmemset(void *dst_off, addr_t dst_seg, byte_t val, size_t count);
 
 #else
 
 typedef seg_t ramdesc_t;	/* ramdesc_t is just a regular segment descriptor */
 #define xms_fmemcpyw	fmemcpyw
 #define xms_fmemcpyb	fmemcpyb
+#define xms_fmemset     fmemsetb
 
 #endif /* CONFIG_FS_XMS_BUFFER */
 

--- a/elks/include/linuxmt/msdos_fs_sb.h
+++ b/elks/include/linuxmt/msdos_fs_sb.h
@@ -47,7 +47,7 @@ struct msdos_sb_info { /* space in struct super_block is 28 bytes */
 #endif
 
 #ifdef CONFIG_FS_DEV
-#define DEVDIR_SIZE             43              /* # entries in FAT device table */
+#define DEVDIR_SIZE             44              /* # entries in FAT device table */
 #define DEVINO_BASE             (MSDOS_DPB*2)   /* (DEVDIR_SIZE+MSDOS_DBP-1) & ~(MSDOS_DBP-1) */
 
 struct msdos_devdir_entry {


### PR DESCRIPTION
Both MINIX and FAT filesystems use `map_buffer` to easily use `memset` for zeroing out new blocks. This PR replaces the expensive L1 mapping with `xms_fmemset` which in turn calls `fmemset` for FAR buffers and the new `linear_fmemset` for XMS buffers.

CONFIG_FS_XMS_INT15 (for Compaq 386 and those using BIOS using internal protected mode) aren't supported, and the older L1 mapping is used.

Adds /dev/ssd to FAT filesystem /dev directory.