### PR TITLE
[boot] Fix boot issues when /linux or /bootopts deleted

### DIFF
--- a/elks/arch/i86/drivers/char/console-direct.c
+++ b/elks/arch/i86/drivers/char/console-direct.c
@@ -207,8 +207,9 @@ void INITPROC console_init(void)
 	VideoSeg = 0xB000;
 	NumConsoles = 1;
         isMDA = 1;
+    } else {
+        isCGA = peekw(0xA8+2, 0x40) == 0;
     }
-    if (!isMDA) isCGA = peekw(0xA8+2, 0x40) == 0;
 
     C = Con;
     Visible = C;

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -146,7 +146,7 @@ void INITPROC kernel_init(void)
 
 #ifdef CONFIG_BOOTOPTS
     finalize_options();
-    if (!opts) printk("/bootopts ignored: header not ## or size > %d\n", OPTSEGSZ-1);
+    if (!opts) printk("/bootopts not found or bad format/size\n");
 #endif
 
 #ifdef CONFIG_FARTEXT_KERNEL


### PR DESCRIPTION
The minix bootblock would recognize a deleted copy of linux and try to load it. This has been fixed.

The kernel setup code would report /bootopts as malformed even if no bootopts file existed. This has been fixed.

Old "Linux found" boot message changed to "/linux" due to lack of space in boot sector.

Fixes courtesy of @Mellvik from his TLVC project.
