### PR TITLE
[kernel] Add physaddr 64k I/O overlap checking to BIOS driver

### DIFF
--- a/elks/fs/inode.c
+++ b/elks/fs/inode.c
@@ -83,13 +83,13 @@ static void list_inode_status(void)
 
     do {
         if (inode->i_count || inode->i_dev || inode->i_dirt) {
-            printk("#%2d: dev %D inode %5lu dirty %d count %u\n", i, inode->i_dev,
+            printk("\n#%2d: dev %D inode %5lu dirty %d count %u", i, inode->i_dev,
                 (unsigned long)inode->i_ino, inode->i_dirt, inode->i_count);
         }
         i++;
         if (inode->i_count) inuse++;
     } while ((inode = inode->i_prev) != NULL);
-    printk("Total inodes inuse %d/%d (%d free)\n", inuse, NR_INODE, nr_free_inodes);
+    printk("\nTotal inodes inuse %d/%d (%d free)\n", inuse, NR_INODE, nr_free_inodes);
 }
 #endif
 


### PR DESCRIPTION
Used in case an L1 cache buffer overlaps a 64k physical boundary, a BIOS restriction on floppy I/O because of the DMA hardware. Also checks overlap for HD I/O since not entirely sure of BIOS limitations.

Next step is adding dynamically allocated L1 cache; previous cache never overlapped 64k but could happen after that.

Also added map, unmap and remap counts to ^O buffer statistics.