### PR TITLE
[kernel] Replace CURRENT_TIME macro with function call

### DIFF
--- a/elks/fs/block_dev.c
+++ b/elks/fs/block_dev.c
@@ -56,7 +56,7 @@ size_t block_read(struct inode *inode, struct file *filp, char *buf, size_t coun
 	count -= chars;
     }
 #ifdef FIXME
-    if (!IS_RDONLY(inode)) inode->i_atime = CURRENT_TIME;
+    if (!IS_RDONLY(inode)) inode->i_atime = current_time();
 #endif
     return read;
 #else
@@ -114,7 +114,7 @@ size_t block_write(struct inode *inode, struct file *filp, char *buf, size_t cou
     }
     if ((loff_t)inode->i_size < filp->f_pos)
         inode->i_size = (__u32) filp->f_pos;
-    inode->i_mtime = inode->i_ctime = CURRENT_TIME;
+    inode->i_mtime = inode->i_ctime = current_time();
     inode->i_dirt = 1;
     return written;
 #else

--- a/elks/fs/inode.c
+++ b/elks/fs/inode.c
@@ -294,7 +294,7 @@ struct inode *new_inode(register struct inode *dir, __u16 mode)
     if (S_ISLNK(mode)) mode |= 0777;
     else mode &= ~(current->fs.umask & 0777);
     inode->i_mode = mode;
-    inode->i_mtime = inode->i_atime = inode->i_ctime = CURRENT_TIME;
+    inode->i_mtime = inode->i_atime = inode->i_ctime = current_time();
 
 #ifdef BLOAT_FS
     inode->i_blocks = inode->i_blksize = 0;
@@ -466,7 +466,7 @@ int notify_change(register struct inode *inode, register struct iattr *attr)
 {
     int retval;
 
-    attr->ia_ctime = CURRENT_TIME;
+    attr->ia_ctime = current_time();
     if (attr->ia_valid & (ATTR_ATIME | ATTR_MTIME)) {
 	if (!(attr->ia_valid & ATTR_ATIME_SET)) attr->ia_atime = attr->ia_ctime;
 	if (!(attr->ia_valid & ATTR_MTIME_SET)) attr->ia_mtime = attr->ia_ctime;

--- a/elks/fs/minix/inode.c
+++ b/elks/fs/minix/inode.c
@@ -227,7 +227,7 @@ static unsigned short map_izone(register struct inode *inode, block_t block, int
 
     if (create && !(*i_zone)) {
 	if ((*i_zone = minix_new_block(inode->i_sb))) {
-	    inode->i_ctime = CURRENT_TIME;
+	    inode->i_ctime = current_time();
 	    inode->i_dirt = 1;
 	}
     }

--- a/elks/fs/minix/namei.c
+++ b/elks/fs/minix/namei.c
@@ -194,15 +194,11 @@ static int minix_add_entry(register struct inode *dir,
 	    return -EEXIST;
 	}
     }
-    dir->i_mtime = dir->i_ctime = CURRENT_TIME;
+    dir->i_mtime = dir->i_ctime = current_time();
     dir->i_dirt = 1;
     memcpy_fromfs(de->name, name, namelen);
     if (info->s_namelen > namelen)
 	memset(de->name + namelen, 0, info->s_namelen - namelen);
-
-#ifdef BLOAT_FS
-    dir->i_version = ++event;
-#endif
 
     de->inode = (__u16)ino;
     mark_buffer_dirty(bh);
@@ -413,14 +409,10 @@ int minix_rmdir(register struct inode *dir, char *name, size_t len)
 		    printk("empty directory has nlink!=2 (%u)\n", inode->i_nlink);
 		de->inode = 0;
 
-#ifdef BLOAT_FS
-		dir->i_version = ++event;
-#endif
-
 		mark_buffer_dirty(bh);
 		inode->i_nlink = 0;
 		inode->i_dirt = 1;
-		inode->i_ctime = dir->i_ctime = dir->i_mtime = CURRENT_TIME;
+		inode->i_ctime = dir->i_ctime = dir->i_mtime = current_time();
 		dir->i_nlink--;
 		dir->i_dirt = 1;
 		retval = 0;
@@ -464,12 +456,8 @@ int minix_unlink(register struct inode *dir, char *name, size_t len)
     }
     de->inode = 0;
 
-#ifdef BLOAT_FS
-    dir->i_version = ++event;
-#endif
-
     mark_buffer_dirty(bh);
-    dir->i_ctime = dir->i_mtime = CURRENT_TIME;
+    dir->i_ctime = dir->i_mtime = current_time();
     dir->i_dirt = 1;
     inode->i_nlink--;
     inode->i_ctime = dir->i_ctime;
@@ -540,7 +528,7 @@ int minix_link(register struct inode *dir, char *name, size_t len,
     }
     else if (!(error = minix_add_entry(dir, name, len, oldinode->i_ino))) {
 	oldinode->i_nlink++;
-	oldinode->i_ctime = CURRENT_TIME;
+	oldinode->i_ctime = current_time();
 	oldinode->i_dirt = 1;
     }
     iput(dir);

--- a/elks/fs/minix/truncate.c
+++ b/elks/fs/minix/truncate.c
@@ -186,6 +186,6 @@ void minix_truncate(register struct inode *inode)
 	if (!retry) break;
 	schedule();
     }
-    inode->i_mtime = inode->i_ctime = CURRENT_TIME;
+    inode->i_mtime = inode->i_ctime = current_time();
     inode->i_dirt = 1;
 }

--- a/elks/fs/msdos/file.c
+++ b/elks/fs/msdos/file.c
@@ -140,7 +140,7 @@ static size_t msdos_file_write(register struct inode *inode,register struct file
 		mark_buffer_dirty(bh);
 		brelse(bh);
 	}
-	inode->i_mtime = CURRENT_TIME;
+	inode->i_mtime = current_time();
 	inode->u.msdos_i.i_attrs |= ATTR_ARCH;
 	inode->i_dirt = 1;
 	return start == buf ? error : buf-start;

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -313,7 +313,7 @@ void msdos_read_inode(register struct inode *inode)
 		inode->i_mode = devnods[(int)inode->i_ino - DEVINO_BASE].mode;
 		inode->i_uid  = 0;
 		inode->i_size = 0;
-		inode->i_mtime= CURRENT_TIME;
+		inode->i_mtime= current_time();
 		inode->i_gid  = 0;
 		inode->i_nlink= 1;
 		inode->i_rdev = devnods[(int)inode->i_ino - DEVINO_BASE].rdev;

--- a/elks/fs/msdos/namei.c
+++ b/elks/fs/msdos/namei.c
@@ -187,14 +187,14 @@ static int FATPROC msdos_create_entry(struct inode *dir,const char *name,int is_
 	memcpy(de->name,name,MSDOS_NAME);
 	de->attr = is_dir ? ATTR_DIR : ATTR_ARCH;
 	de->start = 0;
-	date_unix2dos(CURRENT_TIME,&de->time,&de->date);
+	date_unix2dos(current_time(),&de->time,&de->date);
 	de->size = 0;
 	debug_fat("create_entry block write %lu\n", buffer_blocknr(bh));
 	mark_buffer_dirty(bh);
 	if ((*result = iget(dir->i_sb,ino)) != 0) msdos_read_inode(*result);
 	unmap_brelse(bh);
 	if (!*result) return -EIO;
-	(*result)->i_mtime = CURRENT_TIME;
+	(*result)->i_mtime = current_time();
 	(*result)->i_dirt = 1;
 	return 0;
 }
@@ -319,7 +319,7 @@ int msdos_rmdir(register struct inode *dir,const char *name,int len)
 		if (dbh) unmap_brelse(dbh);
 	}
 	inode->i_nlink = 0;
-	dir->i_mtime = CURRENT_TIME;
+	dir->i_mtime = current_time();
 	inode->i_dirt = dir->i_dirt = 1;
 	de->name[0] = (unsigned char)DELETED_FLAG;
 	debug_fat("rmdir block write %lu\n", buffer_blocknr(bh));

--- a/elks/fs/open.c
+++ b/elks/fs/open.c
@@ -158,7 +158,7 @@ int sys_utime(char *filename, register struct utimbuf *times)
 	if (times) {
 	    inode->i_atime = get_user_long((void *) &times->actime);
 	    inode->i_mtime = get_user_long((void *) &times->modtime);
-	} else inode->i_atime = inode->i_mtime = CURRENT_TIME;
+	} else inode->i_atime = inode->i_mtime = current_time();
 	inode->i_dirt = 1;
 	iput(inode);
     }

--- a/elks/fs/pipe.c
+++ b/elks/fs/pipe.c
@@ -106,7 +106,7 @@ static size_t pipe_read(register struct inode *inode, struct file *filp,
     PIPE_LEN(inode) -= count;
     PIPE_LOCK(inode)--;
     wake_up_interruptible(&PIPE_WAIT(inode));
-    if (count) inode->i_atime = CURRENT_TIME;
+    if (count) inode->i_atime = current_time();
     else if (PIPE_WRITERS(inode)) count = -EAGAIN;
     return count;
 }
@@ -151,7 +151,7 @@ static size_t pipe_write(register struct inode *inode, struct file *filp,
 	wake_up_interruptible(&PIPE_WAIT(inode));
 	free = 1;
     }
-    inode->i_ctime = inode->i_mtime = CURRENT_TIME;
+    inode->i_ctime = inode->i_mtime = current_time();
 
     return written;
 }

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -120,7 +120,7 @@ extern __ptask current;
 extern struct timeval xtime;
 extern jiff_t xtime_jiffies;
 extern int tz_offset;
-#define CURRENT_TIME (xtime.tv_sec + (jiffies - xtime_jiffies)/HZ)
+extern time_t current_time(void);
 
 /* return true if time a is after time b */
 #define time_after(a,b)         (((long)(b) - (long)(a) < 0))

--- a/elks/kernel/time.c
+++ b/elks/kernel/time.c
@@ -52,6 +52,11 @@ void INITPROC tz_init(const char *tzstr)
         tz_offset = atoi(tzstr+3);
 }
 
+time_t current_time(void)
+{
+    return (xtime.tv_sec + (jiffies - xtime_jiffies)/HZ);
+}
+
 /* set the time of day */
 int sys_settimeofday(register struct timeval *tv, struct timezone *tz)
 {


### PR DESCRIPTION
Turns out calculating the time used a lot of code. Replacing the macro with a function call saves 750+ bytes in the kernel!