### PR TITLE
[kernel] Remove dedicated buffer for MINIX super block

### DIFF
--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -602,6 +602,7 @@ void mark_buffer_uptodate(struct buffer_head *bh, int on)
 
 void fsync_dev(kdev_t dev)
 {
+    debug_sup("fsync\n");
     sync_buffers(dev, 0);
     sync_supers(dev);
     sync_inodes(dev);
@@ -610,6 +611,7 @@ void fsync_dev(kdev_t dev)
 
 void sync_dev(kdev_t dev)
 {
+    debug_sup("sync\n");
     sync_buffers(dev, 0);
     sync_supers(dev);
     sync_inodes(dev);

--- a/elks/fs/minix/bitmap.c
+++ b/elks/fs/minix/bitmap.c
@@ -19,7 +19,7 @@
 
 static char nibblemap[] = { 0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4 };
 
-static struct buffer_head *get_map_block(kdev_t dev, block_t block)
+struct buffer_head *get_map_block(kdev_t dev, block_t block)
 {
     struct buffer_head *bh;
 
@@ -29,7 +29,7 @@ static struct buffer_head *get_map_block(kdev_t dev, block_t block)
     else
         bh = bread(dev, block);
     if (!EBH(bh)->b_uptodate) {
-        printk("get_map_block: can't read bitmap on %p/%u\n", dev, block);
+        printk("get_map_block: can't read block %D/%u\n", dev, block);
         brelse(bh);
         return NULL;
     }

--- a/elks/fs/super.c
+++ b/elks/fs/super.c
@@ -93,6 +93,7 @@ void sync_supers(kdev_t dev)
     register struct super_operations *sop;
     register struct super_block *sb = super_blocks;
 
+    debug_sup("sync_supers\n");
     do {
 	if ((!sb->s_dev) || (dev && sb->s_dev != dev)) continue;
 	wait_on_super(sb);

--- a/elks/include/linuxmt/minix_fs.h
+++ b/elks/include/linuxmt/minix_fs.h
@@ -11,6 +11,8 @@
 
 #define MINIX_ROOT_INO 1
 
+#define MINIX_SUPER_BLOCK   1
+
 #define MINIX_LINK_MAX	250
 
 /* MINIX V1 buffers for inode and zone bitmaps*/
@@ -74,6 +76,7 @@ struct minix_dir_entry {
 
 extern unsigned short minix_bmap(register struct inode *,block_t,int);
 extern struct buffer_head *minix_bread(struct inode *,block_t,int);
+extern struct buffer_head *get_map_block(kdev_t dev, block_t block);
 extern unsigned short minix_count_free_blocks(register struct super_block *);
 extern unsigned short minix_count_free_inodes(register struct super_block *);
 extern int minix_create(register struct inode *,char *,size_t,int,

--- a/elks/include/linuxmt/minix_fs_sb.h
+++ b/elks/include/linuxmt/minix_fs_sb.h
@@ -18,7 +18,6 @@ struct minix_sb_info {
     block_t                     s_zmap[MINIX_Z_MAP_SLOTS];
     unsigned short		s_dirsize;
     unsigned short		s_namelen;
-    struct buffer_head *	s_sbh;
     unsigned short		s_mount_state;
 };
 


### PR DESCRIPTION
ELKS no longer requires a dedicated buffer for the seldom-accessed MINIX super block. Now, there is no buffer resource usage when mounting any number of floppy or hard drives. As a result, system throughput should increase. 

Also, when the filesystem "checked" bit is unset after boot, the sync has been changed to not wait for disk I/O to complete before continuing. This should result in the shell prompt appearing slightly faster on boot.

Adds check to not write the superblock if it hasn't changed. This removes a disk write of the superblock when rebooting from a MINIX filesystem after the second boot, when the filesystem "checked" bit remains unset. (Running `reboot` or `poweroff`, or remounting the root filesystem read-only using `umount /` will set the `checked` flag.)

Fixes bug where the superblock was written twice just after boot.

