### PR TITLE
[libc,cmds] Misc minor fixes to reduce file sizes

### DIFF
--- a/elkscmd/rootfs_template/etc/group
+++ b/elkscmd/rootfs_template/etc/group
@@ -11,9 +11,6 @@ kmem::9:
 wheel::10:root
 floppy::11:root
 mail::12:mail,postmaster
-news::13:news
-uucp::14:uucp
-man::15:man
 ftp::50:ftp
 nobody::99:nobody
 users::100:root,user1,user2,user3

--- a/elkscmd/rootfs_template/etc/passwd
+++ b/elkscmd/rootfs_template/etc/passwd
@@ -1,21 +1,14 @@
-root::0:0:System Administrator:/root:/bin/sh
-toor::0:0:System Administrator:/root:/bin/sash
+root::0:0:Admin:/root:/bin/sh
+toor::0:0:Admin:/root:/bin/sash
 bin:*:1:1:bin:/bin:
-daemon:*:2:2:System Daemon:/bin:
-adm:*:3:4:adm:/var/adm:
-lp:*:4:7:Printer Account:/var/spool/lpd:
+daemon:*:2:2:daemon:/bin:
 sync::5:0:sync:/bin:/bin/sync
-shutdown:*:6:0:shutdown:/bin:/bin/shutdown
-halt:*:7:0:halt:/bin:/bin/halt
-mail:*:8:12:Mail Spooler:/var/spool/mail:
-news:*:9:13:News Spooler:/var/spool/news:
-uucp:*:10:14:UUCP Daemon:/var/spool/uucp:
-operator:*:11:0:Operator:/root:/bin/sash
-mem::12:0:meminfo:/root:/bin/meminfo
-man:*:13:15:Manual pages:/usr/man:
+shutdown::6:0:shutdown:/bin:/bin/shutdown
+poweroff::7:0:poweroff:/bin:/bin/poweroff
+reboot::8:0:poweroff:/bin:/bin/reboot
+meminfo::9:0:meminfo:/root:/bin/meminfo
+tty::10:0:tty:/home:/bin/tty
 ftp:*:14:50:FTP User:/home/ftp:/bin/sh
-postmaster:*:14:12:Postmaster:/var/spool/mail:/bin/sh
-tty::15:0:tty command:/home:/bin/tty
 nobody:*:99:99:Nobody:/tmp:
 user1::101:101:User 1:/home:/bin/sh
 user2::102:102:User 2:/home:/bin/sash

--- a/elkscmd/sys_utils/login.c
+++ b/elkscmd/sys_utils/login.c
@@ -44,7 +44,6 @@ void login(register struct passwd *pwd, struct utmp *ut_ent)
 #ifdef USE_UTMP
     ut_ent->ut_type = USER_PROCESS;
     strncpy(ut_ent->ut_user, pwd->pw_name, UT_NAMESIZE);
-    ut_ent->ut_user[UT_NAMESIZE - 1] = '\0';
     time(&ut_ent->ut_time);
     pututline(ut_ent);
     endutent();
@@ -119,7 +118,7 @@ int main(int argc, char **argv)
             lbuf[n] = '\0';
         } else {
             strncpy(lbuf, argv[1], UT_NAMESIZE);
-            lbuf[UT_NAMESIZE - 1] = '\0';
+            lbuf[UT_NAMESIZE] = '\0';
             argc = 1;
         }
         pwd = getpwnam(lbuf);
@@ -143,7 +142,6 @@ int main(int argc, char **argv)
         entryp = &newentry;
         entryp->ut_type = LOGIN_PROCESS;
         strncpy(entryp->ut_user, lbuf, UT_NAMESIZE);
-        entryp->ut_user[UT_NAMESIZE - 1] = '\0';
         time(&entryp->ut_time);
         pututline(entryp);
         endutent();

--- a/elkscmd/sys_utils/poweroff.c
+++ b/elkscmd/sys_utils/poweroff.c
@@ -23,7 +23,7 @@ int main(int argc, char **argv)
 {
 	sync();
 	if (umount("/")) {
-		perror("poweroff umount");
+		perror("umount");
 		return 1;
 	}
 	sleep(3);

--- a/elkscmd/sys_utils/reboot.c
+++ b/elkscmd/sys_utils/reboot.c
@@ -22,7 +22,7 @@ int main(int argc, char **argv)
 	if (umount("/") < 0) {
 		/* -f forces reboot even if mount fails */
 		if (argc < 2 || argv[1][0] != '-' || argv[1][1] != 'f')	 {
-			perror("reboot umount");
+			perror("umount");
 			return 1;
 		}
 	}

--- a/elkscmd/sys_utils/shutdown.c
+++ b/elkscmd/sys_utils/shutdown.c
@@ -23,7 +23,7 @@ int main(int argc, char **argv)
 {
 	sync();
 	if (umount("/")) {
-		perror("shutdown umount");
+		perror("umount");
 		return 1;
 	}
 	sleep(3);

--- a/libc/error/__assert.c
+++ b/libc/error/__assert.c
@@ -7,24 +7,20 @@
 #include <stdlib.h>
 #include <string.h>
 
-static void errput(str)
-const char * str;
+static void errput(const char *str)
 {
    write(2, str, strlen(str));
 }
 
 void
-__assert(assertion, filename, linenumber)
-const char * assertion;
-const char * filename;
-int linenumber;
+__assert(const char *assertion, const char *filename, int linenumber)
 {
    errput("Failed assertion '");
    errput(assertion);
    errput("' in file ");
    errput(filename);
    errput(" at line ");
-   errput(itoa(linenumber));
+   errput(uitoa(linenumber));
    errput(".\n");
    abort();
 }

--- a/libc/error/error.c
+++ b/libc/error/error.c
@@ -45,7 +45,7 @@ strerror(int err)
 done:
    close(fd);
 unknown:
-   strcpy(retbuf, "Unknown error ");
-   strcpy(retbuf+14, itoa(err));
+   strcpy(retbuf, "Error ");
+   strcpy(retbuf+6, uitoa(err));
    return retbuf;
 }

--- a/libc/error/perror.c
+++ b/libc/error/perror.c
@@ -7,9 +7,10 @@ perror(const char *str)
 {
     char *ptr;
 
-    if (!str) str = "perror";
-    write(2, str, strlen(str));
-    write(2, ": ", 2);
+    if (!str) {
+        write(2, str, strlen(str));
+        write(2, ": ", 2);
+    }
     ptr = strerror(errno);
     write(2, ptr, strlen(ptr));
     write(2, "\n", 1);

--- a/libc/include/stdlib.h
+++ b/libc/include/stdlib.h
@@ -63,6 +63,7 @@ void qsort(void *base, size_t nel, size_t width,
 #ifndef __STRICT_ANSI__
 void breakpoint();
 char *itoa(int val);
+char *uitoa(unsigned int val);
 char *ltoa(long val);
 char *ltostr(long val, int radix);
 char *lltostr(long long val, int radix);

--- a/libc/misc/Makefile
+++ b/libc/misc/Makefile
@@ -33,6 +33,7 @@ OBJS = \
 	strtoul.o \
 	system.o \
 	tmpnam.o \
+	uitoa.o \
 	ultostr.o \
 	ulltostr.o \
 	wildcard.o \

--- a/libc/misc/uitoa.c
+++ b/libc/misc/uitoa.c
@@ -1,0 +1,14 @@
+#include <stdlib.h>
+
+/* small unsigned int to ascii */
+char *uitoa(unsigned int i)
+{
+    static char buf[6];
+    char *b = buf + sizeof(buf) - 1;
+
+    *b = '\0';
+    do {
+        *--b = '0' + (i % 10);
+    } while ((i /= 10) != 0);
+   return b;
+}


### PR DESCRIPTION
Removes unused entries in /etc/passwd and /etc/group to keep below 512 bytes for quicker processing.

Fixes `login` bug with 8-character (max) username.

Adds `meminfo` login for quick memory display. (Also can use ^O/^N if CONFIG_TRACE=y for buffers/inodes).
Adds `poweroff`, `shutdown` and `reboot` as logins, but need /etc/passwd edit setting userid=0 to work.

Reduces size of `poweroff` and `shutdown` to 1024 bytes.

Decreases size of `perror` routine.
Adds small `uitoa` unsigned int to ascii routine.
