### PR TITLE
[boot] Allow separate EXT/L2 and XMS buffer overrides to compiled configuration

### DIFF
--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -27,7 +27,12 @@
 #define NR_MAPBUFS  8
 #endif
 
-int boot_bufs;		/* /bootopts # buffers override */
+#ifdef CONFIG_FS_EXTERNAL_BUFFER
+int nr_ext_bufs = CONFIG_FS_NR_EXT_BUFFERS;     /* override with /bootopts buf= */
+#endif
+#ifdef CONFIG_FS_XMS_BUFFER
+int nr_xms_bufs = CONFIG_FS_NR_XMS_BUFFERS;     /* override with /bootopts xmsbuf= */
+#endif
 
 /* Buffer heads: local heap allocated */
 static struct buffer_head *buffer_heads;
@@ -180,17 +185,16 @@ int INITPROC buffer_init(void)
 {
     /* XMS buffers override EXT buffers override internal buffers*/
 #if defined(CONFIG_FS_EXTERNAL_BUFFER) || defined(CONFIG_FS_XMS_BUFFER)
-    int bufs_to_alloc = CONFIG_FS_NR_EXT_BUFFERS;
+    int bufs_to_alloc = nr_ext_bufs;
 
 #ifdef CONFIG_FS_XMS_BUFFER
-    xms_enabled = xms_init();	/* try to enable unreal mode and A20 gate*/
+    if (nr_xms_bufs)
+        xms_enabled = xms_init();	/* try to enable unreal mode and A20 gate*/
     if (xms_enabled)
-	bufs_to_alloc = CONFIG_FS_NR_XMS_BUFFERS;
+        bufs_to_alloc = nr_xms_bufs;
 #endif
-    if (boot_bufs)
-	bufs_to_alloc = boot_bufs;
 #ifdef CONFIG_FAR_BUFHEADS
-    if (bufs_to_alloc > 2500) bufs_to_alloc = 2500; /* max 64K far bufheads @26 bytes*/
+    if (bufs_to_alloc > 2975) bufs_to_alloc = 2975; /* max 64K far bufheads @22 bytes*/
 #else
     if (bufs_to_alloc > 256) bufs_to_alloc = 256; /* protect against high XMS value*/
 #endif

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -40,6 +40,7 @@ struct netif_parms netif_parms[MAX_ETHS] = {
 };
 __u16 kernel_cs, kernel_ds;
 int tracing;
+int nr_ext_bufs, nr_xms_bufs;
 static int boot_console;
 static char bininit[] = "/bin/init";
 static char binshell[] = "/bin/sh";
@@ -68,7 +69,6 @@ static char *envp_init[MAX_INIT_ENVS+1];
 static unsigned char options[OPTSEGSZ];
 
 extern int boot_rootdev;
-extern int boot_bufs;
 extern int dprintk_on;
 static char * INITPROC root_dev_name(int dev);
 static int parse_options(void);
@@ -466,8 +466,12 @@ static int parse_options(void)
 			parse_nic(line+4, &netif_parms[ETH_EL3]);
 			continue;
 		}
-		if (!strncmp(line,"bufs=",5)) {
-			boot_bufs = (int)simple_strtol(line+5, 10);
+		if (!strncmp(line,"buf=",4)) {
+			nr_ext_bufs = (int)simple_strtol(line+4, 10);
+			continue;
+		}
+		if (!strncmp(line,"xmsbuf=",7)) {
+			nr_xms_bufs = (int)simple_strtol(line+7, 10);
 			continue;
 		}
 		if (!strncmp(line,"comirq=",7)) {

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,5 +1,5 @@
-## boot options max 511 bytes
-#console=ttyS0,57600 debug net=ne0 3 # sercons, multiuser, networking
+## boot opts max 511 bytes
+#console=ttyS0,57600 debug net=ne0 3 # sercon+multiuser+net
 #QEMU=1			# QEMU ftp/ftpd
 #TZ=MDT7
 #LOCALIP=10.0.2.16
@@ -8,10 +8,11 @@
 wd0=10,0x300,0xCC00,0x80
 #3c0=11,0x330,,0x80
 #comirq=,,7,10
-#bufs=2500		# system bufs
+#buf=10			# L2
+#xmsbuf=2975
 #umb=0xC000:0x800,0xD000:0x1000
 #sync=30		# autosync secs
-#init=/bin/init 3 n	# multiuser serial no /etc/rc.sys
+#init=/bin/init 3 n	# multiuser serial no rc.sys
 #init=/bin/sh		# singleuser sh
 #root=hda1 ro		# root hd partition 1 read-only
 #kstack


### PR DESCRIPTION
In `/bootopts`, use `buf=20` (for 20 buffers in main memory) to override number of compiled-in EXT/L2 buffers. Replaces older `bufs=` option which specified both EXT and XMS buffers.

Use `xmsbuf=2000` (for 2000 buffers in XMS memory) to override number of compiled-in XMS buffers. Setting `xmsbuf=0` will disable XMS and use EXT/L2 buffers. The new maximum XMS buffers is 2975.

With the recent enhancements to the buffer system, ELKS will now run with as few as 10 EXT buffers, for low memory systems.

Next step is dynamically allocating the L1 cache buffers using `cache=`.

