### PR TITLE
[cmds] Reduce size of ps to 6k

### DIFF
--- a/elks/include/linuxmt/types.h
+++ b/elks/include/linuxmt/types.h
@@ -43,17 +43,9 @@ typedef __u16			umode_t;
 
 typedef __u8			cc_t;
 typedef __u16			sig_t;
-
 typedef __s16			sem_t;
 
-/*@ignore@*/
-
-/* The next three lines cause splint to complain needlessly */
-
 typedef __u32			time_t;
-
-/*@end@*/
-
 typedef __u32			fd_mask_t;
 
 #include <linuxmt/posix_types.h>

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -354,9 +354,7 @@ static void parse_umb(char *line)
 		if((p = strchr(p+1, ':'))) {
 			len = (segext_t)simple_strtol(p+1, 16);
 			end = base + len;
-#if DEBUG
-			printk("umb segment from %x to %x\n", base, end);
-#endif
+			debug("umb segment from %x to %x\n", base, end);
 			seg_add(base, end);
 		}
 	} while((p = strchr(p+1, ',')));
@@ -384,9 +382,7 @@ static int parse_options(void)
 	if (*(unsigned short *)options != 0x2323 || options[OPTSEGSZ-1])
 		return 0;
 
-#if DEBUG
-	printk("/bootopts: %s", &options[3]);
-#endif
+	debug("/bootopts: %s", &options[3]);
 	next = line;
 	while ((line = next) != NULL && *line) {
 		if ((next = option(line)) != NULL) {
@@ -404,9 +400,7 @@ static int parse_options(void)
 		 */
 		if (!strncmp(line,"root=",5)) {
 			int dev = parse_dev(line+5);
-#if DEBUG
-			printk("root %s=%D\n", line+5, dev);
-#endif
+			debug("root %s=%D\n", line+5, dev);
 			ROOT_DEV = (kdev_t)dev;
 			boot_rootdev = dev;    /* stop translation in device_setup*/
 			continue;
@@ -423,9 +417,7 @@ static int parse_options(void)
 			}
 
 
-#if DEBUG
-			printk("console %s=%D\n", line+8, dev);
-#endif
+			debug("console %s=%D\n", line+8, dev);
 			boot_console = dev;
 			continue;
 		}

--- a/elkscmd/sys_utils/ps.c
+++ b/elkscmd/sys_utils/ps.c
@@ -30,7 +30,6 @@
 #include <dirent.h>
 #include <pwd.h>
 #include <getopt.h>
-#include <errno.h>
 
 #define LINEARADDRESS(off, seg)		((off_t) (((off_t)seg << 4) + off))
 
@@ -140,17 +139,17 @@ int main(int argc, char **argv)
             break;
         default:
             printf("Usage: %s: [-lu]\n", progname);
-            exit(1);
+            return 1;
         }
     }
 
 	if ((fd = open("/dev/kmem", O_RDONLY)) < 0) {
-		perror("ps");
-		exit(1);
+		printf("ps: no /dev/kmem\n");
+		return 1;
 	}
 	if (ioctl(fd, MEM_GETDS, &ds) < 0) {
-		perror("ps");
-		exit(1);
+		printf("ps: ioctl mem_getds\n");
+		return 1;
 	}
 
 #ifdef CONFIG_CPU_USAGE
@@ -160,8 +159,8 @@ int main(int argc, char **argv)
 
 	    if (ioctl(fd, MEM_GETUPTIME, &upoff) < 0 ||
                 !memread(fd, upoff, ds, &uptime, sizeof(uptime))) {
-		    perror("ps");
-		    exit(1);
+		    printf("ps: ioctl mem_getuptime\n");
+		    return 1;
 	    }
 
         unsigned long n = uptime / HZ;
@@ -173,13 +172,13 @@ int main(int argc, char **argv)
 
         printf("up for %d days, %d hour%s, and %d minute%s\n",
             days, hours, hours == 1? "": "s", minutes, minutes == 1? "": "s");
-        exit(0);
+        return 0;
     }
 #endif
 
 	if (ioctl(fd, MEM_GETTASK, &off) < 0) {
-		perror("ps");
-		exit(1);
+		printf("ps: ioctl mem_gettask\n");
+		return 1;
 	}
 
 	printf("  PID   GRP  TTY USER STAT ");
@@ -191,14 +190,13 @@ int main(int argc, char **argv)
 	printf(" HEAP  FREE   SIZE COMMAND\n");
 	for (j = 1; j <= MAX_TASKS; j++) {
 		if (!memread(fd, off + j*sizeof(struct task_struct), ds, &task_table, sizeof(task_table))) {
-			perror("ps");
+			printf("ps: memread\n");
 			return 1;
 		}
 
         if (task_table.kstack_magic != KSTACK_MAGIC) {
             if (task_table.kstack_magic == 0) continue;
-            errno = EILSEQ;
-            perror("Recompile ps, mismatched task structure");
+            printf("Recompile ps, mismatched task structure\n");
             return 1;
         }
 		if (task_table.t_regs.ss == 0)
@@ -214,7 +212,7 @@ int main(int argc, char **argv)
 		case TASK_EXITING:			c = 'E'; break;
 		default:					c = '?'; break;
 		}
-		pwent = (getpwuid(task_table.uid));
+		pwent = getpwuid(task_table.uid);
 
 		/* pid grp tty user stat*/
 		printf("%5d %5d %4s %-8s%c ",


### PR DESCRIPTION
Replaces `perror` calls with `printf` to reduce size by 1 block.

Other small cleanups.