### PR TITLE
[kernel] Kernel buffers tune and cleanup

### DIFF
--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -1,11 +1,12 @@
 #ifndef _BLK_H
 #define _BLK_H
 
+#include <linuxmt/config.h>
+#include <linuxmt/limits.h>
 #include <linuxmt/major.h>
 #include <linuxmt/sched.h>
 #include <linuxmt/kdev_t.h>
 #include <linuxmt/genhd.h>
-#include <linuxmt/config.h>
 #include <linuxmt/trace.h>
 
 struct request {

--- a/elks/arch/i86/drivers/block/ll_rw_blk.c
+++ b/elks/arch/i86/drivers/block/ll_rw_blk.c
@@ -10,6 +10,7 @@
  */
 
 #include <linuxmt/config.h>
+#include <linuxmt/limits.h>
 #include <linuxmt/types.h>
 #include <linuxmt/sched.h>
 #include <linuxmt/kernel.h>
@@ -35,13 +36,6 @@
  * NOTE that writes may use only the low 2/3 of these: reads
  * take precedence.
  */
-
-#ifdef CONFIG_ASYNCIO
-#define NR_REQUEST  4
-#else
-#define NR_REQUEST  1   /* only 1 is required for non-async I/O */
-#endif
-
 static struct request all_requests[NR_REQUEST];
 
 /* current request and function pointer for each block device handler */

--- a/elks/fs/block_dev.c
+++ b/elks/fs/block_dev.c
@@ -85,8 +85,6 @@ size_t block_write(struct inode *inode, struct file *filp, char *buf, size_t cou
 	    if (!written) written = -ENOSPC;
 	    break;
 	}
-        if (/*bh->b_dev == 0x200 &&*/ EBH(bh)->b_blocknr >= 5)
-                debug_blk("block_write: have block %ld\n", EBH(bh)->b_blocknr);
 	/* Offset to block/offset */
 	offset = ((size_t)filp->f_pos) & (BLOCK_SIZE - 1);
 	chars = BLOCK_SIZE - offset;

--- a/elks/fs/file_table.c
+++ b/elks/fs/file_table.c
@@ -4,10 +4,9 @@
  *  Copyright (C) 1991, 1992  Linus Torvalds
  */
 
-#include <linuxmt/types.h>
 #include <linuxmt/config.h>
-#include <linuxmt/fs.h>
 #include <linuxmt/limits.h>
+#include <linuxmt/fs.h>
 #include <linuxmt/fcntl.h>
 #include <linuxmt/stat.h>
 #include <linuxmt/string.h>

--- a/elks/fs/minix/bitmap.c
+++ b/elks/fs/minix/bitmap.c
@@ -2,6 +2,9 @@
  *  linux/fs/minix/bitmap.c
  *
  *  Copyright (C) 1991, 1992  Linus Torvalds
+ *
+ * Aug 2023 Greg Haerr - Don't use L1 cache/memset on new filesystem blocks.
+ * Aug 2023 Greg Haerr - Don't dedicate buffers for Z/I maps.
  */
 
 /* bitmap.c contains the code that handles the inode and block bitmaps */

--- a/elks/fs/minix/inode.c
+++ b/elks/fs/minix/inode.c
@@ -3,6 +3,7 @@
  *
  *  Copyright (C) 1991, 1992  Linus Torvalds
  *
+ * Aug 2023 Greg Haerr - Don't dedicate buffers for Z/I maps or super block.
  */
 
 #include <linuxmt/types.h>

--- a/elks/fs/msdos/file.c
+++ b/elks/fs/msdos/file.c
@@ -4,6 +4,8 @@
  *  Written 1992 by Werner Almesberger
  *
  *  MS-DOS regular file handling primitives
+ *
+ * Aug 2023 Greg Haerr - Don't use L1 cache for reading/writing file data.
  */
 
 #include <arch/segment.h>

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -2,6 +2,8 @@
  *  linux-0.97/fs/msdos/misc.c
  *
  *  Written 1992 by Werner Almesberger
+ *
+ * Aug 2023 Greg Haerr - Don't use L1 cache/memset on new filesystem clusters.
  */
 
 #include <linuxmt/msdos_fs.h>

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -29,11 +29,12 @@
 #endif
 #define UTS_MACHINE		"ibmpc i8086"
 
-/* The following can be set for minimal systems or for QEMU emulation testing */
-/* An absolute min heap 24 buffers (@24 = 576), 2 ttyq (@80 = 160), 256 free = ~1328 */
-/* Must now add L1 buffers, +8k MINIX or +12k FAT */
+/* The following can be set for minimal systems or for QEMU emulation testing:
+ * 10 buffers (@20 = 200), 2 ttyq (@80 = 160), 4k L1 cache, 512 heap free = ~4968.
+ * Use buf=10 cache=4 in /bootopts
+ */
 #if defined(CONFIG_HW_MK88)
-#define SETUP_HEAPSIZE            13616   /* force kernel heap size */
+#define SETUP_HEAPSIZE            4968    /* force kernel heap size */
 #endif
 //#undef SETUP_MEM_KBYTES
 //#define SETUP_MEM_KBYTES        256     /* force available memory in 1K bytes */

--- a/elks/include/linuxmt/debug.h
+++ b/elks/include/linuxmt/debug.h
@@ -19,8 +19,9 @@
 #define DEBUG_ETH	0		/* ethernet*/
 #define DEBUG_FAT	0		/* FAT filesystem*/
 #define DEBUG_FILE	0		/* sys open and file i/o*/
-#define DEBUG_NET	0		/* networking*/
+#define DEBUG_MAP	0		/* L1 mapping */
 #define DEBUG_MM	0		/* mem char device*/
+#define DEBUG_NET	0		/* networking*/
 #define DEBUG_SCHED	0		/* scheduler/wait*/
 #define DEBUG_SIG	0		/* signals*/
 #define DEBUG_SUP	0		/* superblock, mount, umount*/
@@ -74,6 +75,12 @@ void debug_setcallback(int evnum, void (*cbfunc)()); /* callback on debug event*
 #define debugmem	PRINTK
 #else
 #define debugmem(...)
+#endif
+
+#if DEBUG_MAP
+#define debug_map	PRINTK
+#else
+#define debug_map(...)
 #endif
 
 #if DEBUG_NET

--- a/elks/include/linuxmt/limits.h
+++ b/elks/include/linuxmt/limits.h
@@ -22,8 +22,16 @@
 
 #define POLL_MAX        6       /* Maximum number of polled queues per process */
 
+/* buffers */
+#define NR_MAPBUFS      8       /* Number of internal L1 buffers */
+
+#ifdef CONFIG_ASYNCIO
+#define NR_REQUEST      4       /* Number of async I/O request headers */
+#else
+#define NR_REQUEST      1       /* only 1 is required for non-async I/O */
+#endif
+
 /* filesystem */
-#define NR_MAPBUFS      12      /* Number of internal L1 buffers */
 #define NR_INODE        96      /* this should be bigger than NR_FILE */
 #define NR_FILE         64      /* this can well be larger on a larger system */
 #define NR_SUPER        6       /* max mounts */

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -2,8 +2,8 @@
 #define __LINUXMT_SCHED_H
 
 #include <linuxmt/config.h>
-#include <linuxmt/types.h>
 #include <linuxmt/limits.h>
+#include <linuxmt/types.h>
 #include <linuxmt/fs.h>
 #include <linuxmt/time.h>
 #include <linuxmt/signal.h>


### PR DESCRIPTION
Reduces L1 cache to 8k as a result of recent testing, which frees up 4k for more tasks or other kernel resources.

Sync buffers in least recently used order (was being done in most recently used order).

Document recent major enhancements to L1 cache system.