### PR TITLE
[kernel] Eliminate tabs from some kernel source files

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -59,13 +59,13 @@
 #define FORCE_PROBE     0       /* =1 to force floppy probing */
 
 /* the following must match with /dev minor numbering scheme*/
-#define NUM_MINOR	32	/* max minor devices per drive*/
-#define MINOR_SHIFT	5	/* =log2(NUM_MINOR) shift to get drive num*/
-#define NUM_DRIVES	8	/* =256/NUM_MINOR max number of drives*/
-#define DRIVE_FD0	4	/* first floppy drive =NUM_DRIVES/2*/
-#define DRIVE_FD1	5	/* second floppy drive*/
-#define DRIVE_FD2	6	/* PC98 only*/
-#define DRIVE_FD3	7	/* PC98 only*/
+#define NUM_MINOR       32      /* max minor devices per drive*/
+#define MINOR_SHIFT     5       /* =log2(NUM_MINOR) shift to get drive num*/
+#define NUM_DRIVES      8       /* =256/NUM_MINOR max number of drives*/
+#define DRIVE_FD0       4       /* first floppy drive =NUM_DRIVES/2*/
+#define DRIVE_FD1       5       /* second floppy drive*/
+#define DRIVE_FD2       6       /* PC98 only*/
+#define DRIVE_FD3       7       /* PC98 only*/
 
 #define MAJOR_NR BIOSHD_MAJOR
 #define BIOSDISK
@@ -73,23 +73,23 @@
 #include "blk.h"
 
 #ifdef CONFIG_ARCH_IBMPC
-#define MAXDRIVES	2	/* max floppy drives*/
+#define MAXDRIVES       2       /* max floppy drives*/
 #endif
 
 #ifdef CONFIG_ARCH_PC98
-#define MAXDRIVES	4	/* max floppy drives*/
+#define MAXDRIVES       4       /* max floppy drives*/
 #endif
 
 /* comment out following line for single-line drive info summary*/
-#define PRINT_DRIVE_INFO	NUM_DRIVES
+#define PRINT_DRIVE_INFO        NUM_DRIVES
 
 struct elks_disk_parms {
-    __u16 track_max;		/* number of tracks, little-endian */
-    __u8 sect_max;		/* number of sectors per track */
-    __u8 head_max;		/* number of disk sides/heads */
-    __u8 size;			/* size of parameter block (everything before
-				   this point) */
-    __u8 marker[2];		/* should be "eL" */
+    __u16 track_max;            /* number of tracks, little-endian */
+    __u8 sect_max;              /* number of sectors per track */
+    __u8 head_max;              /* number of disk sides/heads */
+    __u8 size;                  /* size of parameter block (everything before
+                                   this point) */
+    __u8 marker[2];             /* should be "eL" */
 } __attribute__((packed));
 
 static int bioshd_initialized = 0;
@@ -113,13 +113,13 @@ static struct drive_infot drive_info[NUM_DRIVES];
  * avoids a few senseless seeks in some cases
  */
 
-static struct hd_struct hd[NUM_DRIVES << MINOR_SHIFT];	/* partitions start, size*/
+static struct hd_struct hd[NUM_DRIVES << MINOR_SHIFT];  /* partitions start, size*/
 
-static int access_count[NUM_DRIVES];	/* for invalidating buffers/inodes*/
+static int access_count[NUM_DRIVES];    /* for invalidating buffers/inodes*/
 
-static int bioshd_sizes[NUM_DRIVES << MINOR_SHIFT];	/* used only with BDEV_SIZE_CHK*/
+static int bioshd_sizes[NUM_DRIVES << MINOR_SHIFT];     /* used only with BDEV_SIZE_CHK*/
 
-struct drive_infot fd_types[] = {	/* AT/PS2 BIOS reported floppy formats*/
+struct drive_infot fd_types[] = {       /* AT/PS2 BIOS reported floppy formats*/
     {40,  9, 2, 512, 0},
     {80, 15, 2, 512, 1},
     {80,  9, 2, 512, 2},
@@ -132,25 +132,25 @@ struct drive_infot fd_types[] = {	/* AT/PS2 BIOS reported floppy formats*/
 
 #ifdef CONFIG_ARCH_PC98
 unsigned char hd_drive_map[NUM_DRIVES] = {/* BIOS drive mappings*/
-    0xA0, 0xA1, 0xA2, 0xA3,		/* hda, hdb */
+    0xA0, 0xA1, 0xA2, 0xA3,             /* hda, hdb */
 #ifdef CONFIG_IMG_FD1232
-    0x90, 0x91, 0x92, 0x93		/* fd0, fd1 */
+    0x90, 0x91, 0x92, 0x93              /* fd0, fd1 */
 #else
-    0x30, 0x31, 0x32, 0x33		/* fd0, fd1 */
+    0x30, 0x31, 0x32, 0x33              /* fd0, fd1 */
 #endif
 };
 #else
 unsigned char hd_drive_map[NUM_DRIVES] = {/* BIOS drive mappings*/
-    0x80, 0x81, 0x82, 0x83,		/* hda, hdb */
-    0x00, 0x01, 0x02, 0x03		/* fd0, fd1 */
+    0x80, 0x81, 0x82, 0x83,             /* hda, hdb */
+    0x00, 0x01, 0x02, 0x03              /* fd0, fd1 */
 };
 #endif
 
-static int _fd_count = 0;  		/* number of floppy disks */
-static int _hd_count = 0;  		/* number of hard disks */
+static int _fd_count = 0;               /* number of floppy disks */
+static int _hd_count = 0;               /* number of hard disks */
 
-#define SPT		4	/* DDPT offset of sectors per track*/
-static unsigned char DDPT[14];	/* our copy of diskette drive parameter table*/
+#define SPT             4       /* DDPT offset of sectors per track*/
+static unsigned char DDPT[14];  /* our copy of diskette drive parameter table*/
 unsigned long __far *vec1E = _MK_FP(0, 0x1E << 2);
 
 static int bioshd_ioctl(struct inode *, struct file *, unsigned int, unsigned int);
@@ -160,58 +160,58 @@ static void bioshd_geninit(void);
 static void set_cache_invalid(void);
 
 static struct gendisk bioshd_gendisk = {
-    MAJOR_NR,			/* Major number */
-    "hd",			/* Major name */
-    MINOR_SHIFT,		/* Bits to shift to get real from partition */
-    1 << MINOR_SHIFT,		/* Number of partitions per real */
-    NUM_DRIVES,			/* maximum number of real */
-    bioshd_geninit,		/* init function */
-    hd,				/* hd struct */
-    bioshd_sizes,		/* sizes not blocksizes */
-    0,				/* number */
-    (void *) drive_info,	/* internal */
-    NULL			/* next */
+    MAJOR_NR,                   /* Major number */
+    "hd",                       /* Major name */
+    MINOR_SHIFT,                /* Bits to shift to get real from partition */
+    1 << MINOR_SHIFT,           /* Number of partitions per real */
+    NUM_DRIVES,                 /* maximum number of real */
+    bioshd_geninit,             /* init function */
+    hd,                         /* hd struct */
+    bioshd_sizes,               /* sizes not blocksizes */
+    0,                          /* number */
+    (void *) drive_info,        /* internal */
+    NULL                        /* next */
 };
 
-struct drive_infot *last_drive;	/* set to last drivep-> used in read/write */
+struct drive_infot *last_drive; /* set to last drivep-> used in read/write */
 static struct drive_infot *cache_drive;
 
 static void set_cache_invalid(void)
 {
-	cache_drive = NULL;
+        cache_drive = NULL;
 }
 
 static int bios_disk_rw(unsigned cmd, unsigned num_sectors, unsigned drive,
-	unsigned cylinder, unsigned head, unsigned sector, unsigned seg, unsigned offset)
+        unsigned cylinder, unsigned head, unsigned sector, unsigned seg, unsigned offset)
 {
 #ifdef CONFIG_ARCH_PC98
-	BD_AX = cmd | drive;
+        BD_AX = cmd | drive;
     if (((0xF0 & drive) == 0x80) || ((0xF0 & drive) == 0xA0)) {
-	BD_BX = (unsigned int) (num_sectors << 9);
-	BD_CX = cylinder;
-	BD_DX = (head << 8) | ((sector - 1) & 0xFF);
+        BD_BX = (unsigned int) (num_sectors << 9);
+        BD_CX = cylinder;
+        BD_DX = (head << 8) | ((sector - 1) & 0xFF);
     }
     else {
-	if ((0xF0 & drive) == 0x90) {
-	    BD_BX = (unsigned int) (num_sectors << 10);
-	    BD_CX = (3 << 8) | cylinder;
-	}
-	else {
-	    BD_BX = (unsigned int) (num_sectors << 9);
-	    BD_CX = (2 << 8) | cylinder;
-	}
-	BD_DX = (head << 8) | sector;
+        if ((0xF0 & drive) == 0x90) {
+            BD_BX = (unsigned int) (num_sectors << 10);
+            BD_CX = (3 << 8) | cylinder;
+        }
+        else {
+            BD_BX = (unsigned int) (num_sectors << 9);
+            BD_CX = (2 << 8) | cylinder;
+        }
+        BD_DX = (head << 8) | sector;
     }
-	BD_ES = seg;
-	BD_BP = offset;
+        BD_ES = seg;
+        BD_BP = offset;
 #else
-	BD_AX = cmd | num_sectors;
-	BD_CX = (unsigned int) ((cylinder << 8) | ((cylinder >> 2) & 0xc0) | sector);
-	BD_DX = (head << 8) | drive;
-	BD_ES = seg;
-	BD_BX = offset;
+        BD_AX = cmd | num_sectors;
+        BD_CX = (unsigned int) ((cylinder << 8) | ((cylinder >> 2) & 0xc0) | sector);
+        BD_DX = (head << 8) | drive;
+        BD_ES = seg;
+        BD_BX = offset;
 #endif
-	return call_bios(&bdt);
+        return call_bios(&bdt);
 }
 
 #ifdef CONFIG_BLK_DEV_BHD
@@ -230,83 +230,83 @@ static unsigned short int INITPROC bioshd_gethdinfo(void) {
 
     /* IDE */
     for (drive = 0; drive < 4; drive++) {
-	if (peekb(0x55D,0) & (1 << drive)) {
-	    BD_AX = BIOSHD_MODESET | (drive + 0x80);
-	    BD_ES = BD_DI = BD_SI = 0;
-	    call_bios(&bdt);
-	    hd_drive_map[ide_drives++] = drive + 0x80;
-	}
+        if (peekb(0x55D,0) & (1 << drive)) {
+            BD_AX = BIOSHD_MODESET | (drive + 0x80);
+            BD_ES = BD_DI = BD_SI = 0;
+            call_bios(&bdt);
+            hd_drive_map[ide_drives++] = drive + 0x80;
+        }
     }
     if (ide_drives > 0)
-	printk("bioshd: Detected IDE hd.\n");
+        printk("bioshd: Detected IDE hd.\n");
     ndrives = ide_drives;
 
     /* SCSI */
     if (ndrives < 4) {
-	for (scsi_id = 0; scsi_id < 7; scsi_id++) {
-	    BD_AX = BIOSHD_DRIVE_PARMS | (scsi_id + 0xA0);
-	    BD_ES = BD_DI = BD_SI = 0;
-	    call_bios_rvalue = call_bios(&bdt);
-	    if ((call_bios_rvalue == 0) && (BD_DX & 0xff)) {
-	        BD_AX = BIOSHD_DEVICE_TYPE | (scsi_id + 0xA0);
-	        BD_ES = BD_DI = BD_SI = 0;
-	        BD_BX = 0;
-	        call_bios(&bdt);
-	        device_type = BD_BX & 0xf; /* device_type = 0 for Hard Disk */
-	        if (device_type == 0)
-	            hd_drive_map[ndrives++] = scsi_id + 0xA0;
-	    }
-	    if (ndrives >= 4) break;
-	}
+        for (scsi_id = 0; scsi_id < 7; scsi_id++) {
+            BD_AX = BIOSHD_DRIVE_PARMS | (scsi_id + 0xA0);
+            BD_ES = BD_DI = BD_SI = 0;
+            call_bios_rvalue = call_bios(&bdt);
+            if ((call_bios_rvalue == 0) && (BD_DX & 0xff)) {
+                BD_AX = BIOSHD_DEVICE_TYPE | (scsi_id + 0xA0);
+                BD_ES = BD_DI = BD_SI = 0;
+                BD_BX = 0;
+                call_bios(&bdt);
+                device_type = BD_BX & 0xf; /* device_type = 0 for Hard Disk */
+                if (device_type == 0)
+                    hd_drive_map[ndrives++] = scsi_id + 0xA0;
+            }
+            if (ndrives >= 4) break;
+        }
     }
     if (ndrives > ide_drives)
-	printk("bioshd: Detected SCSI hd.\n");
+        printk("bioshd: Detected SCSI hd.\n");
 #else
     BD_AX = BIOSHD_DRIVE_PARMS;
-    BD_DX = 0x80;		/* query hard drives only*/
-    BD_ES = BD_DI = BD_SI = 0;	/* guard against BIOS bugs*/
+    BD_DX = 0x80;               /* query hard drives only*/
+    BD_ES = BD_DI = BD_SI = 0;  /* guard against BIOS bugs*/
     if (!call_bios(&bdt))
-	ndrives = BD_DX & 0xff;
+        ndrives = BD_DX & 0xff;
     else
-	debug_bios("bioshd: get_drive_parms fail on hd\n");
+        debug_bios("bioshd: get_drive_parms fail on hd\n");
 #endif
     if (ndrives > NUM_DRIVES/2)
-	ndrives = NUM_DRIVES/2;
+        ndrives = NUM_DRIVES/2;
 
     for (drive = 0; drive < ndrives; drive++) {
 #ifdef CONFIG_ARCH_PC98
-	BD_AX = BIOSHD_DRIVE_PARMS | hd_drive_map[drive];
+        BD_AX = BIOSHD_DRIVE_PARMS | hd_drive_map[drive];
 #else
-	BD_AX = BIOSHD_DRIVE_PARMS;
-	BD_DX = drive + 0x80;
+        BD_AX = BIOSHD_DRIVE_PARMS;
+        BD_DX = drive + 0x80;
 #endif
-	BD_ES = BD_DI = BD_SI = 0;	/* guard against BIOS bugs*/
-	if (call_bios(&bdt) == 0) {
+        BD_ES = BD_DI = BD_SI = 0;      /* guard against BIOS bugs*/
+        if (call_bios(&bdt) == 0) {
 #ifdef CONFIG_ARCH_PC98
-	    drivep->heads = BD_DX >> 8;
-	    drivep->sectors = BD_DX & 0xff;
-	    drivep->cylinders = BD_CX;
+            drivep->heads = BD_DX >> 8;
+            drivep->sectors = BD_DX & 0xff;
+            drivep->cylinders = BD_CX;
 #else
-	    drivep->heads = (BD_DX >> 8) + 1;
-	    drivep->sectors = BD_CX & 0x3f;
-	    /* NOTE: some BIOS may underreport cylinders by 1*/
-	    drivep->cylinders = (((BD_CX & 0xc0) << 2) | (BD_CX >> 8)) + 1;
+            drivep->heads = (BD_DX >> 8) + 1;
+            drivep->sectors = BD_CX & 0x3f;
+            /* NOTE: some BIOS may underreport cylinders by 1*/
+            drivep->cylinders = (((BD_CX & 0xc0) << 2) | (BD_CX >> 8)) + 1;
 #endif
-	    drivep->fdtype = -1;
-	    drivep->sector_size = 512;
-	    printk("bioshd: hd%c BIOS CHS %u,%d,%d\n", 'a'+drive, drivep->cylinders,
-		drivep->heads, drivep->sectors);
-	}
+            drivep->fdtype = -1;
+            drivep->sector_size = 512;
+            printk("bioshd: hd%c BIOS CHS %u,%d,%d\n", 'a'+drive, drivep->cylinders,
+                drivep->heads, drivep->sectors);
+        }
 #ifdef CONFIG_IDE_PROBE
-	if (sys_caps & CAP_HD_IDE) {		/* Normally PC/AT or higher */
-	    if (!get_ide_data(drive, drivep)) {	/* get CHS from the drive itself */
-		/* sanity checks already done, accepting data */
-		printk("bioshd: hd%c  IDE CHS %d,%d,%d\n", 'a'+drive, drivep->cylinders,
-		drivep->heads, drivep->sectors);
-	    }
-	}
+        if (sys_caps & CAP_HD_IDE) {            /* Normally PC/AT or higher */
+            if (!get_ide_data(drive, drivep)) { /* get CHS from the drive itself */
+                /* sanity checks already done, accepting data */
+                printk("bioshd: hd%c  IDE CHS %d,%d,%d\n", 'a'+drive, drivep->cylinders,
+                drivep->heads, drivep->sectors);
+            }
+        }
 #endif
-	drivep++;
+        drivep++;
     }
     return ndrives;
 }
@@ -318,8 +318,8 @@ static unsigned short int INITPROC bioshd_getfdinfo(void)
 {
 /* Set this to match your system. Currently it's set to a two drive system:
  *
- *		720KB as /dev/fd0
- *	and	720KB as /dev/fd1
+ *              720KB as /dev/fd0
+ *      and     720KB as /dev/fd1
  *
  * ndrives is number of drives in your system (either 0, 1 or 2)
  */
@@ -333,14 +333,14 @@ static unsigned short int INITPROC bioshd_getfdinfo(void)
  * Enter type 4 in fd_types' brackets for unknown drive type
  * Otherwise use floppy drive type table below:
  *
- *	Type	Format
- *	~~~~	~~~~~~
- *	  0	360 KB
- *	  1	1.2 MB
- *	  2	720 KB
- *	  3	1.44 MB
- *	  4	2.88 MB or Unknown
- *	  5	1.232 MB (PC98 1K sectors)
+ *      Type    Format
+ *      ~~~~    ~~~~~~
+ *        0     360 KB
+ *        1     1.2 MB
+ *        2     720 KB
+ *        3     1.44 MB
+ *        4     2.88 MB or Unknown
+ *        5     1.232 MB (PC98 1K sectors)
  *
  * Warning: drive will be reported as 2880 KB at bootup if you've set it
  * as unknown (4). Floppy probe will detect correct floppy format at each
@@ -362,8 +362,8 @@ static unsigned short int INITPROC bioshd_getfdinfo(void)
 #endif
 
 #ifdef CONFIG_ARCH_IBMPC
-    drive_info[DRIVE_FD0] = fd_types[2];	/*  /dev/fd0    */
-    drive_info[DRIVE_FD1] = fd_types[2];	/*  /dev/fd1    */
+    drive_info[DRIVE_FD0] = fd_types[2];        /*  /dev/fd0    */
+    drive_info[DRIVE_FD1] = fd_types[2];        /*  /dev/fd1    */
 #endif
 
     return ndrives;
@@ -384,39 +384,39 @@ static unsigned short int INITPROC bioshd_getfdinfo(void)
      */
     unsigned char equip_flags = peekb(0x10, 0x40);
     if (equip_flags & 0x01)
-	ndrives = (equip_flags >> 6) + 1;
+        ndrives = (equip_flags >> 6) + 1;
 #endif
 
 #ifdef CONFIG_ARCH_PC98
     for (drive = 0; drive < 4; drive++) {
-	if (peekb(0x55C,0) & (1 << drive)) {
+        if (peekb(0x55C,0) & (1 << drive)) {
 #ifdef CONFIG_IMG_FD1232
-	    hd_drive_map[DRIVE_FD0 + ndrives] = drive + 0x90;
-	    *drivep = fd_types[5];
+            hd_drive_map[DRIVE_FD0 + ndrives] = drive + 0x90;
+            *drivep = fd_types[5];
 #else
-	    hd_drive_map[DRIVE_FD0 + ndrives] = drive + 0x30;
-	    *drivep = fd_types[3];
+            hd_drive_map[DRIVE_FD0 + ndrives] = drive + 0x30;
+            *drivep = fd_types[3];
 #endif
-	    ndrives++;	/* floppy drive count*/
-	    drivep++;
-	}
+            ndrives++;  /* floppy drive count*/
+            drivep++;
+        }
     }
 #else
     /* Floppy query may fail if not PC/AT */
     BD_AX = BIOSHD_DRIVE_PARMS;
     BD_DX = 0;                  /* query floppies only*/
-    BD_ES = BD_DI = BD_SI = 0;	/* guard against BIOS bugs*/
+    BD_ES = BD_DI = BD_SI = 0;  /* guard against BIOS bugs*/
     if (!call_bios(&bdt))
-        ndrives = BD_DX & 0xff;	/* floppy drive count*/
+        ndrives = BD_DX & 0xff; /* floppy drive count*/
     else
         printk("fd: no bios get drives, ndrives %d\n", ndrives);
 
     /* set drive type for floppies*/
     for (drive = 0; drive < ndrives; drive++) {
-	/*
-	 * If type cannot be determined using BIOSHD_DRIVE_PARMS,
-	 * set drive type to 1.4MM on AT systems, and 360K for XT.
-	 */
+        /*
+         * If type cannot be determined using BIOSHD_DRIVE_PARMS,
+         * set drive type to 1.4MM on AT systems, and 360K for XT.
+         */
         BD_AX = BIOSHD_DRIVE_PARMS;
         BD_DX = drive;
         BD_ES = BD_DI = BD_SI = 0;      /* guard against BIOS bugs*/
@@ -446,37 +446,37 @@ static void bioshd_release(struct inode *inode, struct file *filp)
 /* set our DDPT sectors per track value*/
 static void set_ddpt(int max_sectors)
 {
-	DDPT[SPT] = (unsigned char) max_sectors;
+        DDPT[SPT] = (unsigned char) max_sectors;
 }
 
 /* get the diskette drive parameter table from INT 1E and point to our RAM copy of it*/
 static void copy_ddpt(void)
 {
-	unsigned long oldvec = *vec1E;
+        unsigned long oldvec = *vec1E;
 
-	/* We want to prevent the BIOS from accidentally doing a "multitrack"
-	 * floppy read --- and wrapping around from one head to the next ---
-	 * when ELKS only wants to read from a single track.
-	 *
-	 * (E.g. if DDPT SPT = 9, and a disk has 18 sectors per track, and we
-	 * want to read sectors 9--10 from track 0, side 0, then the BIOS may
-	 * read sector 9 from track 0, side 0, followed by sector 1 from track
-	 * 0, side 1, which will be wrong.)
-	 *
-	 * To prevent this, we set the DDPT SPT field to the actual sector
-	 * count per track in the detected disk geometry.  The DDPT SPT
-	 * should never be smaller than the actual SPT, but it can be larger.
-	 *
-	 * Rather than issue INT 13h function 8 (Get Drive Parameters, not implemented
-	 * on IBM XT BIOS v1 and earlier) to get an accurate DDPT, just copy the original
-	 * DDPT to RAM, where the sectors per track value will be modified before each
-	 * INT 13h function 2/3 (Read/Write Disk Sectors).
-	 * Using a patched DDPT also eliminates the need for a seperate fix for #39/#44.
-	 */
-	fmemcpyw(DDPT, _FP_SEG(DDPT), (void *)(unsigned)oldvec, _FP_SEG(oldvec),
-		sizeof(DDPT)/2);
-	debug_bios("bioshd: DDPT vector %x:%x SPT %d\n", _FP_SEG(oldvec), (unsigned)oldvec, DDPT[SPT]);
-	*vec1E = (unsigned long)(void __far *)DDPT;
+        /* We want to prevent the BIOS from accidentally doing a "multitrack"
+         * floppy read --- and wrapping around from one head to the next ---
+         * when ELKS only wants to read from a single track.
+         *
+         * (E.g. if DDPT SPT = 9, and a disk has 18 sectors per track, and we
+         * want to read sectors 9--10 from track 0, side 0, then the BIOS may
+         * read sector 9 from track 0, side 0, followed by sector 1 from track
+         * 0, side 1, which will be wrong.)
+         *
+         * To prevent this, we set the DDPT SPT field to the actual sector
+         * count per track in the detected disk geometry.  The DDPT SPT
+         * should never be smaller than the actual SPT, but it can be larger.
+         *
+         * Rather than issue INT 13h function 8 (Get Drive Parameters, not implemented
+         * on IBM XT BIOS v1 and earlier) to get an accurate DDPT, just copy the original
+         * DDPT to RAM, where the sectors per track value will be modified before each
+         * INT 13h function 2/3 (Read/Write Disk Sectors).
+         * Using a patched DDPT also eliminates the need for a seperate fix for #39/#44.
+         */
+        fmemcpyw(DDPT, _FP_SEG(DDPT), (void *)(unsigned)oldvec, _FP_SEG(oldvec),
+                sizeof(DDPT)/2);
+        debug_bios("bioshd: DDPT vector %x:%x SPT %d\n", _FP_SEG(oldvec), (unsigned)oldvec, DDPT[SPT]);
+        *vec1E = (unsigned long)(void __far *)DDPT;
 }
 
 /* As far as I can tell this doesn't actually work, but we might
@@ -498,7 +498,7 @@ static void reset_bioshd(int drive)
 /* map drives */
 static void map_drive(int *drive)
 {
-	*drive = hd_drive_map[*drive];
+        *drive = hd_drive_map[*drive];
 }
 
 #ifdef CONFIG_ARCH_PC98
@@ -507,15 +507,15 @@ static void switch_device98(int target, unsigned char device, struct drive_infot
 {
     hd_drive_map[target + DRIVE_FD0] = (device | (hd_drive_map[target + DRIVE_FD0] & 0x0F));
     if (device == 0x30)
-	*drivep = fd_types[3];	/* 1.44 MB */
+        *drivep = fd_types[3];  /* 1.44 MB */
     else if (device == 0x90)
-	*drivep = fd_types[5];	/* 1.232 MB */
+        *drivep = fd_types[5];  /* 1.232 MB */
 }
 #endif
 
 static int read_sector(int drive, int cylinder, int sector)
 {
-    int count = 2;		/* one retry on probe or boot sector read */
+    int count = 2;              /* one retry on probe or boot sector read */
 
 #ifdef CONFIG_ARCH_PC98
     drive += DRIVE_FD0;
@@ -524,13 +524,13 @@ static int read_sector(int drive, int cylinder, int sector)
 
     set_cache_invalid();
     do {
-	set_irq();
-	set_ddpt(36);		/* set to large value to avoid BIOS issues*/
-	if (!bios_disk_rw(BIOSHD_READ, 1, drive, cylinder, 0, sector, DMASEG, 0))
-	    return 0;			/* everything is OK */
-	reset_bioshd(drive);
+        set_irq();
+        set_ddpt(36);           /* set to large value to avoid BIOS issues*/
+        if (!bios_disk_rw(BIOSHD_READ, 1, drive, cylinder, 0, sector, DMASEG, 0))
+            return 0;                   /* everything is OK */
+        reset_bioshd(drive);
     } while (--count > 0);
-    return 1;			/* error */
+    return 1;                   /* error */
 }
 
 #ifdef CONFIG_BLK_DEV_BFD
@@ -542,79 +542,79 @@ static void probe_floppy(int target, struct hd_struct *hdp)
  * 1.2 MB and 1.44 MB floppy image and works fine - Blaz Antonic
  */
 
-    if (target >= DRIVE_FD0) {		/* the floppy drives */
-	register struct drive_infot *drivep = &drive_info[target];
+    if (target >= DRIVE_FD0) {          /* the floppy drives */
+        register struct drive_infot *drivep = &drive_info[target];
 
 /* probing range can be easily extended by adding more values to these
  * two lists and adjusting for loop' parameters in line 433 and 446 (or
  * somewhere near)
  */
 #ifdef CONFIG_ARCH_PC98
-	static unsigned char sector_probe[2] = { 8, 18 };
-	static unsigned char track_probe[2] = { 77, 80 };
+        static unsigned char sector_probe[2] = { 8, 18 };
+        static unsigned char track_probe[2] = { 77, 80 };
 #else
-	static unsigned char sector_probe[5] = { 8, 9, 15, 18, 36 };
-	static unsigned char track_probe[2] = { 40, 80 };
+        static unsigned char sector_probe[5] = { 8, 9, 15, 18, 36 };
+        static unsigned char track_probe[2] = { 40, 80 };
 #endif
-	int count, found_PB = 0;
+        int count, found_PB = 0;
 
-	target &= MAXDRIVES - 1;
+        target &= MAXDRIVES - 1;
 
 #if !FORCE_PROBE
-	/* Try to look for an ELKS or DOS parameter block in the first sector.
-	 * If it exists, we can obtain the disk geometry from it.
-	 */
-	if (!read_sector(target, 0, 1)) {
-	    struct elks_disk_parms __far *parms = _MK_FP(DMASEG, drivep->sector_size -
-		2 - sizeof(struct elks_disk_parms));
+        /* Try to look for an ELKS or DOS parameter block in the first sector.
+         * If it exists, we can obtain the disk geometry from it.
+         */
+        if (!read_sector(target, 0, 1)) {
+            struct elks_disk_parms __far *parms = _MK_FP(DMASEG, drivep->sector_size -
+                2 - sizeof(struct elks_disk_parms));
 
-	    /* first check for ELKS parm block */
-	    if (parms->marker[0] == 'e' && parms->marker[1] == 'L'
-		&& parms->size >= offsetof(struct elks_disk_parms, size)) {
-		drivep->cylinders = parms->track_max;
-		drivep->sectors = parms->sect_max;
-		drivep->heads = parms->head_max;
+            /* first check for ELKS parm block */
+            if (parms->marker[0] == 'e' && parms->marker[1] == 'L'
+                && parms->size >= offsetof(struct elks_disk_parms, size)) {
+                drivep->cylinders = parms->track_max;
+                drivep->sectors = parms->sect_max;
+                drivep->heads = parms->head_max;
 
-		if (drivep->cylinders != 0 && drivep->sectors != 0
-		    && drivep->heads != 0) {
-		    found_PB = 1;
+                if (drivep->cylinders != 0 && drivep->sectors != 0
+                    && drivep->heads != 0) {
+                    found_PB = 1;
 #if DEBUG_PROBE
-		    printk("fd: found valid ELKS CHS %d,%d,%d disk parameters on /dev/fd%d "
-			   "boot sector\n", drivep->cylinders, drivep->heads, drivep->sectors,
+                    printk("fd: found valid ELKS CHS %d,%d,%d disk parameters on /dev/fd%d "
+                           "boot sector\n", drivep->cylinders, drivep->heads, drivep->sectors,
                            target);
 #endif
-		    goto got_geom;
-		}
-	    }
+                    goto got_geom;
+                }
+            }
 
-	    /* second check for valid FAT BIOS parm block */
-	    unsigned char __far *boot = _MK_FP(DMASEG, 0);
-	    if (
-		//(boot[510] == 0x55 && boot[511] == 0xAA) &&	/* bootable sig*/
-		((boot[3] == 'M' && boot[4] == 'S') ||		/* OEM 'MSDOS'*/
-		 (boot[3] == 'I' && boot[4] == 'B'))	 &&	/* or 'IBM'*/
-		(boot[54] == 'F' && boot[55] == 'A')	   ) {	/* v4.0 fil_sys 'FAT'*/
+            /* second check for valid FAT BIOS parm block */
+            unsigned char __far *boot = _MK_FP(DMASEG, 0);
+            if (
+                //(boot[510] == 0x55 && boot[511] == 0xAA) &&   /* bootable sig*/
+                ((boot[3] == 'M' && boot[4] == 'S') ||          /* OEM 'MSDOS'*/
+                 (boot[3] == 'I' && boot[4] == 'B'))     &&     /* or 'IBM'*/
+                (boot[54] == 'F' && boot[55] == 'A')       ) {  /* v4.0 fil_sys 'FAT'*/
 
-		/* has valid MSDOS 4.0+ FAT BPB, use it */
-		drivep->sectors = boot[24];		/* bpb_sec_per_trk */
-		drivep->heads = boot[26];		/* bpb_num_heads */
-		unsigned char media = boot[21];		/* bpb_media_byte */
-		drivep->cylinders =
-			(media == 0xFD)? 40:
+                /* has valid MSDOS 4.0+ FAT BPB, use it */
+                drivep->sectors = boot[24];             /* bpb_sec_per_trk */
+                drivep->heads = boot[26];               /* bpb_num_heads */
+                unsigned char media = boot[21];         /* bpb_media_byte */
+                drivep->cylinders =
+                        (media == 0xFD)? 40:
 #ifdef CONFIG_IMG_FD1232
-			(media == 0xFE)? 77:		/* FD1232 is 77 tracks */
+                        (media == 0xFE)? 77:            /* FD1232 is 77 tracks */
 #endif
-					 80;
-		drivep->cylinders = (media == 0xFD)? 40: 80;
-		found_PB = 2;
+                                         80;
+                drivep->cylinders = (media == 0xFD)? 40: 80;
+                found_PB = 2;
 #if DEBUG_PROBE
-		    printk("fd: found valid FAT CHS %d,%d,%d disk parameters on /dev/fd%d "
-			   "boot sector\n", drivep->cylinders, drivep->heads, drivep->cylinders,
+                    printk("fd: found valid FAT CHS %d,%d,%d disk parameters on /dev/fd%d "
+                           "boot sector\n", drivep->cylinders, drivep->heads, drivep->cylinders,
                            target);
 #endif
-		goto got_geom;
-	    }
-	}
+                goto got_geom;
+            }
+        }
 #if DEBUG_PROBE
         else {
             printk("fd: can't read boot sector\n");
@@ -623,41 +623,41 @@ static void probe_floppy(int target, struct hd_struct *hdp)
 #endif /* FORCE_PROBE */
 
 #if DEBUG_PROBE
-	printk("fd: probing disc in /dev/fd%d\n", target);
+        printk("fd: probing disc in /dev/fd%d\n", target);
 #endif
 
-	drivep->heads = 2;
+        drivep->heads = 2;
 
 /* First probe for cylinder number. We probe on sector 1, which is
  * safe for all formats, and if we get a seek error, we assume that
  * the previous format is the correct one.
  */
 
-	count = 0;
+        count = 0;
 #ifdef CONFIG_ARCH_PC98
-	do {
-	    if (count)
-	        switch_device98(target, 0x30, drivep);	/* 1.44 MB */
-	    /* skip probing first entry */
-	    if (count && read_sector(target, track_probe[count] - 1, 1)) {
-	        switch_device98(target, 0x90, drivep);	/* 1.232 MB */
-	        break;
-	    }
-	    drivep->cylinders = track_probe[count];
-	} while (++count < sizeof(track_probe)/sizeof(track_probe[0]));
+        do {
+            if (count)
+                switch_device98(target, 0x30, drivep);  /* 1.44 MB */
+            /* skip probing first entry */
+            if (count && read_sector(target, track_probe[count] - 1, 1)) {
+                switch_device98(target, 0x90, drivep);  /* 1.232 MB */
+                break;
+            }
+            drivep->cylinders = track_probe[count];
+        } while (++count < sizeof(track_probe)/sizeof(track_probe[0]));
 #else
-	do {
-	    /* skip probing first entry */
-	    if (count) {
-		int res = read_sector(target, track_probe[count] - 1, 1);
+        do {
+            /* skip probing first entry */
+            if (count) {
+                int res = read_sector(target, track_probe[count] - 1, 1);
 #if DEBUG_PROBE
-		printk("CYL %d %s, ", track_probe[count]-1, res? "fail": "ok");
+                printk("CYL %d %s, ", track_probe[count]-1, res? "fail": "ok");
 #endif
-		if (res)
-		    break;
-	    }
-	    drivep->cylinders = track_probe[count];
-	} while (++count < sizeof(track_probe)/sizeof(track_probe[0]));
+                if (res)
+                    break;
+            }
+            drivep->cylinders = track_probe[count];
+        } while (++count < sizeof(track_probe)/sizeof(track_probe[0]));
 #endif
 
 /* Next, probe for sector number. We probe on track 0, which is
@@ -666,34 +666,34 @@ static void probe_floppy(int target, struct hd_struct *hdp)
  * use the BIOS disk parameters.
  */
 
-	count = 0;
+        count = 0;
 #ifdef CONFIG_ARCH_PC98
-	do {
-	    if (count)
-	        switch_device98(target, 0x30, drivep);	/* 1.44 MB */
-	    /* skip reading first entry */
-	    if (count && read_sector(target, 0, sector_probe[count])) {
-	        switch_device98(target, 0x90, drivep);	/* 1.232 MB */
-	        break;
-	    }
-	    drivep->sectors = sector_probe[count];
-	} while (++count < sizeof(sector_probe)/sizeof(sector_probe[0]));
+        do {
+            if (count)
+                switch_device98(target, 0x30, drivep);  /* 1.44 MB */
+            /* skip reading first entry */
+            if (count && read_sector(target, 0, sector_probe[count])) {
+                switch_device98(target, 0x90, drivep);  /* 1.232 MB */
+                break;
+            }
+            drivep->sectors = sector_probe[count];
+        } while (++count < sizeof(sector_probe)/sizeof(sector_probe[0]));
 #else
-	do {
-	    int res = read_sector(target, 0, sector_probe[count]);
+        do {
+            int res = read_sector(target, 0, sector_probe[count]);
 #if DEBUG_PROBE
-	    printk("SEC %d %s, ", sector_probe[count], res? "fail": "ok");
+            printk("SEC %d %s, ", sector_probe[count], res? "fail": "ok");
 #endif
-	    if (res) {
-                if (count == 0) {	/* failed on first sector read, use BIOS parms */
-		    printk("fd: disc probe failed, using BIOS settings\n");
-		    *drivep = fd_types[drivep->fdtype];
-		    goto got_geom;
-		}
-		break;
-	    }
-	    drivep->sectors = sector_probe[count];
-	} while (++count < sizeof(sector_probe)/sizeof(sector_probe[0]));
+            if (res) {
+                if (count == 0) {       /* failed on first sector read, use BIOS parms */
+                    printk("fd: disc probe failed, using BIOS settings\n");
+                    *drivep = fd_types[drivep->fdtype];
+                    goto got_geom;
+                }
+                break;
+            }
+            drivep->sectors = sector_probe[count];
+        } while (++count < sizeof(sector_probe)/sizeof(sector_probe[0]));
 #endif
 
 #if DEBUG_PROBE
@@ -701,13 +701,13 @@ static void probe_floppy(int target, struct hd_struct *hdp)
 #endif
 
 got_geom:
-	printk("fd: /dev/fd%d %s has %d cylinders, %d heads, and %d sectors\n", target,
-		   (found_PB == 2)? "DOS format," :
-		   (found_PB == 1)? "ELKS bootable,": "probed, probably",
-		   drivep->cylinders, drivep->heads, drivep->sectors);
-	hdp->start_sect = 0;
-	hdp->nr_sects = ((sector_t)(drivep->sectors * drivep->heads))
-				* ((sector_t)drivep->cylinders);
+        printk("fd: /dev/fd%d %s has %d cylinders, %d heads, and %d sectors\n", target,
+                   (found_PB == 2)? "DOS format," :
+                   (found_PB == 1)? "ELKS bootable,": "probed, probably",
+                   drivep->cylinders, drivep->heads, drivep->sectors);
+        hdp->start_sect = 0;
+        hdp->nr_sects = ((sector_t)(drivep->sectors * drivep->heads))
+                                * ((sector_t)drivep->cylinders);
     }
 }
 #endif /* CONFIG_BLK_DEV_BFD*/
@@ -732,20 +732,20 @@ static int bioshd_open(struct inode *inode, struct file *filp)
     }
     inode->i_size = hdp->nr_sects * drive_info[target].sector_size;
     /* limit inode size to max filesize for CHS >= 4MB (2^22)*/
-    if (hdp->nr_sects >= 0x00400000L)	/* 2^22*/
+    if (hdp->nr_sects >= 0x00400000L)   /* 2^22*/
         inode->i_size = 0x7ffffffL;         /* 2^31 - 1*/
     return 0;
 }
 
 static struct file_operations bioshd_fops = {
-    NULL,			/* lseek - default */
-    block_read,			/* read - general block-dev read */
-    block_write,		/* write - general block-dev write */
-    NULL,			/* readdir - bad */
-    NULL,			/* select */
-    bioshd_ioctl,		/* ioctl */
-    bioshd_open,		/* open */
-    bioshd_release		/* release */
+    NULL,                       /* lseek - default */
+    block_read,                 /* read - general block-dev read */
+    block_write,                /* write - general block-dev write */
+    NULL,                       /* readdir - bad */
+    NULL,                       /* select */
+    bioshd_ioctl,               /* ioctl */
+    bioshd_open,                /* open */
+    bioshd_release              /* release */
 };
 
 int INITPROC bioshd_init(void)
@@ -754,7 +754,7 @@ int INITPROC bioshd_init(void)
     int count;
 
     /* FIXME perhaps remove for speed on floppy boot*/
-    outb_p(0x0C, FDC_DOR);	/* FD motors off, enable IRQ and DMA*/
+    outb_p(0x0C, FDC_DOR);      /* FD motors off, enable IRQ and DMA*/
 
 #ifdef CONFIG_BLK_DEV_BFD
     _fd_count = bioshd_getfdinfo();
@@ -766,78 +766,78 @@ int INITPROC bioshd_init(void)
 
 #ifdef PRINT_DRIVE_INFO
     {
-	register struct drive_infot *drivep;
-	static char UNITS[4] = "kMGT";
+        register struct drive_infot *drivep;
+        static char UNITS[4] = "kMGT";
 
-	drivep = drive_info;
-	for (count = 0; count < PRINT_DRIVE_INFO; count++, drivep++) {
-	    if (drivep->heads != 0) {
-		char *unit = UNITS;
-		__u32 size = ((__u32) drivep->sectors) * 5;	/* 0.1 kB units */
-		if (drivep->sector_size == 1024)
-		    size <<= 1;
-		size *= ((__u32) drivep->cylinders) * drivep->heads;
+        drivep = drive_info;
+        for (count = 0; count < PRINT_DRIVE_INFO; count++, drivep++) {
+            if (drivep->heads != 0) {
+                char *unit = UNITS;
+                __u32 size = ((__u32) drivep->sectors) * 5;     /* 0.1 kB units */
+                if (drivep->sector_size == 1024)
+                    size <<= 1;
+                size *= ((__u32) drivep->cylinders) * drivep->heads;
 
-		/* Select appropriate unit */
-		while (size > 99999 && unit[1]) {
-		    debug("DBG: Size = %lu (%X/%X)\n", size, *unit, unit[1]);
-		    size += 512U;
-		    size /= 1024U;
-		    unit++;
-		}
-		debug("DBG: Size = %lu (%X/%X)\n",size,*unit,unit[1]);
-		printk("/dev/%cd%c: %u cylinders, %d heads, %d sectors = %lu.%u %cb\n",
-		    (count < 4 ? 'h' : 'f'), (count & 3) + (count < 4 ? 'a' : '0'),
-		    drivep->cylinders, drivep->heads, drivep->sectors,
-		    (size/10), (int) (size%10), *unit);
-	    }
-	}
+                /* Select appropriate unit */
+                while (size > 99999 && unit[1]) {
+                    debug("DBG: Size = %lu (%X/%X)\n", size, *unit, unit[1]);
+                    size += 512U;
+                    size /= 1024U;
+                    unit++;
+                }
+                debug("DBG: Size = %lu (%X/%X)\n",size,*unit,unit[1]);
+                printk("/dev/%cd%c: %u cylinders, %d heads, %d sectors = %lu.%u %cb\n",
+                    (count < 4 ? 'h' : 'f'), (count & 3) + (count < 4 ? 'a' : '0'),
+                    drivep->cylinders, drivep->heads, drivep->sectors,
+                    (size/10), (int) (size%10), *unit);
+            }
+        }
     }
 #else /* one line version */
 #ifdef CONFIG_BLK_DEV_BFD
 #ifdef CONFIG_BLK_DEV_BHD
     printk("bioshd: %d floppy drive%s and %d hard drive%s\n",
-	   _fd_count, _fd_count == 1 ? "" : "s",
-	   _hd_count, _hd_count == 1 ? "" : "s");
+           _fd_count, _fd_count == 1 ? "" : "s",
+           _hd_count, _hd_count == 1 ? "" : "s");
 #else
     printk("bioshd: %d floppy drive%s\n",
-	   _fd_count, _fd_count == 1 ? "" : "s");
+           _fd_count, _fd_count == 1 ? "" : "s");
 #endif
 #else
 #ifdef CONFIG_BLK_DEV_BHD
     printk("bioshd: %d hard drive%s\n",
-	   _hd_count, _hd_count == 1 ? "" : "s");
+           _hd_count, _hd_count == 1 ? "" : "s");
 #endif
 #endif
 #endif /* PRINT_DRIVE_INFO */
 
     if (!(_fd_count + _hd_count)) return 0;
 
-    copy_ddpt();	/* make a RAM copy of the disk drive parameter table*/
+    copy_ddpt();        /* make a RAM copy of the disk drive parameter table*/
 
     count = register_blkdev(MAJOR_NR, DEVICE_NAME, &bioshd_fops);
 
     if (count == 0) {
-	blk_dev[MAJOR_NR].request_fn = DEVICE_REQUEST;
+        blk_dev[MAJOR_NR].request_fn = DEVICE_REQUEST;
 
-	if (gendisk_head == NULL) {
-	    bioshd_gendisk.next = gendisk_head;
-	    gendisk_head = &bioshd_gendisk;
-	} else {
-	    for (ptr = gendisk_head; ptr->next != NULL; ptr = ptr->next)
-		/* Do nothing */ ;
-	    ptr->next = &bioshd_gendisk;
-	    bioshd_gendisk.next = NULL;
-	}
-	bioshd_initialized = 1;
+        if (gendisk_head == NULL) {
+            bioshd_gendisk.next = gendisk_head;
+            gendisk_head = &bioshd_gendisk;
+        } else {
+            for (ptr = gendisk_head; ptr->next != NULL; ptr = ptr->next)
+                /* Do nothing */ ;
+            ptr->next = &bioshd_gendisk;
+            bioshd_gendisk.next = NULL;
+        }
+        bioshd_initialized = 1;
     } else {
-	printk("bioshd: init error\n");
+        printk("bioshd: init error\n");
     }
     return count;
 }
 
 static int bioshd_ioctl(struct inode *inode,
-			struct file *file, unsigned int cmd, unsigned int arg)
+                        struct file *file, unsigned int cmd, unsigned int arg)
 {
     register struct hd_geometry *loc = (struct hd_geometry *) arg;
     register struct drive_infot *drivep;
@@ -845,68 +845,68 @@ static int bioshd_ioctl(struct inode *inode,
 
     /* get sector size called with NULL inode and arg = superblock s_dev */
     if (cmd == IOCTL_BLK_GET_SECTOR_SIZE)
-	return drive_info[DEVICE_NR(arg)].sector_size;
+        return drive_info[DEVICE_NR(arg)].sector_size;
 
     if (!inode || !inode->i_rdev)
-	return -EINVAL;
+        return -EINVAL;
 
     dev = DEVICE_NR(inode->i_rdev);
     if (dev >= ((dev < DRIVE_FD0) ? _hd_count : (DRIVE_FD0 + _fd_count)))
-    	return -ENODEV;
+        return -ENODEV;
 
     drivep = &drive_info[dev];
     err = -EINVAL;
     switch (cmd) {
     case HDIO_GETGEO:
-	err = verify_area(VERIFY_WRITE, (void *) arg, sizeof(struct hd_geometry));
-	if (!err) {
-	    put_user_char(drivep->heads, &loc->heads);
-	    put_user_char(drivep->sectors, &loc->sectors);
-	    put_user(drivep->cylinders, &loc->cylinders);
-	    put_user_long(hd[MINOR(inode->i_rdev)].start_sect, &loc->start);
-	}
+        err = verify_area(VERIFY_WRITE, (void *) arg, sizeof(struct hd_geometry));
+        if (!err) {
+            put_user_char(drivep->heads, &loc->heads);
+            put_user_char(drivep->sectors, &loc->sectors);
+            put_user(drivep->cylinders, &loc->cylinders);
+            put_user_long(hd[MINOR(inode->i_rdev)].start_sect, &loc->start);
+        }
     }
     return err;
 }
 
 /* calculate CHS and sectors remaining for track read */
 static void get_chst(struct drive_infot *drivep, sector_t start, unsigned int *c,
-	unsigned int *h, unsigned int *s, unsigned int *t)
+        unsigned int *h, unsigned int *s, unsigned int *t)
 {
-	sector_t tmp;
+        sector_t tmp;
 
-	*s = (unsigned int) ((start % (sector_t)drivep->sectors) + 1);
-	tmp = start / (sector_t)drivep->sectors;
-	*h = (unsigned int) (tmp % (sector_t)drivep->heads);
-	*c = (unsigned int) (tmp / (sector_t)drivep->heads);
-	*t = drivep->sectors - *s + 1;
-	debug_bios("bioshd: lba %ld is CHS %d/%d/%d remaining sectors %d\n",
-		start, *c, *h, *s, *t);
+        *s = (unsigned int) ((start % (sector_t)drivep->sectors) + 1);
+        tmp = start / (sector_t)drivep->sectors;
+        *h = (unsigned int) (tmp % (sector_t)drivep->heads);
+        *c = (unsigned int) (tmp / (sector_t)drivep->heads);
+        *t = drivep->sectors - *s + 1;
+        debug_bios("bioshd: lba %ld is CHS %d/%d/%d remaining sectors %d\n",
+                start, *c, *h, *s, *t);
 }
 
 /* do bios I/O, return # sectors read/written */
 static int do_bios_readwrite(struct drive_infot *drivep, sector_t start, char *buf,
-	ramdesc_t seg, int cmd, unsigned int count)
+        ramdesc_t seg, int cmd, unsigned int count)
 {
-	int drive, errs;
-	unsigned int cylinder, head, sector, this_pass;
-	unsigned int segment, offset;
-	unsigned short in_ax, out_ax;
+        int drive, errs;
+        unsigned int cylinder, head, sector, this_pass;
+        unsigned int segment, offset;
+        unsigned short in_ax, out_ax;
     unsigned int physaddr;
     size_t end;
     int usedmaseg;
 
-	drive = drivep - drive_info;
-	map_drive(&drive);
-	get_chst(drivep, start, &cylinder, &head, &sector, &this_pass);
+        drive = drivep - drive_info;
+        map_drive(&drive);
+        get_chst(drivep, start, &cylinder, &head, &sector, &this_pass);
 
-	/* limit I/O to requested sector count*/
-	if (this_pass > count) this_pass = count;
-	if (cmd == READ) debug_bios("bioshd(%d): read lba %ld count %d\n",
-				drive, start, this_pass);
+        /* limit I/O to requested sector count*/
+        if (this_pass > count) this_pass = count;
+        if (cmd == READ) debug_bios("bioshd(%d): read lba %ld count %d\n",
+                                drive, start, this_pass);
 
-	errs = MAX_ERRS;	/* BIOS disk reads should be retried at least three times */
-	do {
+        errs = MAX_ERRS;        /* BIOS disk reads should be retried at least three times */
+        do {
 #pragma GCC diagnostic ignored "-Wshift-count-overflow"
         usedmaseg = seg >> 16; /* will be nonzero only if XMS configured and XMS buffer */
         if (!usedmaseg) {
@@ -918,197 +918,197 @@ static int do_bios_readwrite(struct drive_infot *drivep, sector_t start, char *b
                 (unsigned int)seg, buf, physaddr, this_pass, usedmaseg);
         }
         if (usedmaseg) {
-			segment = DMASEG;	/* if xms buffer use DMASEG*/
-			offset = 0;
-			if (cmd == WRITE)	/* copy xms buffer down before write*/
-				xms_fmemcpyw(0, DMASEG, buf, seg, this_pass*(drivep->sector_size >> 1));
-			set_cache_invalid();
-		} else {
-			segment = (seg_t)seg;
-			offset = (unsigned) buf;
-		}
-		debug_bios("bioshd(%d): cmd %d CHS %d/%d/%d count %d\n",
-		    drive, cmd, cylinder, head, sector, this_pass);
-		in_ax = BD_AX;
-		out_ax = 0;
+                        segment = DMASEG;       /* if xms buffer use DMASEG*/
+                        offset = 0;
+                        if (cmd == WRITE)       /* copy xms buffer down before write*/
+                                xms_fmemcpyw(0, DMASEG, buf, seg, this_pass*(drivep->sector_size >> 1));
+                        set_cache_invalid();
+                } else {
+                        segment = (seg_t)seg;
+                        offset = (unsigned) buf;
+                }
+                debug_bios("bioshd(%d): cmd %d CHS %d/%d/%d count %d\n",
+                    drive, cmd, cylinder, head, sector, this_pass);
+                in_ax = BD_AX;
+                out_ax = 0;
 
-		set_ddpt(drivep->sectors);
-		if (bios_disk_rw(cmd == WRITE? BIOSHD_WRITE: BIOSHD_READ, this_pass,
-					drive, cylinder, head, sector, segment, offset)) {
-			printk("bioshd(%d): cmd %d retry #%d CHS %d/%d/%d count %d\n",
-			    drive, cmd, MAX_ERRS - errs + 1, cylinder, head, sector, this_pass);
-		    out_ax = BD_AX;
-		    reset_bioshd(drive);
-		}
-	} while (out_ax && --errs);	/* On error, retry up to MAX_ERRS times */
-	last_drive = drivep;
+                set_ddpt(drivep->sectors);
+                if (bios_disk_rw(cmd == WRITE? BIOSHD_WRITE: BIOSHD_READ, this_pass,
+                                        drive, cylinder, head, sector, segment, offset)) {
+                        printk("bioshd(%d): cmd %d retry #%d CHS %d/%d/%d count %d\n",
+                            drive, cmd, MAX_ERRS - errs + 1, cylinder, head, sector, this_pass);
+                    out_ax = BD_AX;
+                    reset_bioshd(drive);
+                }
+        } while (out_ax && --errs);     /* On error, retry up to MAX_ERRS times */
+        last_drive = drivep;
 
-	if (out_ax) {
-		printk("bioshd: error: out AX=%04X in AX=%04X "
-		       "ES:BX=%04X:%04X\n", out_ax, in_ax, BD_ES, BD_BX);
-		return 0;
-	}
-	if (usedmaseg) {
-		if (cmd == READ)	/* copy DMASEG up to xms*/
-			xms_fmemcpyw(buf, seg, 0, DMASEG, this_pass*(drivep->sector_size >> 1));
-		set_cache_invalid();
-	}
-	return this_pass;
+        if (out_ax) {
+                printk("bioshd: error: out AX=%04X in AX=%04X "
+                       "ES:BX=%04X:%04X\n", out_ax, in_ax, BD_ES, BD_BX);
+                return 0;
+        }
+        if (usedmaseg) {
+                if (cmd == READ)        /* copy DMASEG up to xms*/
+                        xms_fmemcpyw(buf, seg, 0, DMASEG, this_pass*(drivep->sector_size >> 1));
+                set_cache_invalid();
+        }
+        return this_pass;
 }
 
-#ifdef CONFIG_TRACK_CACHE		/* use track-sized sector cache*/
+#ifdef CONFIG_TRACK_CACHE               /* use track-sized sector cache*/
 static sector_t cache_startsector;
 static sector_t cache_endsector;
 
 /* read from start sector to end of track into DMASEG track buffer, no retries*/
 static void bios_readtrack(struct drive_infot *drivep, sector_t start)
 {
-	unsigned int cylinder, head, sector, num_sectors;
-	int drive = drivep - drive_info;
-	int errs = 0;
-	unsigned short out_ax;
+        unsigned int cylinder, head, sector, num_sectors;
+        int drive = drivep - drive_info;
+        int errs = 0;
+        unsigned short out_ax;
 
-	map_drive(&drive);
-	get_chst(drivep, start, &cylinder, &head, &sector, &num_sectors);
+        map_drive(&drive);
+        get_chst(drivep, start, &cylinder, &head, &sector, &num_sectors);
 
-	if (num_sectors > (DMASEGSZ / drivep->sector_size))
-		num_sectors = DMASEGSZ / drivep->sector_size;
+        if (num_sectors > (DMASEGSZ / drivep->sector_size))
+                num_sectors = DMASEGSZ / drivep->sector_size;
 
-	do {
-		out_ax = 0;
-		debug_bios("bioshd(%d): track read CHS %d/%d/%d count %d\n",
-			drive, cylinder, head, sector, num_sectors);
+        do {
+                out_ax = 0;
+                debug_bios("bioshd(%d): track read CHS %d/%d/%d count %d\n",
+                        drive, cylinder, head, sector, num_sectors);
 
-		set_ddpt(drivep->sectors);
-		if (bios_disk_rw(BIOSHD_READ, num_sectors, drive,
-						cylinder, head, sector, DMASEG, 0)) {
-			printk("bioshd(%d): track read retry #%d CHS %d/%d/%d count %d\n",
-			    drive, errs + 1, cylinder, head, sector, num_sectors);
-		    out_ax = BD_AX;
-		    reset_bioshd(drive);
-		}
-	} while (out_ax && ++errs < 1);	/* no track retries, for testing only*/
-	last_drive = drivep;
+                set_ddpt(drivep->sectors);
+                if (bios_disk_rw(BIOSHD_READ, num_sectors, drive,
+                                                cylinder, head, sector, DMASEG, 0)) {
+                        printk("bioshd(%d): track read retry #%d CHS %d/%d/%d count %d\n",
+                            drive, errs + 1, cylinder, head, sector, num_sectors);
+                    out_ax = BD_AX;
+                    reset_bioshd(drive);
+                }
+        } while (out_ax && ++errs < 1); /* no track retries, for testing only*/
+        last_drive = drivep;
 
-	if (out_ax) {
-		set_cache_invalid();
-		return;
-	}
+        if (out_ax) {
+                set_cache_invalid();
+                return;
+        }
 
-	cache_drive = drivep;
-	cache_startsector = start;
-	cache_endsector = start + num_sectors - 1;
-	debug_bios("bioshd(%d): track read lba %ld to %ld count %d\n",
-		drive, cache_startsector, cache_endsector, num_sectors);
+        cache_drive = drivep;
+        cache_startsector = start;
+        cache_endsector = start + num_sectors - 1;
+        debug_bios("bioshd(%d): track read lba %ld to %ld count %d\n",
+                drive, cache_startsector, cache_endsector, num_sectors);
 }
 
 /* check whether cache is valid for one sector*/
 static int cache_valid(struct drive_infot *drivep, sector_t start, char *buf,
-	ramdesc_t seg)
+        ramdesc_t seg)
 {
-	unsigned int offset;
+        unsigned int offset;
 
-	if (drivep != cache_drive || start < cache_startsector || start > cache_endsector)
-	    return 0;
+        if (drivep != cache_drive || start < cache_startsector || start > cache_endsector)
+            return 0;
 
-	offset = (int)(start - cache_startsector) * drivep->sector_size;
-	debug_bios("bioshd(%d): cache hit lba %ld\n", hd_drive_map[drivep-drive_info], start);
-	xms_fmemcpyw(buf, seg, (void *)offset, DMASEG, drivep->sector_size >> 1);
-	return 1;
+        offset = (int)(start - cache_startsector) * drivep->sector_size;
+        debug_bios("bioshd(%d): cache hit lba %ld\n", hd_drive_map[drivep-drive_info], start);
+        xms_fmemcpyw(buf, seg, (void *)offset, DMASEG, drivep->sector_size >> 1);
+        return 1;
 }
 
 /* read from cache, return # sectors read*/
 static int do_cache_read(struct drive_infot *drivep, sector_t start, char *buf,
-	ramdesc_t seg, int cmd)
+        ramdesc_t seg, int cmd)
 {
-	if (cmd == READ) {
-	    if (cache_valid(drivep, start, buf, seg))	/* try cache first*/
-		return 1;
-	    bios_readtrack(drivep, start);		/* read whole track*/
-	    if (cache_valid(drivep, start, buf, seg)) 	/* try cache again*/
-		return 1;
-	}
-	set_cache_invalid();
-	return 0;
+        if (cmd == READ) {
+            if (cache_valid(drivep, start, buf, seg))   /* try cache first*/
+                return 1;
+            bios_readtrack(drivep, start);              /* read whole track*/
+            if (cache_valid(drivep, start, buf, seg))   /* try cache again*/
+                return 1;
+        }
+        set_cache_invalid();
+        return 0;
 }
 #endif
 
 static void do_bioshd_request(void)
 {
-	struct drive_infot *drivep;
-	struct request *req;
-	unsigned short minor;
-	sector_t start;
-	int drive, count;
-	char *buf;
+        struct drive_infot *drivep;
+        struct request *req;
+        unsigned short minor;
+        sector_t start;
+        int drive, count;
+        char *buf;
 
-	spin_timer(1);
-	while (1) {
+        spin_timer(1);
+        while (1) {
       next_block:
 
-	req = CURRENT;
-	if (!req)
-	    break;
-	CHECK_REQUEST(req);
+        req = CURRENT;
+        if (!req)
+            break;
+        CHECK_REQUEST(req);
 
-	if (bioshd_initialized != 1) {
-	    end_request(0);
-	    continue;
-	}
-	minor = MINOR(req->rq_dev);
-	drive = minor >> MINOR_SHIFT;
-	drivep = &drive_info[drive];
+        if (bioshd_initialized != 1) {
+            end_request(0);
+            continue;
+        }
+        minor = MINOR(req->rq_dev);
+        drive = minor >> MINOR_SHIFT;
+        drivep = &drive_info[drive];
 
-	/* make sure it's a disk that we are dealing with. */
-	if (drive > (DRIVE_FD0 + MAXDRIVES - 1) || drivep->heads == 0) {
-	    printk("bioshd: non-existent drive\n");
-	    end_request(0);
-	    continue;
-	}
+        /* make sure it's a disk that we are dealing with. */
+        if (drive > (DRIVE_FD0 + MAXDRIVES - 1) || drivep->heads == 0) {
+            printk("bioshd: non-existent drive\n");
+            end_request(0);
+            continue;
+        }
 
-	/* get request start sector and sector count */
-	count = req->rq_nr_sectors;
-	start = req->rq_sector;
+        /* get request start sector and sector count */
+        count = req->rq_nr_sectors;
+        start = req->rq_sector;
 
-	if (hd[minor].start_sect == -1U || start >= hd[minor].nr_sects) {
-	    printk("bioshd: bad partition start=%ld sect=%ld nr_sects=%ld.\n",
-		   start, hd[minor].start_sect, hd[minor].nr_sects);
-	    end_request(0);
-	    continue;
-	}
-	start += hd[minor].start_sect;
+        if (hd[minor].start_sect == -1U || start >= hd[minor].nr_sects) {
+            printk("bioshd: bad partition start=%ld sect=%ld nr_sects=%ld.\n",
+                   start, hd[minor].start_sect, hd[minor].nr_sects);
+            end_request(0);
+            continue;
+        }
+        start += hd[minor].start_sect;
 
-	buf = req->rq_buffer;
-	while (count > 0) {
-	    int num_sectors;
+        buf = req->rq_buffer;
+        while (count > 0) {
+            int num_sectors;
 #ifdef CONFIG_TRACK_CACHE
-	    /* first try reading track cache*/
-	    num_sectors = do_cache_read(drivep, start, buf, req->rq_seg, req->rq_cmd);
-	    if (!num_sectors)
+            /* first try reading track cache*/
+            num_sectors = do_cache_read(drivep, start, buf, req->rq_seg, req->rq_cmd);
+            if (!num_sectors)
 #endif
-		/* then fallback with retries if required*/
-		num_sectors = do_bios_readwrite(drivep, start, buf, req->rq_seg, req->rq_cmd,
-			count);
+                /* then fallback with retries if required*/
+                num_sectors = do_bios_readwrite(drivep, start, buf, req->rq_seg, req->rq_cmd,
+                        count);
 
-	    if (num_sectors == 0) {
-		end_request(0);
-		goto next_block;
-	    }
+            if (num_sectors == 0) {
+                end_request(0);
+                goto next_block;
+            }
 
-	    count -= num_sectors;
-	    start += num_sectors;
-	    buf += num_sectors * drivep->sector_size;
-	}
+            count -= num_sectors;
+            start += num_sectors;
+            buf += num_sectors * drivep->sector_size;
+        }
 
-	/* satisfied that request */
-	end_request(1);
+        /* satisfied that request */
+        end_request(1);
     }
     spin_timer(0);
 }
 
 #if UNUSED
 static struct wait_queue busy_wait;
-static int revalidate_hddisk(int, int);	/* Currently not used*/
+static int revalidate_hddisk(int, int); /* Currently not used*/
 
 #define DEVICE_BUSY busy[target]
 #define USAGE access_count[target]
@@ -1138,8 +1138,8 @@ static int revalidate_hddisk(int dev, int maxusage)
     gdev = &GENDISK_STRUCT;
     clr_irq();
     if (DEVICE_BUSY || USAGE > maxusage) {
-	set_irq();
-	return -EBUSY;
+        set_irq();
+        return -EBUSY;
     }
     DEVICE_BUSY = 1;
     set_irq();
@@ -1147,11 +1147,11 @@ static int revalidate_hddisk(int dev, int maxusage)
     start = target << gdev->minor_shift;
     major = MAJOR_NR << 8;
     for (i = max_p - 1; i >= 0; i--) {
-	sync_dev(major | start | i);
-	invalidate_inodes(major | start | i);
-	invalidate_buffers(major | start | i);
-	gdev->part[start + i].start_sect = 0;
-	gdev->part[start + i].nr_sects = 0;
+        sync_dev(major | start | i);
+        invalidate_inodes(major | start | i);
+        invalidate_buffers(major | start | i);
+        gdev->part[start + i].start_sect = 0;
+        gdev->part[start + i].nr_sects = 0;
     };
     MAYBE_REINIT;
     gdev->part[start].nr_sects = CAPACITY;
@@ -1170,16 +1170,16 @@ static void bioshd_geninit(void)
 
     drivep = drive_info;
     for (i = 0; i < NUM_DRIVES << MINOR_SHIFT; i++) {
-	if ((i & ((1 << MINOR_SHIFT) - 1)) == 0) {
-	    hdp->nr_sects = (sector_t) drivep->sectors *
-		drivep->heads * drivep->cylinders;
-	    hdp->start_sect = 0;
-	    drivep++;
-	} else {
-	    hdp->nr_sects = 0;
-	    hdp->start_sect = -1;
-	}
-	hdp++;
+        if ((i & ((1 << MINOR_SHIFT) - 1)) == 0) {
+            hdp->nr_sects = (sector_t) drivep->sectors *
+                drivep->heads * drivep->cylinders;
+            hdp->start_sect = 0;
+            drivep++;
+        } else {
+            hdp->nr_sects = 0;
+            hdp->start_sect = -1;
+        }
+        hdp++;
     }
 
 }
@@ -1192,24 +1192,24 @@ kdev_t INITPROC bioshd_conv_bios_drive(unsigned int biosdrive)
     extern int boot_partition;
 
 #ifdef CONFIG_ARCH_PC98
-    if (((biosdrive & 0xF0) == 0x80) || ((biosdrive & 0xF0) == 0xA0)) {		/* hard drive*/
-	for (minor = 0; minor < 4; minor++) {
-	    if (biosdrive == hd_drive_map[minor]) break;
-	}
-	if (minor >= 4) minor = 0;
-	partition = boot_partition;	/* saved from add_partition()*/
+    if (((biosdrive & 0xF0) == 0x80) || ((biosdrive & 0xF0) == 0xA0)) {         /* hard drive*/
+        for (minor = 0; minor < 4; minor++) {
+            if (biosdrive == hd_drive_map[minor]) break;
+        }
+        if (minor >= 4) minor = 0;
+        partition = boot_partition;     /* saved from add_partition()*/
     } else {
-	for (minor = 4; minor < 8; minor++) {
-	    if (biosdrive == hd_drive_map[minor]) break;
-	}
-	if (minor >= 8) minor = 4;
+        for (minor = 4; minor < 8; minor++) {
+            if (biosdrive == hd_drive_map[minor]) break;
+        }
+        if (minor >= 8) minor = 4;
     }
 #else
-    if (biosdrive & 0x80) {		/* hard drive*/
-	minor = biosdrive & 0x03;
-	partition = boot_partition;	/* saved from add_partition()*/
+    if (biosdrive & 0x80) {             /* hard drive*/
+        minor = biosdrive & 0x03;
+        partition = boot_partition;     /* saved from add_partition()*/
     } else
-	minor = (biosdrive & 0x03) + DRIVE_FD0;
+        minor = (biosdrive & 0x03) + DRIVE_FD0;
 #endif
 
     return MKDEV(BIOSHD_MAJOR, (minor << MINOR_SHIFT) + partition);

--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -21,8 +21,8 @@ struct request {
     struct request *rq_next;    /* next request, used when async I/O */
 };
 
-#define RQ_INACTIVE	0
-#define RQ_ACTIVE	1
+#define RQ_INACTIVE     0
+#define RQ_ACTIVE       1
 
 /*
  * This is used in the elevator algorithm.  We don't prioritise reads
@@ -48,7 +48,7 @@ struct drive_infot {            /* CHS per drive*/
     int sector_size;
     int fdtype;                 /* floppy fd_types[] index  or -1 if hd */
 };
-extern struct drive_infot *last_drive;	/* set to last drivep-> used in read/write */
+extern struct drive_infot *last_drive;  /* set to last drivep-> used in read/write */
 
 extern unsigned char hd_drive_map[];
 
@@ -128,8 +128,8 @@ static void floppy_off(unsigned int nr);
 
 #endif
 
-#define CURRENT		(blk_dev[MAJOR_NR].current_request)
-#define CURRENT_DEV	DEVICE_NR(CURRENT->rq_dev)
+#define CURRENT         (blk_dev[MAJOR_NR].current_request)
+#define CURRENT_DEV     DEVICE_NR(CURRENT->rq_dev)
 
 static void (DEVICE_REQUEST) ();
 

--- a/elks/arch/i86/drivers/block/ssd-test.c
+++ b/elks/arch/i86/drivers/block/ssd-test.c
@@ -4,17 +4,17 @@
  * June 2020 Greg Haerr
  *
  * Use ramdisk utility for testing: (block argument = half of NUM_SECTS below)
- *	ramdisk /dev/ssd make 96
- *	mkfs /dev/ssd 96
- *	sync
- *	fsck -lvf /dev/ssd
- *	mount /dev/ssd /mnt
- *	cp /bin/ls /mnt
- *	/mnt/ls
- *	sync
- *	df /dev/ssd
- *	umount /dev/ssd
- *	fsck -lvf /dev/ssd
+ *      ramdisk /dev/ssd make 96
+ *      mkfs /dev/ssd 96
+ *      sync
+ *      fsck -lvf /dev/ssd
+ *      mount /dev/ssd /mnt
+ *      cp /bin/ls /mnt
+ *      /mnt/ls
+ *      sync
+ *      df /dev/ssd
+ *      umount /dev/ssd
+ *      fsck -lvf /dev/ssd
  */
 #include <linuxmt/config.h>
 #include <linuxmt/rd.h>
@@ -27,50 +27,50 @@
 #include <linuxmt/debug.h>
 #include "ssd.h"
 
-#define NUM_SECTS	192		/* set to max # sectors on SSD device */
+#define NUM_SECTS       192             /* set to max # sectors on SSD device */
 
 static segment_s *ssd_seg = 0;
 
 /* initialize SSD device */
 sector_t ssddev_init(void)
 {
-    return NUM_SECTS;	/* return max # 512-byte sectors on device */
+    return NUM_SECTS;   /* return max # 512-byte sectors on device */
 }
 
 int ssddev_ioctl(struct inode *inode, struct file *file,
-			unsigned int cmd, unsigned int arg)
+                        unsigned int cmd, unsigned int arg)
 {
     unsigned int sector;
 
     if (!suser())
-	return -EPERM;
+        return -EPERM;
 
     switch (cmd) {
     case RDCREATE:
-	debug_blk("SSD: ioctl make %d\n", arg); /* size ignored, always NUM_SECTS */
-	if (ssd_seg)
-	    return -EBUSY;
-	ssd_seg = seg_alloc((segext_t)NUM_SECTS << 5, SEG_FLAG_RAMDSK);
-	if (!ssd_seg)
-	    return -ENOMEM;
+        debug_blk("SSD: ioctl make %d\n", arg); /* size ignored, always NUM_SECTS */
+        if (ssd_seg)
+            return -EBUSY;
+        ssd_seg = seg_alloc((segext_t)NUM_SECTS << 5, SEG_FLAG_RAMDSK);
+        if (!ssd_seg)
+            return -ENOMEM;
 
-	for (sector = 0; sector < NUM_SECTS; sector++) {
-	    unsigned long offset = (unsigned long)sector << 9;
-	    fmemsetw(0, ssd_seg->base + (unsigned int)(offset >> 4), 0, 256);
-	}
-	ssd_initialized = 1;
-	return 0;
+        for (sector = 0; sector < NUM_SECTS; sector++) {
+            unsigned long offset = (unsigned long)sector << 9;
+            fmemsetw(0, ssd_seg->base + (unsigned int)(offset >> 4), 0, 256);
+        }
+        ssd_initialized = 1;
+        return 0;
 
     case RDDESTROY:
-	debug_blk("SSD: ioctl kill\n");
-	if (ssd_seg) {
-	    invalidate_inodes(inode->i_rdev);
-	    invalidate_buffers(inode->i_rdev);
-	    seg_put(ssd_seg);
-	    ssd_seg = NULL;
-	    ssd_initialized = 0;
-	    return 0;
-	}
+        debug_blk("SSD: ioctl kill\n");
+        if (ssd_seg) {
+            invalidate_inodes(inode->i_rdev);
+            invalidate_buffers(inode->i_rdev);
+            seg_put(ssd_seg);
+            ssd_seg = NULL;
+            ssd_initialized = 0;
+            return 0;
+        }
         return -ENXIO;          /* return separate error if ramdisk not inited */
     }
     return -EINVAL;
@@ -83,7 +83,7 @@ int ssddev_write(sector_t start, char *buf, ramdesc_t seg)
 
     xms_fmemcpyw(0, ssd_seg->base + (unsigned int)(offset >> 4), buf, seg,
         SD_FIXED_SECTOR_SIZE/2);
-    return 1;	/* # sectors written */
+    return 1;   /* # sectors written */
 }
 
 /* read one sector from SSD */
@@ -93,5 +93,5 @@ int ssddev_read(sector_t start, char *buf, ramdesc_t seg)
 
     xms_fmemcpyw(buf, seg, 0, ssd_seg->base + (unsigned int)(offset >> 4),
         SD_FIXED_SECTOR_SIZE/2);
-    return 1;	/* # sectors read */
+    return 1;   /* # sectors read */
 }

--- a/elks/arch/i86/drivers/char/console-bios.c
+++ b/elks/arch/i86/drivers/char/console-bios.c
@@ -25,46 +25,46 @@
 /* Assumes ASCII values. */
 #define isalpha(c) (((unsigned char)(((c) | 0x20) - 'a')) < 26)
 
-#define A_DEFAULT 	0x07
-#define A_BOLD 		0x08
-#define A_UNDERLINE 	0x07	/* only works on MDA, normal video on EGA */
-#define A_BLINK 	0x80
-#define A_REVERSE	0x70
-#define A_BLANK		0x00
+#define A_DEFAULT       0x07
+#define A_BOLD          0x08
+#define A_UNDERLINE     0x07    /* only works on MDA, normal video on EGA */
+#define A_BLINK         0x80
+#define A_REVERSE       0x70
+#define A_BLANK         0x00
 
 /* character definitions*/
-#define BS		'\b'
-#define NL		'\n'
-#define CR		'\r'
-#define TAB		'\t'
-#define ESC		'\x1B'
-#define BEL		'\x07'
+#define BS              '\b'
+#define NL              '\n'
+#define CR              '\r'
+#define TAB             '\t'
+#define ESC             '\x1B'
+#define BEL             '\x07'
 
-#define MAXPARMS	10
+#define MAXPARMS        10
 
 struct console;
 typedef struct console Console;
 
 struct console {
-    int cx, cy;			/* cursor position */
+    int cx, cy;                 /* cursor position */
     void (*fsm)(Console *, int);
-    unsigned char attr;		/* current attribute */
-    unsigned char XN;		/* delayed newline on column 80 */
-    unsigned char color;	/* fg/bg attr */
+    unsigned char attr;         /* current attribute */
+    unsigned char XN;           /* delayed newline on column 80 */
+    unsigned char color;        /* fg/bg attr */
 #ifdef CONFIG_EMUL_VT52
-    unsigned char tmp;		/* ESC Y ch save */
+    unsigned char tmp;          /* ESC Y ch save */
 #endif
 #ifdef CONFIG_EMUL_ANSI
-    int savex, savey;		/* saved cursor position */
-    unsigned char *parmptr;	/* ptr to params */
-    unsigned char params[MAXPARMS];	/* ANSI params */
+    int savex, savey;           /* saved cursor position */
+    unsigned char *parmptr;     /* ptr to params */
+    unsigned char params[MAXPARMS];     /* ANSI params */
 #endif
-    int pageno;			/* video ram page # */
+    int pageno;                 /* video ram page # */
 };
 
 static struct wait_queue glock_wait;
 static Console Con[MAX_CONSOLES], *Visible;
-static Console *glock;		/* Which console owns the graphics hardware */
+static Console *glock;          /* Which console owns the graphics hardware */
 static int Width, MaxCol, Height, MaxRow;
 static int NumConsoles = MAX_CONSOLES;
 static int kraw;
@@ -93,10 +93,10 @@ static void PositionCursor(register Console * C)
 
 static void PositionCursorGet (int * x, int * y)
 {
-	byte_t col, row;
-	bios_getcursor (&col, &row);
-	*x = col;
-	*y = row;
+        byte_t col, row;
+        bios_getcursor (&col, &row);
+        *x = col;
+        *y = row;
 }
 
 static void DisplayCursor(int onoff)
@@ -118,13 +118,13 @@ static void scroll(register Console * C, int n, int x, int y, int xx, int yy)
 
     a = C->attr;
     if (C != Visible) {
-	bios_setpage(C->pageno);
+        bios_setpage(C->pageno);
     }
 
     bios_scroll (a, n, x, y, xx, yy);
 
     if (C != Visible) {
-	bios_setpage(Visible->pageno);
+        bios_setpage(Visible->pageno);
     }
 }
 
@@ -155,7 +155,7 @@ static void ScrollDown(register Console * C, int y)
 void Console_set_vc(int N)
 {
     if ((N >= NumConsoles) || (Visible == &Con[N]) || glock)
-	return;
+        return;
     Visible = &Con[N];
 
     bios_setpage(N);
@@ -183,37 +183,37 @@ void INITPROC console_init(void)
     MaxRow = (Height = SETUP_VID_LINES) - 1;
 
     if (peekb(0x49, 0x40) == 7)  /* BIOS data segment */
-	NumConsoles = 1;
+        NumConsoles = 1;
 
     C = Con;
     Visible = C;
 
     for (i = 0; i < NumConsoles; i++) {
-	C->cx = C->cy = 0;
-	if (!i) {
-		// Get current cursor position
-		// to write after boot messages
-		PositionCursorGet (&C->cx, &C->cy);
-	}
-	C->fsm = std_char;
-	C->pageno = i;
-	C->attr = A_DEFAULT;
-	C->color = A_DEFAULT;
+        C->cx = C->cy = 0;
+        if (!i) {
+                // Get current cursor position
+                // to write after boot messages
+                PositionCursorGet (&C->cx, &C->cy);
+        }
+        C->fsm = std_char;
+        C->pageno = i;
+        C->attr = A_DEFAULT;
+        C->color = A_DEFAULT;
 
 #ifdef CONFIG_EMUL_ANSI
 
-	C->savex = C->savey = 0;
+        C->savex = C->savey = 0;
 
 #endif
 
-	/* Do not erase early printk() */
-	/* ClearRange(C, 0, C->cy, MaxCol, MaxRow); */
+        /* Do not erase early printk() */
+        /* ClearRange(C, 0, C->cy, MaxCol, MaxRow); */
 
-	C++;
+        C++;
     }
 
     kbd_init();
 
     printk("BIOS console %ux%u"TERM_TYPE"(%d virtual consoles)\n",
-	   Width, Height, NumConsoles);
+           Width, Height, NumConsoles);
 }

--- a/elks/arch/i86/drivers/char/console-direct.c
+++ b/elks/arch/i86/drivers/char/console-direct.c
@@ -25,46 +25,46 @@
 /* Assumes ASCII values. */
 #define isalpha(c) (((unsigned char)(((c) | 0x20) - 'a')) < 26)
 
-#define A_DEFAULT 	0x07
-#define A_BOLD 		0x08
-#define A_UNDERLINE 	0x07	/* only works on MDA, normal video on EGA */
-#define A_BLINK 	0x80
-#define A_REVERSE	0x70
-#define A_BLANK		0x00
+#define A_DEFAULT       0x07
+#define A_BOLD          0x08
+#define A_UNDERLINE     0x07    /* only works on MDA, normal video on EGA */
+#define A_BLINK         0x80
+#define A_REVERSE       0x70
+#define A_BLANK         0x00
 
 /* character definitions*/
-#define BS		'\b'
-#define NL		'\n'
-#define CR		'\r'
-#define TAB		'\t'
-#define ESC		'\x1B'
-#define BEL		'\x07'
+#define BS              '\b'
+#define NL              '\n'
+#define CR              '\r'
+#define TAB             '\t'
+#define ESC             '\x1B'
+#define BEL             '\x07'
 
-#define MAXPARMS	10
+#define MAXPARMS        10
 
 struct console;
 typedef struct console Console;
 
 struct console {
-    int cx, cy;			/* cursor position */
+    int cx, cy;                 /* cursor position */
     void (*fsm)(Console *, int);
-    unsigned char attr;		/* current attribute */
-    unsigned char XN;		/* delayed newline on column 80 */
-    unsigned int vseg;		/* video segment for page */
-    int basepage;		/* start of video ram */
+    unsigned char attr;         /* current attribute */
+    unsigned char XN;           /* delayed newline on column 80 */
+    unsigned int vseg;          /* video segment for page */
+    int basepage;               /* start of video ram */
 #ifdef CONFIG_EMUL_ANSI
-    int savex, savey;		/* saved cursor position */
-    unsigned char *parmptr;	/* ptr to params */
-    unsigned char params[MAXPARMS];	/* ANSI params */
+    int savex, savey;           /* saved cursor position */
+    unsigned char *parmptr;     /* ptr to params */
+    unsigned char params[MAXPARMS];     /* ANSI params */
 #endif
 #ifdef CONFIG_EMUL_VT52
-    unsigned char tmp;		/* ESC Y ch save */
+    unsigned char tmp;          /* ESC Y ch save */
 #endif
 };
 
 static struct wait_queue glock_wait;
 static Console Con[MAX_CONSOLES], *Visible;
-static Console *glock;		/* Which console owns the graphics hardware */
+static Console *glock;          /* Which console owns the graphics hardware */
 static unsigned short CCBase;   /* 6845 CRTC base I/O address */
 static int Width, MaxCol, Height, MaxRow;
 static int NumConsoles = MAX_CONSOLES;
@@ -118,7 +118,7 @@ static void DisplayCursor(int onoff)
 static void VideoWrite(register Console * C, int c)
 {
     pokew((C->cx + C->cy * Width) << 1, (seg_t) C->vseg,
-	  (C->attr << 8) | (c & 255));
+          (C->attr << 8) | (c & 255));
 }
 
 static void ClearRange(register Console * C, int x, int y, int x2, int y2)
@@ -128,11 +128,11 @@ static void ClearRange(register Console * C, int x, int y, int x2, int y2)
     x2 = x2 - x + 1;
     vp = (x + y * Width) << 1;
     do {
-	for (x = 0; x < x2; x++) {
+        for (x = 0; x < x2; x++) {
             pokew(vp, (seg_t) C->vseg, (C->attr << 8) | ' ');
             vp += 2;
         }
-	vp += (Width - x2) << 1;
+        vp += (Width - x2) << 1;
     } while (++y <= y2);
 }
 
@@ -142,7 +142,7 @@ static void ScrollUp(register Console * C, int y)
 
     vp = y * (Width << 1);
     if ((unsigned int)y < MaxRow)
-	fmemcpyw((void *)vp, C->vseg,
+        fmemcpyw((void *)vp, C->vseg,
                  (void *)(vp + (Width << 1)), C->vseg, (MaxRow - y) * Width);
     ClearRange(C, 0, MaxRow, MaxCol, MaxRow);
 }
@@ -155,8 +155,8 @@ static void ScrollDown(register Console * C, int y)
 
     vp = yy * (Width << 1);
     while (--yy >= y) {
-	fmemcpyw((void *)vp, C->vseg, (void *)(vp - (Width << 1)), C->vseg, Width);
-	vp -= Width << 1;
+        fmemcpyw((void *)vp, C->vseg, (void *)(vp - (Width << 1)), C->vseg, Width);
+        vp -= Width << 1;
     }
     ClearRange(C, 0, y, MaxCol, y);
 }
@@ -172,7 +172,7 @@ static void ScrollDown(register Console * C, int y)
 void Console_set_vc(int N)
 {
     if ((N >= NumConsoles) || (Visible == &Con[N]) || glock)
-	return;
+        return;
     Visible = &Con[N];
 
     SetDisplayPage(Visible);
@@ -204,8 +204,8 @@ void INITPROC console_init(void)
 
     VideoSeg = 0xb800;
     if (peekb(0x49, 0x40) == 7) {
-	VideoSeg = 0xB000;
-	NumConsoles = 1;
+        VideoSeg = 0xB000;
+        NumConsoles = 1;
         isMDA = 1;
     } else {
         isCGA = peekw(0xA8+2, 0x40) == 0;
@@ -215,28 +215,28 @@ void INITPROC console_init(void)
     Visible = C;
 
     for (i = 0; i < NumConsoles; i++) {
-	C->cx = C->cy = 0;
-	if (!i) {
-	    C->cx = peekb(0x50, 0x40);
-	    C->cy = peekb(0x51, 0x40);
-	}
-	C->fsm = std_char;
-	C->basepage = i * PageSizeW;
-	C->vseg = VideoSeg + (C->basepage >> 3);
-	C->attr = A_DEFAULT;
+        C->cx = C->cy = 0;
+        if (!i) {
+            C->cx = peekb(0x50, 0x40);
+            C->cy = peekb(0x51, 0x40);
+        }
+        C->fsm = std_char;
+        C->basepage = i * PageSizeW;
+        C->vseg = VideoSeg + (C->basepage >> 3);
+        C->attr = A_DEFAULT;
 
 #ifdef CONFIG_EMUL_ANSI
-	C->savex = C->savey = 0;
+        C->savex = C->savey = 0;
 #endif
 
-	/* Do not erase early printk() */
-	/* ClearRange(C, 0, C->cy, MaxCol, MaxRow); */
+        /* Do not erase early printk() */
+        /* ClearRange(C, 0, C->cy, MaxCol, MaxRow); */
 
-	C++;
+        C++;
     }
 
     kbd_init();
 
     printk("Direct console, %s kbd %ux%u"TERM_TYPE"(%d virtual consoles)\n",
-	   kbd_name, Width, Height, NumConsoles);
+           kbd_name, Width, Height, NumConsoles);
 }

--- a/elks/arch/i86/drivers/char/console.c
+++ b/elks/arch/i86/drivers/char/console.c
@@ -4,9 +4,9 @@ static void WriteChar(register Console * C, int c)
 {
     /* check for graphics lock */
     while (glock) {
-	if (glock == C)
-	    return;
-	sleep_on(&glock_wait);
+        if (glock == C)
+            return;
+        sleep_on(&glock_wait);
     }
     C->fsm(C, c);
 }
@@ -16,7 +16,7 @@ void Console_conout(dev_t dev, int Ch)
     Console *C = &Con[MINOR(dev)];
 
     if (Ch == '\n')
-	WriteChar(C, '\r');
+        WriteChar(C, '\r');
     WriteChar(C, Ch);
     PositionCursor(C);
 }
@@ -26,7 +26,7 @@ void Console_conin(unsigned char Key)
     register struct tty *ttyp = &ttys[Current_VCminor];
 
     if (!tty_intcheck(ttyp, Key))
-	chq_addch(&ttyp->inq, Key);
+        chq_addch(&ttyp->inq, Key);
 }
 
 #if defined (CONFIG_EMUL_VT52) || defined (CONFIG_EMUL_ANSI)
@@ -47,16 +47,16 @@ static int parm1(register unsigned char *buf)
     int n;
 
     if (!(n = atoi((char *)buf)))
-	n = 1;
+        n = 1;
     return n;
 }
 
 static int parm2(register unsigned char *buf)
 {
     while (*buf != ';' && *buf)
-	buf++;
+        buf++;
     if (*buf)
-	buf++;
+        buf++;
     return parm1(buf);
 }
 
@@ -71,7 +71,7 @@ static void itoaQueue(int i)
       i /= 10;
    } while (i);
    while (*b)
-	Console_conin(*b++);
+        Console_conin(*b++);
 }
 
 /* reverse map table ANSI -> ega      blk red grn yel blu mag cyn wht */
@@ -85,138 +85,138 @@ static void AnsiCmd(register Console * C, int c)
 
     /* ANSI param gathering and processing */
     if (C->parmptr < &C->params[MAXPARMS - 1])
-	*C->parmptr++ = (unsigned char) c;
+        *C->parmptr++ = (unsigned char) c;
     if (!isalpha(c)) {
-	return;
+        return;
     }
     *C->parmptr = '\0';
 
     switch (c) {
-    case 's':			/* Save the current location */
-	C->savex = C->cx;
-	C->savey = C->cy;
-	break;
-    case 'u':			/* Restore saved location */
-	C->cx = C->savex;
-	C->cy = C->savey;
-	break;
-    case 'A':			/* Move up n lines */
-	C->cy -= parm1(C->params);
-	if (C->cy < 0)
-	    C->cy = 0;
-	break;
-    case 'B':			/* Move down n lines */
-	C->cy += parm1(C->params);
-	if (C->cy > MaxRow)
-	    C->cy = MaxRow;
-	break;
-    case 'd':			/* Vertical position absolute */
-	C->cy = parm1(C->params) - 1;
-	if (C->cy > MaxRow)
-	    C->cy = MaxRow;
-	break;
-    case 'C':			/* Move right n characters */
-	C->cx += parm1(C->params);
-	if (C->cx > MaxCol)
-	    C->cx = MaxCol;
-	break;
-    case 'G':			/* Horizontal position absolute */
-	C->cx = parm1(C->params) - 1;
-	if (C->cx > MaxCol)
-	    C->cx = MaxCol;
-	break;
-    case 'D':			/* Move left n characters */
-	C->cx -= parm1(C->params);
-	if (C->cx < 0)
-	    C->cx = 0;
-	break;
-    case 'H':			/* cursor move */
-	Console_gotoxy(C, parm2(C->params) - 1, parm1(C->params) - 1);
-	break;
-    case 'J':			/* clear screen */
-	n = atoi((char *)C->params);
-	if (n == 0) { 		/* to bottom */
-	    ClearRange(C, C->cx, C->cy, MaxCol, C->cy);
-	    if (C->cy < MaxRow)
-		ClearRange(C, 0, C->cy, MaxCol, MaxRow);
-	} else if (n == 2)	/* all*/
-	    ClearRange(C, 0, 0, MaxCol, MaxRow);
-	break;
-    case 'K':			/* clear line */
-	n = atoi((char *)C->params);
-	if (n == 0)		/* to EOL */
-	    ClearRange(C, C->cx, C->cy, MaxCol, C->cy);
-	else if (n == 1)	/* to BOL */
-	    ClearRange(C, 0, C->cy, C->cx, C->cy);
-	else if (n == 2)	/* all */
-	    ClearRange(C, 0, C->cy, MaxCol, C->cy);
-	break;
-    case 'L':			/* insert line */
-	ScrollDown(C, C->cy);
-	break;
-    case 'M':			/* remove line */
-	ScrollUp(C, C->cy);
-	break;
-    case 'm':			/* ansi color */
+    case 's':                   /* Save the current location */
+        C->savex = C->cx;
+        C->savey = C->cy;
+        break;
+    case 'u':                   /* Restore saved location */
+        C->cx = C->savex;
+        C->cy = C->savey;
+        break;
+    case 'A':                   /* Move up n lines */
+        C->cy -= parm1(C->params);
+        if (C->cy < 0)
+            C->cy = 0;
+        break;
+    case 'B':                   /* Move down n lines */
+        C->cy += parm1(C->params);
+        if (C->cy > MaxRow)
+            C->cy = MaxRow;
+        break;
+    case 'd':                   /* Vertical position absolute */
+        C->cy = parm1(C->params) - 1;
+        if (C->cy > MaxRow)
+            C->cy = MaxRow;
+        break;
+    case 'C':                   /* Move right n characters */
+        C->cx += parm1(C->params);
+        if (C->cx > MaxCol)
+            C->cx = MaxCol;
+        break;
+    case 'G':                   /* Horizontal position absolute */
+        C->cx = parm1(C->params) - 1;
+        if (C->cx > MaxCol)
+            C->cx = MaxCol;
+        break;
+    case 'D':                   /* Move left n characters */
+        C->cx -= parm1(C->params);
+        if (C->cx < 0)
+            C->cx = 0;
+        break;
+    case 'H':                   /* cursor move */
+        Console_gotoxy(C, parm2(C->params) - 1, parm1(C->params) - 1);
+        break;
+    case 'J':                   /* clear screen */
+        n = atoi((char *)C->params);
+        if (n == 0) {           /* to bottom */
+            ClearRange(C, C->cx, C->cy, MaxCol, C->cy);
+            if (C->cy < MaxRow)
+                ClearRange(C, 0, C->cy, MaxCol, MaxRow);
+        } else if (n == 2)      /* all*/
+            ClearRange(C, 0, 0, MaxCol, MaxRow);
+        break;
+    case 'K':                   /* clear line */
+        n = atoi((char *)C->params);
+        if (n == 0)             /* to EOL */
+            ClearRange(C, C->cx, C->cy, MaxCol, C->cy);
+        else if (n == 1)        /* to BOL */
+            ClearRange(C, 0, C->cy, C->cx, C->cy);
+        else if (n == 2)        /* all */
+            ClearRange(C, 0, C->cy, MaxCol, C->cy);
+        break;
+    case 'L':                   /* insert line */
+        ScrollDown(C, C->cy);
+        break;
+    case 'M':                   /* remove line */
+        ScrollUp(C, C->cy);
+        break;
+    case 'm':                   /* ansi color */
       {
-	char *p = (char *)C->params;
-	do {
-	  n = atoi(p);
-	  if (n >= 30 && n <= 37) {             /* set fg color */
-	    C->attr &= 0xf0;                    /* don't save bright bit */
-	    C->attr |= ega_color[n-30];
-	  }
-	  else if (n >= 40 && n <= 47) {
-	    C->attr &= 0x8f;                    /* save blink bit */
-	    C->attr |= ega_color[n-40] << 4;
-	  }
-	  else if (n >= 90 && n <= 97) {        /* set bright fg color */
-	    C->attr &= 0xf0;                    /* don't save bright bit */
-	    C->attr |= ega_color[n-90+8];
-	  }
-	  else switch (n) {
-	    case 1:
-		C->attr |= A_BOLD;
-		break;
-	    case 4:
-		n = C->attr;
-		C->attr &= ~(A_DEFAULT | A_REVERSE);
-		C->attr |= A_UNDERLINE;
-		break;
-	    case 5:
-		C->attr |= A_BLINK;
-		break;
-	    case 7:
-		n = C->attr;
-		C->attr &= ~(A_DEFAULT | A_REVERSE);
-		C->attr |= ((n >> 4) & 0x07) | ((n << 4) & 0x70);
-		break;
-	    case 8:
-		C->attr = A_BLANK;
-		break;
-	    case 39:
-	    case 49:
-	    case 0:
-	    default:
-		C->attr = A_DEFAULT;
-		break;
-	  }
-	  while (*p >= '0' && *p <= '9')
-	    p++;
-	} while (*p++ == ';');
+        char *p = (char *)C->params;
+        do {
+          n = atoi(p);
+          if (n >= 30 && n <= 37) {             /* set fg color */
+            C->attr &= 0xf0;                    /* don't save bright bit */
+            C->attr |= ega_color[n-30];
+          }
+          else if (n >= 40 && n <= 47) {
+            C->attr &= 0x8f;                    /* save blink bit */
+            C->attr |= ega_color[n-40] << 4;
+          }
+          else if (n >= 90 && n <= 97) {        /* set bright fg color */
+            C->attr &= 0xf0;                    /* don't save bright bit */
+            C->attr |= ega_color[n-90+8];
+          }
+          else switch (n) {
+            case 1:
+                C->attr |= A_BOLD;
+                break;
+            case 4:
+                n = C->attr;
+                C->attr &= ~(A_DEFAULT | A_REVERSE);
+                C->attr |= A_UNDERLINE;
+                break;
+            case 5:
+                C->attr |= A_BLINK;
+                break;
+            case 7:
+                n = C->attr;
+                C->attr &= ~(A_DEFAULT | A_REVERSE);
+                C->attr |= ((n >> 4) & 0x07) | ((n << 4) & 0x70);
+                break;
+            case 8:
+                C->attr = A_BLANK;
+                break;
+            case 39:
+            case 49:
+            case 0:
+            default:
+                C->attr = A_DEFAULT;
+                break;
+          }
+          while (*p >= '0' && *p <= '9')
+            p++;
+        } while (*p++ == ';');
       }
       break;
     case 'n':
-	if (parm1(C->params) == 6) {		/* device status report*/
-	    //FIXME sequence can be interrupted by kbd input
-	    Console_conin(ESC);
-	    Console_conin('[');
-	    itoaQueue(C->cy+1);
-	    Console_conin(';');
-	    itoaQueue(C->cx+1);
-	    Console_conin('R');
-	}
-	break;
+        if (parm1(C->params) == 6) {            /* device status report*/
+            //FIXME sequence can be interrupted by kbd input
+            Console_conin(ESC);
+            Console_conin('[');
+            itoaQueue(C->cy+1);
+            Console_conin(';');
+            itoaQueue(C->cx+1);
+            Console_conin('R');
+        }
+        break;
     case 'h':                   /* cursor on */
     case 'l':                   /* cursor off */
         if (C->params[0] == '?' && atoi((const char *)C->params+1) == 25) {
@@ -260,14 +260,14 @@ static void esc_YS(register Console * C, int c)
 {
     switch(C->tmp) {
     case 'Y':
-	C->tmp = (unsigned char) (c - ' ');
-	C->fsm = esc_Y2;
-	break;
+        C->tmp = (unsigned char) (c - ' ');
+        C->fsm = esc_Y2;
+        break;
     case '/':
-	C->tmp = 'Z';		/* Discard next char */
-	break;
+        C->tmp = 'Z';           /* Discard next char */
+        break;
     case 'Z':
-	C->fsm = std_char;
+        C->fsm = std_char;
     }
 }
 
@@ -277,50 +277,50 @@ static void esc_char(register Console * C, int c)
     /* process single ESC char sequences */
     C->fsm = std_char;
     switch (c) {
-    case 'I':			/* linefeed reverse */
-	if (!C->cy) {
-	    ScrollDown(C, 0);
-	    break;
-	}
-    case 'A':			/* up */
-	if (C->cy)
-	    --C->cy;
-	break;
-    case 'B':			/* down */
-	if (C->cy < MaxRow)
-	    ++C->cy;
-	break;
-    case 'C':			/* right */
-	if (C->cx < MaxCol)
-	    ++C->cx;
-	break;
-    case 'D':			/* left */
-	if (C->cx)
-	    --C->cx;
-	break;
-    case 'H':			/* home */
-	C->cx = C->cy = 0;
-	break;
-    case 'J':			/* clear to eoscreen */
-	ClearRange(C, 0, C->cy+1, MaxCol, MaxRow);
-    case 'K':			/* clear to eol */
-	ClearRange(C, C->cx, C->cy, MaxCol, C->cy);
-	break;
-    case 'L':			/* insert line */
-	ScrollDown(C, C->cy);
-	break;
-    case 'M':			/* remove line */
-	ScrollUp(C, C->cy);
-	break;
-    case '/':			/* Remove echo for identify response */
-    case 'Y':			/* cursor move */
-	C->tmp = c;
-	C->fsm = esc_YS;
-	break;
-    case 'Z':			/* identify as VT52 */
-	Console_conin(ESC);
-	Console_conin('/');
-	Console_conin('K');
+    case 'I':                   /* linefeed reverse */
+        if (!C->cy) {
+            ScrollDown(C, 0);
+            break;
+        }
+    case 'A':                   /* up */
+        if (C->cy)
+            --C->cy;
+        break;
+    case 'B':                   /* down */
+        if (C->cy < MaxRow)
+            ++C->cy;
+        break;
+    case 'C':                   /* right */
+        if (C->cx < MaxCol)
+            ++C->cx;
+        break;
+    case 'D':                   /* left */
+        if (C->cx)
+            --C->cx;
+        break;
+    case 'H':                   /* home */
+        C->cx = C->cy = 0;
+        break;
+    case 'J':                   /* clear to eoscreen */
+        ClearRange(C, 0, C->cy+1, MaxCol, MaxRow);
+    case 'K':                   /* clear to eol */
+        ClearRange(C, C->cx, C->cy, MaxCol, C->cy);
+        break;
+    case 'L':                   /* insert line */
+        ScrollDown(C, C->cy);
+        break;
+    case 'M':                   /* remove line */
+        ScrollUp(C, C->cy);
+        break;
+    case '/':                   /* Remove echo for identify response */
+    case 'Y':                   /* cursor move */
+        C->tmp = c;
+        C->fsm = esc_YS;
+        break;
+    case 'Z':                   /* identify as VT52 */
+        Console_conin(ESC);
+        Console_conin('/');
+        Console_conin('K');
     }
 }
 #endif
@@ -330,68 +330,68 @@ static void std_char(register Console * C, int c)
 {
     switch(c) {
     case BEL:
-	bell();
-	break;
+        bell();
+        break;
     case '\b':
-	C->XN = 0;
-	if (C->cx > 0) {
-	    --C->cx;
+        C->XN = 0;
+        if (C->cx > 0) {
+            --C->cx;
 #ifdef CONFIG_CONSOLE_BIOS
-	    PositionCursor(C);
+            PositionCursor(C);
 #endif
-	    VideoWrite(C, ' ');
-	}
-	break;
+            VideoWrite(C, ' ');
+        }
+        break;
     case '\t':
-	C->cx = (C->cx | 0x07) + 1;
-	goto linewrap;
+        C->cx = (C->cx | 0x07) + 1;
+        goto linewrap;
     case '\n':
-	C->XN = 0;
-	++C->cy;
-	break;
+        C->XN = 0;
+        ++C->cy;
+        break;
     case '\r':
-	C->XN = 0;
-	C->cx = 0;
-	break;
+        C->XN = 0;
+        C->cx = 0;
+        break;
 
 #if defined (CONFIG_EMUL_VT52) || defined (CONFIG_EMUL_ANSI)
     case ESC:
-	C->fsm = esc_char;
-	break;
+        C->fsm = esc_char;
+        break;
 #endif
 
     default:
-	if (C->XN) {
-	    C->XN = 0;
-	    C->cx = 0;
-	    C->cy++;
-	    if (C->cy > MaxRow) {
-		ScrollUp(C, 0);
-		C->cy = MaxRow;
-	    }
-	}
+        if (C->XN) {
+            C->XN = 0;
+            C->cx = 0;
+            C->cy++;
+            if (C->cy > MaxRow) {
+                ScrollUp(C, 0);
+                C->cy = MaxRow;
+            }
+        }
 #ifdef CONFIG_CONSOLE_BIOS
-	PositionCursor(C);
+        PositionCursor(C);
 #endif
-	if (c != 0) {
-		VideoWrite(C, c);
-		C->cx++;
-	}
+        if (c != 0) {
+                VideoWrite(C, c);
+                C->cx++;
+        }
       linewrap:
-	if (C->cx > MaxCol) {
+        if (C->cx > MaxCol) {
 
 #ifdef CONFIG_EMUL_VT52
-	    C->cx = MaxCol;
+            C->cx = MaxCol;
 #else
-	    C->XN = 1;
-	    C->cx = MaxCol;
+            C->XN = 1;
+            C->cx = MaxCol;
 #endif
 
-	}
+        }
     }
     if (C->cy > MaxRow) {
-	ScrollUp(C, 0);
-	C->cy = MaxRow;
+        ScrollUp(C, 0);
+        C->cy = MaxRow;
     }
 }
 
@@ -401,43 +401,43 @@ static int Console_ioctl(struct tty *tty, int cmd, char *arg)
 
     switch (cmd) {
     case DCGET_GRAPH:
-	if (!glock) {
-	    glock = C;
-	    return 0;
-	}
-	return -EBUSY;
+        if (!glock) {
+            glock = C;
+            return 0;
+        }
+        return -EBUSY;
     case DCREL_GRAPH:
-	if (glock == C) {
-	    glock = NULL;
-	    wake_up(&glock_wait);
-	    return 0;
-	}
-	break;
+        if (glock == C) {
+            glock = NULL;
+            wake_up(&glock_wait);
+            return 0;
+        }
+        break;
     case DCSET_KRAW:
-	if (glock == C) {
-	    kraw = 1;
-	    return 0;
-	}
-	break;
+        if (glock == C) {
+            kraw = 1;
+            return 0;
+        }
+        break;
     case DCREL_KRAW:
-	if ((glock == C) && (kraw == 1)) {
-	    kraw = 0;
-	    return 1;
-	}
-	break;
+        if ((glock == C) && (kraw == 1)) {
+            kraw = 0;
+            return 1;
+        }
+        break;
     case KIOCSOUND:
-	{
-	    unsigned period = (unsigned) arg;
-	    if (period)
-		soundp(period);
-	    else
-		nosound();
-	}
-	return 0;
+        {
+            unsigned period = (unsigned) arg;
+            if (period)
+                soundp(period);
+            else
+                nosound();
+        }
+        return 0;
     case TCSETS:
     case TCSETSW:
     case TCSETSF:
-	return 0;
+        return 0;
     }
 
     return -EINVAL;
@@ -449,11 +449,11 @@ static int Console_write(register struct tty *tty)
     int cnt = 0;
 
     while ((tty->outq.len > 0) && !glock) {
-	WriteChar(C, tty_outproc(tty));
-	cnt++;
+        WriteChar(C, tty_outproc(tty));
+        cnt++;
     }
     if (C == Visible)
-	PositionCursor(C);
+        PositionCursor(C);
     return cnt;
 }
 
@@ -465,6 +465,6 @@ static void Console_release(struct tty *tty)
 static int Console_open(register struct tty *tty)
 {
     if ((int)tty->minor >= NumConsoles)
-	return -ENODEV;
+        return -ENODEV;
     return ttystd_open(tty);
 }

--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -31,28 +31,28 @@
 
 /* default termios, set at init time, not reset at open*/
 struct termios def_vals = {
-    BRKINT|ICRNL,					/* c_iflag*/
-    OPOST|ONLCR,					/* c_oflag*/
-    (tcflag_t) (B9600 | CS8),				/* c_cflag*/
-    (tcflag_t) (ISIG | ICANON | ECHO | ECHOE),		/* c_lflag*/
-    0,							/* c_line*/
-    { 3,	/* VINTR*/
-    28,		/* VQUIT*/
-    8,		/* VERASE*/
-    21,		/* VKILL unused*/
-    4,		/* VEOF*/
-    0,		/* VTIME*/
-    1,		/* VMIN*/
-    0,		/* VSWTCH unused*/
-    17,		/* VSTART unused*/
-    19,		/* VSTOP unused*/
-    26,		/* VSUSP unused*/
-    0,		/* VEOL*/
-    18,		/* VREPRINT unused*/
-    15,		/* VDISCARD unused*/
-    23,		/* VWERASE unused*/
-    22,		/* VLNEXT unused*/
-    127 	/* VERASE2*/
+    BRKINT|ICRNL,                                       /* c_iflag*/
+    OPOST|ONLCR,                                        /* c_oflag*/
+    (tcflag_t) (B9600 | CS8),                           /* c_cflag*/
+    (tcflag_t) (ISIG | ICANON | ECHO | ECHOE),          /* c_lflag*/
+    0,                                                  /* c_line*/
+    { 3,        /* VINTR*/
+    28,         /* VQUIT*/
+    8,          /* VERASE*/
+    21,         /* VKILL unused*/
+    4,          /* VEOF*/
+    0,          /* VTIME*/
+    1,          /* VMIN*/
+    0,          /* VSWTCH unused*/
+    17,         /* VSTART unused*/
+    19,         /* VSTOP unused*/
+    26,         /* VSUSP unused*/
+    0,          /* VEOL*/
+    18,         /* VREPRINT unused*/
+    15,         /* VDISCARD unused*/
+    23,         /* VWERASE unused*/
+    22,         /* VLNEXT unused*/
+    127         /* VERASE2*/
     }
 };
 
@@ -65,22 +65,22 @@ int tty_intcheck(register struct tty *ttyp, unsigned char key)
     sig_t sig = 0;
 
     if ((ttyp->termios.c_lflag & ISIG) && ttyp->pgrp) {
-	if (key == ttyp->termios.c_cc[VINTR])
-	    sig = SIGINT;
-	if (key == ttyp->termios.c_cc[VQUIT])
-	    sig = SIGQUIT;
-	if (key == ttyp->termios.c_cc[VSUSP])
-	    sig = SIGTSTP;
+        if (key == ttyp->termios.c_cc[VINTR])
+            sig = SIGINT;
+        if (key == ttyp->termios.c_cc[VQUIT])
+            sig = SIGQUIT;
+        if (key == ttyp->termios.c_cc[VSUSP])
+            sig = SIGTSTP;
 #if DEBUG_EVENT
-	if (key >= ('N' & 0x1f) && key <= ('P' & 0x1f)) {       /* CTRLN-CTRLP */
-	    debug_event((key - 'N') & 0x1f);
-	    return 1;
-	}
+        if (key >= ('N' & 0x1f) && key <= ('P' & 0x1f)) {       /* CTRLN-CTRLP */
+            debug_event((key - 'N') & 0x1f);
+            return 1;
+        }
 #endif
-	if (sig) {
-	    debug_tty("TTY signal %d to pgrp %d pid %d\n", sig, ttyp->pgrp, current->pid);
-	    kill_pg(ttyp->pgrp, sig, 1);
-	}
+        if (sig) {
+            debug_tty("TTY signal %d to pgrp %d pid %d\n", sig, ttyp->pgrp, current->pid);
+            kill_pg(ttyp->pgrp, sig, 1);
+        }
     }
     return sig;
 }
@@ -95,15 +95,15 @@ struct tty *determine_tty(dev_t dev)
 
     /* handle /dev/tty*/
     if (minor == 255 && current->pgrp && (current->pgrp == ttyp->pgrp))
-	return current->tty;
+        return current->tty;
 
     /* handle /dev/console*/
     if (minor == 254)
-	return determine_tty(dev_console);
+        return determine_tty(dev_console);
 
     do {
-	if (ttyp->minor == minor)
-	    return ttyp;
+        if (ttyp->minor == minor)
+            return ttyp;
     } while (++ttyp < &ttys[MAX_TTYS]);
 
     return NULL;
@@ -114,23 +114,23 @@ int ttystd_open(struct tty *tty)
 {
     /* increment use count, don't init if already open*/
     if (tty->usecount++)
-	return 0;
+        return 0;
     return tty_allocq(tty, INQ_SIZE, OUTQ_SIZE);
 }
 
 void ttystd_release(struct tty *tty)
 {
     if (--tty->usecount == 0)
-	tty_freeq(tty);
+        tty_freeq(tty);
 }
 
 int tty_allocq(struct tty *tty, int insize, int outsize)
 {
     if ((tty->inq.base = heap_alloc(insize, HEAP_TAG_TTY)) == NULL)
-	return -ENOMEM;
+        return -ENOMEM;
     if ((tty->outq.base = heap_alloc(outsize, HEAP_TAG_TTY)) == NULL) {
-	heap_free(tty->inq.base);
-	return -ENOMEM;
+        heap_free(tty->inq.base);
+        return -ENOMEM;
     }
     chq_init(&tty->inq, tty->inq.base, insize);
     chq_init(&tty->outq, tty->outq.base, outsize);
@@ -150,7 +150,7 @@ int tty_open(struct inode *inode, struct file *file)
     int err;
 
     if (!(otty = determine_tty(inode->i_rdev)))
-	return -ENODEV;
+        return -ENODEV;
 
     debug_tty("TTY open pid %d\n", currentp->pid);
 #if UNUSED
@@ -158,21 +158,21 @@ int tty_open(struct inode *inode, struct file *file)
 #endif
 
     if ((file->f_flags & O_EXCL) && (otty->flags & TTY_OPEN))
-	return -EBUSY;
+        return -EBUSY;
 
     /* don't call driver on /dev/tty open*/
     if (MINOR(inode->i_rdev) == 255)
-	return 0;
+        return 0;
 
     err = otty->ops->open(otty);
     if (!err) {
-	if (!(file->f_flags & O_NOCTTY) && currentp->session == currentp->pid
-		&& currentp->tty == NULL && otty->pgrp == 0) {
-	    debug_tty("TTY setting pgrp %d pid %d\n", currentp->pgrp, currentp->pid);
-	    otty->pgrp = currentp->pgrp;
-	    currentp->tty = otty;
-	}
-	otty->flags |= TTY_OPEN;
+        if (!(file->f_flags & O_NOCTTY) && currentp->session == currentp->pid
+                && currentp->tty == NULL && otty->pgrp == 0) {
+            debug_tty("TTY setting pgrp %d pid %d\n", currentp->pgrp, currentp->pid);
+            otty->pgrp = currentp->pgrp;
+            currentp->tty = otty;
+        }
+        otty->flags |= TTY_OPEN;
     }
     return err;
 }
@@ -183,22 +183,22 @@ void tty_release(struct inode *inode, struct file *file)
 
     rtty = determine_tty(inode->i_rdev);
     if (!rtty)
-	return;
+        return;
 
     debug_tty("TTY close pid %d\n", current->pid);
 
     /* no action if closing /dev/tty*/
     if (MINOR(inode->i_rdev) == 255)
-	return;
+        return;
 
     /* don't release pgrp for /dev/tty, only real tty*/
     if (current->pid == rtty->pgrp) {
-	debug_tty("TTY release pgrp %d\n", current->pid);
-	if ((int)rtty->termios.c_cflag & HUPCL) {	/* warning truncated to 16 bits*/
-		debug_tty("TTY sending SIGHUP\n", current->pid);
-		kill_pg(rtty->pgrp, SIGHUP, 1);
-	}
-	rtty->pgrp = 0;
+        debug_tty("TTY release pgrp %d\n", current->pid);
+        if ((int)rtty->termios.c_cflag & HUPCL) {       /* warning truncated to 16 bits*/
+                debug_tty("TTY sending SIGHUP\n", current->pid);
+                kill_pg(rtty->pgrp, SIGHUP, 1);
+        }
+        rtty->pgrp = 0;
     }
     rtty->flags &= ~TTY_OPEN;
     rtty->ops->release(rtty);
@@ -211,53 +211,53 @@ void tty_release(struct inode *inode, struct file *file)
  * construct:
  *
  * while (tty->outq.len > 0) {
- * 	ch = tty_outproc(tty);
- * 	write_char_to_device(device, (char)ch);
- * 	cnt++;
+ *      ch = tty_outproc(tty);
+ *      write_char_to_device(device, (char)ch);
+ *      cnt++;
  * }
  *
  */
 int tty_outproc(register struct tty *tty)
 {
-    int t_oflag;	/* WARNING: highly arch dependent, termios.c_oflag truncated to 16 bits*/
+    int t_oflag;        /* WARNING: highly arch dependent, termios.c_oflag truncated to 16 bits*/
     int ch;
 
     ch = tty->outq.base[tty->outq.tail];
     if ((t_oflag = (int)tty->termios.c_oflag) & OPOST) {
-	switch((int)(tty->ostate & ~0x0F)) {
-	case 0x20:		/* Expand tabs to spaces */
-	    ch = ' ';
-	    if (--tty->ostate & 0xF)
-		break;
-	case 0x10:		/* Expand NL -> CR NL */
-	    tty->ostate = 0;
-	    break;
-	default:
-	    switch(ch) {
-	    case '\n':
-		if (t_oflag & ONLCR) {
-		    ch = '\r';				/* Expand NL -> CR NL */
-		    tty->ostate = 0x10;
-		}
-		break;
+        switch((int)(tty->ostate & ~0x0F)) {
+        case 0x20:              /* Expand tabs to spaces */
+            ch = ' ';
+            if (--tty->ostate & 0xF)
+                break;
+        case 0x10:              /* Expand NL -> CR NL */
+            tty->ostate = 0;
+            break;
+        default:
+            switch(ch) {
+            case '\n':
+                if (t_oflag & ONLCR) {
+                    ch = '\r';                          /* Expand NL -> CR NL */
+                    tty->ostate = 0x10;
+                }
+                break;
 #if UNUSED
-	    case '\r':
-		if (t_oflag & OCRNL)
-		    ch = '\n';				/* Map CR to NL */
-		break;
+            case '\r':
+                if (t_oflag & OCRNL)
+                    ch = '\n';                          /* Map CR to NL */
+                break;
 #endif
-	    case '\t':
-		if ((t_oflag & TABDLY) == TAB3) {
-		    ch = ' ';				/* Expand tabs to spaces */
-		    tty->ostate = 0x20 + TAB_SPACES - 1;
-		}
-	    }
-	}
+            case '\t':
+                if ((t_oflag & TABDLY) == TAB3) {
+                    ch = ' ';                           /* Expand tabs to spaces */
+                    tty->ostate = 0x20 + TAB_SPACES - 1;
+                }
+            }
+        }
     }
     if (!tty->ostate) {
-	if (++tty->outq.tail >= tty->outq.size)
-	    tty->outq.tail = 0;
-	tty->outq.len--;
+        if (++tty->outq.tail >= tty->outq.size)
+            tty->outq.tail = 0;
+        tty->outq.len--;
     }
     return ch;
 }
@@ -265,20 +265,20 @@ int tty_outproc(register struct tty *tty)
 static void tty_echo(register struct tty *tty, unsigned char ch)
 {
     if ((tty->termios.c_lflag & ECHO)
-		|| ((tty->termios.c_lflag & ECHONL) && (ch == '\n'))) {
-	if ((ch == tty->termios.c_cc[VERASE] || ch == tty->termios.c_cc[VERASE2])
+                || ((tty->termios.c_lflag & ECHONL) && (ch == '\n'))) {
+        if ((ch == tty->termios.c_cc[VERASE] || ch == tty->termios.c_cc[VERASE2])
        && (tty->termios.c_lflag & ECHOE)) {
-	    chq_addch(&tty->outq, '\b');
-	    chq_addch(&tty->outq, ' ');
-	    chq_addch(&tty->outq, '\b');
-	} else
-	    chq_addch(&tty->outq, ch);
-	tty->ops->write(tty);
+            chq_addch(&tty->outq, '\b');
+            chq_addch(&tty->outq, ' ');
+            chq_addch(&tty->outq, '\b');
+        } else
+            chq_addch(&tty->outq, ch);
+        tty->ops->write(tty);
     }
 }
 
 /*
- *	Write to a terminal
+ *      Write to a terminal
  *
  */
 
@@ -290,21 +290,21 @@ size_t tty_write(struct inode *inode, struct file *file, char *data, size_t len)
 
     i = 0;
     while (i < len) {
-	s = chq_wait_wr(&tty->outq, file->f_flags & O_NONBLOCK);
-	if (s < 0) {
-	    /* FIXME EAGAIN not returned, cycle required on telnet nonblocking terminal */
-	    if (s == -EINTR || s == -EAGAIN) {
-		wake_up(&tty->outq.wait);
-		schedule();
-		continue;
-	    }
-	    if (i == 0)
-		i = s;
-	    break;
-	}
-	chq_addch_nowakeup(&tty->outq, get_user_char((void *)data++));
-	tty->ops->write(tty);
-	i++;
+        s = chq_wait_wr(&tty->outq, file->f_flags & O_NONBLOCK);
+        if (s < 0) {
+            /* FIXME EAGAIN not returned, cycle required on telnet nonblocking terminal */
+            if (s == -EINTR || s == -EAGAIN) {
+                wake_up(&tty->outq.wait);
+                schedule();
+                continue;
+            }
+            if (i == 0)
+                i = s;
+            break;
+        }
+        chq_addch_nowakeup(&tty->outq, get_user_char((void *)data++));
+        tty->ops->write(tty);
+        i++;
     }
     wake_up(&tty->outq.wait);
     return i;
@@ -322,65 +322,65 @@ size_t tty_read(struct inode *inode, struct file *file, char *data, size_t len)
     int ch, k;
 
     while (i < len) {
-	timeout = jiffies + vtime * (HZ / 10);
+        timeout = jiffies + vtime * (HZ / 10);
 again:
-	if (tty->ops->read) {
-	    tty->ops->read(tty);
-	    nonblock = 1;
-	}
+        if (tty->ops->read) {
+            tty->ops->read(tty);
+            nonblock = 1;
+        }
 
-	if (chq_peekch(&tty->inq))
-	    ch = chq_getch(&tty->inq);
-	else {
-	    if (!icanon && !vtime && (i >= vmin))
-		break;
-	    ch = chq_wait_rd(&tty->inq, nonblock);
-	    if (ch < 0) {
-		if (!icanon && vtime) {
-		    if (jiffies < timeout) {
-			schedule();
-			goto again;		/* don't reset timer*/
-		    } else {
-			if (vmin && (i == 0)) {
-			    nonblock = 1;
-			    continue;		/* VMIN > 0 reset timer*/
-			}
-		    }
-		    ch = 0;	/* return 0 on VTIME timeout*/
-		}
-		if (i == 0)
-		    i = ch;
-		break;
-	    }
-	    ch = chq_getch(&tty->inq);
-	}
+        if (chq_peekch(&tty->inq))
+            ch = chq_getch(&tty->inq);
+        else {
+            if (!icanon && !vtime && (i >= vmin))
+                break;
+            ch = chq_wait_rd(&tty->inq, nonblock);
+            if (ch < 0) {
+                if (!icanon && vtime) {
+                    if (jiffies < timeout) {
+                        schedule();
+                        goto again;             /* don't reset timer*/
+                    } else {
+                        if (vmin && (i == 0)) {
+                            nonblock = 1;
+                            continue;           /* VMIN > 0 reset timer*/
+                        }
+                    }
+                    ch = 0;     /* return 0 on VTIME timeout*/
+                }
+                if (i == 0)
+                    i = ch;
+                break;
+            }
+            ch = chq_getch(&tty->inq);
+        }
 
-	if ((tty->termios.c_iflag & ICRNL) && (ch == '\r'))
-	    ch = '\n';
+        if ((tty->termios.c_iflag & ICRNL) && (ch == '\r'))
+            ch = '\n';
 
-	if (icanon) {
-	    if (ch == tty->termios.c_cc[VERASE] || ch == tty->termios.c_cc[VERASE2]) {
-		if (i > 0) {
-		    i--;
-		    k = ((get_user_char((void *)(--data)) == '\t') ? TAB_SPACES : 1);
-		    do {
-			tty_echo(tty, ch);
-		    } while (--k);
-		}
-		continue;
-	    }
+        if (icanon) {
+            if (ch == tty->termios.c_cc[VERASE] || ch == tty->termios.c_cc[VERASE2]) {
+                if (i > 0) {
+                    i--;
+                    k = ((get_user_char((void *)(--data)) == '\t') ? TAB_SPACES : 1);
+                    do {
+                        tty_echo(tty, ch);
+                    } while (--k);
+                }
+                continue;
+            }
 
-	    if (ch == tty->termios.c_cc[VEOF])
-		break;
-	} else {
-	    if (vtime && vmin)	/* start timeout after first character*/
-		nonblock = 1;
-	}
-	put_user_char(ch, (void *)(data++));
-	tty_echo(tty, ch);
-	i++;
-	if (icanon && ((ch == '\n') || (ch == tty->termios.c_cc[VEOL])))
-	    break;
+            if (ch == tty->termios.c_cc[VEOF])
+                break;
+        } else {
+            if (vtime && vmin)  /* start timeout after first character*/
+                nonblock = 1;
+        }
+        put_user_char(ch, (void *)(data++));
+        tty_echo(tty, ch);
+        i++;
+        if (icanon && ((ch == '\n') || (ch == tty->termios.c_cc[VEOL])))
+            break;
     }
     return i;
 }
@@ -392,27 +392,27 @@ int tty_ioctl(struct inode *inode, struct file *file, int cmd, char *arg)
 
     switch (cmd) {
     case TCGETS:
-	ret = verified_memcpy_tofs(arg, &tty->termios, sizeof(struct termios));
-	break;
+        ret = verified_memcpy_tofs(arg, &tty->termios, sizeof(struct termios));
+        break;
     case TCSETS:
     case TCSETSW:
     case TCSETSF:
-	ret = verified_memcpy_fromfs(&tty->termios, arg, sizeof(struct termios));
+        ret = verified_memcpy_fromfs(&tty->termios, arg, sizeof(struct termios));
 
-	/* Inform subdriver of new settings*/
-	if (ret == 0 && tty->ops->ioctl != NULL)
-	    ret = tty->ops->ioctl(tty, cmd, arg);
-	break;
+        /* Inform subdriver of new settings*/
+        if (ret == 0 && tty->ops->ioctl != NULL)
+            ret = tty->ops->ioctl(tty, cmd, arg);
+        break;
     case TIOSETCONSOLE:
-	dev = get_user(arg);
-	if (MAJOR(dev) != TTY_MAJOR)
-	    return -EINVAL;
-	set_console(dev);
-	return 0;
+        dev = get_user(arg);
+        if (MAJOR(dev) != TTY_MAJOR)
+            return -EINVAL;
+        set_console(dev);
+        return 0;
     default:
-	ret = ((tty->ops->ioctl == NULL)
-	    ? -EINVAL
-	    : tty->ops->ioctl(tty, cmd, arg));
+        ret = ((tty->ops->ioctl == NULL)
+            ? -EINVAL
+            : tty->ops->ioctl(tty, cmd, arg));
     }
     return ret;
 }
@@ -424,17 +424,17 @@ int tty_select(struct inode *inode, struct file *file, int sel_type)
 
     switch (sel_type) {
     case SEL_IN:
-	if (tty->inq.len != 0)
-	    return 1;
-	select_wait(&tty->inq.wait);
-	break;
+        if (tty->inq.len != 0)
+            return 1;
+        select_wait(&tty->inq.wait);
+        break;
     case SEL_OUT:
-	ret = (tty->outq.len != tty->outq.size);
-	if (!ret)
-	    select_wait(&tty->outq.wait);
-	    /*@fallthrough@*/
+        ret = (tty->outq.len != tty->outq.size);
+        if (!ret)
+            select_wait(&tty->outq.wait);
+            /*@fallthrough@*/
 /*      case SEL_EX: */
-/*  	break; */
+/*      break; */
     }
     return ret;
 }
@@ -452,7 +452,7 @@ int wait_for_keypress(void)
 /*@-type@*/
 
 static struct file_operations tty_fops = {
-    pipe_lseek,			/* Same behavoir, return -ESPIPE */
+    pipe_lseek,                 /* Same behavoir, return -ESPIPE */
     tty_read,
     tty_write,
     NULL,
@@ -463,12 +463,12 @@ static struct file_operations tty_fops = {
 };
 
 /* TTY subdrivers, linked in via configuration*/
-extern struct tty_ops dircon_ops;	/* CONFIG_CONSOLE_DIRECT*/
-extern struct tty_ops bioscon_ops;	/* CONFIG_CONSOLE_BIOS*/
-extern struct tty_ops headlesscon_ops;	/* CONFIG_CONSOLE_HEADLESS*/
-extern struct tty_ops rs_ops;		/* CONFIG_CHAR_DEV_RS*/
-extern struct tty_ops ttyp_ops;		/* CONFIG_PSEUDO_TTY*/
-extern struct tty_ops i8018xcon_ops;	/* CONFIG_CONSOLE_8018X*/
+extern struct tty_ops dircon_ops;       /* CONFIG_CONSOLE_DIRECT*/
+extern struct tty_ops bioscon_ops;      /* CONFIG_CONSOLE_BIOS*/
+extern struct tty_ops headlesscon_ops;  /* CONFIG_CONSOLE_HEADLESS*/
+extern struct tty_ops rs_ops;           /* CONFIG_CHAR_DEV_RS*/
+extern struct tty_ops ttyp_ops;         /* CONFIG_PSEUDO_TTY*/
+extern struct tty_ops i8018xcon_ops;    /* CONFIG_CONSOLE_8018X*/
 
 void INITPROC tty_init(void)
 {
@@ -477,29 +477,29 @@ void INITPROC tty_init(void)
 
     ttyp = &ttys[MAX_TTYS];
     do {
-	ttyp--;
-	ttyp->minor = (unsigned short int)(-1L); /* set unsigned to -1 */
-	memcpy(&ttyp->termios, &def_vals, sizeof(struct termios));
+        ttyp--;
+        ttyp->minor = (unsigned short int)(-1L); /* set unsigned to -1 */
+        memcpy(&ttyp->termios, &def_vals, sizeof(struct termios));
     } while (ttyp > ttys);
 
     for (i = TTY_MINOR_OFFSET ; i < NR_CONSOLES + TTY_MINOR_OFFSET ; i++) {
 #if defined(CONFIG_CONSOLE_DIRECT)
-	ttyp->ops = &dircon_ops;
+        ttyp->ops = &dircon_ops;
 #elif defined(CONFIG_CONSOLE_BIOS)
-	ttyp->ops = &bioscon_ops;
+        ttyp->ops = &bioscon_ops;
 #elif defined(CONFIG_CONSOLE_8018X)
-	ttyp->ops = &i8018xcon_ops;
+        ttyp->ops = &i8018xcon_ops;
 #else
-	ttyp->ops = &headlesscon_ops;
+        ttyp->ops = &headlesscon_ops;
 #endif
-	(ttyp++)->minor = i;
+        (ttyp++)->minor = i;
     }
 
 #ifdef CONFIG_CHAR_DEV_RS
     /* put serial entries after console entries */
     for (i = RS_MINOR_OFFSET; i < NR_SERIAL + RS_MINOR_OFFSET; i++) {
-	ttyp->ops = &rs_ops;
-	(ttyp++)->minor = i;		/* ttyS0 = RS_MINOR_OFFSET */
+        ttyp->ops = &rs_ops;
+        (ttyp++)->minor = i;            /* ttyS0 = RS_MINOR_OFFSET */
     }
 #endif
 
@@ -507,8 +507,8 @@ void INITPROC tty_init(void)
     /* start at minor = 8 fixed to match pty entries in MAKEDEV */
     /* put slave pseudo tty entries after serial entries */
     for (i = PTY_MINOR_OFFSET; (i) < NR_PTYS + PTY_MINOR_OFFSET; i++) {
-	ttyp->ops = &ttyp_ops;
-	(ttyp++)->minor = i;		/* ttyp0 = PTY slave PTY_MINOR_OFFSET */
+        ttyp->ops = &ttyp_ops;
+        (ttyp++)->minor = i;            /* ttyp0 = PTY slave PTY_MINOR_OFFSET */
     }
 #endif
 

--- a/elks/arch/i86/drivers/char/serial-8250.c
+++ b/elks/arch/i86/drivers/char/serial-8250.c
@@ -27,29 +27,29 @@ struct serial_info {
     unsigned char mcr;
     unsigned int  divisor;
     struct tty *tty;
-    int pad1, pad2, pad3;	// round out to 16 bytes for faster addressing of ports[]
+    int pad1, pad2, pad3;       // round out to 16 bytes for faster addressing of ports[]
 };
 
 /* flags*/
-#define SERF_TYPE	15
-#define SERF_EXIST	16
-#define ST_8250		0
-#define ST_16450	1
-#define ST_16550	2
-#define ST_16550A	3
-#define ST_16750	4
-#define ST_UNKNOWN	15
+#define SERF_TYPE       15
+#define SERF_EXIST      16
+#define ST_8250         0
+#define ST_16450        1
+#define ST_16550        2
+#define ST_16550A       3
+#define ST_16750        4
+#define ST_UNKNOWN      15
 
 #define CONSOLE_PORT 0
 
 /* I/O delay settings*/
-#define INB		inb	// use inb_p for 1us delay
-#define OUTB		outb	// use outb_p for 1us delay
+#define INB             inb     // use inb_p for 1us delay
+#define OUTB            outb    // use outb_p for 1us delay
 
-#define DEFAULT_LCR		UART_LCR_WLEN8
+#define DEFAULT_LCR             UART_LCR_WLEN8
 
-#define DEFAULT_MCR		\
-	((unsigned char) (UART_MCR_DTR | UART_MCR_RTS | UART_MCR_OUT2))
+#define DEFAULT_MCR             \
+        ((unsigned char) (UART_MCR_DTR | UART_MCR_RTS | UART_MCR_OUT2))
 
 static struct serial_info ports[NR_SERIAL] = {
     {(char *)COM1_PORT, COM1_IRQ, 0, DEFAULT_LCR, DEFAULT_MCR, 0, NULL, 0,0,0},
@@ -60,39 +60,39 @@ static struct serial_info ports[NR_SERIAL] = {
 
 static char irq_to_port[16];
 static unsigned int divisors[] = {
-    0,				/*  0 = B0      */
-    2304,			/*  1 = B50     */
-    1536,			/*  2 = B75     */
-    1047,			/*  3 = B110    */
-    860,			/*  4 = B134    */
-    768,			/*  5 = B150    */
-    576,			/*  6 = B200    */
-    384,			/*  7 = B300    */
-    192,			/*  8 = B600    */
-    96,				/*  9 = B1200   */
-    64,				/* 10 = B1800   */
-    48,				/* 11 = B2400   */
-    24,				/* 12 = B4800   */
-    12,				/* 13 = B9600   */
-    6,				/* 14 = B19200  */
-    3,				/* 15 = B38400  */
-    2,				/* 16 = B57600  */
-    1,				/* 17 = B115200 */
-    0				/*  0 = B230400 */
+    0,                          /*  0 = B0      */
+    2304,                       /*  1 = B50     */
+    1536,                       /*  2 = B75     */
+    1047,                       /*  3 = B110    */
+    860,                        /*  4 = B134    */
+    768,                        /*  5 = B150    */
+    576,                        /*  6 = B200    */
+    384,                        /*  7 = B300    */
+    192,                        /*  8 = B600    */
+    96,                         /*  9 = B1200   */
+    64,                         /* 10 = B1800   */
+    48,                         /* 11 = B2400   */
+    24,                         /* 12 = B4800   */
+    12,                         /* 13 = B9600   */
+    6,                          /* 14 = B19200  */
+    3,                          /* 15 = B38400  */
+    2,                          /* 16 = B57600  */
+    1,                          /* 17 = B115200 */
+    0                           /*  0 = B230400 */
 };
 
 extern struct tty ttys[];
 
 /* Flow control buffer markers */
-#define	RS_IALLMOSTFULL 	(3 * INQ_SIZE / 4)
-#define	RS_IALLMOSTEMPTY	(    INQ_SIZE / 4)
+#define RS_IALLMOSTFULL         (3 * INQ_SIZE / 4)
+#define RS_IALLMOSTEMPTY        (    INQ_SIZE / 4)
 
 /* allow init to easily update the port irq from bootopts */
 void set_serial_irq(int tty, int irq)
 {
-	ports[tty].irq = irq;
+        ports[tty].irq = irq;
 }
-	
+
 /*
  * Flush input by reading RX register.
  * Not used when FIFO enabled, as HW fifo cleared when enabled.
@@ -101,7 +101,7 @@ static void flush_input(register struct serial_info *sp)
 {
 #ifndef CONFIG_HW_SERIAL_FIFO
     do {
-	INB(sp->io + UART_RX);
+        INB(sp->io + UART_RX);
     } while (INB(sp->io + UART_LSR) & UART_LSR_DR);
 #endif
 }
@@ -116,26 +116,26 @@ static int rs_probe(register struct serial_info *sp)
     scratch = INB(sp->io + UART_IER);
     OUTB(scratch, sp->io + UART_IER);
     if (scratch)
-	return -1;
+        return -1;
 
     /* try to enable 64 byte FIFO and max trigger*/
     OUTB(0xE7, sp->io + UART_FCR);
 
     /* then read FIFO status*/
     status = INB(sp->io + UART_IIR);
-    if (status & 0x80) {		/* FIFO available*/
-	if (status & 0x20)		/* 64 byte FIFO enabled*/
-	    type = ST_16750;
-	else if (status & 0x40)		/* 16 byte FIFO OK */
-	    type = ST_16550A;
-	else
-	    type = ST_16550;		/* Non-functional FIFO */
+    if (status & 0x80) {                /* FIFO available*/
+        if (status & 0x20)              /* 64 byte FIFO enabled*/
+            type = ST_16750;
+        else if (status & 0x40)         /* 16 byte FIFO OK */
+            type = ST_16550A;
+        else
+            type = ST_16550;            /* Non-functional FIFO */
     } else {
-	/* no FIFO, try writing arbitrary value to scratch reg*/
-	OUTB(0x2A, sp->io + UART_SCR);
-	if (INB(sp->io + UART_SCR) == 0x2a)
-	    type = ST_16450;
-	else type = ST_8250;
+        /* no FIFO, try writing arbitrary value to scratch reg*/
+        OUTB(0x2A, sp->io + UART_SCR);
+        if (INB(sp->io + UART_SCR) == 0x2a)
+            type = ST_16450;
+        else type = ST_8250;
     }
 
     sp->flags = SERF_EXIST | type;
@@ -156,34 +156,34 @@ static int rs_probe(register struct serial_info *sp)
 
 static void update_port(register struct serial_info *port)
 {
-    unsigned int cflags;	/* use smaller 16-bit width to save code*/
+    unsigned int cflags;        /* use smaller 16-bit width to save code*/
     unsigned divisor;
 
     /* set baud rate divisor, first lower, then higher byte */
     cflags = port->tty->termios.c_cflag & CBAUD;
     if (cflags & CBAUDEX)
-	cflags = B38400 + (cflags & 03);
+        cflags = B38400 + (cflags & 03);
     divisor = divisors[cflags];
 
     //FIXME: update lcr parity and data width from termios values
 
     /* update divisor only if changed, since we have not TCSETW*/
     if (divisor != port->divisor) {
-	port->divisor = divisor;
+        port->divisor = divisor;
 
-	clr_irq();
+        clr_irq();
 
-	/* Set the divisor latch bit */
-	OUTB(port->lcr | UART_LCR_DLAB, port->io + UART_LCR);
+        /* Set the divisor latch bit */
+        OUTB(port->lcr | UART_LCR_DLAB, port->io + UART_LCR);
 
-	/* Set the divisor low and high byte */
-	OUTB((unsigned char)divisor, port->io + UART_DLL);
-	OUTB((unsigned char)(divisor >> 8), port->io + UART_DLM);
+        /* Set the divisor low and high byte */
+        OUTB((unsigned char)divisor, port->io + UART_DLL);
+        OUTB((unsigned char)(divisor >> 8), port->io + UART_DLM);
 
-	/* Clear the divisor latch bit */
-	OUTB(port->lcr, port->io + UART_LCR);
+        /* Clear the divisor latch bit */
+        OUTB(port->lcr, port->io + UART_LCR);
 
-	set_irq();
+        set_irq();
     }
 }
 
@@ -194,11 +194,11 @@ static int rs_write(struct tty *tty)
     int i = 0;
 
     while (tty->outq.len > 0) {
-	/* Wait until transmitter hold buffer empty */
-	while (!(INB(port->io + UART_LSR) & UART_LSR_THRE))
-		;
-	outb((char)tty_outproc(tty), port->io + UART_TX);
-	i++;
+        /* Wait until transmitter hold buffer empty */
+        while (!(INB(port->io + UART_LSR) & UART_LSR_THRE))
+                ;
+        outb((char)tty_outproc(tty), port->io + UART_TX);
+        i++;
     }
     return i;
 }
@@ -215,14 +215,14 @@ void rs_pump(void)
     q = &sp->tty->inq;
 
     if (sp->tty->usecount && q->len)
-	wake_up(&q->wait);
+        wake_up(&q->wait);
 #endif
 #ifdef CONFIG_FAST_IRQ3
     sp = &ports[1];
     q = &sp->tty->inq;
 
     if (sp->tty->usecount && q->len)
-	wake_up(&q->wait);
+        wake_up(&q->wait);
 #endif
 }
 #endif
@@ -246,12 +246,12 @@ void fast_com1_irq(void)
     struct ch_queue *q = &sp->tty->inq;
     unsigned char c;
 
-    c = INB(io + UART_RX);		/* Read received data */
+    c = INB(io + UART_RX);              /* Read received data */
     if (q->len < q->size) {
-	q->base[q->head] = c;
-	if (++q->head >= q->size)
-	    q->head = 0;
-	q->len++;
+        q->base[q->head] = c;
+        if (++q->head >= q->size)
+            q->head = 0;
+        q->len++;
     }
 }
 #endif
@@ -265,12 +265,12 @@ void fast_com2_irq(void)
     struct ch_queue *q = &sp->tty->inq;
     unsigned char c;
 
-    c = INB(io + UART_RX);		/* Read received data */
+    c = INB(io + UART_RX);              /* Read received data */
     if (q->len < q->size) {
-	q->base[q->head] = c;
-	if (++q->head >= q->size)
-	    q->head = 0;
-	q->len++;
+        q->base[q->head] = c;
+        if (++q->head >= q->size)
+            q->head = 0;
+        q->len++;
     }
 }
 #endif
@@ -288,26 +288,26 @@ void rs_irq(int irq, struct pt_regs *regs)
     char *io = sp->io;
     struct ch_queue *q = &sp->tty->inq;
 
-    int status = INB(io + UART_LSR);			/* check for data overrun*/
-    if ((status & UART_LSR_DR) == 0)			/* QEMU may interrupt w/no data*/
-	return;
+    int status = INB(io + UART_LSR);                    /* check for data overrun*/
+    if ((status & UART_LSR_DR) == 0)                    /* QEMU may interrupt w/no data*/
+        return;
 
 #if UNUSED      // turn on for serial stats
     if (status & UART_LSR_OE)
-	printk("serial: data overrun\n");
+        printk("serial: data overrun\n");
     if (status & (UART_LSR_FE|UART_LSR_PE))
-	printk("serial: frame/parity error\n");
+        printk("serial: frame/parity error\n");
 #endif
 
     /* read uart/fifo until empty*/
     do {
-	unsigned char c = INB(io + UART_RX);		/* Read received data */
-	if (!tty_intcheck(sp->tty, c))
-	    chq_addch_nowakeup(q, c);
+        unsigned char c = INB(io + UART_RX);            /* Read received data */
+        if (!tty_intcheck(sp->tty, c))
+            chq_addch_nowakeup(q, c);
     } while (INB(io + UART_LSR) & UART_LSR_DR); /* while data available (for FIFOs)*/
 
-    if (q->len)		/* don't wakeup unless chars else EINTR result*/
-	wake_up(&q->wait);
+    if (q->len)         /* don't wakeup unless chars else EINTR result*/
+        wake_up(&q->wait);
 }
 
 #endif  // !defined(CONFIG_FAST_IRQ4) || !defined(CONFIG_FAST_IRQ3)
@@ -319,9 +319,9 @@ static void rs_release(struct tty *tty)
 
     debug_tty("SERIAL close %d\n", current->pid);
     if (--tty->usecount == 0) {
-	OUTB(0, port->io + UART_IER);	/* Disable all interrupts */
-	free_irq(port->irq);
-	tty_freeq(tty);
+        OUTB(0, port->io + UART_IER);   /* Disable all interrupts */
+        free_irq(port->irq);
+        tty_freeq(tty);
     }
 }
 
@@ -333,35 +333,35 @@ static int rs_open(struct tty *tty)
     debug_tty("SERIAL open %d\n", current->pid);
 
     if (!(port->flags & SERF_EXIST))
-	return -ENXIO;
+        return -ENXIO;
 
     /* increment use count, don't init if already open*/
     if (tty->usecount++)
-	return 0;
+        return 0;
 
     switch(port->irq) {
 #ifdef CONFIG_FAST_IRQ4
     case 4:
-	err = request_irq(port->irq, (irq_handler) _irq_com1, INT_SPECIFIC);
-	break;
+        err = request_irq(port->irq, (irq_handler) _irq_com1, INT_SPECIFIC);
+        break;
 #endif
 #ifdef CONFIG_FAST_IRQ3
     case 3:
-	err = request_irq(port->irq, (irq_handler) _irq_com2, INT_SPECIFIC);
-	break;
+        err = request_irq(port->irq, (irq_handler) _irq_com2, INT_SPECIFIC);
+        break;
 #endif
     default:
-	err = request_irq(port->irq, rs_irq, INT_GENERIC);
-	break;
+        err = request_irq(port->irq, rs_irq, INT_GENERIC);
+        break;
     }
     if (err) goto errout;
-    irq_to_port[port->irq] = port - ports;	/* Map irq to this tty # */
+    irq_to_port[port->irq] = port - ports;      /* Map irq to this tty # */
 
     err = tty_allocq(tty, RSINQ_SIZE, RSOUTQ_SIZE);
     if (err) {
 errout:
-	--tty->usecount;
-	return err;
+        --tty->usecount;
+        return err;
     }
 
     /* clear RX buffer */
@@ -370,7 +370,7 @@ errout:
     /* enable FIFO and flush input*/
 #ifdef CONFIG_HW_SERIAL_FIFO
     if ((port->flags & SERF_TYPE) > ST_16550)
-	OUTB(UART_FCR_ENABLE_FIFO14, port->io + UART_FCR);
+        OUTB(UART_FCR_ENABLE_FIFO14, port->io + UART_FCR);
 #else
     /* flush input*/
     flush_input(port);
@@ -396,9 +396,9 @@ errout:
     return 0;
 }
 
-#if UNUSED	// removed for bloat
+#if UNUSED      // removed for bloat
 static int set_serial_info(struct serial_info *info,
-			   struct serial_info *new_info)
+                           struct serial_info *new_info)
 {
     register struct tty *tty;
     int err;
@@ -406,20 +406,20 @@ static int set_serial_info(struct serial_info *info,
     tty = info->tty;
     err = verified_memcpy_fromfs(info, new_info, sizeof(struct serial_info));
     if (!err) {
-	/* shutdown serial port and restart UART with new settings */
+        /* shutdown serial port and restart UART with new settings */
 
-	/* witty cheat :) - either we do this (and waste some DS) or duplicate
-	 * almost whole rs_release and rs_open (and waste much more CS)
-	 */
-	info->tty = tty;
-	rs_release(tty);
-	err = rs_open(tty);
+        /* witty cheat :) - either we do this (and waste some DS) or duplicate
+         * almost whole rs_release and rs_open (and waste much more CS)
+         */
+        info->tty = tty;
+        rs_release(tty);
+        err = rs_open(tty);
     }
     return err;
 }
 
 static int get_serial_info(struct serial_info *info,
-			   struct serial_info *ret_info)
+                           struct serial_info *ret_info)
 {
     return verified_memcpy_tofs(ret_info, info, sizeof(struct serial_info));
 }
@@ -436,21 +436,21 @@ static int rs_ioctl(struct tty *tty, int cmd, char *arg)
     case TCSETS:
     case TCSETSW:
     case TCSETSF:
-	/* verified_memcpy*fs() already called by ntty.c ioctl handler*/
-	//FIXME: update_port() only sets baud rate from termios, not parity or wordlen*/
-	update_port(port);	/* ignored return value*/
-	break;
+        /* verified_memcpy*fs() already called by ntty.c ioctl handler*/
+        //FIXME: update_port() only sets baud rate from termios, not parity or wordlen*/
+        update_port(port);      /* ignored return value*/
+        break;
 #if UNUSED
     case TIOCSSERIAL:
-	retval = set_serial_info(port, (struct serial_info *)arg);
-	break;
+        retval = set_serial_info(port, (struct serial_info *)arg);
+        break;
 
     case TIOCGSERIAL:
-	retval = get_serial_info(port, (struct serial_info *)arg);
+        retval = get_serial_info(port, (struct serial_info *)arg);
 #endif
 
     default:
-	return -EINVAL;
+        return -EINVAL;
     }
 
     return retval;
@@ -462,11 +462,11 @@ static void rs_init(void)
     register struct tty *tty = ttys + NR_CONSOLES;
 
     do {
-	if (!rs_probe(sp)) {
-	    sp->tty = tty;
-	    update_port(sp);
-	}
-	tty++;
+        if (!rs_probe(sp)) {
+            sp->tty = tty;
+            update_port(sp);
+        }
+        tty++;
     } while (++sp < &ports[NR_SERIAL]);
 }
 
@@ -476,7 +476,7 @@ void rs_conout(dev_t dev, int Ch)
     register struct serial_info *sp = &ports[MINOR(dev) - RS_MINOR_OFFSET];
 
     while (!(INB(sp->io + UART_LSR) & UART_LSR_TEMT))
-	continue;
+        continue;
     outb(Ch, sp->io + UART_TX);
 }
 
@@ -486,21 +486,21 @@ void INITPROC rs_setbaud(dev_t dev, unsigned long baud)
 {
     register struct serial_info *sp = &ports[MINOR(dev) - RS_MINOR_OFFSET];
     register struct tty *tty = ttys + NR_CONSOLES + MINOR(dev) - RS_MINOR_OFFSET;
-    unsigned int b;	/* use smaller 16-bit width to reduce code*/
+    unsigned int b;     /* use smaller 16-bit width to reduce code*/
 
-	if (baud == 115200) b = B115200;
-	else if ((unsigned)baud == 57600) b = B57600;
-	else if ((unsigned)baud == 38400) b = B38400;
-	else if ((unsigned)baud == 19200) b = B19200;
-	else if ((unsigned)baud == 9600) b = B9600;
-	else if ((unsigned)baud == 4800) b = B4800;
-	else if ((unsigned)baud == 2400) b = B2400;
-	else if ((unsigned)baud == 1200) b = B1200;
-	else if ((unsigned)baud == 300) b = B300;
-	else if ((unsigned)baud == 110) b = 110;
-	else return;
+    if (baud == 115200) b = B115200;
+    else if ((unsigned)baud == 57600) b = B57600;
+    else if ((unsigned)baud == 38400) b = B38400;
+    else if ((unsigned)baud == 19200) b = B19200;
+    else if ((unsigned)baud == 9600) b = B9600;
+    else if ((unsigned)baud == 4800) b = B4800;
+    else if ((unsigned)baud == 2400) b = B2400;
+    else if ((unsigned)baud == 1200) b = B1200;
+    else if ((unsigned)baud == 300) b = B300;
+    else if ((unsigned)baud == 110) b = 110;
+    else return;
 
-    sp->tty = tty;	/* force tty association with serial port*/
+    sp->tty = tty;      /* force tty association with serial port*/
     tty->termios.c_cflag = b | CS8;
     update_port(sp);
 }
@@ -511,22 +511,22 @@ void INITPROC serial_init(void)
     register struct serial_info *sp = ports;
     int ttyno = 0;
     static const char *serial_type[] = {
-	"n 8250",
-	" 16450",
-	" 16550",
-	" 16550A",
-	" 16750",
-	" UNKNOWN",
+        "n 8250",
+        " 16450",
+        " 16550",
+        " 16550A",
+        " 16750",
+        " UNKNOWN",
     };
 
     rs_init();
 
     do {
-	if (sp->tty != NULL) {
-	    printk("ttyS%d at 0x%x, irq %d is a%s\n", ttyno,
-		       sp->io, sp->irq, serial_type[sp->flags & SERF_TYPE]);
-	}
-	sp++;
+        if (sp->tty != NULL) {
+            printk("ttyS%d at 0x%x, irq %d is a%s\n", ttyno,
+                       sp->io, sp->irq, serial_type[sp->flags & SERF_TYPE]);
+        }
+        sp++;
     } while (++ttyno < NR_SERIAL);
 }
 

--- a/elks/arch/i86/kernel/irq.c
+++ b/elks/arch/i86/kernel/irq.c
@@ -35,10 +35,10 @@ static void *irq_trampoline [16];
 // including the 0..7 processor exceptions & traps
 
 struct int_handler {
-	byte_t call;		/* CALLF opcode (9Ah) */
-	int_proc proc;
-	word_t seg;
-	byte_t irq;
+    byte_t call;        /* CALLF opcode (9Ah) */
+    int_proc proc;
+    word_t seg;
+    byte_t irq;
 } __attribute__ ((packed));
 
 typedef struct int_handler int_handler_s;
@@ -57,22 +57,22 @@ void do_IRQ(int i,void *regs)
 
 static int_handler_s *handler_alloc(void)
 {
-	return (int_handler_s *) heap_alloc (sizeof (int_handler_s), HEAP_TAG_INTHAND);
+    return (int_handler_s *) heap_alloc (sizeof (int_handler_s), HEAP_TAG_INTHAND);
 }
 
 static int int_handler_add (int irq, int vect, int_proc proc, int_handler_s *h)
 {
-	if (!h) h = handler_alloc();
-	if (!h) return -ENOMEM;
+    if (!h) h = handler_alloc();
+    if (!h) return -ENOMEM;
 
-	h->call = 0x9A;		/* CALLF opcode */
-	h->proc = proc;
-	h->seg  = kernel_cs;	/* resident kernel code segment */
-	h->irq  = irq;
+    h->call = 0x9A;     /* CALLF opcode */
+    h->proc = proc;
+    h->seg  = kernel_cs;    /* resident kernel code segment */
+    h->irq  = irq;
 
-	int_vector_set (vect, (int_proc) h, kernel_ds);
+    int_vector_set (vect, (int_proc) h, kernel_ds);
 
-	return 0;
+    return 0;
 }
 
 int request_irq(int irq, irq_handler handler, int hflag)
@@ -133,7 +133,7 @@ int free_irq(int irq)
 }
 
 /*
- *	IRQ setup.
+ *  IRQ setup.
  */
 void INITPROC irq_init(void)
 {
@@ -161,7 +161,7 @@ void INITPROC irq_init(void)
 
     /* Connect timer interrupt handler to hardware IRQ 0 */
     if (request_irq(TIMER_IRQ, timer_tick, INT_GENERIC))
-    	panic("Unable to get timer");
+        panic("Unable to get timer");
 
     enable_timer_tick();        /* reprogram timer for 100 HZ */
 #endif

--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -11,16 +11,16 @@
 #include <arch/segment.h>
 
 static char *args[] = {
-(char *)0x01,	/* 0 argc     */
-(char *)0x08,	/* 2 &argv[0] */
-    NULL,		/* 4 end argv */
-    NULL,		/* 6 envp     */
-    NULL,		/* 8-19 argv[0], 12 chars space for cmd path*/
+(char *)0x01,   /* 0 argc     */
+(char *)0x08,   /* 2 &argv[0] */
+    NULL,       /* 4 end argv */
+    NULL,       /* 6 envp     */
+    NULL,       /* 8-19 argv[0], 12 chars space for cmd path*/
     NULL,
     NULL,
     NULL,
     NULL,
-    NULL		/* 18-19*/
+    NULL        /* 18-19*/
 };
 
 int run_init_process(const char *cmd)
@@ -29,7 +29,7 @@ int run_init_process(const char *cmd)
 
     strcpy((char *)&args[4], cmd);
     if (!(num = sys_execve(cmd, (char *)args, sizeof(args))))
-		ret_from_syscall();		/* no return, returns to user mode*/
+        ret_from_syscall();             /* no return, returns to user mode*/
     return num;
 }
 
@@ -38,7 +38,7 @@ int run_init_process_sptr(const char *cmd, char *sptr, int slen)
     int num;
 
     if (!(num = sys_execve(cmd, sptr, slen)))
-		ret_from_syscall();		/* no return, returns to user mode*/
+        ret_from_syscall();             /* no return, returns to user mode*/
     return num;
 }
 
@@ -52,32 +52,32 @@ void stack_check(void)
     register char *end = (char *)currentp->t_endbrk;
 
 #ifdef CONFIG_EXEC_LOW_STACK
-    if (currentp->t_begstack <= currentp->t_enddata) {	/* stack below heap?*/
-	if (currentp->t_regs.sp < (__u16)end)
-	    return;
-	end = 0;
+    if (currentp->t_begstack <= currentp->t_enddata) {  /* stack below heap?*/
+        if (currentp->t_regs.sp < (__u16)end)
+            return;
+        end = 0;
     } else
 #endif
     {
-	/* optional: check stack over min stack*/
-	if (currentp->t_regs.sp < currentp->t_begstack - currentp->t_minstack) {
-	  if (currentp->t_minstack)	/* display if protected stack*/
-	    printk("(%d)STACK OVER MINSTACK by %u BYTES\n", currentp->pid,
-		currentp->t_begstack - currentp->t_minstack - currentp->t_regs.sp);
-	}
+        /* optional: check stack over min stack*/
+        if (currentp->t_regs.sp < currentp->t_begstack - currentp->t_minstack) {
+          if (currentp->t_minstack)     /* display if protected stack*/
+            printk("(%d)STACK OVER MINSTACK by %u BYTES\n", currentp->pid,
+                currentp->t_begstack - currentp->t_minstack - currentp->t_regs.sp);
+        }
 
-	/* check stack overflow heap*/
-	if (currentp->t_regs.sp > (__u16)end)
-	    return;
+        /* check stack overflow heap*/
+        if (currentp->t_regs.sp > (__u16)end)
+            return;
     }
     printk("(%d)STACK OVERFLOW BY %u BYTES\n",
-	currentp->pid, (__u16)end - currentp->t_regs.sp);
+        currentp->pid, (__u16)end - currentp->t_regs.sp);
     do_exit(SIGSEGV);
 }
 
 /*
- *	Make task t fork into kernel space. We are in kernel mode
- *	so we fork onto our kernel stack.
+ *  Make task t fork into kernel space. We are in kernel mode
+ *  so we fork onto our kernel stack.
  */
 
 void kfork_proc(void (*addr)())
@@ -86,18 +86,18 @@ void kfork_proc(void (*addr)())
 
     t = find_empty_process();
 
-    t->t_xregs.cs = kernel_cs;			/* Run in kernel space */
+    t->t_xregs.cs = kernel_cs;                  /* Run in kernel space */
     t->t_regs.ds = t->t_regs.es = t->t_regs.ss = kernel_ds;
     if (addr)
-	arch_build_stack(t, addr);
+        arch_build_stack(t, addr);
 }
 
 /*
- *	Build a user return stack for exec*(). This is quite easy,
- *	especially as our syscall entry doesnt use the user stack.
+ *  Build a user return stack for exec*(). This is quite easy,
+ *  especially as our syscall entry doesnt use the user stack.
  */
 
-#define USER_FLAGS 0x3200		/* IPL 3, interrupt enabled */
+#define USER_FLAGS 0x3200               /* IPL 3, interrupt enabled */
 
 void put_ustack(register struct task_struct *t,int off,int val)
 {
@@ -114,10 +114,10 @@ unsigned get_ustack(register struct task_struct *t,int off)
  */
 void arch_setup_user_stack (register struct task_struct * t, word_t entry)
 {
-    put_ustack(t, -2, USER_FLAGS);		/* Flags */
-    put_ustack(t, -4, (int) t->t_xregs.cs);	/* user CS */
-    put_ustack(t, -6, entry);			/* user entry point */
-    put_ustack(t, -8, 0);			/* user BP */
+    put_ustack(t, -2, USER_FLAGS);              /* Flags */
+    put_ustack(t, -4, (int) t->t_xregs.cs);     /* user CS */
+    put_ustack(t, -6, entry);                   /* user entry point */
+    put_ustack(t, -8, 0);                       /* user BP */
     t->t_regs.sp -= 8;
 }
 
@@ -138,10 +138,10 @@ void arch_setup_user_stack (register struct task_struct * t, word_t entry)
  */
 
 void arch_setup_sighandler_stack(register struct task_struct *t,
-				 __kern_sighandler_t addr,unsigned signr)
+                                 __kern_sighandler_t addr,unsigned signr)
 {
     debug("Stack %x:%x was %x %x %x %x\n", _FP_SEG(addr), _FP_OFF(addr),
-	   get_ustack(t,0), get_ustack(t,2), get_ustack(t,4), get_ustack(t,6));
+           get_ustack(t,0), get_ustack(t,2), get_ustack(t,4), get_ustack(t,6));
     put_ustack(t, -6, (int)get_ustack(t,0));
     put_ustack(t, -4, _FP_OFF(addr));
     put_ustack(t, -2, _FP_SEG(addr));
@@ -149,12 +149,12 @@ void arch_setup_sighandler_stack(register struct task_struct *t,
     put_ustack(t, 6, (int)signr);
     t->t_regs.sp -= 6;
     debug("Stack is %x %x %x %x %x %x %x\n", get_ustack(t,0), get_ustack(t,2),
-	   get_ustack(t,4), get_ustack(t,6), get_ustack(t,8), get_ustack(t,10),
-	   get_ustack(t,12));
+           get_ustack(t,4), get_ustack(t,6), get_ustack(t,8), get_ustack(t,10),
+           get_ustack(t,12));
 }
 
 /*
- *	arch_build_stack(t, addr);
+ *  arch_build_stack(t, addr);
  *
  * Called by do_fork() and kfork_proc().
  *
@@ -197,13 +197,13 @@ void arch_build_stack(struct task_struct *t, void (*addr)())
     register __u16 *tsp = ((__u16 *)(&(t->t_regs.ax))) - 1;
 
     if (addr == NULL)
-	addr = ret_from_syscall;
-    *tsp = (__u16)addr;			/* Start execution address */
+        addr = ret_from_syscall;
+    *tsp = (__u16)addr;                 /* Start execution address */
 #ifdef __ia16__
-    *(tsp-2) = kernel_ds;		/* Initial value for ES register */
-    t->t_xregs.ksp = (__u16)(tsp - 4);	/* Initial value for SP register */
+    *(tsp-2) = kernel_ds;               /* Initial value for ES register */
+    t->t_xregs.ksp = (__u16)(tsp - 4);  /* Initial value for SP register */
 #else
-    t->t_xregs.ksp = (__u16)(tsp - 3);	/* Initial value for SP register */
+    t->t_xregs.ksp = (__u16)(tsp - 3);  /* Initial value for SP register */
 #endif
 }
 
@@ -217,6 +217,6 @@ int restart_syscall(void)
     struct uregs __far *user_stack;
 
     user_stack = _MK_FP(current->t_regs.ss, current->t_regs.sp);
-    user_stack->ip -= 2;		/* backup to INT 80h*/
-    return current->t_regs.orig_ax;	/* restore syscall # to user mode AX*/
+    user_stack->ip -= 2;                /* backup to INT 80h*/
+    return current->t_regs.orig_ax;     /* restore syscall # to user mode AX*/
 }

--- a/elks/arch/i86/kernel/timer.c
+++ b/elks/arch/i86/kernel/timer.c
@@ -11,7 +11,7 @@
 #include <arch/ports.h>
 
 /*
- *	Timer tick routine
+ *  Timer tick routine
  *
  * 9/1999 The 100 Hz system timer 0 can configure for variable input
  *        frequency. Christian Mardm"oller (chm@kdt.de)
@@ -71,7 +71,7 @@ void timer_tick(int irq, struct pt_regs *regs)
 #endif
 
 #if defined(CONFIG_CHAR_DEV_RS) && (defined(CONFIG_FAST_IRQ4) || defined(CONFIG_FAST_IRQ3))
-    rs_pump();		/* check if received serial chars and call wake_up*/
+    rs_pump();          /* check if received serial chars and call wake_up*/
 #endif
 
 #if defined(CONFIG_BLK_DEV_SSD_TEST) && defined(CONFIG_ASYNCIO)
@@ -83,10 +83,10 @@ void timer_tick(int irq, struct pt_regs *regs)
 #ifdef CONFIG_CONSOLE_DIRECT
     /* spin timer wheel in upper right of screen*/
     if (spin_on && !(jiffies & 7)) {
-	static unsigned char wheel[4] = {'-', '\\', '|', '/'};
-	static int c = 0;
+        static unsigned char wheel[4] = {'-', '\\', '|', '/'};
+        static int c = 0;
 
-	pokeb((79 + 0*80) * 2, VideoSeg, wheel[c++ & 0x03]);
+        pokeb((79 + 0*80) * 2, VideoSeg, wheel[c++ & 0x03]);
     }
 #endif
 }
@@ -95,6 +95,6 @@ void spin_timer(int onflag)
 {
 #ifdef CONFIG_CONSOLE_DIRECT
     if ((spin_on = onflag) == 0)
-	pokeb((79 + 0*80) * 2, VideoSeg, ' ');
+        pokeb((79 + 0*80) * 2, VideoSeg, ' ');
 #endif
 }

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -43,8 +43,8 @@ static ext_buffer_head *ext_buffer_heads;
 /* convert a buffer_head ptr to ext_buffer_head ptr */
 ext_buffer_head *EBH(struct buffer_head *bh)
 {
-	int idx = bh - buffer_heads;
-	return ext_buffer_heads + idx;
+    int idx = bh - buffer_heads;
+    return ext_buffer_heads + idx;
 }
 
 /* functions for buffer_head points called outside of buffer.c */
@@ -77,7 +77,7 @@ static struct buffer_head *bh_next;
  */
 #if defined(CONFIG_FS_EXTERNAL_BUFFER) || defined(CONFIG_FS_XMS_BUFFER)
 static struct buffer_head *L1map[MAX_NR_MAPBUFS]; /* L1 indexed pointer to L2 buffer */
-static struct wait_queue L1wait;		  /* Wait for a free L1 buffer area */
+static struct wait_queue L1wait;                  /* Wait for a free L1 buffer area */
 static int lastL1map;
 #endif
 static int xms_enabled;
@@ -96,26 +96,26 @@ static int nr_free_bh, nr_bh;
 #define SET_COUNT(bh)
 #endif
 
-#define buf_num(bh)	((bh) - buffer_heads)	/* buffer number, for debugging */
+#define buf_num(bh)     ((bh) - buffer_heads)   /* buffer number, for debugging */
 
 static void put_last_lru(struct buffer_head *bh)
 {
     ext_buffer_head *ebh = EBH(bh);
 
     if (bh_llru != bh) {
-	struct buffer_head *bhn = ebh->b_next_lru;
-	ext_buffer_head *ebhn = EBH(bhn);
+        struct buffer_head *bhn = ebh->b_next_lru;
+        ext_buffer_head *ebhn = EBH(bhn);
 
-	if ((ebhn->b_prev_lru = ebh->b_prev_lru))	/* Unhook */
-	    EBH(ebh->b_prev_lru)->b_next_lru = bhn;
-	else					/* Alter head */
-	    bh_lru = bhn;
-	/*
-	 *      Put on lru end
-	 */
-	ebh->b_next_lru = NULL;
-	EBH(ebh->b_prev_lru = bh_llru)->b_next_lru = bh;
-	bh_llru = bh;
+        if ((ebhn->b_prev_lru = ebh->b_prev_lru))       /* Unhook */
+            EBH(ebh->b_prev_lru)->b_next_lru = bhn;
+        else                                    /* Alter head */
+            bh_lru = bhn;
+        /*
+         *      Put on lru end
+         */
+        ebh->b_next_lru = NULL;
+        EBH(ebh->b_prev_lru = bh_llru)->b_next_lru = bh;
+        bh_llru = bh;
     }
 }
 
@@ -126,12 +126,12 @@ static void INITPROC add_buffers(int nbufs, char *buf, ramdesc_t seg)
     size_t offset;
 
     for (bh = bh_next; n < nbufs; n++, bh = ++bh_next) {
-	ext_buffer_head *ebh = EBH(bh);
+        ext_buffer_head *ebh = EBH(bh);
 
-	if (bh != buffer_heads) {
-	    ebh->b_next_lru = ebh->b_prev_lru = bh;
-	    put_last_lru(bh);
-	}
+        if (bh != buffer_heads) {
+            ebh->b_next_lru = ebh->b_prev_lru = bh;
+            put_last_lru(bh);
+        }
 
 #if defined(CONFIG_FS_EXTERNAL_BUFFER) || defined(CONFIG_FS_XMS_BUFFER)
         /* segment adjusted to require no offset to buffer */
@@ -139,8 +139,8 @@ static void INITPROC add_buffers(int nbufs, char *buf, ramdesc_t seg)
                               ((n & 63) << (BLOCK_SIZE_BITS - 4));
         ebh->b_L2seg = seg + offset;
 #else
-	bh->b_data = buf;
-	buf += BLOCK_SIZE;
+        bh->b_data = buf;
+        buf += BLOCK_SIZE;
 #endif
     }
 }
@@ -193,7 +193,7 @@ int INITPROC buffer_init(void)
 
 #ifdef CONFIG_FS_XMS_BUFFER
     if (nr_xms_bufs)
-        xms_enabled = xms_init();	/* try to enable unreal mode and A20 gate*/
+        xms_enabled = xms_init();       /* try to enable unreal mode and A20 gate*/
     if (xms_enabled)
         bufs_to_alloc = nr_xms_bufs;
 #endif
@@ -218,7 +218,7 @@ int INITPROC buffer_init(void)
         return 1;
 
     buffer_heads = heap_alloc(bufs_to_alloc * sizeof(struct buffer_head),
-	HEAP_TAG_BUFHEAD|HEAP_TAG_CLEAR);
+        HEAP_TAG_BUFHEAD|HEAP_TAG_CLEAR);
     if (!buffer_heads) return 1;
 #ifdef CONFIG_FAR_BUFHEADS
     size_t size = bufs_to_alloc * sizeof(ext_buffer_head);
@@ -231,24 +231,24 @@ int INITPROC buffer_init(void)
 
 #if defined(CONFIG_FS_EXTERNAL_BUFFER) || defined(CONFIG_FS_XMS_BUFFER)
     do {
-	int nbufs;
+        int nbufs;
 
-	/* allocate buffers in 64k chunks so addressable with segment/offset*/
-	if ((nbufs = bufs_to_alloc) > 64)
-	    nbufs = 64;
-	bufs_to_alloc -= nbufs;
+        /* allocate buffers in 64k chunks so addressable with segment/offset*/
+        if ((nbufs = bufs_to_alloc) > 64)
+            nbufs = 64;
+        bufs_to_alloc -= nbufs;
 #ifdef CONFIG_FS_XMS_BUFFER
-	if (xms_enabled) {
-	    ramdesc_t xmsseg = xms_alloc((long_t)nbufs << BLOCK_SIZE_BITS);
-	    add_buffers(nbufs, 0, xmsseg);
-	} else
+        if (xms_enabled) {
+            ramdesc_t xmsseg = xms_alloc((long_t)nbufs << BLOCK_SIZE_BITS);
+            add_buffers(nbufs, 0, xmsseg);
+        } else
 #endif
-	{
-	    segment_s *extseg = seg_alloc (nbufs << (BLOCK_SIZE_BITS - 4),
-		SEG_FLAG_EXTBUF|SEG_FLAG_ALIGN1K);
-	    if (!extseg) return 2;
-	    add_buffers(nbufs, 0, extseg->base);
-	}
+        {
+            segment_s *extseg = seg_alloc (nbufs << (BLOCK_SIZE_BITS - 4),
+                SEG_FLAG_EXTBUF|SEG_FLAG_ALIGN1K);
+            if (!extseg) return 2;
+            add_buffers(nbufs, 0, extseg->base);
+        }
     } while (bufs_to_alloc > 0);
 #else
     /* no EXT or XMS buffers, internal L1 only */
@@ -258,7 +258,7 @@ int INITPROC buffer_init(void)
 }
 
 /*
- *	Wait on a buffer
+ *      Wait on a buffer
  */
 
 void wait_on_buffer(struct buffer_head *bh)
@@ -292,7 +292,7 @@ void unlock_buffer(struct buffer_head *bh)
 {
     EBH(bh)->b_locked = 0;
 #ifdef CONFIG_ASYNCIO
-    wake_up((struct wait_queue *)bh);	/* use bh as wait address*/
+    wake_up((struct wait_queue *)bh);   /* use bh as wait address*/
 #endif
 }
 
@@ -303,19 +303,19 @@ void invalidate_buffers(kdev_t dev)
 
     debug_blk("INVALIDATE dev %x\n", dev);
     do {
-	ebh = EBH(bh);
+        ebh = EBH(bh);
 
-	if (ebh->b_dev != dev) continue;
-	wait_on_buffer(bh);
+        if (ebh->b_dev != dev) continue;
+        wait_on_buffer(bh);
         if (ebh->b_count) {
             printk("invalidate_buffers: skipping active block %ld\n", ebh->b_blocknr);
             continue;
         }
         debug_blk("invalidating blk %ld\n", ebh->b_blocknr);
-	ebh->b_uptodate = 0;
-	ebh->b_dirty = 0;
+        ebh->b_uptodate = 0;
+        ebh->b_dirty = 0;
         brelseL1(bh, 0);        /* release buffer from L1 if present */
-	unlock_buffer(bh);
+        unlock_buffer(bh);
     } while ((bh = ebh->b_prev_lru) != NULL);
 }
 
@@ -327,36 +327,36 @@ static void sync_buffers(kdev_t dev, int wait)
 
     debug_blk("sync_buffers dev %p wait %d\n", dev, wait);
     do {
-	ebh = EBH(bh);
+        ebh = EBH(bh);
 
-	/*
-	 *      Skip clean buffers.
-	 */
-	if ((dev && (ebh->b_dev != dev)) || !ebh->b_dirty)
-	   continue;
+        /*
+         *      Skip clean buffers.
+         */
+        if ((dev && (ebh->b_dev != dev)) || !ebh->b_dirty)
+           continue;
 
-	/*
-	 *      Locked buffers..
-	 *
-	 *      If buffer is locked; skip it unless wait is requested
-	 *      AND pass > 0.
-	 */
-	if (ebh->b_locked) {
+        /*
+         *      Locked buffers..
+         *
+         *      If buffer is locked; skip it unless wait is requested
+         *      AND pass > 0.
+         */
+        if (ebh->b_locked) {
             debug_blk("SYNC: dev %p buf %d block %ld LOCKED mapped %d skipped %d data %04x\n",
                 ebh->b_dev, buf_num(bh), ebh->b_blocknr, ebh->b_mapcount, !wait,
                 bh->b_data);
-	    if (!wait) continue;
-	    wait_on_buffer(bh);
-	}
+            if (!wait) continue;
+            wait_on_buffer(bh);
+        }
 
-	/*
-	 *      Do the stuff
-	 */
+        /*
+         *      Do the stuff
+         */
         debug_blk("sync: dev %p write buf %d block %ld count %d dirty %d\n",
             ebh->b_dev, buf_num(bh), ebh->b_blocknr, ebh->b_count, ebh->b_dirty);
-	ebh->b_count++;
-	ll_rw_blk(WRITE, bh);
-	ebh->b_count--;
+        ebh->b_count++;
+        ll_rw_blk(WRITE, bh);
+        ebh->b_count--;
         count++;
     } while ((bh = ebh->b_next_lru) != NULL);
     debug_blk("SYNC_BUFFERS END %d wrote %d\n", wait, count);
@@ -412,7 +412,7 @@ void brelse(struct buffer_head *bh)
     DCR_COUNT(ebh);
 #ifdef BLOAT_FS
     if (!ebh->b_count)
-	wake_up(&bufwait);
+        wake_up(&bufwait);
 #endif
 }
 
@@ -439,9 +439,9 @@ static struct buffer_head *find_buffer(kdev_t dev, block32_t block)
     ext_buffer_head *ebh;
 
     do {
-	ebh = EBH(bh);
+        ebh = EBH(bh);
 
-	if (ebh->b_blocknr == block && ebh->b_dev == dev) break;
+        if (ebh->b_blocknr == block && ebh->b_dev == dev) break;
     } while ((bh = ebh->b_prev_lru) != NULL);
     return bh;
 }
@@ -451,10 +451,10 @@ struct buffer_head *get_hash_table(kdev_t dev, block_t block)
     struct buffer_head *bh;
 
     if ((bh = find_buffer(dev, (block32_t)block)) != NULL) {
-	ext_buffer_head *ebh = EBH(bh);
+        ext_buffer_head *ebh = EBH(bh);
 
-	INR_COUNT(ebh);
-	wait_on_buffer(bh);
+        INR_COUNT(ebh);
+        wait_on_buffer(bh);
     }
     return bh;
 }
@@ -473,7 +473,7 @@ struct buffer_head *get_hash_table(kdev_t dev, block_t block)
 /* 16 bit block numbers for super blocks and MINIX filesystem driver*/
 struct buffer_head *getblk(kdev_t dev, block_t block)
 {
-	return getblk32(dev, (block32_t)block);
+        return getblk32(dev, (block32_t)block);
 }
 
 /* 32 bit block numbers for FAT filesystem driver*/
@@ -490,14 +490,14 @@ struct buffer_head *getblk32(kdev_t dev, block32_t block)
     n_bh = NULL;
     goto start;
     do {
-	/*
-	 * Block not found. Create a buffer for this job.
-	 */
-	n_bh = get_free_buffer();	/* This function may sleep and someone else */
-      start:				/* can create the block */
-	if ((bh = find_buffer(dev, block)) != NULL) goto found_it;
+        /*
+         * Block not found. Create a buffer for this job.
+         */
+        n_bh = get_free_buffer();       /* This function may sleep and someone else */
+      start:                            /* can create the block */
+        if ((bh = find_buffer(dev, block)) != NULL) goto found_it;
     } while (n_bh == NULL);
-    bh = n_bh;				/* Block not found, use the new buffer */
+    bh = n_bh;                          /* Block not found, use the new buffer */
 /* OK, FINALLY we know that this buffer is the only one of its kind,
  * and that it's unused (b_count=0), unlocked (b_locked=0), and clean
  */
@@ -508,16 +508,16 @@ struct buffer_head *getblk32(kdev_t dev, block32_t block)
 
   found_it:
     if (n_bh != NULL) {
-	ext_buffer_head *en_bh = EBH(n_bh);
+        ext_buffer_head *en_bh = EBH(n_bh);
 
-	CLR_COUNT(en_bh);
-	en_bh->b_count = 0;	/* Release previously created buffer head */
+        CLR_COUNT(en_bh);
+        en_bh->b_count = 0;     /* Release previously created buffer head */
     }
     ebh = EBH(bh);
     INR_COUNT(ebh);
     wait_on_buffer(bh);
     if (!ebh->b_dirty && ebh->b_uptodate)
-	put_last_lru(bh);
+        put_last_lru(bh);
 
   return_it:
     return bh;
@@ -531,12 +531,12 @@ struct buffer_head *readbuf(struct buffer_head *bh)
     ext_buffer_head *ebh = EBH(bh);
 
     if (!ebh->b_uptodate) {
-	ll_rw_blk(READ, bh);
-	wait_on_buffer(bh);
-	if (!ebh->b_uptodate) {
-	    brelse(bh);
-	    bh = NULL;
-	}
+        ll_rw_blk(READ, bh);
+        wait_on_buffer(bh);
+        if (!ebh->b_uptodate) {
+            brelse(bh);
+            bh = NULL;
+        }
     }
     return bh;
 }
@@ -561,34 +561,34 @@ struct buffer_head *bread32(kdev_t dev, block32_t block)
 #ifdef BLOAT_FS
 /* NOTHING is using breada at this point, so I can pull it out... Chad */
 struct buffer_head *breada(kdev_t dev, block_t block, int bufsize,
-			   unsigned int pos, unsigned int filesize)
+                           unsigned int pos, unsigned int filesize)
 {
     struct buffer_head *bh, *bha;
     int i, j;
 
     if (pos >= filesize)
-	return NULL;
+        return NULL;
 
     if (block < 0)
-	return NULL;
+        return NULL;
     bh = getblk(dev, block);
 
     if (bh->b_uptodate)
-	return bh;
+        return bh;
 
     bha = getblk(dev, block + 1);
     if (bha->b_uptodate) {
-	brelse(bha);
-	bha = NULL;
+        brelse(bha);
+        bha = NULL;
     } else {
-	/* Request the read for these buffers, and then release them */
-	ll_rw_blk(READ, bha);
-	brelse(bha);
+        /* Request the read for these buffers, and then release them */
+        ll_rw_blk(READ, bha);
+        brelse(bha);
     }
     /* Wait for this buffer, and then continue on */
     wait_on_buffer(bh);
     if (bh->b_uptodate)
-	return bh;
+        return bh;
     brelse(bh);
     return NULL;
 }
@@ -676,39 +676,39 @@ void map_buffer(struct buffer_head *bh)
         }
 #endif
         remap_count++;
-	goto end_map_buffer;
+        goto end_map_buffer;
     }
 
     i = lastL1map;
     /* search for free L1 buffer or wait until one is available*/
     for (;;) {
-	struct buffer_head *bmap;
-	ext_buffer_head *ebmap;
+        struct buffer_head *bmap;
+        ext_buffer_head *ebmap;
 
-	if (++i >= nr_map_bufs) i = 0;
-	debug("map:   %d try %d\n", buf_num(bh), i);
+        if (++i >= nr_map_bufs) i = 0;
+        debug("map:   %d try %d\n", buf_num(bh), i);
 
-	/* First check for the trivial case, to avoid dereferencing a null pointer */
-	if (!(bmap = L1map[i]))
-	    break;
-	ebmap = EBH(bmap);
+        /* First check for the trivial case, to avoid dereferencing a null pointer */
+        if (!(bmap = L1map[i]))
+            break;
+        ebmap = EBH(bmap);
 
-	/* L1 with zero count can be unmapped and reused for this request*/
+        /* L1 with zero count can be unmapped and reused for this request*/
 #ifdef CHECK_BLOCKIO
-	if (ebmap->b_mapcount < 0)
-	    printk("map_buffer: %d BAD mapcount %d\n", buf_num(bmap), ebmap->b_mapcount);
+        if (ebmap->b_mapcount < 0)
+            printk("map_buffer: %d BAD mapcount %d\n", buf_num(bmap), ebmap->b_mapcount);
 #endif
         /* don't remap if I/O in progress to prevent bh/req buffer unpairing */
-	if (!ebmap->b_mapcount && !ebmap->b_locked) {
-	    debug_map("UNMAP: L%02d block %ld\n", i+1, ebmap->b_blocknr);
-	    brelseL1_index(i, 1);       /* Unmap/copy L1 to L2 */
-	    break;
-	}
-	if (i == lastL1map) {
-	    /* no free L1 buffers, must wait for L1 unmap_buffer*/
-	    debug_map("MAPWAIT: block %ld\n", ebh->b_blocknr);
-	    sleep_on(&L1wait);
-	}
+        if (!ebmap->b_mapcount && !ebmap->b_locked) {
+            debug_map("UNMAP: L%02d block %ld\n", i+1, ebmap->b_blocknr);
+            brelseL1_index(i, 1);       /* Unmap/copy L1 to L2 */
+            break;
+        }
+        if (i == lastL1map) {
+            /* no free L1 buffers, must wait for L1 unmap_buffer*/
+            debug_map("MAPWAIT: block %ld\n", ebh->b_blocknr);
+            sleep_on(&L1wait);
+        }
     }
 
     /* Map/copy L2 to L1 */
@@ -716,7 +716,7 @@ void map_buffer(struct buffer_head *bh)
     L1map[i] = bh;
     bh->b_data = L1buf + (i << BLOCK_SIZE_BITS);
     if (ebh->b_uptodate)
-	xms_fmemcpyw(bh->b_data, kernel_ds, 0, ebh->b_L2seg, BLOCK_SIZE/2);
+        xms_fmemcpyw(bh->b_data, kernel_ds, 0, ebh->b_L2seg, BLOCK_SIZE/2);
     map_count++;
     debug_map("MAP:   L%02d block %ld\n", i+1, ebh->b_blocknr);
   end_map_buffer:
@@ -731,19 +731,19 @@ void map_buffer(struct buffer_head *bh)
 void unmap_buffer(struct buffer_head *bh)
 {
     if (bh) {
-	ext_buffer_head *ebh = EBH(bh);
+        ext_buffer_head *ebh = EBH(bh);
 
 #ifdef CHECK_BLOCKIO
-	if (ebh->b_mapcount <= 0) {
-	    printk("unmap_buffer: %d BAD mapcount %d\n", buf_num(bh), ebh->b_mapcount);
-	    ebh->b_mapcount = 0;
-	} else
+        if (ebh->b_mapcount <= 0) {
+            printk("unmap_buffer: %d BAD mapcount %d\n", buf_num(bh), ebh->b_mapcount);
+            ebh->b_mapcount = 0;
+        } else
 #endif
         if (--ebh->b_mapcount == 0) {
-	    debug("unmap: %d\n", buf_num(bh));
-	    wake_up(&L1wait);
-	} else
-	    debug("unmap_buffer: %d mapcount %d\n", buf_num(bh), ebh->b_mapcount+1);
+            debug("unmap: %d\n", buf_num(bh));
+            wake_up(&L1wait);
+        } else
+            debug("unmap_buffer: %d mapcount %d\n", buf_num(bh), ebh->b_mapcount+1);
     }
 }
 

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -9,25 +9,25 @@
  */
 
 #ifdef CONFIG_ARCH_IBMPC
-#define MAX_SERIAL		4		/* max number of serial tty devices*/
+#define MAX_SERIAL              4               /* max number of serial tty devices*/
 
 /*
  * Setup data - normally queried by startup setup.S code, but can
  * be overridden for embedded systems with less overhead.
  * See setup.S for more details.
  */
-#define SETUP_VID_COLS		setupb(7)	/* BIOS video # columns */
-#define SETUP_VID_LINES		setupb(14)	/* BIOS video # lines */
-#define SETUP_CPU_TYPE		setupb(0x20)	/* processor type */
-#define SETUP_MEM_KBYTES	setupw(0x2a)	/* base memory in 1K bytes */
-#define SETUP_ROOT_DEV		setupw(0x1fc)	/* root device, kdev_t or BIOS dev */
-#define SETUP_ELKS_FLAGS	setupb(0x1f6)	/* flags for root device type */
-#define SETUP_PART_OFFSETLO	setupw(0x1e2)	/* partition offset low word */
-#define SETUP_PART_OFFSETHI	setupw(0x1e4)	/* partition offset high word */
+#define SETUP_VID_COLS          setupb(7)       /* BIOS video # columns */
+#define SETUP_VID_LINES         setupb(14)      /* BIOS video # lines */
+#define SETUP_CPU_TYPE          setupb(0x20)    /* processor type */
+#define SETUP_MEM_KBYTES        setupw(0x2a)    /* base memory in 1K bytes */
+#define SETUP_ROOT_DEV          setupw(0x1fc)   /* root device, kdev_t or BIOS dev */
+#define SETUP_ELKS_FLAGS        setupb(0x1f6)   /* flags for root device type */
+#define SETUP_PART_OFFSETLO     setupw(0x1e2)   /* partition offset low word */
+#define SETUP_PART_OFFSETHI     setupw(0x1e4)   /* partition offset high word */
 #ifdef CONFIG_ROMCODE
-#define SYS_CAPS	(CAP_PC_AT)
+#define SYS_CAPS        (CAP_PC_AT)
 #endif
-#define UTS_MACHINE		"ibmpc i8086"
+#define UTS_MACHINE             "ibmpc i8086"
 
 /* The following can be set for minimal systems or for QEMU emulation testing:
  * 10 buffers (@20 = 200), 2 ttyq (@80 = 160), 4k L1 cache, 512 heap free = ~4968.
@@ -43,19 +43,19 @@
 #endif /* CONFIG_ARCH_IBMPC */
 
 #ifdef CONFIG_ARCH_PC98
-#define MAX_SERIAL		1	/* max number of serial tty devices*/
-#define SETUP_VID_COLS		80	/* video # columns */
-#define SETUP_VID_LINES		25	/* video # lines */
-#define SETUP_CPU_TYPE		1	/* processor type = 8086 */
-#define SETUP_MEM_KBYTES	setupw(0x2a)	/* base memory in 1K bytes */
-#define SETUP_ROOT_DEV		setupw(0x1fc)	/* root device, kdev_t or BIOS dev */
-#define SETUP_ELKS_FLAGS	setupb(0x1f6)	/* flags for root device type */
-#define SETUP_PART_OFFSETLO	setupw(0x1e2)	/* partition offset low word */
-#define SETUP_PART_OFFSETHI	setupw(0x1e4)	/* partition offset high word */
-#define SYS_CAPS		CAP_IRQ8TO15	/* enable capabilities */
-#define UTS_MACHINE		"pc-98 i8086"
+#define MAX_SERIAL              1       /* max number of serial tty devices*/
+#define SETUP_VID_COLS          80      /* video # columns */
+#define SETUP_VID_LINES         25      /* video # lines */
+#define SETUP_CPU_TYPE          1       /* processor type = 8086 */
+#define SETUP_MEM_KBYTES        setupw(0x2a)    /* base memory in 1K bytes */
+#define SETUP_ROOT_DEV          setupw(0x1fc)   /* root device, kdev_t or BIOS dev */
+#define SETUP_ELKS_FLAGS        setupb(0x1f6)   /* flags for root device type */
+#define SETUP_PART_OFFSETLO     setupw(0x1e2)   /* partition offset low word */
+#define SETUP_PART_OFFSETHI     setupw(0x1e4)   /* partition offset high word */
+#define SYS_CAPS                CAP_IRQ8TO15    /* enable capabilities */
+#define UTS_MACHINE             "pc-98 i8086"
 
-#define CONFIG_VAR_SECTOR_SIZE	/* sector size may vary across disks */
+#define CONFIG_VAR_SECTOR_SIZE  /* sector size may vary across disks */
 //#undef SETUP_MEM_KBYTES
 //#define SETUP_MEM_KBYTES        640     /* force available memory in 1K bytes */
 //#define SETUP_MEM_KBYTES_ASM    SETUP_MEM_KBYTES
@@ -63,19 +63,19 @@
 #endif /* CONFIG_ARCH_PC98 */
 
 #ifdef CONFIG_ARCH_8018X
-#define MAX_SERIAL		2	/* max number of serial tty devices*/
-#define SETUP_VID_COLS		80	/* video # columns */
-#define SETUP_VID_LINES		25	/* video # lines */
-#define SETUP_CPU_TYPE		5	/* processor type 80186 */
-#define SETUP_MEM_KBYTES	512	/* base memory in 1K bytes */
-#define SETUP_ROOT_DEV		0x0600	/* root device ROMFS */
-#define SETUP_ELKS_FLAGS	0	/* flags for root device type */
-#define SETUP_PART_OFFSETLO	0	/* partition offset low word */
-#define SETUP_PART_OFFSETHI	0	/* partition offset high word */
-#define SYS_CAPS		0	/* no XT/AT capabilities */
-#define UTS_MACHINE		"8018x"
+#define MAX_SERIAL              2       /* max number of serial tty devices*/
+#define SETUP_VID_COLS          80      /* video # columns */
+#define SETUP_VID_LINES         25      /* video # lines */
+#define SETUP_CPU_TYPE          5       /* processor type 80186 */
+#define SETUP_MEM_KBYTES        512     /* base memory in 1K bytes */
+#define SETUP_ROOT_DEV          0x0600  /* root device ROMFS */
+#define SETUP_ELKS_FLAGS        0       /* flags for root device type */
+#define SETUP_PART_OFFSETLO     0       /* partition offset low word */
+#define SETUP_PART_OFFSETHI     0       /* partition offset high word */
+#define SYS_CAPS                0       /* no XT/AT capabilities */
+#define UTS_MACHINE             "8018x"
 
-#define CONFIG_8018X_FCPU	16
+#define CONFIG_8018X_FCPU       16
 #define CONFIG_8018X_EB
 #endif
 
@@ -92,60 +92,60 @@
 #define CAP_ALL         0xFF      /* all capabilities if PC/AT only */
 
 /* Don't touch these, unless you really know what you are doing. */
-#define DEF_INITSEG	0x0100	/* initial Image load address by boot code */
-#define DEF_SYSSEG	0x1300	/* kernel copied here by setup.S code */
-#define DEF_SETUPSEG	DEF_INITSEG + 0x20
-#define DEF_SYSSIZE	0x2F00
+#define DEF_INITSEG     0x0100  /* initial Image load address by boot code */
+#define DEF_SYSSEG      0x1300  /* kernel copied here by setup.S code */
+#define DEF_SETUPSEG    DEF_INITSEG + 0x20
+#define DEF_SYSSIZE     0x2F00
 
 #ifdef CONFIG_ROMCODE
 #ifdef CONFIG_BLK_DEV_BIOS    /* BIOS disk driver*/
-#define DMASEG		0x80  /* 0x400 bytes floppy sector buffer */
+#define DMASEG          0x80  /* 0x400 bytes floppy sector buffer */
 #ifdef CONFIG_TRACK_CACHE     /* floppy track buffer in low mem */
 #define DMASEGSZ 0x2400       /* SECTOR_SIZE * 18 (9216) */
-#define KERNEL_DATA	0x2C0 /* kernel data segment */
+#define KERNEL_DATA     0x2C0 /* kernel data segment */
 #else
-#define DMASEGSZ 0x040	      /* BLOCK_SIZE (1024) */
-#define KERNEL_DATA	0x0C0 /* kernel data segment */
+#define DMASEGSZ 0x040        /* BLOCK_SIZE (1024) */
+#define KERNEL_DATA     0x0C0 /* kernel data segment */
 #endif
 #else
 #define KERNEL_DATA     0x80  /* kernel data segment */
 #endif
-#define SETUP_DATA	CONFIG_ROM_SETUP_DATA
+#define SETUP_DATA      CONFIG_ROM_SETUP_DATA
 #endif /* CONFIG_ROMCODE */
 
 
 #if (defined(CONFIG_ARCH_IBMPC) || defined(CONFIG_ARCH_8018X)) && !defined(CONFIG_ROMCODE)
 /* Define segment locations of low memory, must not overlap */
-#define DEF_OPTSEG	0x50  /* 0x200 bytes boot options*/
+#define DEF_OPTSEG      0x50  /* 0x200 bytes boot options*/
 #define OPTSEGSZ 0x200    /* max size of /bootopts file (1K max) */
-#define REL_INITSEG	0x70  /* 0x200 bytes setup data */
-#define DMASEG		0x90  /* 0x400 bytes floppy sector buffer */
+#define REL_INITSEG     0x70  /* 0x200 bytes setup data */
+#define DMASEG          0x90  /* 0x400 bytes floppy sector buffer */
 
 #ifdef CONFIG_TRACK_CACHE     /* floppy track buffer in low mem */
-#define DMASEGSZ 0x2400	      /* SECTOR_SIZE * 18 (9216) */
-#define REL_SYSSEG	0x2D0 /* kernel code segment */
+#define DMASEGSZ 0x2400       /* SECTOR_SIZE * 18 (9216) */
+#define REL_SYSSEG      0x2D0 /* kernel code segment */
 #else
-#define DMASEGSZ 0x0400	      /* BLOCK_SIZE (1024) */
-#define REL_SYSSEG	0x0D0 /* kernel code segment */
+#define DMASEGSZ 0x0400       /* BLOCK_SIZE (1024) */
+#define REL_SYSSEG      0x0D0 /* kernel code segment */
 #endif
-#define SETUP_DATA	REL_INITSEG
+#define SETUP_DATA      REL_INITSEG
 #endif /* (CONFIG_ARCH_IBMPC || CONFIG_ARCH_8018X) && !CONFIG_ROMCODE */
 
 #if defined(CONFIG_ARCH_PC98) && !defined(CONFIG_ROMCODE)
 /* Define segment locations of low memory, must not overlap */
-#define DEF_OPTSEG	0x60  /* 0x200 bytes boot options*/
+#define DEF_OPTSEG      0x60  /* 0x200 bytes boot options*/
 #define OPTSEGSZ 0x200    /* max size of /bootopts file (1K max) */
-#define REL_INITSEG	0x80  /* 0x200 bytes setup data */
-#define DMASEG		0xA0  /* 0x400 bytes floppy sector buffer */
+#define REL_INITSEG     0x80  /* 0x200 bytes setup data */
+#define DMASEG          0xA0  /* 0x400 bytes floppy sector buffer */
 
 #ifdef CONFIG_TRACK_CACHE     /* floppy track buffer in low mem */
-#define DMASEGSZ 0x2400	      /* SECTOR_SIZE * 18 (9216) > SECTOR_SIZE * 8 (8192) */
-#define REL_SYSSEG	0x2E0 /* kernel code segment */
+#define DMASEGSZ 0x2400       /* SECTOR_SIZE * 18 (9216) > SECTOR_SIZE * 8 (8192) */
+#define REL_SYSSEG      0x2E0 /* kernel code segment */
 #else
-#define DMASEGSZ 0x0400	      /* BLOCK_SIZE (1024) */
-#define REL_SYSSEG	0x0E0 /* kernel code segment */
+#define DMASEGSZ 0x0400       /* BLOCK_SIZE (1024) */
+#define REL_SYSSEG      0x0E0 /* kernel code segment */
 #endif
-#define SETUP_DATA	REL_INITSEG
+#define SETUP_DATA      REL_INITSEG
 #endif /* CONFIG_ARCH_PC98 && !CONFIG_ROMCODE */
 
 
@@ -160,6 +160,6 @@
  * kernel compilation parameters, and should only be used by elks/kernel/version.c
  */
 #define UTS_SYSNAME "ELKS"
-#define UTS_NODENAME "elks"		/* someday set by sethostname() */
+#define UTS_NODENAME "elks"             /* someday set by sethostname() */
 
 #endif

--- a/elks/include/linuxmt/debug.h
+++ b/elks/include/linuxmt/debug.h
@@ -13,42 +13,42 @@
  * Kernel debug options, set =1 to turn on. Works across multiple files.
  */
 #define DEBUG_EVENT     1               /* generate debug events on CTRLN-CTRLP*/
-#define DEBUG_STARTDEF	1		/* default startup debug display*/
-#define DEBUG_BIOS	0		/* BIOS driver*/
-#define DEBUG_BLK	0		/* block i/o*/
-#define DEBUG_ETH	0		/* ethernet*/
-#define DEBUG_FAT	0		/* FAT filesystem*/
-#define DEBUG_FILE	0		/* sys open and file i/o*/
-#define DEBUG_MAP	0		/* L1 mapping */
-#define DEBUG_MM	0		/* mem char device*/
-#define DEBUG_NET	0		/* networking*/
-#define DEBUG_SCHED	0		/* scheduler/wait*/
-#define DEBUG_SIG	0		/* signals*/
-#define DEBUG_SUP	0		/* superblock, mount, umount*/
-#define DEBUG_TTY	0		/* tty driver*/
-#define DEBUG_TUNE	0		/* tunable debug statements*/
-#define DEBUG_WAIT	0		/* wait, exit*/
+#define DEBUG_STARTDEF  1               /* default startup debug display*/
+#define DEBUG_BIOS      0               /* BIOS driver*/
+#define DEBUG_BLK       0               /* block i/o*/
+#define DEBUG_ETH       0               /* ethernet*/
+#define DEBUG_FAT       0               /* FAT filesystem*/
+#define DEBUG_FILE      0               /* sys open and file i/o*/
+#define DEBUG_MAP       0               /* L1 mapping */
+#define DEBUG_MM        0               /* mem char device*/
+#define DEBUG_NET       0               /* networking*/
+#define DEBUG_SCHED     0               /* scheduler/wait*/
+#define DEBUG_SIG       0               /* signals*/
+#define DEBUG_SUP       0               /* superblock, mount, umount*/
+#define DEBUG_TTY       0               /* tty driver*/
+#define DEBUG_TUNE      0               /* tunable debug statements*/
+#define DEBUG_WAIT      0               /* wait, exit*/
 
 #if DEBUG_EVENT
 void dprintk(const char *, ...);        /* printk when debugging on*/
 void debug_event(int evnum);            /* generate debug event*/
 void debug_setcallback(int evnum, void (*cbfunc)()); /* callback on debug event*/
-#define PRINTK		dprintk
+#define PRINTK          dprintk
 #else
-#define PRINTK		printk
+#define PRINTK          printk
 #define dprintk(...)
 #define debug_event(evnum)
 #define debug_setcallback(evnum,cbfunc)
 #endif
 
 #if DEBUG_BIOS
-#define debug_bios	PRINTK
+#define debug_bios      PRINTK
 #else
 #define debug_bios(...)
 #endif
 
 #if DEBUG_BLK
-#define debug_blk	PRINTK
+#define debug_blk       PRINTK
 #else
 #define debug_blk(...)
 #endif
@@ -60,67 +60,67 @@ void debug_setcallback(int evnum, void (*cbfunc)()); /* callback on debug event*
 #endif
 
 #if DEBUG_FAT
-#define debug_fat	PRINTK
+#define debug_fat       PRINTK
 #else
 #define debug_fat(...)
 #endif
 
 #if DEBUG_FILE
-#define debug_file	PRINTK
+#define debug_file      PRINTK
 #else
 #define debug_file(...)
 #endif
 
 #if DEBUG_MM
-#define debugmem	PRINTK
+#define debugmem        PRINTK
 #else
 #define debugmem(...)
 #endif
 
 #if DEBUG_MAP
-#define debug_map	PRINTK
+#define debug_map       PRINTK
 #else
 #define debug_map(...)
 #endif
 
 #if DEBUG_NET
-#define debug_net	PRINTK
+#define debug_net       PRINTK
 #else
 #define debug_net(...)
 #endif
 
 #if DEBUG_SCHED
-#define debug_sched	printk
+#define debug_sched     printk
 #else
 #define debug_sched(...)
 #endif
 
 #if DEBUG_SIG
-#define debug_sig	PRINTK
+#define debug_sig       PRINTK
 #else
 #define debug_sig(...)
 #endif
 
 #if DEBUG_SUP
-#define debug_sup	PRINTK
+#define debug_sup       PRINTK
 #else
 #define debug_sup(...)
 #endif
 
 #if DEBUG_TTY
-#define debug_tty	PRINTK
+#define debug_tty       PRINTK
 #else
 #define debug_tty(...)
 #endif
 
 #if DEBUG_TUNE
-#define debug_tune	PRINTK
+#define debug_tune      PRINTK
 #else
 #define debug_tune(...)
 #endif
 
 #if DEBUG_WAIT
-#define debug_wait	PRINTK
+#define debug_wait      PRINTK
 #else
 #define debug_wait(...)
 #endif
@@ -136,9 +136,9 @@ void debug_setcallback(int evnum, void (*cbfunc)()); /* callback on debug event*
  */
 
 #ifdef DEBUG
-#	define	debug(...)	PRINTK(__VA_ARGS__)
+#       define  debug(...)      PRINTK(__VA_ARGS__)
 #else
-#	define	debug(...)
+#       define  debug(...)
 #endif
 
 #endif

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -44,50 +44,50 @@
  *  longs, but uses the new fd_set structure..
  */
 
-#define NR_OPEN 	20
+#define NR_OPEN         20
 
-#define BLOCK_SIZE	1024
+#define BLOCK_SIZE      1024
 #define BLOCK_SIZE_BITS 10
 
-#define MAY_EXEC	1
-#define MAY_WRITE	2
-#define MAY_READ	4
+#define MAY_EXEC        1
+#define MAY_WRITE       2
+#define MAY_READ        4
 
-#define FMODE_READ	1
-#define FMODE_WRITE	2
+#define FMODE_READ      1
+#define FMODE_WRITE     2
 
-#define READ		0
-#define WRITE		1
+#define READ            0
+#define WRITE           1
 
-#define SEL_IN		1
-#define SEL_OUT		2
-#define SEL_EX		4
+#define SEL_IN          1
+#define SEL_OUT         2
+#define SEL_EX          4
 
 /*
- *	Passed to namei
+ *      Passed to namei
  */
 
-#define IS_DIR		1
-#define NOT_DIR 	2
+#define IS_DIR          1
+#define NOT_DIR         2
 
 /* filesystem types, used by sys_mount*/
-#define FST_MINIX	1
-#define FST_MSDOS	2
-#define FST_ROMFS	3
+#define FST_MINIX       1
+#define FST_MSDOS       2
+#define FST_ROMFS       3
 
 /*
  * These are the fs-independent mount-flags: up to 16 flags are supported
  */
-#define MS_RDONLY	    1	/* mount read-only */
-#define MS_NOSUID	    2	/* ignore suid and sgid bits */
-#define MS_NODEV	    4	/* disallow access to device special files */
-#define MS_NOEXEC	    8	/* disallow program execution */
-#define MS_SYNCHRONOUS	   16	/* writes are synced at once */
-#define MS_REMOUNT	   32	/* alter flags of a mounted FS */
-#define MS_AUTOMOUNT	   64	/* auto mount based on superblock */
+#define MS_RDONLY           1   /* mount read-only */
+#define MS_NOSUID           2   /* ignore suid and sgid bits */
+#define MS_NODEV            4   /* disallow access to device special files */
+#define MS_NOEXEC           8   /* disallow program execution */
+#define MS_SYNCHRONOUS     16   /* writes are synced at once */
+#define MS_REMOUNT         32   /* alter flags of a mounted FS */
+#define MS_AUTOMOUNT       64   /* auto mount based on superblock */
 
-#define S_APPEND	  256	/* append-only file */
-#define S_IMMUTABLE	  512	/* immutable file */
+#define S_APPEND          256   /* append-only file */
+#define S_IMMUTABLE       512   /* immutable file */
 
 /*
  * Flags that can be altered by MS_REMOUNT
@@ -115,34 +115,34 @@
 #define IS_IMMUTABLE(inode) ((inode)->i_flags & S_IMMUTABLE)
 
 #ifdef CONFIG_FS_XMS_BUFFER
-#define CONFIG_FAR_BUFHEADS	/* split buffer_head and move to far memory */
+#define CONFIG_FAR_BUFHEADS     /* split buffer_head and move to far memory */
 #endif
 
 struct buffer_head {
-    char			*b_data;	/* Address if in L1 buffer area, else 0 */
+    char                        *b_data;    /* Address if in L1 buffer area, else 0 */
 #ifdef CONFIG_FAR_BUFHEADS
 };
 /* a little tricky here - buffer_head is split into near and far components */
 struct ext_buffer_head_s {
 #endif
-    block32_t			b_blocknr;	/* 32-bit block numbers required for FAT */
-    kdev_t			b_dev;
-    struct buffer_head		*b_next_lru;
-    struct buffer_head		*b_prev_lru;
-    unsigned char		b_count;
-    unsigned char		b_locked;
-    unsigned char		b_dirty;
-    unsigned char		b_uptodate;
+    block32_t                   b_blocknr;  /* 32-bit block numbers required for FAT */
+    kdev_t                      b_dev;
+    struct buffer_head          *b_next_lru;
+    struct buffer_head          *b_prev_lru;
+    unsigned char               b_count;
+    unsigned char               b_locked;
+    unsigned char               b_dirty;
+    unsigned char               b_uptodate;
 #ifdef CONFIG_FS_EXTERNAL_BUFFER
-    ramdesc_t			b_L2seg;	/* EXT seg:0 or XMS linear addr of L2 */
-    char			b_mapcount;	/* count of L2 buffer mapped into L1 */
+    ramdesc_t                   b_L2seg;    /* EXT seg:0 or XMS linear addr of L2 */
+    char                        b_mapcount; /* count of L2 buffer mapped into L1 */
 #endif
 };
 
 #ifdef CONFIG_FAR_BUFHEADS
 /* buffer heads allocated in main (far) memory */
-#define ext_buffer_head		struct ext_buffer_head_s __far
-ext_buffer_head *EBH(struct buffer_head *);	/* convert bh to ebh */
+#define ext_buffer_head         struct ext_buffer_head_s __far
+ext_buffer_head *EBH(struct buffer_head *);     /* convert bh to ebh */
 
 /* functions for buffer_head pointers called outside of buffer.c */
 void mark_buffer_dirty(struct buffer_head *bh);
@@ -153,20 +153,20 @@ kdev_t buffer_dev(struct buffer_head *bh);
 
 #else
 /* buffer heads in kernel data segment */
-typedef struct buffer_head	ext_buffer_head;
-#define EBH(bh)		(bh)
+typedef struct buffer_head      ext_buffer_head;
+#define EBH(bh)         (bh)
 
 /* macros for buffer_head pointers called outside of buffer.c */
-#define mark_buffer_dirty(bh)	((bh)->b_dirty = 1)
-#define mark_buffer_clean(bh)	((bh)->b_dirty = 0)
-#define buffer_count(bh)	((bh)->b_count)
-#define buffer_blocknr(bh)	((bh)->b_blocknr)
-#define buffer_dev(bh)		((bh)->b_dev)
+#define mark_buffer_dirty(bh)   ((bh)->b_dirty = 1)
+#define mark_buffer_clean(bh)   ((bh)->b_dirty = 0)
+#define buffer_count(bh)        ((bh)->b_count)
+#define buffer_blocknr(bh)      ((bh)->b_blocknr)
+#define buffer_dev(bh)          ((bh)->b_dev)
 
 #endif /* CONFIG_FAR_BUFHEADS */
 
-#define BLOCK_READ	0
-#define BLOCK_WRITE	1
+#define BLOCK_READ      0
+#define BLOCK_WRITE     1
 
 void brelse(struct buffer_head *);
 void bforget(struct buffer_head *);
@@ -177,94 +177,94 @@ void unlock_buffer (struct buffer_head *);
 struct inode {
 
     /* This stuff is on disk */
-    __u16			i_mode;
-    __u16			i_uid;
-    __u32			i_size;
-    __u32			i_mtime;
-    __u8			i_gid;
-    __u8			i_nlink;
+    __u16                       i_mode;
+    __u16                       i_uid;
+    __u32                       i_size;
+    __u32                       i_mtime;
+    __u8                        i_gid;
+    __u8                        i_nlink;
 
     /* This stuff is just in-memory... */
-    ino_t			i_ino;
-    kdev_t			i_dev;
-    kdev_t			i_rdev;
-    time_t			i_atime;
-    time_t			i_ctime;
-    struct inode_operations	*i_op;
-    struct super_block		*i_sb;
-    struct inode		*i_next;
-    struct inode		*i_prev;
-    struct inode		*i_mount;
-    unsigned short		i_count;
-    unsigned short		i_flags;
-    unsigned char		i_lock;
-    unsigned char		i_dirt;
-    sem_t			i_sem;
+    ino_t                       i_ino;
+    kdev_t                      i_dev;
+    kdev_t                      i_rdev;
+    time_t                      i_atime;
+    time_t                      i_ctime;
+    struct inode_operations     *i_op;
+    struct super_block          *i_sb;
+    struct inode                *i_next;
+    struct inode                *i_prev;
+    struct inode                *i_mount;
+    unsigned short              i_count;
+    unsigned short              i_flags;
+    unsigned char               i_lock;
+    unsigned char               i_dirt;
+    sem_t                       i_sem;
 #ifdef BLOAT_FS
-    unsigned long int		i_blksize;
-    unsigned long int		i_blocks;
-    unsigned long int		i_version;
-    unsigned short int		i_wcount;
-    unsigned char int		i_seek;
-    unsigned char int		i_update;
+    unsigned long int           i_blksize;
+    unsigned long int           i_blocks;
+    unsigned long int           i_version;
+    unsigned short int          i_wcount;
+    unsigned char int           i_seek;
+    unsigned char int           i_update;
 #endif
 
     union {
 #ifdef CONFIG_PIPE
-		struct pipe_inode_info pipe_i;
+                struct pipe_inode_info pipe_i;
 #endif
 #ifdef CONFIG_MINIX_FS
-		struct minix_inode_info minix_i;
+                struct minix_inode_info minix_i;
 #endif
 #ifdef CONFIG_FS_FAT
-		struct msdos_inode_info msdos_i;
-#endif	
+                struct msdos_inode_info msdos_i;
+#endif
 #ifdef CONFIG_ROMFS_FS
-		struct romfs_inode_info romfs;
+                struct romfs_inode_info romfs;
 #endif
 #ifdef CONFIG_SOCKET
-		struct socket socket_i;
+                struct socket socket_i;
 #endif
-		void * generic_i;
+                void * generic_i;
     } u;
 };
 
 struct file {
-    mode_t			f_mode;
-    loff_t			f_pos;
-    unsigned short		f_flags;
-    unsigned short		f_count;
-    struct inode		*f_inode;
-    struct file_operations	*f_op;
+    mode_t                      f_mode;
+    loff_t                      f_pos;
+    unsigned short              f_flags;
+    unsigned short              f_count;
+    struct inode                *f_inode;
+    struct file_operations      *f_op;
 };
 
 struct super_block {
-    kdev_t			s_dev;
-    unsigned char		s_lock;
-    unsigned char		s_dirt;
-    struct file_system_type	*s_type;
-    struct super_operations	*s_op;
-    unsigned short 		s_flags;
-    struct inode		*s_covered;
-    struct inode		*s_mounted;
-    struct wait_queue		s_wait;
-    char			s_mntonname[MNAMELEN];
+    kdev_t                      s_dev;
+    unsigned char               s_lock;
+    unsigned char               s_dirt;
+    struct file_system_type     *s_type;
+    struct super_operations     *s_op;
+    unsigned short              s_flags;
+    struct inode                *s_covered;
+    struct inode                *s_mounted;
+    struct wait_queue           s_wait;
+    char                        s_mntonname[MNAMELEN];
 #ifdef BLOAT_FS
-    unsigned char		s_rd_only;
-    __u32			s_magic;
-    time_t			s_time;
+    unsigned char               s_rd_only;
+    __u32                       s_magic;
+    time_t                      s_time;
 #endif
     union {
 #ifdef CONFIG_MINIX_FS
-		struct minix_sb_info minix_sb;
+                struct minix_sb_info minix_sb;
 #endif
 #ifdef CONFIG_FS_FAT
-		struct msdos_sb_info msdos_sb;
+                struct msdos_sb_info msdos_sb;
 #endif
 #ifdef CONFIG_ROMFS_FS
-		struct romfs_super_info romfs;
+                struct romfs_super_info romfs;
 #endif
-		void * generic_sbp;
+                void * generic_sbp;
     } u;
 };
 
@@ -282,53 +282,53 @@ void unlock_super (struct super_block *);
 typedef int (*filldir_t) (char *, char *, size_t, off_t, ino_t);
 
 struct file_operations {
-    int				(*lseek) ();
-    size_t			(*read)(struct inode *,struct file *,char *,size_t);
-    size_t			(*write)(struct inode *,struct file *,char *,size_t);
-    int 			(*readdir) ();
-    int 			(*select) (struct inode *,struct file *, int flag);
-    int 			(*ioctl) ();
-    int 			(*open) ();
-    void			(*release) (struct inode *, struct file *);
+    int                         (*lseek) ();
+    size_t                      (*read)(struct inode *,struct file *,char *,size_t);
+    size_t                      (*write)(struct inode *,struct file *,char *,size_t);
+    int                         (*readdir) ();
+    int                         (*select) (struct inode *,struct file *, int flag);
+    int                         (*ioctl) ();
+    int                         (*open) ();
+    void                        (*release) (struct inode *, struct file *);
 #ifdef BLOAT_FS
-    int 			(*fsync) ();
-    int 			(*check_media_change) ();
-    int 			(*revalidate) ();
+    int                         (*fsync) ();
+    int                         (*check_media_change) ();
+    int                         (*revalidate) ();
 #endif
 };
 
 struct inode_operations {
-    struct file_operations	*default_file_ops;
-    int 			(*create) ();
-    int 			(*lookup) (struct inode * dir, const char * name, size_t len, struct inode ** res);
-    int 			(*link) ();
-    int 			(*unlink) ();
-    int 			(*symlink) ();
-    int 			(*mkdir) ();
-    int 			(*rmdir) ();
-    int 			(*mknod) ();
-    int 			(*readlink) (struct inode * i, char * buf, size_t len);
-    int 			(*follow_link) ();
-    struct buffer_head *	(*getblk) (struct inode *, block_t, int);
-    void			(*truncate) ();
+    struct file_operations      *default_file_ops;
+    int                         (*create) ();
+    int                         (*lookup) (struct inode * dir, const char * name, size_t len, struct inode ** res);
+    int                         (*link) ();
+    int                         (*unlink) ();
+    int                         (*symlink) ();
+    int                         (*mkdir) ();
+    int                         (*rmdir) ();
+    int                         (*mknod) ();
+    int                         (*readlink) (struct inode * i, char * buf, size_t len);
+    int                         (*follow_link) ();
+    struct buffer_head *        (*getblk) (struct inode *, block_t, int);
+    void                        (*truncate) ();
 };
 
 struct super_operations {
-    void			(*read_inode) ();
-    void			(*write_inode) ();
-    void			(*put_inode) ();
-    void			(*put_super) ();
-    void			(*write_super) ();
-    int 			(*remount_fs) ();
-    void			(*statfs_kern) ();
+    void                        (*read_inode) ();
+    void                        (*write_inode) ();
+    void                        (*put_inode) ();
+    void                        (*put_super) ();
+    void                        (*write_super) ();
+    int                         (*remount_fs) ();
+    void                        (*statfs_kern) ();
 #ifdef BLOAT_FS
-    int 			(*notify_change) ();
+    int                         (*notify_change) ();
 #endif
 };
 
 struct file_system_type {
-    struct super_block		*(*read_super) ();
-    int				type;
+    struct super_block          *(*read_super) ();
+    int                         type;
 };
 
 /*
@@ -348,16 +348,16 @@ struct file_system_type {
  * has been changed!
  */
 
-#define ATTR_MODE	1
-#define ATTR_UID	2
-#define ATTR_GID	4
-#define ATTR_SIZE	8
-#define ATTR_ATIME	16
-#define ATTR_MTIME	32
-#define ATTR_CTIME	64
-#define ATTR_ATIME_SET	128
-#define ATTR_MTIME_SET	256
-#define ATTR_FORCE	512
+#define ATTR_MODE       1
+#define ATTR_UID        2
+#define ATTR_GID        4
+#define ATTR_SIZE       8
+#define ATTR_ATIME      16
+#define ATTR_MTIME      32
+#define ATTR_CTIME      64
+#define ATTR_ATIME_SET  128
+#define ATTR_MTIME_SET  256
+#define ATTR_FORCE      512
 
 /*
  * This is the Inode Attributes structure, used for notify_change(). It uses
@@ -370,29 +370,25 @@ struct file_system_type {
  * Derek Atkins <warlord@MIT.EDU> 94-10-20
  */
 struct iattr {
-    unsigned int		ia_valid;
-    umode_t			ia_mode;
-    uid_t			ia_uid;
-    gid_t			ia_gid;
-    off_t			ia_size;
-    time_t			ia_atime;
-    time_t			ia_mtime;
-    time_t			ia_ctime;
+    unsigned int                ia_valid;
+    umode_t                     ia_mode;
+    uid_t                       ia_uid;
+    gid_t                       ia_gid;
+    off_t                       ia_size;
+    time_t                      ia_atime;
+    time_t                      ia_mtime;
+    time_t                      ia_ctime;
 };
 
 extern int notify_change(struct inode *,struct iattr *);
 #endif
 
 extern int sys_open(const char *,int,int);
-extern int sys_close(unsigned int);	/* yes, it's really unsigned */
-
-/*@-namechecks@*/
+extern int sys_close(unsigned int);     /* yes, it's really unsigned */
 
 extern void _close_allfiles(void);
 
 extern struct inode *iget(struct super_block *,ino_t);
-
-/*@+namechecks@*/
 
 extern struct file_operations *get_blkfops(unsigned int);
 extern int register_blkdev(unsigned int,const char *,struct file_operations *);
@@ -496,11 +492,7 @@ extern void put_write_access(struct inode *);
 #define put_write_access(_a)
 #endif
 
-/*@-namechecks@*/
-
 extern int _namei(const char *,struct inode *,int,struct inode **);
-
-/*@+namechecks@*/
 
 extern int sys_dup(unsigned int);
 

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -12,65 +12,65 @@
 #include <arch/param.h>
 
 struct file_struct {
-    fd_mask_t			close_on_exec;
-    struct file 		*fd[NR_OPEN];
+    fd_mask_t                   close_on_exec;
+    struct file                 *fd[NR_OPEN];
 };
 
 struct fs_struct {
-    unsigned short int		umask;
-    struct inode		*root;
-    struct inode		*pwd;
+    unsigned short int          umask;
+    struct inode                *root;
+    struct inode                *pwd;
 };
 
 struct mm_struct {
-    struct segment		*seg_code;
-    struct segment		*seg_data;
+    struct segment              *seg_code;
+    struct segment              *seg_data;
 };
 
 struct signal_struct {
-    __kern_sighandler_t		handler;
+    __kern_sighandler_t         handler;
     struct __kern_sigaction_struct action[NSIG];
 };
 
 struct task_struct {
 
 /* Executive stuff */
-    struct xregs		t_xregs;
-    __pptr			t_enddata;
-    __pptr			t_begstack;
-    __pptr			t_endbrk;
-    __pptr			t_endseg;
-    int				t_minstack;
+    struct xregs                t_xregs;
+    __pptr                      t_enddata;
+    __pptr                      t_begstack;
+    __pptr                      t_endbrk;
+    __pptr                      t_endseg;
+    int                         t_minstack;
 
 /* Kernel info */
-    pid_t			pid;
-    pid_t			ppid;
-    pid_t			pgrp;
-    pid_t			session;
-    uid_t			uid;
-    uid_t			euid;
-    uid_t			suid;
-    gid_t			gid;
-    gid_t			egid;
-    gid_t			sgid;
+    pid_t                       pid;
+    pid_t                       ppid;
+    pid_t                       pgrp;
+    pid_t                       session;
+    uid_t                       uid;
+    uid_t                       euid;
+    uid_t                       suid;
+    gid_t                       gid;
+    gid_t                       egid;
+    gid_t                       sgid;
 
 /* Scheduling + status variables */
-    unsigned char		state;
-    struct wait_queue		child_wait;
-    jiff_t			timeout;	/* for select() */
-    struct wait_queue		*waitpt;	/* Wait pointer */
-    struct wait_queue		*poll[POLL_MAX];  /* polled queues */
-    struct task_struct		*next_run;
-    struct task_struct		*prev_run;
-    struct file_struct		files;		/* File system structure */
-    struct fs_struct		fs;		/* File roots */
-    struct mm_struct		mm;		/* Memory blocks */
-    struct tty			*tty;
-    struct task_struct		*p_parent;
-    int				exit_status;	/* process exit status*/
-    struct inode		*t_inode;
-    sigset_t			signal;		/* Signal status */
-    struct signal_struct	sig;		/* Signal block */
+    unsigned char               state;
+    struct wait_queue           child_wait;
+    jiff_t                      timeout;        /* for select() */
+    struct wait_queue           *waitpt;        /* Wait pointer */
+    struct wait_queue           *poll[POLL_MAX];  /* polled queues */
+    struct task_struct          *next_run;
+    struct task_struct          *prev_run;
+    struct file_struct          files;          /* File system structure */
+    struct fs_struct            fs;             /* File roots */
+    struct mm_struct            mm;             /* Memory blocks */
+    struct tty                  *tty;
+    struct task_struct          *p_parent;
+    int                         exit_status;    /* process exit status*/
+    struct inode                *t_inode;
+    sigset_t                    signal;         /* Signal status */
+    struct signal_struct        sig;            /* Signal block */
 
 #ifdef CONFIG_CPU_USAGE
     unsigned long               average;        /* fixed point CPU % usage */
@@ -79,7 +79,7 @@ struct task_struct {
 
 #ifdef CONFIG_SUPPLEMENTARY_GROUPS
 #define NGROUPS     13
-    gid_t			groups[NGROUPS];
+    gid_t                       groups[NGROUPS];
 #endif
 
     /* next two words are only used by CONFIG_TRACE but left in to avoid
@@ -87,34 +87,32 @@ struct task_struct {
     int                         kstack_max;
     int                         kstack_prevmax;
 
-    unsigned int		kstack_magic;	/* To detect stack corruption */
-    __u16			t_kstack[KSTACK_BYTES/2];
-    struct pt_regs 		t_regs;         /* registers on stack during syscall */
+    unsigned int                kstack_magic;   /* To detect stack corruption */
+    __u16                       t_kstack[KSTACK_BYTES/2];
+    struct pt_regs              t_regs;         /* registers on stack during syscall */
 };
 
 #define KSTACK_MAGIC 0x5476
 
 /* the order of these matter for signal handling*/
-#define TASK_RUNNING 		0
-#define TASK_INTERRUPTIBLE	1
-#define TASK_UNINTERRUPTIBLE 	2
-#define TASK_WAITING		3
-#define TASK_STOPPED		4
-#define TASK_ZOMBIE		5
-#define TASK_EXITING		6
-#define TASK_UNUSED		7
-
-/*@-namechecks@*/
+#define TASK_RUNNING            0
+#define TASK_INTERRUPTIBLE      1
+#define TASK_UNINTERRUPTIBLE    2
+#define TASK_WAITING            3
+#define TASK_STOPPED            4
+#define TASK_ZOMBIE             5
+#define TASK_EXITING            6
+#define TASK_UNUSED             7
 
 #define DEPRECATED
-//#define DEPRECATED	__attribute__ ((deprecated))
+//#define DEPRECATED    __attribute__ ((deprecated))
 
 /* We use typedefs to avoid using struct foobar (*) */
 typedef struct task_struct __task, *__ptask;
 
 extern __task task[MAX_TASKS];
 
-extern volatile jiff_t jiffies;	/* ticks updated by the timer interrupt*/
+extern volatile jiff_t jiffies; /* ticks updated by the timer interrupt*/
 extern __ptask current;
 
 extern struct timeval xtime;
@@ -126,7 +124,7 @@ extern time_t current_time(void);
 #define time_after(a,b)         (((long)(b) - (long)(a) < 0))
 
 #define for_each_task(p) \
-	for (p = &task[0] ; p!=&task[MAX_TASKS]; p++ )
+        for (p = &task[0] ; p!=&task[MAX_TASKS]; p++ )
 
 /* Scheduling and sleeping function prototypes */
 
@@ -150,11 +148,7 @@ void prepare_to_wait(struct wait_queue *p);
 void do_wait(void);
 void finish_wait(struct wait_queue *p);
 
-/*@-namechecks@*/
-
 extern void _wake_up(struct wait_queue *,int);
-
-/*@+namechecks@*/
 
 extern void down(sem_t *);
 extern void up(sem_t *);

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -20,8 +20,8 @@
 /*
  *	System variable setups
  */
-#define ENV		1		/* allow environ variables as bootopts*/
-#define DEBUG		0		/* display parsing at boot*/
+#define ENV             1       /* allow environ variables as bootopts*/
+#define DEBUG           0       /* display parsing at boot*/
 
 #define MAX_INIT_ARGS	8
 #define MAX_INIT_ENVS	8
@@ -33,7 +33,7 @@ int root_mountflags = 0;
 #endif
 struct netif_parms netif_parms[MAX_ETHS] = {
     /* NOTE:  The order must match the defines in netstat.h:
-     * ETH_NE2K, ETH_WD, ETH_EL3	*/
+     * ETH_NE2K, ETH_WD, ETH_EL3    */
     { NE2K_IRQ, NE2K_PORT, 0, NE2K_FLAGS },
     { WD_IRQ, WD_PORT, WD_RAM, WD_FLAGS },
     { EL3_IRQ, EL3_PORT, 0, EL3_FLAGS },
@@ -134,7 +134,7 @@ void INITPROC kernel_init(void)
 
     inode_init();
     if (buffer_init())	/* also enables xms and unreal mode if configured and possible*/
-	panic("No buf mem");
+        panic("No buf mem");
 
     device_init();
 
@@ -213,12 +213,12 @@ static void init_task(void)
 
     /* Don't open /dev/console for /bin/init, 0-2 closed immediately and fragments heap*/
     //if (strcmp(init_command, bininit) != 0) {
-	/* Set stdin/stdout/stderr to /dev/console if not running /bin/init*/
-	num = sys_open(s="/dev/console", O_RDWR, 0);
-	if (num < 0)
-	    printk("Unable to open %s (error %d)\n", s, num);
-	sys_dup(num);		/* open stdout*/
-	sys_dup(num);		/* open stderr*/
+        /* Set stdin/stdout/stderr to /dev/console if not running /bin/init*/
+        num = sys_open(s="/dev/console", O_RDWR, 0);
+        if (num < 0)
+            printk("Unable to open %s (error %d)\n", s, num);
+        sys_dup(num);		/* open stdout*/
+        sys_dup(num);		/* open stderr*/
     //}
 
 #ifdef CONFIG_BOOTOPTS
@@ -359,7 +359,7 @@ static void parse_umb(char *line)
 #endif
 			seg_add(base, end);
 		}
-	}while((p = strchr(p+1, ',')));
+	} while((p = strchr(p+1, ',')));
 }
 
 /*

--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -14,84 +14,84 @@ extern struct task_struct *next_task_slot;
 
 static void reparent_children(void)
 {
-	register struct task_struct *p;
+    register struct task_struct *p;
 
-	for_each_task(p) {
-		if (p->p_parent == current) {
-			/* remove orphaned zombies, no need to reparent them to init*/
-			if (p->state == TASK_ZOMBIE) {
-				debug_wait("Zombie orphan pid %d ppid %d removed\n", p->pid, p->ppid);
-				p->state = TASK_UNUSED;		/* unassign task entry*/
-				next_task_slot = p;
-				task_slots_unused++;
-			}
+    for_each_task(p) {
+        if (p->p_parent == current) {
+            /* remove orphaned zombies, no need to reparent them to init*/
+            if (p->state == TASK_ZOMBIE) {
+                debug_wait("Zombie orphan pid %d ppid %d removed\n", p->pid, p->ppid);
+                p->state = TASK_UNUSED;     /* unassign task entry*/
+                next_task_slot = p;
+                task_slots_unused++;
+            }
 
-			/* reparent orphans to init*/
-			if (p->state != TASK_UNUSED) {
-				debug_wait("Reparenting orphan pid %d ppid %d to init\n",
-					p->pid, p->p_parent->pid);
-				p->p_parent = &task[1];
-				p->ppid = task[1].pid;
-			}
-		}
-	}
+            /* reparent orphans to init*/
+            if (p->state != TASK_UNUSED) {
+                debug_wait("Reparenting orphan pid %d ppid %d to init\n",
+                    p->pid, p->p_parent->pid);
+                p->p_parent = &task[1];
+                p->ppid = task[1].pid;
+            }
+        }
+    }
 }
 
 /* note: 'usage' parameter ignored */
 int sys_wait4(pid_t pid, int *status, int options, void *usage)
 {
-	register struct task_struct *p;
-	int waitagain;
+    register struct task_struct *p;
+    int waitagain;
 
-	debug_wait("WAIT(%d) for %d %s\n", current->pid, pid, (options & WNOHANG)? "nohang": "");
+    debug_wait("WAIT(%d) for %d %s\n", current->pid, pid, (options & WNOHANG)? "nohang": "");
 
  for (;;) {
-	waitagain = 0;
+    waitagain = 0;
 
-	for_each_task(p) {
-		if (p->p_parent == current && p->state != TASK_UNUSED) {
-		  if (p->state == TASK_ZOMBIE || p->state == TASK_STOPPED) {
-			if (pid == (pid_t)-1 || p->pid == pid || (!pid && p->pgrp == current->pgrp)) {
-				if (status) {
-					if (verified_memcpy_tofs(status, &p->exit_status, sizeof(int)))
-						return -EFAULT;
-				}
+    for_each_task(p) {
+        if (p->p_parent == current && p->state != TASK_UNUSED) {
+          if (p->state == TASK_ZOMBIE || p->state == TASK_STOPPED) {
+            if (pid == (pid_t)-1 || p->pid == pid || (!pid && p->pgrp == current->pgrp)) {
+                if (status) {
+                    if (verified_memcpy_tofs(status, &p->exit_status, sizeof(int)))
+                        return -EFAULT;
+                }
 
-				/* just return status on stopped state, don't release task*/
-				if (p->state == TASK_STOPPED)
-					return p->pid;
+                /* just return status on stopped state, don't release task*/
+                if (p->state == TASK_STOPPED)
+                    return p->pid;
 
-				p->state = TASK_UNUSED;		/* unassign task entry*/
-				next_task_slot = p;
-				task_slots_unused++;
+                p->state = TASK_UNUSED;     /* unassign task entry*/
+                next_task_slot = p;
+                task_slots_unused++;
 
-				debug_wait("WAIT(%d) got %d\n", current->pid, p->pid);
-				return p->pid;
-			}
-		} else {
-			/* keep waiting while process has non-zombie/stopped children*/
-			debug_wait("WAIT(%d) again for pid %d state %d\n", current->pid, p->pid, p->state);
-			waitagain = 1;
-		}
-	  }
-	}
+                debug_wait("WAIT(%d) got %d\n", current->pid, p->pid);
+                return p->pid;
+            }
+        } else {
+            /* keep waiting while process has non-zombie/stopped children*/
+            debug_wait("WAIT(%d) again for pid %d state %d\n", current->pid, p->pid, p->state);
+            waitagain = 1;
+        }
+      }
+    }
 
-	if (options & WNOHANG)
-		return 0;
-	if (!waitagain)
-		break;
+    if (options & WNOHANG)
+        return 0;
+    if (!waitagain)
+        break;
 
-	debug_wait("WAIT(%d) sleep\n", current->pid);
-	interruptible_sleep_on(&current->child_wait);
-	if (current->signal) {
-		debug_wait("WAIT(%d) return -EINTR\n", current->pid);
-		return -EINTR;
-	}
-	debug_wait("WAIT(%d) wakeup\n", current->pid);
+    debug_wait("WAIT(%d) sleep\n", current->pid);
+    interruptible_sleep_on(&current->child_wait);
+    if (current->signal) {
+        debug_wait("WAIT(%d) return -EINTR\n", current->pid);
+        return -EINTR;
+    }
+    debug_wait("WAIT(%d) wakeup\n", current->pid);
   }
 
     debug_wait("WAIT(%d) return -ECHILD\n", current->pid);
-	return -ECHILD;
+    return -ECHILD;
 }
 
 void do_exit(int status)
@@ -108,9 +108,9 @@ void do_exit(int status)
     /* Let go of the process */
     current->state = TASK_EXITING;
     if (current->mm.seg_code)
-	seg_put(current->mm.seg_code);
+        seg_put(current->mm.seg_code);
     if (current->mm.seg_data)
-	seg_put(current->mm.seg_data);
+        seg_put(current->mm.seg_data);
     current->mm.seg_code = current->mm.seg_data = 0;
 
     /* free program allocated memory */
@@ -120,16 +120,16 @@ void do_exit(int status)
     /* Keep all of the family stuff straight */
     struct task_struct *task;
     if ((task = current->p_prevsib)) {
-	task->p_nextsib = current->p_nextsib;
+        task->p_nextsib = current->p_nextsib;
     }
     if ((task = current->p_nextsib)) {
-	task->p_prevsib = current->p_prevsib;
+        task->p_prevsib = current->p_prevsib;
     }
 
     /* Ack. I hate repeating code like this */
     if ((parent = current->p_parent)->p_child == current) {
-	if ((task = current->p_prevsib) || (task = current->p_nextsib))
-	    parent->p_child = task;
+        if ((task = current->p_prevsib) || (task = current->p_nextsib))
+            parent->p_child = task;
     }
 #else
     parent = current->p_parent;

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -20,19 +20,19 @@ static pid_t get_pid(void)
     do {
         if (p->state == TASK_UNUSED)
             continue;
-	if (p->pid == last_pid || p->pgrp == last_pid ||
-	    p->session == last_pid) {
-	  startgp:
-	    if ((int)(++last_pid) < 0)
-		last_pid = 1;
-	    p = &task[0];
-	}
+        if (p->pid == last_pid || p->pgrp == last_pid ||
+            p->session == last_pid) {
+          startgp:
+            if ((int)(++last_pid) < 0)
+                last_pid = 1;
+            p = &task[0];
+        }
     } while (++p < &task[MAX_TASKS]);
     return last_pid;
 }
 
 /*
- *	Find a free task slot.
+ *  Find a free task slot.
  */
 struct task_struct *find_empty_process(void)
 {
@@ -68,7 +68,7 @@ struct task_struct *find_empty_process(void)
 }
 
 /*
- *	Clone a process.
+ *  Clone a process.
  */
 
 pid_t do_fork(int virtual)
@@ -89,27 +89,27 @@ pid_t do_fork(int virtual)
     seg_get(currentp->mm.seg_code);
 
     if (virtual) {
-	seg_get(currentp->mm.seg_data);
+        seg_get(currentp->mm.seg_data);
     } else {
-	t->mm.seg_data = seg_dup(currentp->mm.seg_data);
+        t->mm.seg_data = seg_dup(currentp->mm.seg_data);
 
-	if (t->mm.seg_data == 0) {
-	    seg_put (currentp->mm.seg_code);
-	    t->state = TASK_UNUSED;
+        if (t->mm.seg_data == 0) {
+            seg_put (currentp->mm.seg_code);
+            t->state = TASK_UNUSED;
             task_slots_unused++;
             next_task_slot = t;
-	    return -ENOMEM;
-	}
+            return -ENOMEM;
+        }
 
-	t->t_regs.ds = t->t_regs.es = t->t_regs.ss = (t->mm.seg_data)->base;
+        t->t_regs.ds = t->t_regs.es = t->t_regs.ss = (t->mm.seg_data)->base;
     }
 
     /* Increase the reference count to all open files */
 
     j = 0;
     do {
-	if ((filp = t->files.fd[j]))
-	    filp->f_count++;
+        if ((filp = t->files.fd[j]))
+            filp->f_count++;
     } while (++j < NR_OPEN);
 
     /* Increase the reference count for program text inode - tgm */
@@ -150,24 +150,24 @@ pid_t sys_vfork(void)
 
     if ((retval = do_fork(1)) >= 0) {
 
-	/* Parent and child are sharing the user stack at this point.
-	 * The child will go first, coming into life in the middle of
-	 * the tswitch() function, returning to user space, then will
-	 * return from the library code where the actual syscall was
-	 * done and then will issue an exec syscall, destroying the
-	 * first few bytes at the top of the user stack. Save those
-	 * bytes in the parent's kernel stack.
-	 */
-	memcpy_fromfs(sc, (void *)currentp->t_regs.sp, sizeof(sc));
-	/*
-	 * Let the child go on first.
-	 */
-	sleep_on(&currentp->child_wait);
-	/*
-	 * By now, the child should have its own user stack. Restore
-	 * the parent's user stack.
-	 */
-	memcpy_tofs((void *)currentp->t_regs.sp, sc, sizeof(sc));
+        /* Parent and child are sharing the user stack at this point.
+         * The child will go first, coming into life in the middle of
+         * the tswitch() function, returning to user space, then will
+         * return from the library code where the actual syscall was
+         * done and then will issue an exec syscall, destroying the
+         * first few bytes at the top of the user stack. Save those
+         * bytes in the parent's kernel stack.
+         */
+        memcpy_fromfs(sc, (void *)currentp->t_regs.sp, sizeof(sc));
+        /*
+         * Let the child go on first.
+         */
+        sleep_on(&currentp->child_wait);
+        /*
+         * By now, the child should have its own user stack. Restore
+         * the parent's user stack.
+         */
+        memcpy_tofs((void *)currentp->t_regs.sp, sc, sizeof(sc));
     }
     return retval;
 #endif

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -1,29 +1,29 @@
 /*
- *	This is NOT stunningly portable, but works for pretty dumb non-ANSI
- *	compilers and is tight. Adjust the sizes to taste.
+ *      This is NOT stunningly portable, but works for pretty dumb non-ANSI
+ *      compilers and is tight. Adjust the sizes to taste.
  *
- *	Illegal format strings will break it. Only the following simple
- *	printf() subset is supported:
+ *      Illegal format strings will break it. Only the following simple
+ *      printf() subset is supported:
  *
- *		%%	literal % sign
- *		%c	char
- *		%d/%i	signed decimal
- *		%u	unsigned decimal
- *		%o	octal
- *		%s	string in kernel space
- *		%t	string in user space
- *		%T	string w/specified segment
- *		%x/%X	hexadecimal with lower/upper case letters
- *		%#x/%#X	hexadecimal using 0x alt prefix
- *		%p/%P	pointer - same as %04x/%04X respectively
- *		%D      device name as %#04x
+ *              %%      literal % sign
+ *              %c      char
+ *              %d/%i   signed decimal
+ *              %u      unsigned decimal
+ *              %o      octal
+ *              %s      string in kernel space
+ *              %t      string in user space
+ *              %T      string w/specified segment
+ *              %x/%X   hexadecimal with lower/upper case letters
+ *              %#x/%#X hexadecimal using 0x alt prefix
+ *              %p/%P   pointer - same as %04x/%04X respectively
+ *              %D      device name as %#04x
  *
- *	All except %% can be followed by a width specifier 1 -> 31 only
- *	and the h/l length specifiers also work where appropriate.
+ *      All except %% can be followed by a width specifier 1 -> 31 only
+ *      and the h/l length specifiers also work where appropriate.
  *
- *		Alan Cox.
+ *              Alan Cox.
  *
- *	MTK:	Sep 97 - Misc hacks to shrink generated code
+ *      MTK:    Sep 97 - Misc hacks to shrink generated code
  */
 
 #include <linuxmt/config.h>
@@ -41,43 +41,43 @@
 dev_t dev_console;
 
 #ifdef CONFIG_CONSOLE_SERIAL
-#define DEVCONSOLE  MKDEV(TTY_MAJOR,RS_MINOR_OFFSET)	/* /dev/ttyS0*/
+#define DEVCONSOLE  MKDEV(TTY_MAJOR,RS_MINOR_OFFSET)    /* /dev/ttyS0*/
 #else
-#define DEVCONSOLE  MKDEV(TTY_MAJOR,TTY_MINOR_OFFSET)	/* /dev/tty1*/
+#define DEVCONSOLE  MKDEV(TTY_MAJOR,TTY_MINOR_OFFSET)   /* /dev/tty1*/
 #endif
 static void (*kputc)(dev_t, int) = 0;
 
 
 void set_console(dev_t dev)
 {
-	register struct tty *ttyp;
+    register struct tty *ttyp;
 
-	if (dev == 0)
-		dev = DEVCONSOLE;
-	if ((ttyp = determine_tty(dev))) {
-		kputc = ttyp->ops->conout;
-		dev_console = dev;
-	}
+    if (dev == 0)
+            dev = DEVCONSOLE;
+    if ((ttyp = determine_tty(dev))) {
+            kputc = ttyp->ops->conout;
+            dev_console = dev;
+    }
 }
 
 void kputchar(int ch)
 {
-	if (ch == '\n')
-		kputchar('\r');
-	if (kputc)
-		(*kputc)(dev_console, ch);
-	else early_putchar(ch);
+    if (ch == '\n')
+            kputchar('\r');
+    if (kputc)
+            (*kputc)(dev_console, ch);
+    else early_putchar(ch);
 }
 
 static void kputs(const char *buf)
 {
     while (*buf)
-	kputchar(*buf++);
+        kputchar(*buf++);
 }
 
 /************************************************************************
  *
- *	Output a number
+ *      Output a number
  */
 
 static char hex_string[] = "0123456789ABCDEF 0123456789abcdef ";
@@ -90,46 +90,46 @@ static void numout(__u32 v, int width, int base, int useSign, int Lower, int Zer
     i = 10;
     dvr = 1000000000L;
     if (base > 10) {
-	i = 8;
-	dvr = 0x10000000L;
+        i = 8;
+        dvr = 0x10000000L;
     }
     if (base < 10) {
-	i = 11;
-	dvr = 0x40000000L;
+        i = 11;
+        dvr = 0x40000000L;
     }
 
     if (useSign && ((long)v < 0L))
-	v = (-(long)v);
+        v = (-(long)v);
     else
-	useSign = 0;
+        useSign = 0;
 
     if (Lower)
-	Lower = 17;
+        Lower = 17;
     vch = 0;
     if (alt && base == 16) {
         kputchar('0');
         kputchar('x');
     }
     do {
-	c = (int)(v / dvr);
-	v %= dvr;
-	dvr /= (unsigned int)base;
-	if (c || (i <= width) || (i < 2)) {
-	    if (i > width)
-		width = (int)i;
-	    if (!Zero && !c && (i > 1))
-		c = 16;
-	    else {
-		Zero = 1;
-		if (useSign) {
-		    useSign = 0;
-		    vch = '-';
-		}
-	    }
-	    if (vch)
-		kputchar(vch);
-	    vch = *(hex_string + Lower + c);
-	}
+        c = (int)(v / dvr);
+        v %= dvr;
+        dvr /= (unsigned int)base;
+        if (c || (i <= width) || (i < 2)) {
+            if (i > width)
+                width = (int)i;
+            if (!Zero && !c && (i > 1))
+                c = 16;
+            else {
+                Zero = 1;
+                if (useSign) {
+                    useSign = 0;
+                    vch = '-';
+                }
+            }
+            if (vch)
+                kputchar(vch);
+            vch = *(hex_string + Lower + c);
+        }
     } while (--i);
     kputchar(vch);
 }
@@ -141,87 +141,87 @@ static void vprintk(const char *fmt, va_list p)
     char *str;
 
     while ((c = *fmt++)) {
-	if (c != '%')
-	    kputchar(c);
-	else {
-	    c = *fmt++;
+        if (c != '%')
+            kputchar(c);
+        else {
+            c = *fmt++;
 
-	    if (c == '%') {
-		kputchar(c);
-		continue;
-	    }
+            if (c == '%') {
+                kputchar(c);
+                continue;
+            }
 
-	    ptrfmt = alt = width = 0;
+            ptrfmt = alt = width = 0;
             if (c == '#') {
                 alt = 1;
                 c = *fmt++;
             }
-	    zero = (c == '0');
-	    while ((n = (c - '0')) <= 9) {
-		width = width*10 + n;
-		c = *fmt++;
-	    }
+            zero = (c == '0');
+            while ((n = (c - '0')) <= 9) {
+                width = width*10 + n;
+                c = *fmt++;
+            }
 
-	    if ((c == 'h') || (c == 'l'))
-		c = *fmt++;
-	    n = 16;
-	    switch (c) {
-	    case 'i':
-	    case 'd':
-		c = 'd';
-		n = 18;
-	    case 'o':
-		n -= 2;
-	    case 'u':
-		n -= 6;
-	    case 'X':
-	    case 'x':
+            if ((c == 'h') || (c == 'l'))
+                c = *fmt++;
+            n = 16;
+            switch (c) {
+            case 'i':
+            case 'd':
+                c = 'd';
+                n = 18;
+            case 'o':
+                n -= 2;
+            case 'u':
+                n -= 6;
+            case 'X':
+            case 'x':
             hex:
-		if (*(fmt-2) == 'l') {
+                if (*(fmt-2) == 'l') {
                     if (ptrfmt) width = 8;
-		    v = va_arg(p, unsigned long);
-		} else {
-		    if (c == 'd')
-			v = (long)(va_arg(p, int));
-		    else
-			v = (unsigned long)(va_arg(p, unsigned int));
-		}
-		numout(v, width, n, (c == 'd'), (c != 'X'), zero, alt);
-		break;
+                    v = va_arg(p, unsigned long);
+                } else {
+                    if (c == 'd')
+                        v = (long)(va_arg(p, int));
+                    else
+                        v = (unsigned long)(va_arg(p, unsigned int));
+                }
+                numout(v, width, n, (c == 'd'), (c != 'X'), zero, alt);
+                break;
             case 'D':
                 c += 'X' - 'D';
                 alt = 1;
-	    case 'P':
-	    case 'p':
+            case 'P':
+            case 'p':
                 c += 'X' - 'P';
                 ptrfmt = 1;
                 zero = 1;
                 width = 4;
                 goto hex;
-	    case 'T':
-		n = va_arg(p, unsigned int);
-		goto str;
-	    case 't':
-		n = current->t_regs.ds;
-		goto str;
-	    case 's':
-		n = kernel_ds;
-	    str:
-		str = va_arg(p, char *);
-		while ((zero = peekb((word_t)str++, n))) {
-		    kputchar(zero);
-		    width--;
-		}
-	    case 'c':
-		while (--width >= 0)
-		    kputchar(' ');
-		if (c == 'c')
-		    kputchar(va_arg(p, int));
-		break;
-	    default:
-		kputchar('?');
-	    }
-	}
+            case 'T':
+                n = va_arg(p, unsigned int);
+                goto str;
+            case 't':
+                n = current->t_regs.ds;
+                goto str;
+            case 's':
+                n = kernel_ds;
+            str:
+                str = va_arg(p, char *);
+                while ((zero = peekb((word_t)str++, n))) {
+                    kputchar(zero);
+                    width--;
+                }
+            case 'c':
+                while (--width >= 0)
+                    kputchar(' ');
+                if (c == 'c')
+                    kputchar(va_arg(p, int));
+                break;
+            default:
+                kputchar('?');
+            }
+        }
     }
 }
 
@@ -240,7 +240,7 @@ void halt(void)
     kputs("\nSYSTEM HALTED - Press CTRL-ALT-DEL to reboot:");
 
     while (1)
-	idle_halt();
+        idle_halt();
 }
 
 void panic(const char *error, ...)
@@ -257,23 +257,23 @@ void panic(const char *error, ...)
     char *j;
     int i = 0;
     kputs("\napparent call stack:\n"
-	  "Line: Addr    Parameters\n"
-	  "~~~~: ~~~~    ~~~~~~~~~~");
+          "Line: Addr    Parameters\n"
+          "~~~~: ~~~~    ~~~~~~~~~~");
 
     do {
-	printk("\n%4u: %04P =>", i, bp[1]);
-	bp = (int *) bp[0];
-	j = (char *)2;
-	do {
-	    printk(" %04X", bp[(int)j]);
-	} while ((int)(++j) <= 8);
+        printk("\n%4u: %04P =>", i, bp[1]);
+        bp = (int *) bp[0];
+        j = (char *)2;
+        do {
+            printk(" %04X", bp[(int)j]);
+        } while ((int)(++j) <= 8);
     } while (++i < 9);
 #endif
 
     halt();
 }
 
-int dprintk_on = DEBUG_STARTDEF;	/* toggled by debug events*/
+int dprintk_on = DEBUG_STARTDEF;        /* toggled by debug events*/
 #if DEBUG_EVENT
 static void (*debug_cbfuncs[3])();  /* debug event callback function*/
 
@@ -290,7 +290,7 @@ void debug_event(int evnum)
         kill_all(SIGURG);
     }
     if (debug_cbfuncs[evnum])
-	debug_cbfuncs[evnum]();
+        debug_cbfuncs[evnum]();
 }
 
 void dprintk(const char *fmt, ...)
@@ -298,7 +298,7 @@ void dprintk(const char *fmt, ...)
     va_list p;
 
     if (!dprintk_on)
-	return;
+        return;
     va_start(p, fmt);
     vprintk(fmt, p);
     va_end(p);

--- a/elks/kernel/sched.c
+++ b/elks/kernel/sched.c
@@ -80,7 +80,7 @@ void schedule(void)
 
     /* We have to let a task exit! */
     if (prev->state == TASK_EXITING)
-	return;
+        return;
 
     clr_irq();
     if (prev->state == TASK_INTERRUPTIBLE) {
@@ -89,14 +89,14 @@ void schedule(void)
             prev->state = TASK_RUNNING;
         }
         else {
-	    timeout = prev->timeout;
-	}
+            timeout = prev->timeout;
+        }
     }
 
     /* Choose a task to run next */
     next = prev->next_run;
     if (prev->state != TASK_RUNNING)
-	del_from_runqueue(prev);
+        del_from_runqueue(prev);
     if (next == &idle_task)
         next = next->next_run;
     set_irq();
@@ -112,14 +112,14 @@ void schedule(void)
 
         previous = prev;
         current = next;
-	debug_sched("sched: %d\n", current->pid);
+        debug_sched("sched: %d\n", current->pid);
         tswitch();  /* Won't return for a new task */
 
         if (timeout) {
             del_timer(&timer);
         }
     } else if (current->pid)
-	debug_sched("resched: %d prevstate %d\n", current->pid, prev->state);
+        debug_sched("resched: %d prevstate %d\n", current->pid, prev->state);
 }
 
 static struct timer_list *next_timer;
@@ -208,9 +208,9 @@ void do_timer(void)
 {
     jiffies++;
 
-#ifdef NEED_RESCHED		/* need_resched is not checked anywhere */
+#ifdef NEED_RESCHED             /* need_resched is not checked anywhere */
     if (!((int) jiffies & 7))
-	need_resched = 1;	/* how primitive can you get? */
+        need_resched = 1;       /* how primitive can you get? */
 #endif
 
     run_timer_list();
@@ -222,14 +222,14 @@ void INITPROC sched_init(void)
     register struct task_struct *t = &task[MAX_TASKS];
 
 /*
- *	Mark tasks 0-(MAX_TASKS-1) as not in use.
+ *  Mark tasks 0-(MAX_TASKS-1) as not in use.
  */
     do {
-	(--t)->state = TASK_UNUSED;
+        (--t)->state = TASK_UNUSED;
     } while (t > task);
 
 /*
- *	Now create task 0 to be ourself.
+ *  Now create task 0 to be ourself.
  */
     kfork_proc(NULL);
 

--- a/elks/kernel/signal.c
+++ b/elks/kernel/signal.c
@@ -24,16 +24,16 @@ static void generate(sig_t sig, sigset_t msksig, register struct task_struct *p)
     if ((sd == SIGDISP_IGN) ||
        ((sd == SIGDISP_DFL) &&
         (msksig & (SM_SIGCONT | SM_SIGCHLD | SM_SIGWINCH | SM_SIGURG)))) {
-	if (!(msksig & SM_SIGCHLD))
-	    debug_sig("SIGNAL ignoring %d pid %d\n", sig, p->pid);
-	return;
+        if (!(msksig & SM_SIGCHLD))
+            debug_sig("SIGNAL ignoring %d pid %d\n", sig, p->pid);
+        return;
     }
     debug_sig("SIGNAL gen_sig %d mask %x action %x:%x pid %d\n", sig, msksig,
-	      _FP_SEG(p->sig.handler), _FP_OFF(p->sig.handler), p->pid);
+              _FP_SEG(p->sig.handler), _FP_OFF(p->sig.handler), p->pid);
     p->signal |= msksig;
     if ((p->state == TASK_INTERRUPTIBLE) /* && (p->signal & ~p->blocked) */ ) {
-	debug_sig("SIGNAL wakeup pid %d\n", p->pid);
-	wake_up_process(p);
+        debug_sig("SIGNAL wakeup pid %d\n", p->pid);
+        wake_up_process(p);
     }
 }
 
@@ -44,17 +44,17 @@ int send_sig(sig_t sig, register struct task_struct *p, int priv)
 
     if (sig != SIGCHLD) debug_sig("SIGNAL send_sig %d pid %d\n", sig, p->pid);
     if (!priv && ((sig != SIGCONT) || (currentp->session != p->session)) &&
-	(currentp->euid ^ p->suid) && (currentp->euid ^ p->uid) &&
-	(currentp->uid ^ p->suid) && (currentp->uid ^ p->uid) && !suser())
-	return -EPERM;
+        (currentp->euid ^ p->suid) && (currentp->euid ^ p->uid) &&
+        (currentp->uid ^ p->suid) && (currentp->uid ^ p->uid) && !suser())
+        return -EPERM;
     msksig = (((sigset_t)1) << (sig - 1));
     if (msksig & (SM_SIGKILL | SM_SIGCONT)) {
-	if (p->state == TASK_STOPPED)
-	    wake_up_process(p);
-	p->signal &= ~(SM_SIGSTOP | SM_SIGTSTP | SM_SIGTTIN | SM_SIGTTOU);
+        if (p->state == TASK_STOPPED)
+            wake_up_process(p);
+        p->signal &= ~(SM_SIGSTOP | SM_SIGTSTP | SM_SIGTTIN | SM_SIGTTOU);
     }
     if (msksig & (SM_SIGSTOP | SM_SIGTSTP | SM_SIGTTIN | SM_SIGTTOU))
-	p->signal &= ~SM_SIGCONT;
+        p->signal &= ~SM_SIGCONT;
     /* Actually generate the signal */
     generate(sig, msksig, p);
     return 0;
@@ -66,18 +66,18 @@ int kill_pg(pid_t pgrp, sig_t sig, int priv)
     int err = -ESRCH;
 
     if (!pgrp) {
-	debug_sig("SIGNAL kill_pg 0 ignored\n");
-	return 0;
+        debug_sig("SIGNAL kill_pg 0 ignored\n");
+        return 0;
     }
     debug_sig("SIGNAL kill_pg sig %d pgrp %d\n", sig, pgrp);
     for_each_task(p) {
-	if (p->pgrp == pgrp) {
-		if (p->state < TASK_ZOMBIE)
-		    err = send_sig(sig, p, priv);
-		else if (p->state != TASK_UNUSED)
-		    debug_sig("SIGNAL skip kill_pg pgrp %d pid %d state %d\n",
-					pgrp, p->pid, p->state);
-	}
+        if (p->pgrp == pgrp) {
+                if (p->state < TASK_ZOMBIE)
+                    err = send_sig(sig, p, priv);
+                else if (p->state != TASK_UNUSED)
+                    debug_sig("SIGNAL skip kill_pg pgrp %d pid %d state %d\n",
+                                        pgrp, p->pid, p->state);
+        }
     }
     return err;
 }
@@ -88,8 +88,8 @@ int kill_process(pid_t pid, sig_t sig, int priv)
 
     debug_sig("SIGNAL kill_proc sig %d pid %d\n", sig, pid);
     for_each_task(p)
-	if (p->pid == pid && p->state < TASK_ZOMBIE)
-	    return send_sig(sig, p, 0);
+        if (p->pid == pid && p->state < TASK_ZOMBIE)
+            return send_sig(sig, p, 0);
     return -ESRCH;
 }
 
@@ -99,8 +99,8 @@ void kill_all(sig_t sig)
 
     debug_sig("SIGNAL kill_all %d\n", sig);
     for_each_task(p)
-	if (p->state < TASK_ZOMBIE)
-	    send_sig(sig, p, 0);
+        if (p->state < TASK_ZOMBIE)
+            send_sig(sig, p, 0);
 }
 
 int sys_kill(pid_t pid, sig_t sig)
@@ -111,45 +111,45 @@ int sys_kill(pid_t pid, sig_t sig)
 
     debug_sig("SIGNAL sys_kill %d, %d pid %d\n", pid, sig, current->pid);
     if ((unsigned int)(sig - 1) > (NSIG-1))
-	return -EINVAL;
+        return -EINVAL;
 
     count = retval = 0;
     if (pid == (pid_t)-1) {
-	for_each_task(p)
-	    if (p->pid > 1 && p != pcurrent && p->state < TASK_ZOMBIE) {
-		count++;
-		if ((err = send_sig(sig, p, 0)) != -EPERM)
-		    retval = err;
-	    }
-	return (count ? retval : -ESRCH);
+        for_each_task(p)
+            if (p->pid > 1 && p != pcurrent && p->state < TASK_ZOMBIE) {
+                count++;
+                if ((err = send_sig(sig, p, 0)) != -EPERM)
+                    retval = err;
+            }
+        return (count ? retval : -ESRCH);
     }
     if (pid < 1)
-	return kill_pg((!pid ? pcurrent->pgrp : -pid), sig, 0);
+        return kill_pg((!pid ? pcurrent->pgrp : -pid), sig, 0);
     return kill_process(pid, sig, 0);
 }
 
 int sys_signal(int signr, __kern_sighandler_t handler)
 {
     debug_sig("SIGNAL sys_signal %d action %x:%x pid %d\n", signr,
-	      _FP_SEG(handler), _FP_OFF(handler), current->pid);
+              _FP_SEG(handler), _FP_OFF(handler), current->pid);
     if (((unsigned int)signr > NSIG) || signr == SIGKILL || signr == SIGSTOP)
-	return -EINVAL;
+        return -EINVAL;
     if (handler == KERN_SIG_DFL)
-	current->sig.action[signr - 1].sa_dispose = SIGDISP_DFL;
+        current->sig.action[signr - 1].sa_dispose = SIGDISP_DFL;
     else if (handler == KERN_SIG_IGN)
-	current->sig.action[signr - 1].sa_dispose = SIGDISP_IGN;
+        current->sig.action[signr - 1].sa_dispose = SIGDISP_IGN;
     else {
-	if (_FP_SEG(handler) < current->mm.seg_code->base ||
-	    _FP_SEG(handler) >= current->mm.seg_code->base
-				+ current->mm.seg_code->size) {
-	    debug_sig("SIGNAL sys_signal supplied handler is bogus!\n");
-	    debug_sig("SIGNAL sys_signal cs not in [%x, %x)\n",
-		      current->mm.seg_code->base,
-		      current->mm.seg_code->base + current->mm.seg_code->size);
-	    return -EINVAL;
-	}
-	current->sig.handler = handler;
-	current->sig.action[signr - 1].sa_dispose = SIGDISP_CUSTOM;
+        if (_FP_SEG(handler) < current->mm.seg_code->base ||
+            _FP_SEG(handler) >= current->mm.seg_code->base
+                                + current->mm.seg_code->size) {
+            debug_sig("SIGNAL sys_signal supplied handler is bogus!\n");
+            debug_sig("SIGNAL sys_signal cs not in [%x, %x)\n",
+                      current->mm.seg_code->base,
+                      current->mm.seg_code->base + current->mm.seg_code->size);
+            return -EINVAL;
+        }
+        current->sig.handler = handler;
+        current->sig.action[signr - 1].sa_dispose = SIGDISP_CUSTOM;
     }
     return 0;
 }

--- a/elks/kernel/sleepwake.c
+++ b/elks/kernel/sleepwake.c
@@ -10,15 +10,15 @@
 #include <arch/segment.h>
 
 /*
- *	Wait queue functionality for Linux ELKS. Taken from sched.c/h of
- *	its big brother..
+ *  Wait queue functionality for Linux ELKS. Taken from sched.c/h of
+ *  its big brother..
  *
- *	Copyright (C) 1991, 1992  Linus Torvalds
- *	Elks tweaks  (C) 1995 Alan Cox.
+ *  Copyright (C) 1991, 1992  Linus Torvalds
+ *  Elks tweaks  (C) 1995 Alan Cox.
  *
- *	Copyright (C) 2000 Alan Cox.
- *	Rewrote the entire queue functionality to reflect ELKS actual needs
- *	not Linux needs
+ *  Copyright (C) 2000 Alan Cox.
+ *  Rewrote the entire queue functionality to reflect ELKS actual needs
+ *  not Linux needs
  */
 
 /*
@@ -26,13 +26,13 @@
  * Only required when wait queue used or condition check changed by hw interrupt.
  *
  * Old:
- *	if (!ready())
- *	    interruptible_sleep_on(&waitq);
+ *      if (!ready())
+ *          interruptible_sleep_on(&waitq);
  * New:
- *	prepare_to_wait_interruptible(&waitq);
- *	if (!ready())
- *	    do_wait();
- *	finish_wait(&waitq);
+ *      prepare_to_wait_interruptible(&waitq);
+ *      if (!ready())
+ *          do_wait();
+ *      finish_wait(&waitq);
  */
 
 void prepare_to_wait_interruptible(struct wait_queue *p)
@@ -114,15 +114,15 @@ void interruptible_sleep_on(struct wait_queue *p)
 
 void wake_up_process(register struct task_struct *p)
 {
-	flag_t flags;
+    flag_t flags;
 
-	debug_sched("wakeup: %d\n", p->pid);
-	save_flags(flags);
-	clr_irq();
-	p->state = TASK_RUNNING;
-	if (!p->next_run)
-	    add_to_runqueue(p);
-	restore_flags(flags);
+    debug_sched("wakeup: %d\n", p->pid);
+    save_flags(flags);
+    clr_irq();
+    p->state = TASK_RUNNING;
+    if (!p->next_run)
+        add_to_runqueue(p);
+    restore_flags(flags);
 }
 
 /*
@@ -139,24 +139,24 @@ void _wake_up(register struct wait_queue *q, int it)
     register struct task_struct *p;
 
     for_each_task(p) {
-	if (p->state == TASK_UNUSED)
-		continue;
-	if ((p->waitpt == q) || ((p->waitpt == &select_queue) && select_poll (p, q)))
-	    if (p->state == TASK_INTERRUPTIBLE ||
-		(it && p->state == TASK_UNINTERRUPTIBLE)) {
-		wake_up_process(p);
-	    }
+        if (p->state == TASK_UNUSED)
+                continue;
+        if ((p->waitpt == q) || ((p->waitpt == &select_queue) && select_poll (p, q)))
+            if (p->state == TASK_INTERRUPTIBLE ||
+                (it && p->state == TASK_UNINTERRUPTIBLE)) {
+                wake_up_process(p);
+            }
     }
 }
 
 /*
- *	Semaphores. These are not IRQ safe nor needed to be so for ELKS
+ *  Semaphores. These are not IRQ safe nor needed to be so for ELKS
  */
 
 void up(register sem_t *s)
 {
-    if (++(*s) == 0)		/* Gone non-negative */
-	wake_up((void *) s);
+    if (++(*s) == 0)            /* Gone non-negative */
+        wake_up((void *) s);
 
     if (*s != 0) debug_net("kernel: sem up %x FAIL %d\n", s, *s);
 }
@@ -165,7 +165,7 @@ void down(register sem_t *s)
 {
     /* Wait for the semaphore */
     while (*s < 0)
-	    sleep_on((void *) s);
+        sleep_on((void *) s);
 
     /* Take it */
     --(*s);


### PR DESCRIPTION
Starting the process of maintaining readability of kernel source by eliminating the mixed use of 4 character initial tab indents, followed by tabs sometimes meant for 8-char tabs, and other times meant for 4-char tabs. All are replaced by spaces and use 4-space indents. Going forward I highly recommend setting your editor to insert spaces rather than tabs to maintain readability for any contributions.

This enables the source to be easily read and maintained regardless of the tab settings in use by a given editor. I can't count the number of times in the last few weeks (years) I've had to use `:set noexpandtab`/`:set expandtab`  (on vi) to get things to look right when modifying the code. (I have `vi` set to move between 4- and 8-character tabs using `k` and `l` just to read the source in various files). 

No functionality changes. Starting with these few oft-updated files and likely more to come. Using `%retab` command in `vi` for reformatting.