### PR TITLE
[kernel] Add char and network driver init routines to INITPROC

### DIFF
--- a/elks/arch/i86/drivers/block/rd.c
+++ b/elks/arch/i86/drivers/block/rd.c
@@ -281,7 +281,7 @@ static struct file_operations rd_fops = {
     rd_release			/* release */
 };
 
-void rd_init(void)
+void INITPROC rd_init(void)
 {
     if (register_blkdev(MAJOR_NR, DEVICE_NAME, &rd_fops) == 0) {
 	blk_dev[MAJOR_NR].request_fn = DEVICE_REQUEST;

--- a/elks/arch/i86/drivers/block/ssd.c
+++ b/elks/arch/i86/drivers/block/ssd.c
@@ -37,7 +37,7 @@ static struct file_operations ssd_fops = {
     ssd_release                 /* release */
 };
 
-void ssd_init(void)
+void INITPROC ssd_init(void)
 {
     if (register_blkdev(MAJOR_NR, DEVICE_NAME, &ssd_fops) == 0) {
         blk_dev[MAJOR_NR].request_fn = DEVICE_REQUEST;

--- a/elks/arch/i86/drivers/char/cgatext.c
+++ b/elks/arch/i86/drivers/char/cgatext.c
@@ -1,6 +1,4 @@
-#include <linuxmt/cgatext.h>
 #include <linuxmt/errno.h>
-#include <linuxmt/cgatext.h>
 #include <linuxmt/kernel.h>
 #include <linuxmt/sched.h>
 #include <arch/cgatext.h>
@@ -90,12 +88,7 @@ static struct file_operations cgatext_fops =
   NULL	/* release */
 };
 
-void
-cgatext_init(void)
+void INITPROC cgatext_init(void)
 {
-  int i;
-
-  i = register_chrdev(CGATEXT_MAJOR, CGATEXT_DEVICE_NAME, &cgatext_fops);
-  if(i)
-	  printk("cgatext: unable to register: %d\n", i);
+  register_chrdev(CGATEXT_MAJOR, "cgatext", &cgatext_fops);
 }

--- a/elks/arch/i86/drivers/char/console-bios.c
+++ b/elks/arch/i86/drivers/char/console-bios.c
@@ -172,7 +172,7 @@ struct tty_ops bioscon_ops = {
     Console_conout
 };
 
-void console_init(void)
+void INITPROC console_init(void)
 {
     Console *C;
     int i;

--- a/elks/arch/i86/drivers/char/console-direct-pc98.c
+++ b/elks/arch/i86/drivers/char/console-direct-pc98.c
@@ -216,7 +216,7 @@ struct tty_ops dircon_ops = {
     Console_conout
 };
 
-void console_init(void)
+void INITPROC console_init(void)
 {
     Console *C;
     int i;

--- a/elks/arch/i86/drivers/char/console-direct.c
+++ b/elks/arch/i86/drivers/char/console-direct.c
@@ -184,7 +184,7 @@ struct tty_ops dircon_ops = {
     Console_conout
 };
 
-void console_init(void)
+void INITPROC console_init(void)
 {
     Console *C;
     int i;

--- a/elks/arch/i86/drivers/char/console-headless.c
+++ b/elks/arch/i86/drivers/char/console-headless.c
@@ -16,7 +16,7 @@
 #include "conio.h"
 
 
-void console_init(void)
+void INITPROC console_init(void)
 {
     kbd_init();
     printk("Headless console\n");

--- a/elks/arch/i86/drivers/char/console-serial-8018x.c
+++ b/elks/arch/i86/drivers/char/console-serial-8018x.c
@@ -140,7 +140,7 @@ static void update_port(struct serial_info *port)
 }
 
 /* Called from main.c! */
-void console_init(void)
+void INITPROC console_init(void)
 {
     struct serial_info *sp = &ports[0]; /* TODO: add support for Serial 1 */
 

--- a/elks/arch/i86/drivers/char/eth.c
+++ b/elks/arch/i86/drivers/char/eth.c
@@ -93,7 +93,7 @@ static struct file_operations eth_fops = {
     eth_release
 };
 
-void /*INITPROC*/ eth_init(void)
+void INITPROC eth_init(void)
 {
     register_chrdev(ETH_MAJOR, "eth", &eth_fops);
 

--- a/elks/arch/i86/drivers/char/init.c
+++ b/elks/arch/i86/drivers/char/init.c
@@ -2,7 +2,7 @@
 #include <linuxmt/types.h>
 #include <linuxmt/init.h>
 
-void chr_dev_init(void)
+void INITPROC chr_dev_init(void)
 {
 #ifdef CONFIG_CHAR_DEV_LP
     lp_init();

--- a/elks/arch/i86/drivers/char/lp.c
+++ b/elks/arch/i86/drivers/char/lp.c
@@ -266,7 +266,7 @@ static struct file_operations lp_fops = {
 
 /*@+type@*/
 
-void lp_init(void)
+void INITPROC lp_init(void)
 {
     register struct lp_info *lp = &ports[0];
     int i;

--- a/elks/arch/i86/drivers/char/mem.c
+++ b/elks/arch/i86/drivers/char/mem.c
@@ -414,10 +414,9 @@ static struct file_operations memory_fops = {
 
 /*@+type@*/
 
-void mem_dev_init(void)
+void INITPROC mem_dev_init(void)
 {
-    if (register_chrdev(MEM_MAJOR, "mem", &memory_fops))
-	printk("MEM: Unable to get major %d for memory devices\n", MEM_MAJOR);
+    register_chrdev(MEM_MAJOR, "mem", &memory_fops);
 }
 
 #endif

--- a/elks/arch/i86/drivers/char/meta.c
+++ b/elks/arch/i86/drivers/char/meta.c
@@ -15,6 +15,7 @@
 #ifdef CONFIG_DEV_META
 
 #include <linuxmt/major.h>
+#include <linuxmt/init.h>
 #include <linuxmt/fs.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/mm.h>
@@ -345,9 +346,9 @@ static struct file_operations meta_chr_fops = {
     meta_release		/* release */
 };
 
-void meta_init(void)
+void INITPROC meta_init(void)
 {
-    printk("Userspace device driver Copyright (C) 1999 Alistair Riddoch\n");
+    debug("Userspace device driver Copyright (C) 1999 Alistair Riddoch\n");
     if (!register_chrdev(MAJOR_NR, DEVICE_NAME, &meta_chr_fops))
 	meta_initialised = 1;
 }

--- a/elks/arch/i86/drivers/char/pty.c
+++ b/elks/arch/i86/drivers/char/pty.c
@@ -182,7 +182,7 @@ struct tty_ops ttyp_ops = {
 
 /*@+type@*/
 
-void pty_init(void)
+void INITPROC pty_init(void)
 {
     register_chrdev(PTY_MASTER_MAJOR, "pty", &pty_fops);
 }

--- a/elks/arch/i86/drivers/char/tcpdev.c
+++ b/elks/arch/i86/drivers/char/tcpdev.c
@@ -176,7 +176,7 @@ static struct file_operations tcpdev_fops = {
 
 /*@+type@*/
 
-void tcpdev_init(void)
+void INITPROC tcpdev_init(void)
 {
     register_chrdev(TCPDEV_MAJOR, "tcpdev", &tcpdev_fops);
     bufin_sem = bufout_sem = 0;

--- a/elks/arch/i86/drivers/net/el3.c
+++ b/elks/arch/i86/drivers/net/el3.c
@@ -90,7 +90,7 @@ enum RxFilter {
 #define EP_ID_PORT_END 0x200
 #define EP_TAG_MAX		0x7 /* must be 2^n - 1 */
 
-static int el3_isa_probe();
+static int INITPROC el3_isa_probe();
 //static word_t read_eeprom(int, int);
 static word_t id_read_eeprom(int);
 static size_t el3_write(struct inode *, struct file *, char *, size_t);
@@ -141,7 +141,7 @@ struct file_operations el3_fops =
     el3_release
 };
 
-void el3_drv_init(void) {
+void INITPROC el3_drv_init(void) {
 	ioaddr = net_port;		// temporary
 
 	verbose = (net_flags&ETHF_VERBOSE);
@@ -156,7 +156,7 @@ void el3_drv_init(void) {
 
 }
 
-static int el3_find_id_port ( void ) {
+static int INITPROC el3_find_id_port ( void ) {
 
 	for ( el3_id_port = EP_ID_PORT_START ;
 	      el3_id_port < EP_ID_PORT_END ;
@@ -176,7 +176,7 @@ static int el3_find_id_port ( void ) {
 }
 
 /* Return 0 on success, 1 on error */
-static int el3_isa_probe( void )
+static int INITPROC el3_isa_probe( void )
 {
 	short lrs_state = 0xff;
 	int i;

--- a/elks/arch/i86/drivers/net/ne2k.c
+++ b/elks/arch/i86/drivers/net/ne2k.c
@@ -382,7 +382,7 @@ void ne2k_display_status(void)
 #endif
 
 /* return 0 if NE2K NIC present */
-word_t ne2k_probe()
+static word_t INITPROC ne2k_probe(void)
 {
     int reg0;
 
@@ -422,7 +422,7 @@ word_t ne2k_probe()
  * FIXME: Needs return value to signal that initalization failed.
  */
 
-void ne2k_drv_init(void)
+void INITPROC ne2k_drv_init(void)
 {
 	int err, i;
 	word_t prom[16];	/* PROM containing HW MAC address and more 

--- a/elks/arch/i86/drivers/net/ne2k.h
+++ b/elks/arch/i86/drivers/net/ne2k.h
@@ -31,7 +31,6 @@
 
 extern word_t ne2k_int_stat();
 
-extern word_t ne2k_probe();
 extern void   ne2k_reset();
 
 extern void   ne2k_init();

--- a/elks/arch/i86/drivers/net/wd.c
+++ b/elks/arch/i86/drivers/net/wd.c
@@ -175,7 +175,7 @@ static void wd_get_hw_addr(word_t * data)
  * determine bus width if possible.
  */
 
-static int wd_probe(void) {
+static int INITPROC wd_probe(void) {
 	int i, tmp = 0;
 
 	for (i = 0; i < 8; i++)
@@ -706,7 +706,7 @@ static void wd_int(int irq, struct pt_regs * regs)
  * Ethernet main initialization (during boot)
  */
 
-void wd_drv_init(void)
+void INITPROC wd_drv_init(void)
 {
 	unsigned u;
 	word_t hw_addr[6U];
@@ -734,7 +734,7 @@ void wd_drv_init(void)
 /* Using this wrapper saves 44 bytes of RAM */
 /* Using word transfers when possible improves transfer time ~10%
  * on large packets (measured @ 1200 bytes) */
-void fmemcpy(void *dst_off, seg_t dst_seg, void *src_off, seg_t src_seg, size_t count, int type) {
+static void fmemcpy(void *dst_off, seg_t dst_seg, void *src_off, seg_t src_seg, size_t count, int type) {
 
 	if (type == is_8bit)
 		fmemcpyb(dst_off, dst_seg, src_off, src_seg, count);

--- a/elks/include/linuxmt/cgatext.h
+++ b/elks/include/linuxmt/cgatext.h
@@ -1,6 +1,0 @@
-#ifndef __LINUXMT_CGATEXT_H
-#define __LINUXMT_CGATEXT_H
-
-#define CGATEXT_DEVICE_NAME	"cgatext"
-
-#endif

--- a/elks/include/linuxmt/init.h
+++ b/elks/include/linuxmt/init.h
@@ -37,7 +37,7 @@ extern void INITPROC tty_init(void);
 extern void INITPROC device_init(void);
 extern void INITPROC setup_dev(register struct gendisk *);
 
-extern void tz_init(const char *tzstr);
+extern void INITPROC tz_init(const char *tzstr);
 
 /* block device init routines*/
 extern void INITPROC blk_dev_init(void);

--- a/elks/include/linuxmt/init.h
+++ b/elks/include/linuxmt/init.h
@@ -45,22 +45,22 @@ extern int INITPROC bioshd_init(void);
 extern int INITPROC get_ide_data(int, struct drive_infot *);
 extern int directhd_init(void);
 extern void floppy_init(void);
-extern void rd_init(void);
-extern void ssd_init(void);
+extern void INITPROC rd_init(void);
+extern void INITPROC ssd_init(void);
 extern void romflash_init(void);
 
 /* char device init routines*/
-extern void chr_dev_init(void);
-extern void cgatext_init(void);
-extern void eth_init(void);
+extern void INITPROC chr_dev_init(void);
+extern void INITPROC cgatext_init(void);
+extern void INITPROC eth_init(void);
 extern void ne2k_drv_init(void);
-extern void el3_drv_init(void);
-extern void wd_drv_init(void);
-extern void lp_init(void);
-extern void mem_dev_init(void);
-extern void meta_init(void);
-extern void pty_init(void);
-extern void tcpdev_init(void);
+extern void INITPROC el3_drv_init(void);
+extern void INITPROC wd_drv_init(void);
+extern void INITPROC lp_init(void);
+extern void INITPROC mem_dev_init(void);
+extern void INITPROC meta_init(void);
+extern void INITPROC pty_init(void);
+extern void INITPROC tcpdev_init(void);
 
 extern void kfork_proc(void (*addr)());
 extern void arch_setup_user_stack(struct task_struct *, word_t entry);

--- a/elks/include/linuxmt/init.h
+++ b/elks/include/linuxmt/init.h
@@ -21,7 +21,7 @@ struct drive_infot;
 /* kernel init routines*/
 extern void INITPROC kernel_init(void);
 extern int  INITPROC buffer_init(void);
-extern void console_init(void);
+extern void INITPROC console_init(void);
 extern void INITPROC fs_init(void);
 extern void INITPROC inode_init(void);
 extern void INITPROC irq_init(void);
@@ -53,7 +53,7 @@ extern void romflash_init(void);
 extern void INITPROC chr_dev_init(void);
 extern void INITPROC cgatext_init(void);
 extern void INITPROC eth_init(void);
-extern void ne2k_drv_init(void);
+extern void INITPROC ne2k_drv_init(void);
 extern void INITPROC el3_drv_init(void);
 extern void INITPROC wd_drv_init(void);
 extern void INITPROC lp_init(void);

--- a/elks/kernel/time.c
+++ b/elks/kernel/time.c
@@ -46,7 +46,7 @@ static struct timezone xzone;
 /* timezone offset (in hours) from CONFIG_TIME_TZ or /bootopts TZ= string */
 int tz_offset;
 
-void tz_init(const char *tzstr)
+void INITPROC tz_init(const char *tzstr)
 {
     if (strlen(tzstr) > 3)
         tz_offset = atoi(tzstr+3);


### PR DESCRIPTION
Increases available application space as init routines are only called at kernel startup. The network init routines were using a fair amount of space.

The kernel can now be built when configured for XMS and TRACE checking.