### PR TITLE
[kernel] Source cleanup replace #if 0 with #if UNUSED

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -720,7 +720,7 @@ static int bioshd_open(struct inode *inode, struct file *filp)
     if (!bioshd_initialized || target >= NUM_DRIVES || hdp->start_sect == -1U)
         return -ENXIO;
 
-#if 0
+#if UNUSED
     while (busy[target])
         sleep_on(&busy_wait);
 #endif
@@ -1106,7 +1106,7 @@ static void do_bioshd_request(void)
     spin_timer(0);
 }
 
-#if 0			/* Currently not used, removing for size. */
+#if UNUSED
 static struct wait_queue busy_wait;
 static int revalidate_hddisk(int, int);	/* Currently not used*/
 

--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -74,7 +74,7 @@ static void INITPROC add_partition(struct gendisk *hd, unsigned short int minor,
      * Some BIOS subtract a cylinder, making direct comparison incorrect.
      * A CHS cylinder can have 63 max sectors * 255 heads, so adjust for that.
      */
-#if 0	/* partition skipping disabled as virtual cylinder values sometimes needed for CF cards*/
+#if UNUSED /* partition skipping disabled as virtual cylinder values sometimes needed for CF cards*/
     struct hd_struct *hd0 = &hd->part[0];
     sector_t adj_nr_sects = hd0->nr_sects + 63 * 255;
     if (start > adj_nr_sects || start+size > adj_nr_sects) {
@@ -302,7 +302,7 @@ static void INITPROC check_partition(register struct gendisk *hd, kdev_t dev)
     first_time = 0;
     first_sector = hd->part[MINOR(dev)].start_sect;
 
-#if 0
+#if UNUSED
     /*
      * This is a kludge to allow the partition check to be
      * skipped for specific drives (e.g. IDE cd-rom drives)
@@ -328,7 +328,7 @@ static void INITPROC check_partition(register struct gendisk *hd, kdev_t dev)
    Much of the cleanup from the old partition tables should have already been
    done */
 
-#if 0				/* Currently unused */
+#if UNUSED
 /* This function will re-read the partition tables for a given device, and set
  * things back up again. There are some important caveats, however. You must
  * ensure that no one is using the device, and no one can start using the

--- a/elks/arch/i86/drivers/char/lp.c
+++ b/elks/arch/i86/drivers/char/lp.c
@@ -102,7 +102,7 @@ static int lp_char_polled(int c, unsigned int target)
 	    return 0;
 	}
 
-#if 0
+#if UNUSED
 
 	if (!(status & LP_SELECTED)) { /* printer offline */
 	    printk("lp%d: printer offline\n", target);

--- a/elks/arch/i86/drivers/char/meta.c
+++ b/elks/arch/i86/drivers/char/meta.c
@@ -97,10 +97,8 @@ static void do_meta_request(void)
 
 	/* Should really check here whether we have a request */
 	if (req->rq_cmd == WRITE) {
-	    /* Can't do this, copies to the wrong task */
-#if 0
+#if UNUSED  /* FIXME Can't do this, copies to the wrong task */
 	    verified_memcpy_tofs(driver->udd_data, buff, BLOCK_SIZE);
-/* FIXME FIXME	*/
 	    fmemcpyw(driver->udd_data, driver->udd_task->mm.dseg,
 	    		buff, kernel_ds, 1024/2);
 #endif
@@ -122,10 +120,8 @@ static void do_meta_request(void)
 	udr->udr_status = 0;
 	buff = req->rq_buffer;
 	if (req->rq_cmd == READ) {
-	    /* Can't do this, copies from the wrong task */
-#if 0
+#if UNUSED  /* FIXME Can't do this, copies to the wrong task */
 	    verified_memcpy_fromfs(buff, driver->udd_data, BLOCK_SIZE);
-/* FIXME FIXME */
 	    fmemcpyw(buff, kernel_ds,
 	    		driver->udd_data, driver->udd_task->mm.dseg, 1024/2);
 #endif

--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -153,7 +153,7 @@ int tty_open(struct inode *inode, struct file *file)
 	return -ENODEV;
 
     debug_tty("TTY open pid %d\n", currentp->pid);
-#if 0
+#if UNUSED
     memcpy(&otty->termios, &def_vals, sizeof(struct termios));
 #endif
 
@@ -240,7 +240,7 @@ int tty_outproc(register struct tty *tty)
 		    tty->ostate = 0x10;
 		}
 		break;
-#if 0
+#if UNUSED
 	    case '\r':
 		if (t_oflag & OCRNL)
 		    ch = '\n';				/* Map CR to NL */

--- a/elks/arch/i86/drivers/char/serial-8250.c
+++ b/elks/arch/i86/drivers/char/serial-8250.c
@@ -292,7 +292,7 @@ void rs_irq(int irq, struct pt_regs *regs)
     if ((status & UART_LSR_DR) == 0)			/* QEMU may interrupt w/no data*/
 	return;
 
-#if 0	// turn on for serial stats
+#if UNUSED      // turn on for serial stats
     if (status & UART_LSR_OE)
 	printk("serial: data overrun\n");
     if (status & (UART_LSR_FE|UART_LSR_PE))

--- a/elks/arch/i86/drivers/net/wd.c
+++ b/elks/arch/i86/drivers/net/wd.c
@@ -561,7 +561,7 @@ static int wd_ioctl(struct inode * inode, struct file * file,
 		err = verified_memcpy_tofs((char *)arg, &netif_stat.mac_addr, 6U);
 		break;
 
-#if 0 /* unused*/
+#if UNUSED
 	case IOCTL_ETH_ADDR_SET:
 		err = -ENOSYS;
 		break;

--- a/elks/arch/i86/lib/bios15.S
+++ b/elks/arch/i86/lib/bios15.S
@@ -47,7 +47,7 @@ block_move:
 	pop	%es
 	ret
 
-#if 0
+#if UNUSED
 #
 # Test functions
 #

--- a/elks/arch/i86/lib/unreal.S
+++ b/elks/arch/i86/lib/unreal.S
@@ -274,7 +274,7 @@ sync_8042:
 	ret
 #endif
 
-#if 0
+#if UNUSED
 #
 # word_t linear32_peekw(void *src_off, addr_t src_seg)
 # WARNING: Requires 32-bit CPU, with unreal mode and A20 gate enabled!

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -518,7 +518,7 @@ int sys_execve(const char *filename, char *sptr, size_t slen)
      */
     arch_setup_user_stack(currentp, (word_t) mh.entry);
 
-#if 0	/* used only for vfork()*/
+#if UNUSED      /* used only for vfork()*/
     wake_up(&currentp->p_parent->child_wait);
 #endif
 

--- a/elks/fs/inode.c
+++ b/elks/fs/inode.c
@@ -210,7 +210,7 @@ void iput(register struct inode *inode)
 	        inode->i_rdev, (unsigned long)inode->i_ino, inode->i_mode);
 	    return;
 	}
-#ifdef NOT_YET
+#if UNUSED
 	if ((inode->i_mode & S_IFMT) == S_IFIFO)
 	    wake_up_interruptible(&PIPE_WAIT(*inode));
 #endif

--- a/elks/fs/minix/inode.c
+++ b/elks/fs/minix/inode.c
@@ -260,11 +260,7 @@ unsigned short _minix_bmap(register struct inode *inode, block_t block, int crea
 {
     int i;
 
-#if 0
-/* I do not understand what this bit means, it cannot be this big,
- * it is a short. If this was a long it would make sense. We need to
- * check for overruns in the block num elsewhere.. FIXME
- */
+#if UNUSED  /* block always less than 65536 */
     if (block > (7 + 512 + 512 * 512))
 	panic("_minix_bmap: block (%d) >big", block);
 #endif

--- a/elks/fs/msdos/fat.c
+++ b/elks/fs/msdos/fat.c
@@ -99,13 +99,13 @@ cluster_t FATPROC fat_access(struct super_block *sb,cluster_t this,cluster_t new
 #endif
 		debug_fat("fat_access block bh dirty %lu\n", buffer_blocknr(bh));
 		mark_buffer_dirty(bh);
-#if 0000 //FIXME
+#if UNUSED  /* FIXME update 2nd FAT table? */
 		/* update extra FAT table copies*/
 		//FIXME does not look like multiple fat table update is working
-		//FIXME should use copy=2 and <= #fats below
-		//FIXME temp removed because of useless slow memcpy below w/each file write
-		//FIXME needs rewrite for speed using operations above then mark dirty
-		//FIXME or perhaps just make a complete FAT table copy on unmount!
+		// should use copy=2 and <= #fats below
+		// temp removed because of useless slow memcpy below w/each file write
+		// needs rewrite for speed using operations above then mark dirty
+		// or perhaps just make a complete FAT table copy on unmount!
 		for (copy = 1; copy < MSDOS_SB(sb)->fats; copy++) {
 			if (!(c_bh = msdos_sread(sb,
 				(sector_t)(MSDOS_SB(sb)->fat_start+(first >> SECTOR_BITS_SB(sb)) +

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -197,7 +197,7 @@ printk("FAT: me=%x,csz=%d,#f=%d,floc=%d,fsz=%d,rloc=%d,#d=%d,dloc=%d,#s=%ld,ts=%
 	}
 
 	total_displayed = total_sectors >> (BLOCK_SIZE_BITS - SECTOR_BITS_SB(s));
-#if UNUSED
+#if UNUSED      /* calculate free count on mount */
 	long free_displayed = 0;
 	cluster_t cluster;
 	for (cluster = 2; cluster < sb->clusters + 2; cluster++)

--- a/elks/fs/stat.c
+++ b/elks/fs/stat.c
@@ -33,6 +33,7 @@ static int cp_stat(register struct inode *inode, struct stat *statbuf)
     tmp.st_atime	= inode->i_atime;
     tmp.st_ctime	= inode->i_ctime;
 
+#if UNUSED
 /*
  * st_blocks and st_blksize are approximated with a simple algorithm if
  * they aren't supported directly by the filesystem. The minix and msdos
@@ -40,24 +41,18 @@ static int cp_stat(register struct inode *inode, struct stat *statbuf)
  * be counted explicitly (by delving into the file itself), or by using
  * this simple algorithm to get a reasonable (although not 100% accurate)
  * value.
- */
-
-/*
+ *
  * Use minix fs values for the number of direct and indirect blocks.  The
  * count is now exact for the minix fs except that it counts zero blocks.
  * Everything is in BLOCK_SIZE'd units until the assignment to
  * tmp.st_blksize.
- */
-
-#if 0
-
-#define D_B   7
-#define I_B   (BLOCK_SIZE / sizeof(unsigned short))
-
-/* This code does nothing useful. The results of the calculations below
+ *
+ * This code does nothing useful. The results of the calculations below
  * are stored in local variables and nothing is done with them.
  * Al
  */
+#define D_B   7
+#define I_B   (BLOCK_SIZE / sizeof(unsigned short))
 
     if (!inode->i_blksize) {
 	unsigned int blocks, indirect;

--- a/elks/fs/super.c
+++ b/elks/fs/super.c
@@ -296,11 +296,6 @@ int sys_umount(char *name)
 	register struct file_operations *fops;
 	fops = get_blkfops(MAJOR(dev));
 	if (fops && fops->release) fops->release(inodep, NULL);
-
-#ifdef NOT_YET
-	if (MAJOR(dev) == UNNAMED_MAJOR) put_unnamed_dev(dev);
-#endif
-
     }
     iput(inodep);
     if (!retval) {

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -252,7 +252,7 @@ void panic(const char *error, ...)
     vprintk(error, p);
     va_end(p);
 
-#if 0
+#if UNUSED      // FIXME rewrite for ia16 call stack
     int *bp = (int *) &error - 2;
     char *j;
     int i = 0;

--- a/elks/kernel/sched.c
+++ b/elks/kernel/sched.c
@@ -178,9 +178,8 @@ static void run_timer_list(void)
     set_irq();
 }
 
-/* maybe someday I'll implement these profiling things -PL */
-
 #if UNUSED
+/* maybe someday I'll implement these profiling things -PL */
 
 static void do_it_prof(struct task_struct *p, jiff_t ticks)
 {

--- a/elks/kernel/sys.c
+++ b/elks/kernel/sys.c
@@ -164,8 +164,20 @@ int sys_setuid(uid_t uid)
     return 0;
 }
 
-#ifdef NOT_YET
+int sys_setsid(void)
+{
+    register __ptask currentp = current;
 
+    if (currentp->session == currentp->pid)
+	return -EPERM;
+    debug_tty("SETSID pgrp %d\n", currentp->pid);
+    currentp->session = currentp->pgrp = currentp->pid;
+    currentp->tty = NULL;
+
+    return currentp->pgrp;
+}
+
+#if UNUSED
 int sys_times(struct tms *tbuf)
 {
     if (tbuf) {
@@ -274,21 +286,7 @@ int sys_getsid(pid_t pid)
     return -ESRCH;
 
 }
-
-#endif /* NOT_YET */
-
-int sys_setsid(void)
-{
-    register __ptask currentp = current;
-
-    if (currentp->session == currentp->pid)
-	return -EPERM;
-    debug_tty("SETSID pgrp %d\n", currentp->pid);
-    currentp->session = currentp->pgrp = currentp->pid;
-    currentp->tty = NULL;
-
-    return currentp->pgrp;
-}
+#endif
 
 #ifdef CONFIG_SUPPLEMENTARY_GROUPS
 /*

--- a/elks/net/unix/af_unix.c
+++ b/elks/net/unix/af_unix.c
@@ -15,6 +15,7 @@
 #include <linuxmt/mm.h>
 #include <linuxmt/stat.h>
 #include <linuxmt/fcntl.h>
+#include <linuxmt/debug.h>
 
 #include <arch/segment.h>
 #include "af_unix.h"
@@ -36,11 +37,6 @@ static struct unix_proto_data *unix_data_alloc(void)
 	    upd->socket = NULL;
 	    upd->sockaddr_len = 0;
 	    upd->sockaddr_un.sun_family = 0;
-
-#if 0
-	    upd->buf = NULL;
-#endif
-
 	    upd->bp_head = upd->bp_tail = 0;
 	    upd->inode = NULL;
 	    upd->peerupd = NULL;
@@ -91,10 +87,6 @@ static int unix_create(struct socket *sock, int protocol)
     if (!(upd = unix_data_alloc()))
 	return -ENOMEM;
 
-#if 0
-    upd->protocol = protocol;	/* I don't think this is necessary */
-#endif
-
     upd->socket = sock;
     sock->data = upd;
     upd->refcnt = 1;
@@ -104,10 +96,6 @@ static int unix_create(struct socket *sock, int protocol)
 
 static int unix_dup(struct socket *newsock, struct socket *oldsock)
 {
-#if 0
-    struct unix_proto_data *upd = oldsock->data;
-#endif
-
     return unix_create(newsock, 0);
 }
 
@@ -170,9 +158,7 @@ static int unix_bind(struct socket *sock,
 
     current->t_regs.ds = old_ds;
     if (i < 0) {
-#if 0
-	printk("UNIX: bind: can't open socket %s\n", upd->sockaddr_un.sun_path);
-#endif
+	debug("UNIX: bind: can't open socket %s\n", upd->sockaddr_un.sun_path);
 	if (i == -EEXIST)
 	    i = -EADDRINUSE;
 	return i;
@@ -290,7 +276,7 @@ static int unix_accept(struct socket *sock, struct socket *newsock, int flags)
     UN_DATA(newsock)->sockaddr_len = UN_DATA(sock)->sockaddr_len;
     wake_up_interruptible(clientsock->wait);
 
-#if 0
+#if UNUSED
     sock_wake_async(clientsock, 0);	/* Don't need */
 #endif
 
@@ -367,7 +353,7 @@ static int unix_read(struct socket *sock, char *ubuf, int size, int nonblock)
 
 	if (sock->state == SS_CONNECTED) {
 	    wake_up_interruptible(sock->conn->wait);
-#if 0
+#if UNUSED
 	    sock_wake_async(sock->conn, 2);
 #endif
 	}
@@ -455,7 +441,7 @@ static int unix_write(struct socket *sock, char *ubuf, int size, int nonblock)
 
 	if (sock->state == SS_CONNECTED) {
 	    wake_up_interruptible(sock->conn->wait);
-#if 0
+#if UNUSED
 	    sock_wake_async(sock->conn, 1);
 #endif
 	}

--- a/elks/net/unix/af_unix.h
+++ b/elks/net/unix/af_unix.h
@@ -16,11 +16,6 @@
 struct unix_proto_data {
     int refcnt;
     struct socket *socket;
-
-#if BLOAT_NET
-    int protocol;
-#endif
-
     struct sockaddr_un sockaddr_un;
     short sockaddr_len;
     char buf[UN_BUF_SIZE];


### PR DESCRIPTION
More cleanup, removing some `#if 0` and replacing others with `#if UNUSED` if valid code but not desired or fully implemented.

Various `#if NOT_YET` replaced with `#if UNUSED`.

Overall result allows easier searching for future implementation.