### PR TITLE
[libc] Rewrite getpwent/getgrent routines to cache opens

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -57,6 +57,7 @@
 
 #define DEBUG_PROBE     0       /* =1 to display more floppy probing information */
 #define FORCE_PROBE     0       /* =1 to force floppy probing */
+//#define IODELAY       5       /* times 10ms, emulated delay for floppy on QEMU */
 
 /* the following must match with /dev minor numbering scheme*/
 #define NUM_MINOR       32      /* max minor devices per drive*/
@@ -210,6 +211,11 @@ static int bios_disk_rw(unsigned cmd, unsigned num_sectors, unsigned drive,
         BD_DX = (head << 8) | drive;
         BD_ES = seg;
         BD_BX = offset;
+#endif
+#ifdef IODELAY
+        /* emulate floppy delay for QEMU */
+        unsigned long timeout = jiffies + IODELAY*HZ/100;
+        while (!time_after(jiffies, timeout)) continue;
 #endif
         return call_bios(&bdt);
 }

--- a/elkscmd/cron/runjob.c
+++ b/elkscmd/cron/runjob.c
@@ -136,6 +136,7 @@ runjob(crontab *tab, cron *job)
     if ((pid = fork()) == -1)
         error("fork() in runjob: %s", strerror(errno));
     else if (pid == 0) {
+        endpwent();
         runjobprocess(tab, job, pwd);
         exit(0);
     }

--- a/elkscmd/minix3/mail.c
+++ b/elkscmd/minix3/mail.c
@@ -606,6 +606,7 @@ void savelet(struct letter *let, char *savefile)
     }
 
     /* Child */
+    endpwent();
     setgid(getgid());
     setuid(getuid());
     if ((savefp = fopen(savefile, "a")) == NULL) {
@@ -705,6 +706,7 @@ void doshell(char *command)
     }
 
     /* Child */
+    endpwent();
     setgid(getgid());
     setuid(getuid());
     umask(oldmask);

--- a/elkscmd/sash/sash.c
+++ b/elkscmd/sash/sash.c
@@ -11,6 +11,8 @@
 
 #include <signal.h>
 #include <errno.h>
+#include <pwd.h>
+#include <grp.h>
 
 typedef struct {
     char    *name;
@@ -560,6 +562,8 @@ runcmd(char *cmd, int argc, char **argv)
 {
 	int		pid, status, ret;
 
+	endpwent();
+	endgrent();
 	/*
 	 * If a full shell is required, run 'sh -c cmd' unless we are the only shell.
 	 */

--- a/elkscmd/sys_utils/login.c
+++ b/elkscmd/sys_utils/login.c
@@ -40,6 +40,7 @@ void login(register struct passwd *pwd, struct utmp *ut_ent)
     char sh_name[STR_SIZE];
     char *renv[16];
 
+    endpwent();
     if (fchown(0, pwd->pw_uid, pwd->pw_gid) < 0) perror("login (chown)");
 #ifdef USE_UTMP
     ut_ent->ut_type = USER_PROCESS;

--- a/libc/getent/Makefile
+++ b/libc/getent/Makefile
@@ -2,14 +2,24 @@
 
 include $(TOPDIR)/libc/Makefile.inc
 
-SRCS= utent.c pwent.c getpwuid.c getpwnam.c __getpwent.c getgrgid.c getgrnam.c __getgrent.c putpwent.c
-OBJS= $(SRCS:.c=.o)
+LIB = out.a
 
-$(OBJS): $(SRCS)
+OBJS = \
+    utent.o \
+    pwent.o \
+    getpwuid.o \
+    getpwnam.o \
+    __getpwent.o \
+    grent.o \
+    getgrgid.o \
+    getgrnam.o \
+    __getgrent.o \
+    putpwent.o \
+    # end of list
 
-all: out.a
+all: $(LIB)
 
-out.a: $(OBJS)
+$(LIB): $(OBJS)
 	$(RM) $@
 	$(AR) $(ARFLAGS_SUB) $@ $^
 

--- a/libc/getent/config-grp.h
+++ b/libc/getent/config-grp.h
@@ -18,48 +18,17 @@
  *
  */
 
-
 #ifndef _CONFIG_GRP_H
 #define _CONFIG_GRP_H
 
 /*
- * Define GR_SCALE_DYNAMIC if you want grp to dynamically scale its read buffer
- * so that lines of any length can be used.  On very very small systems,
- * you may want to leave this undefined becasue it will make the grp functions
- * somewhat larger (because of the inclusion of malloc and the code necessary).
- * On larger systems, you will want to define this, because grp will _not_
- * deal with long lines gracefully (they will be skipped).
+ * GR_MAX_LINE_LEN is the maximum number of characters per line in the group file.
+ * GR_MAX_MEMBERS is the maximum number of members of any given group.
  */
-//#define GR_SCALE_DYNAMIC	/* option must remain off, memory overwrite bugs when on*/
 
-#ifndef GR_SCALE_DYNAMIC
-/*
- * If scaling is not dynamic, the buffers will be statically allocated, and
- * maximums must be chosen.  GR_MAX_LINE_LEN is the maximum number of
- * characters per line in the group file.  GR_MAX_MEMBERS is the maximum
- * number of members of any given group.
- */
 #define GR_MAX_LINE_LEN 128
+
 /* GR_MAX_MEMBERS = (GR_MAX_LINE_LEN-(24+3+6))/9 */
-#define GR_MAX_MEMBERS 11
+#define GR_MAX_MEMBERS  11
 
-#endif /* !GR_SCALE_DYNAMIC */
-
-
-/*
- * Define GR_DYNAMIC_GROUP_LIST to make initgroups() dynamically allocate
- * space for it's GID array before calling setgroups().  This is probably
- * unnecessary scalage, so it's undefined by default.
- */
-#undef GR_DYNAMIC_GROUP_LIST
-
-#ifndef GR_DYNAMIC_GROUP_LIST
-/*
- * GR_MAX_GROUPS is the size of the static array initgroups() uses for
- * its static GID array if GR_DYNAMIC_GROUP_LIST isn't defined.
- */
-#define GR_MAX_GROUPS 64
-
-#endif /* !GR_DYNAMIC_GROUP_LIST */
-
-#endif /* !_CONFIG_GRP_H */
+#endif /* _CONFIG_GRP_H */

--- a/libc/getent/getgrgid.c
+++ b/libc/getent/getgrgid.c
@@ -28,17 +28,13 @@ struct group *
 getgrgid(const gid_t gid)
 {
     struct group *group;
-    int grp_fd;
 
-    if ((grp_fd = open(_PATH_GROUP, O_RDONLY)) < 0)
-        return NULL;
-
-    while ((group = __getgrent(grp_fd)) != NULL) {
+    setgrent();
+    while ((group = getgrent()) != NULL) {
         if (group->gr_gid == gid) {
             break;
         }
     }
 
-    close(grp_fd);
     return group;
 }

--- a/libc/getent/getgrnam.c
+++ b/libc/getent/getgrnam.c
@@ -28,7 +28,6 @@
 struct group *
 getgrnam(const char *name)
 {
-    int grp_fd;
     struct group *group;
 
     if (name == NULL) {
@@ -36,15 +35,12 @@ getgrnam(const char *name)
         return NULL;
     }
 
-    if ((grp_fd = open(_PATH_GROUP, O_RDONLY)) < 0)
-        return NULL;
-
-    while ((group = __getgrent(grp_fd)) != NULL) {
+    setgrent();
+    while ((group = getgrent()) != NULL) {
         if (!strcmp(group->gr_name, name)) {
             break;
         }
     }
 
-    close(grp_fd);
     return group;
 }

--- a/libc/getent/getpwnam.c
+++ b/libc/getent/getpwnam.c
@@ -28,23 +28,19 @@
 struct passwd *
 getpwnam(const char *name)
 {
-    int passwd_fd;
     struct passwd *passwd;
 
-    if (name == NULL) {
+    if (!name) {
         errno = EINVAL;
         return NULL;
     }
 
-    if ((passwd_fd = open(_PATH_PASSWD, O_RDONLY)) < 0)
-        return NULL;
-
-    while ((passwd = __getpwent(passwd_fd)) != NULL) {
+    setpwent();
+    while ((passwd = getpwent()) != NULL) {
         if (!strcmp(passwd->pw_name, name)) {
             break;
         }
     }
 
-    close(passwd_fd);
     return passwd;
 }

--- a/libc/getent/getpwuid.c
+++ b/libc/getent/getpwuid.c
@@ -27,18 +27,14 @@
 struct passwd *
 getpwuid(uid_t uid)
 {
-    int passwd_fd;
     struct passwd *passwd;
 
-    if ((passwd_fd = open(_PATH_PASSWD, O_RDONLY)) < 0)
-        return NULL;
-
-    while ((passwd = __getpwent(passwd_fd)) != NULL) {
+    setpwent();
+    while ((passwd = getpwent()) != NULL) {
         if (passwd->pw_uid == uid) {
             break;
         }
     }
 
-    close(passwd_fd);
     return passwd;
 }

--- a/libc/getent/grent.c
+++ b/libc/getent/grent.c
@@ -1,0 +1,38 @@
+/*
+ * Sep 2023 Greg Haerr
+ */
+#include <unistd.h>
+#include <stdlib.h>
+#include <grp.h>
+#include <fcntl.h>
+#include <paths.h>
+
+static int __grfd = -1;     /* file descriptor for group file */
+
+void
+setgrent(void)
+{
+    if (__grfd < 0)
+        __grfd = open(_PATH_GROUP, O_RDONLY);
+    lseek(__grfd, 0L, SEEK_SET);
+}
+
+void
+endgrent(void)
+{
+    if (__grfd >= 0) {
+        close(__grfd);
+        __grfd = -1;
+    }
+}
+
+struct group *
+getgrent(void)
+{
+    if (__grfd < 0) {
+        setgrent();
+        if (__grfd < 0)
+            return NULL;
+    }
+    return __getgrent(__grfd);
+}

--- a/libc/include/grp.h
+++ b/libc/include/grp.h
@@ -17,21 +17,11 @@ struct group
 void setgrent(void);
 void endgrent(void);
 struct group * getgrent(void);
-
 struct group * getgrgid(const gid_t gid);
 struct group * getgrnam(const char * name);
-
-struct group * fgetgrent(FILE * file);
-
-int setgroups(size_t n, const gid_t * groups);
-int initgroups(const char * user, gid_t gid);
-
 
 #ifdef __LIBC__
 struct group * __getgrent(int grp_fd);
 #endif
 
-#endif /* _GRP_H */
-
-
-
+#endif /* __GRP_H */

--- a/libc/include/pwd.h
+++ b/libc/include/pwd.h
@@ -17,18 +17,12 @@ struct passwd
   char *pw_shell;		/* Shell program.  */
 };
 
-
 void setpwent(void);
 void endpwent(void);
 struct passwd * getpwent(void);
-
-int putpwent (const struct passwd * p, FILE * stream);
-int getpw(uid_t uid, char *buf);
-
-struct passwd * fgetpwent(FILE * file);
-
 struct passwd * getpwuid(uid_t);
 struct passwd * getpwnam(const char *);
+int putpwent (const struct passwd * p, FILE * stream);
 
 #ifdef __LIBC__
 struct passwd * __getpwent(int passwd_fd);
@@ -36,7 +30,4 @@ struct passwd * __getpwent(int passwd_fd);
 
 char *getpass(char *prompt);
 
-#endif /* pwd.h  */
-
-
-
+#endif /* __PWD_H */

--- a/libc/include/pwd.h
+++ b/libc/include/pwd.h
@@ -27,11 +27,11 @@ int getpw(uid_t uid, char *buf);
 
 struct passwd * fgetpwent(FILE * file);
 
-struct passwd * getpwuid(const uid_t);
+struct passwd * getpwuid(uid_t);
 struct passwd * getpwnam(const char *);
 
 #ifdef __LIBC__
-struct passwd * __getpwent(const int passwd_fd);
+struct passwd * __getpwent(int passwd_fd);
 #endif
 
 char *getpass(char *prompt);

--- a/libc/include/time.h
+++ b/libc/include/time.h
@@ -60,6 +60,12 @@ void	tzset(void);
 struct tm*	gmtime(const time_t *__tp);
 struct tm*	localtime(const time_t * __tp);
 
+#ifdef __LIBC__
+extern int _tz_is_set;
+void __tm_conv(struct tm *tmbuf, const time_t *timep, time_t offset);
+void __asctime(char *buffer, const struct tm *ptm);
+#endif
+
 __END_DECLS
 
 #endif

--- a/libc/time/asctime.c
+++ b/libc/time/asctime.c
@@ -1,7 +1,4 @@
-
 #include <time.h>
-
-extern void __asctime(char *buffer, const struct tm *ptm);
 
 char *
 asctime(const struct tm *timeptr)

--- a/libc/time/ctime.c
+++ b/libc/time/ctime.c
@@ -1,18 +1,13 @@
-
 #include <time.h>
 #include <sys/time.h>
-
-extern int _tz_is_set;
-void __tm_conv(struct tm *tmbuf, const time_t *timep, time_t offset);
-extern void __asctime(char *buffer, const struct tm *ptm);
 
 char *
 ctime(const time_t *timep)
 {
-  static char cbuf[26];
+  time_t offt;
   struct tm tmb;
   struct timezone tz;
-  time_t offt;
+  static char cbuf[26];
   
   gettimeofday((void*)0, &tz);
   

--- a/libc/time/localtime.c
+++ b/libc/time/localtime.c
@@ -1,9 +1,6 @@
 #include <time.h>
 #include <sys/time.h>
 
-extern int _tz_is_set;
-void __tm_conv(struct tm *tmbuf, const time_t *timep, time_t offset);
-
 struct tm * localtime (const time_t * timep)
 {
    static struct tm tmb;

--- a/libc/time/tm_conv.c
+++ b/libc/time/tm_conv.c
@@ -66,7 +66,7 @@ __tm_conv(struct tm *tmbuf, const time_t *t, time_t offset)
   tmbuf->tm_isdst = -1;
 }
 
-#if NOTUSED
+#if UNUSED
 #include <time.h>
 
 /* This is a translation from ALGOL in Collected Algorithms of CACM. */


### PR DESCRIPTION
Caches `open` calls for /etc/passwd and /etc/group in `getpwent`/`getgrent` routines, used by `ps`, `ls` and others, for speed.

Reduces code and data size in `getpwent`/`getgrent` routines.

Replaces calls to `strtoul` with `atoi` in `getpwent`/`getgrent` routines and saves 600+ bytes per application.

Deletes buggy "dynamic group" handling in `__getgrent`.

Added calls to `endpwent` and `endgrent` to close file descriptors before fork/exec in various commands.

Adds optional `IODELAY` to BIOS driver to simulate 50ms floppy delay on QEMU (see bioshd.c, used for debugging this PR).

Optimize `ps` further by caching `devname()` results, not closing `opendir("/dev")`, and caching last tty device searched; thanks to @Mellvik for this enhancement.

Cleans up some time-related function headers in C library.
