### PR TITLE
[kernel] Don't mark inode dirty in fchown unless uid or gid changed, cleanup

### DIFF
--- a/elks/arch/i86/drivers/block/ll_rw_blk.c
+++ b/elks/arch/i86/drivers/block/ll_rw_blk.c
@@ -186,7 +186,7 @@ static void make_request(unsigned short major, int rw, struct buffer_head *bh)
     int max_req;
 
     //debug_blk("BLK %lu %s %lx:%x\n", buffer_blocknr(bh), rw==READ? "read": "write",
-	//buffer_seg(bh), buffer_data(bh));
+	//(unsigned long)buffer_seg(bh), buffer_data(bh));
 
 #ifdef BDEV_SIZE_CHK
     sector_t count = BLOCK_SIZE / SECTOR_SIZE;	/* FIXME must move to lower level*/

--- a/elks/arch/i86/drivers/char/mem.c
+++ b/elks/arch/i86/drivers/char/mem.c
@@ -45,8 +45,8 @@
 /*
  * generally useful code...
  */
-int memory_lseek(struct inode *inode, register struct file *filp,
-		    loff_t offset, unsigned int origin)
+int memory_lseek(struct inode *inode, struct file *filp, loff_t offset,
+        unsigned int origin)
 {
     debugmem("mem_lseek()\n");
     switch (origin) {
@@ -60,12 +60,6 @@ int memory_lseek(struct inode *inode, register struct file *filp,
     }
     if (offset != filp->f_pos) {
 	filp->f_pos = offset;
-
-#ifdef BLOAT_FS
-	filp->f_reada = 0;
-	filp->f_version = ++event;
-#endif
-
     }
     return 0;
 }
@@ -89,7 +83,7 @@ size_t null_read(struct inode *inode, struct file *filp, char *data, size_t len)
 size_t null_write(struct inode *inode, struct file *filp, char *data, size_t len)
 {
     debugmem("null write: ignoring %d bytes!\n", len);
-    return (size_t)len;
+    return len;
 }
 
 /*

--- a/elks/fs/block_dev.c
+++ b/elks/fs/block_dev.c
@@ -112,13 +112,10 @@ size_t block_write(struct inode *inode, struct file *filp, char *buf, size_t cou
 	written += chars;
 	count -= chars;
     }
-    {
-	register struct inode *pinode = inode;
-	if ((loff_t)pinode->i_size < filp->f_pos)
-	    pinode->i_size = (__u32) filp->f_pos;
-	pinode->i_mtime = pinode->i_ctime = CURRENT_TIME;
-	pinode->i_dirt = 1;
-    }
+    if ((loff_t)inode->i_size < filp->f_pos)
+        inode->i_size = (__u32) filp->f_pos;
+    inode->i_mtime = inode->i_ctime = CURRENT_TIME;
+    inode->i_dirt = 1;
     return written;
 #else
     return -EINVAL;

--- a/elks/fs/file_table.c
+++ b/elks/fs/file_table.c
@@ -33,8 +33,8 @@ int open_filp(unsigned short flags, struct inode *inode, struct file **fp)
     register struct file_operations *fop;
 
     while (f->f_count) {
-	if (++f >= &file_array[NR_FILE]) {	/* TODO: is nr_file const? */
-	    printk("\nNo filps\n");
+	if (++f >= &file_array[NR_FILE]) {
+	    printk("open: No files\n");
 	    return -ENFILE;
 	}
     }
@@ -42,20 +42,14 @@ int open_filp(unsigned short flags, struct inode *inode, struct file **fp)
     f->f_flags = flags;
     f->f_mode = (mode_t) ((flags + 1) & O_ACCMODE);
     f->f_count = 1;
-/*    f->f_pos = 0;*/	/* FIXME - should call lseek *//* Set to zero by memset() */
-#ifdef BLOAT_FS
-    f->f_version = ++event;
-#endif
+/*  f->f_pos = 0;*/	/* FIXME - should call lseek */
     f->f_inode = inode;
+
 #ifdef BLOAT_FS
     if (f->f_mode & FMODE_WRITE) {
 	result = get_write_access(inode);
 	if (result) goto cleanup_file;
     }
-#endif
-
-#ifdef BLOAT_FS
-/*    f->f_reada = 0;*/ /* Set to zero by memset() */
 #endif
 
     if (inode->i_op) f->f_op = inode->i_op->default_file_ops;

--- a/elks/fs/read_write.c
+++ b/elks/fs/read_write.c
@@ -41,7 +41,6 @@ int sys_lseek(unsigned int fd, loff_t * p_offset, unsigned int origin)
 #ifdef BLOAT_FS
     if (offset != file->f_pos) {
 	file->f_reada = 0;
-	file->f_version = ++event;
     }
 #endif
 

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -236,10 +236,6 @@ struct file {
     unsigned short		f_count;
     struct inode		*f_inode;
     struct file_operations	*f_op;
-#ifdef BLOAT_FS
-    off_t			f_reada;
-    unsigned long		f_version;
-#endif
 };
 
 struct super_block {

--- a/elks/include/linuxmt/limits.h
+++ b/elks/include/linuxmt/limits.h
@@ -39,7 +39,6 @@
 #define PIPE_BUFSIZ     80      /* doesn't have to be power of two */
 
 #define NR_ALARMS       5       /* Max number of simultaneous alarms system-wide */
-#define NGROUPS         13      /* Supplementary groups */
 
 #define MAX_PACKET_ETH 1536     /* Max packet size, 6 blocks of 256 bytes */
 

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -78,6 +78,7 @@ struct task_struct {
 #endif
 
 #ifdef CONFIG_SUPPLEMENTARY_GROUPS
+#define NGROUPS     13
     gid_t			groups[NGROUPS];
 #endif
 

--- a/elks/kernel/sys.c
+++ b/elks/kernel/sys.c
@@ -295,7 +295,7 @@ int sys_setsid(void)
  * Supplementary group ID's
  */
 
-#define NGROUP	0xFFFF
+#define NOGROUP     0xFFFF
 
 int sys_getgroups(int gidsetsize, gid_t * grouplist)
 {
@@ -325,20 +325,11 @@ int sys_setgroups(int gidsetsize, gid_t * grouplist)
     if (!suser())
         return -EPERM;
 
-#if 1
-    /* semantics change.. return EINVAL for gidsetsize < 0. */
     if (((unsigned int)gidsetsize) > NGROUPS)
         return -EINVAL;
 
     pg = current->groups;
     lg = pg + gidsetsize;
-#else
-    if (gidsetsize > NGROUPS)
-        return -EINVAL;
-
-    pg = current->groups;
-    lg = pg + ((gidsetsize >= 0) ? gidsetsize : 0);
-#endif
 
     if (lg > pg) {
 	if (verified_memcpy_fromfs(pg, grouplist, ((char *)lg) - ((char *)pg)))
@@ -354,11 +345,11 @@ int sys_setgroups(int gidsetsize, gid_t * grouplist)
 
 int in_group_p(gid_t grp)
 {
-    register char *p = (char *) current;
+    gid_t *pg;
+    char *p;
 
-    if (grp != ((__ptask) p)->egid) {
-	register gid_t *pg = ((__ptask) p)->groups - 1;
-
+    if (grp != (current->egid) {
+	pg = current->groups - 1;
 	p = (char *)(pg + NGROUPS);
 
 	do {


### PR DESCRIPTION
This fixes the kernel writing the `/dev/tty1` inode directly after boot, because `/bin/login` calls `fchown` to change the user and group ID to the logged in user. This unnecessary block write (which also clears the track cache) is now avoided for root user login, as `fchown` no longer marks the inode as changed unless the user or group ID is actually changing. Discussed initially in https://github.com/Mellvik/TLVC/issues/20#issuecomment-1695837312.

During the rabbit chase to find out the reason for the block write, a number of source files were cleaned up, which ended up being the majority of the changes in this PR (but no functional changes).