### PR TITLE
[kernel] Release /bootopts parsing and kernel init_task code after init

### DIFF
--- a/elks/fs/msdos/fat.c
+++ b/elks/fs/msdos/fat.c
@@ -169,7 +169,7 @@ void FATPROC cache_lookup(struct inode *inode,cluster_t cluster,
 }
 
 
-#ifdef DEBUG
+#if DEBUG
 static void FATPROC list_cache(void)
 {
 	struct fat_cache *walk;
@@ -203,7 +203,7 @@ void FATPROC cache_add(struct inode *inode, cluster_t f_clu, cluster_t d_clu)
 			last->next = walk->next;
 			walk->next = fat_cache;
 			fat_cache = walk;
-#ifdef DEBUG
+#if DEBUG
 			list_cache();
 #endif
 			return;
@@ -215,7 +215,7 @@ void FATPROC cache_add(struct inode *inode, cluster_t f_clu, cluster_t d_clu)
 	last->next = NULL;
 	walk->next = fat_cache;
 	fat_cache = walk;
-#ifdef DEBUG
+#if DEBUG
 	list_cache();
 #endif
 }

--- a/elks/include/linuxmt/debug.h
+++ b/elks/include/linuxmt/debug.h
@@ -125,17 +125,15 @@ void debug_setcallback(int evnum, void (*cbfunc)()); /* callback on debug event*
 #define debug_wait(...)
 #endif
 
-/* Old debug mechanism - deprecated.
- * This sets up a standard set of macros that can be used with any of the
- * files that make up the ELKS kernel.
+/* Old debug mechanism - enables debug() macro.
  *
- * To enable debugging for any particular module, just include -DDEBUG
- * on the command line for that module.
+ * To enable debugging for any particular module, just include -DDEBUG=1
+ * on the command line or #define DEBUG 1 in the module.
  *
  * Riley Williams <Riley@Williams.Name> 25 Apr 2002
  */
 
-#ifdef DEBUG
+#if DEBUG
 #       define  debug(...)      PRINTK(__VA_ARGS__)
 #else
 #       define  debug(...)


### PR DESCRIPTION
The amount of freed memory is up to almost 9k now, large enough for /bin/init to run in.