### PR TITLE
[kernel] Slightly reorganize boot and kernel messages

### DIFF
--- a/Documentation/text/parameter-passing.txt
+++ b/Documentation/text/parameter-passing.txt
@@ -1,0 +1,13 @@
+ELKS system calls requires registers set in order of parameters:
+    BX, CX, DX, DI, SI
+
+
+Cdecl calling convention, stack has parms, passed in this order in registers:
+    BX, CX, DX, DI, SI
+    caller pops all args after call
+
+
+Regparmcall calling convention, args passed in following registers in order:
+    AX, DX, CX, DI, SI
+    callee pops args > 3 before return!
+

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -717,7 +717,7 @@ static void probe_floppy(int target, struct hd_struct *hdp)
 #endif
 
 got_geom:
-        printk("fd: /dev/fd%d %s has %d cylinders, %d heads, and %d sectors\n", target,
+        printk("fd%d: %s has %d cylinders, %d heads, and %d sectors\n", target,
                    (found_PB == 2)? "DOS format," :
                    (found_PB == 1)? "ELKS bootable,": "probed, probably",
                    drivep->cylinders, drivep->heads, drivep->sectors);
@@ -783,7 +783,7 @@ int INITPROC bioshd_init(void)
 #ifdef PRINT_DRIVE_INFO
     {
         register struct drive_infot *drivep;
-        static char UNITS[4] = "kMGT";
+        static char UNITS[4] = "KMGT";
 
         drivep = drive_info;
         for (count = 0; count < PRINT_DRIVE_INFO; count++, drivep++) {
@@ -802,10 +802,10 @@ int INITPROC bioshd_init(void)
                     unit++;
                 }
                 debug("DBG: Size = %lu (%X/%X)\n",size,*unit,unit[1]);
-                printk("/dev/%cd%c: %u cylinders, %d heads, %d sectors = %lu.%u %cb\n",
+                printk("%cd%c: %4lu%c CHS %3u,%2d,%d\n",
                     (count < 4 ? 'h' : 'f'), (count & 3) + (count < 4 ? 'a' : '0'),
-                    drivep->cylinders, drivep->heads, drivep->sectors,
-                    (size/10), (int) (size%10), *unit);
+                    (size/10), *unit,
+                    drivep->cylinders, drivep->heads, drivep->sectors);
             }
         }
     }

--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -54,7 +54,7 @@ static void INITPROC print_minor_name(register struct gendisk *hd,
     unsigned int part;
     struct hd_struct *hdp = &hd->part[minor];
 
-    printk(" %s%c", hd->major_name, 'a' + (unsigned char)(minor >> hd->minor_shift));
+    printk("%s%c", hd->major_name, 'a' + (unsigned char)(minor >> hd->minor_shift));
     if ((part = (unsigned) (minor & ((1 << hd->minor_shift) - 1))))
 	printk("%d", part);
     printk(":(%lu,%lu) ", hdp->start_sect, hdp->nr_sects);
@@ -216,10 +216,8 @@ static int INITPROC msdos_partition(struct gendisk *hd,
     register struct hd_struct *hdp;
     unsigned short int i, minor = current_minor;
 
-    if (!(bh = bread(dev, (block_t) 0))) {
-	printk(" no MBR");
+    if (!(bh = bread(dev, (block_t) 0)))
 	return 0;
-    }
     map_buffer(bh);
 
     /* In some cases we modify the geometry of the drive (below), so ensure
@@ -227,7 +225,7 @@ static int INITPROC msdos_partition(struct gendisk *hd,
      */
     if (*(unsigned short *) (bh->b_data + 0x1fe) != 0xAA55) {
 out:
-	printk(" no mbr,");
+	printk("no mbr,");
 	unmap_brelse(bh);
 	return 0;
     }
@@ -294,12 +292,8 @@ out:
 
 static void INITPROC check_partition(register struct gendisk *hd, kdev_t dev)
 {
-    static int first_time = 1;
     sector_t first_sector;
 
-    if (first_time)
-	printk("Partitions:");
-    first_time = 0;
     first_sector = hd->part[MINOR(dev)].start_sect;
 
 #if UNUSED
@@ -320,7 +314,7 @@ static void INITPROC check_partition(register struct gendisk *hd, kdev_t dev)
 	return;
 #endif
 
-    printk(" none.\n");
+    printk(" no partitions\n");
 }
 #endif
 

--- a/elks/arch/i86/drivers/block/init.c
+++ b/elks/arch/i86/drivers/block/init.c
@@ -54,8 +54,7 @@ void INITPROC device_init(void)
 
 	kdev_t rootdev = bioshd_conv_bios_drive((unsigned)ROOT_DEV);
 
-	printk("device_setup: BIOS drive 0x%x, root device 0x%x\n",
-		ROOT_DEV, rootdev);
+	printk("boot: BIOS drive %x, root device %04x\n", ROOT_DEV, rootdev);
 	ROOT_DEV = rootdev;
     }
 #endif

--- a/elks/arch/i86/drivers/block/ll_rw_blk.c
+++ b/elks/arch/i86/drivers/block/ll_rw_blk.c
@@ -263,7 +263,7 @@ void ll_rw_blk(int rw, struct buffer_head *bh)
     if ((major = MAJOR(buffer_dev(bh))) < MAX_BLKDEV)
         dev = blk_dev + major;
     if (!dev || !dev->request_fn)
-        panic("ll_rw_blk: unknown device %D", buffer_dev(bh));
+        panic("ll_rw_blk: unknown dev %D", buffer_dev(bh));
     make_request(major, rw, bh);
 }
 

--- a/elks/arch/i86/drivers/char/serial-8250.c
+++ b/elks/arch/i86/drivers/char/serial-8250.c
@@ -523,7 +523,7 @@ void INITPROC serial_init(void)
 
     do {
         if (sp->tty != NULL) {
-            printk("ttyS%d at 0x%x, irq %d is a%s\n", ttyno,
+            printk("ttyS%d at %x, irq %d is a%s\n", ttyno,
                        sp->io, sp->irq, serial_type[sp->flags & SERF_TYPE]);
         }
         sp++;

--- a/elks/arch/i86/drivers/char/serial-pc98.c
+++ b/elks/arch/i86/drivers/char/serial-pc98.c
@@ -259,7 +259,7 @@ void INITPROC serial_init(void)
 	    printk("Can't get serial IRQ %d\n", sp->irq);
 	else {
 	    sp->tty = tty;
-	    printk("ttyS%d at 0x%x, irq %d\n", sp-ports, sp->io, sp->irq);
+	    printk("ttyS%d at %x, irq %d\n", sp-ports, sp->io, sp->irq);
 	    update_port(sp);
 	}
     }

--- a/elks/arch/i86/drivers/char/serial-template.c
+++ b/elks/arch/i86/drivers/char/serial-template.c
@@ -216,7 +216,7 @@ void INITPROC serial_init(void)
 	    printk("Can't get serial IRQ %d\n", sp->irq);
 	else {
 	    sp->tty = tty;
-	    printk("ttyS%d at 0x%x, irq %d\n", sp-ports, sp->io, sp->irq);
+	    printk("ttyS%d at %x, irq %d\n", sp-ports, sp->io, sp->irq);
 	    update_port(sp);
 	}
     }

--- a/elks/arch/i86/drivers/net/el3.c
+++ b/elks/arch/i86/drivers/net/el3.c
@@ -202,7 +202,7 @@ static int INITPROC el3_isa_probe( void )
 
 	outb(0xd0, el3_id_port);		// select tag (0)
 	outb(0xe0 |(ioaddr >> 4), el3_id_port );// Set IOBASE address, activate
-	printk("eth: %s at 0x%x, irq %d", dev_name, ioaddr, net_irq);
+	printk("eth: %s at %x, irq %d", dev_name, ioaddr, net_irq);
 
 	if (id_read_eeprom(EEPROM_MFG_ID) != 0x6d50) {
 		printk(" not found\n");

--- a/elks/arch/i86/drivers/net/ne2k.c
+++ b/elks/arch/i86/drivers/net/ne2k.c
@@ -448,7 +448,7 @@ void INITPROC ne2k_drv_init(void)
 
 		err = ne2k_probe();
 		verbose = (net_flags&ETHF_VERBOSE);
-		printk("eth: %s at 0x%x, irq %d", dev_name, net_port, net_irq);
+		printk("eth: %s at %x, irq %d", dev_name, net_port, net_irq);
 		if (err) {
 			printk(" not found\n");
 			break;

--- a/elks/arch/i86/drivers/net/wd.c
+++ b/elks/arch/i86/drivers/net/wd.c
@@ -713,7 +713,7 @@ void INITPROC wd_drv_init(void)
 	byte_t *mac_addr = (byte_t *)&netif_stat.mac_addr;
 
 	u = wd_probe();
-	printk("eth: %s at 0x%x, irq %d, ram 0x%x",
+	printk("eth: %s at %x, irq %d, ram %04x",
 		dev_name, net_port, net_irq, net_ram);
 	if (u) {
 		printk(" not found\n");

--- a/elks/fs/inode.c
+++ b/elks/fs/inode.c
@@ -83,7 +83,7 @@ static void list_inode_status(void)
 
     do {
         if (inode->i_count || inode->i_dev || inode->i_dirt) {
-            printk("\n#%2d: dev %D inode %5lu dirty %d count %u", i, inode->i_dev,
+            printk("\n#%2d: dev %p inode %5lu dirty %d count %u", i, inode->i_dev,
                 (unsigned long)inode->i_ino, inode->i_dirt, inode->i_count);
         }
         i++;
@@ -201,7 +201,7 @@ void iput(register struct inode *inode)
 {
     register struct super_operations *sop;
 
-    debug("iput dev %D ino %lu count %d\n",
+    debug("iput dev %p ino %lu count %d\n",
         inode->i_dev, (unsigned long)inode->i_ino, inode->i_count);
     if (inode) {
 	wait_on_inode(inode);
@@ -310,7 +310,7 @@ struct inode *iget(struct super_block *sb, ino_t inr)
     register struct inode *n_ino;
 
     if (!sb) panic("iget sb 0");
-    debug("iget dev %D ino %lu\n", sb->s_dev, (unsigned long)inr);
+    debug("iget dev %p ino %lu\n", sb->s_dev, (unsigned long)inr);
 
     n_ino = NULL;
     goto start;

--- a/elks/fs/minix/inode.c
+++ b/elks/fs/minix/inode.c
@@ -91,9 +91,9 @@ static struct super_operations minix_sops = {
 static void minix_mount_warning(register struct super_block *sb, const char *prefix)
 {
 	if ((sb->u.minix_sb.s_mount_state & (MINIX_VALID_FS|MINIX_ERROR_FS)) != MINIX_VALID_FS)
-		printk("MINIX-fs: %smounting %s %D, running fsck is recommended.\n", prefix,
+		printk("MINIX-fs: %smounting %s %D, running fsck is recommended\n", prefix,
 	     !(sb->u.minix_sb.s_mount_state & MINIX_VALID_FS) ?
-		 "unchecked file system" : "file system with errors", sb->s_dev);
+		 "unchecked filesystem" : "filesystem with errors", sb->s_dev);
 }
 
 
@@ -143,7 +143,7 @@ struct super_block *minix_read_super(register struct super_block *s, char *data,
 	ms = (struct minix_super_block *) bh->b_data;
 	if (ms->s_magic != MINIX_SUPER_MAGIC) {
 	    if (!silent)
-		printk("VFS: dev %D is not minixfs.\n", dev);
+		printk("VFS: device %D is not minixfs\n", dev);
 	    msgerr = err0;
 	    goto err_read_super_1;
 	}

--- a/elks/fs/super.c
+++ b/elks/fs/super.c
@@ -482,7 +482,7 @@ void mount_root(void)
 	    memcpy(sb->s_mntonname, "/", 2);
 /*	    sb->s_flags = (unsigned short int) root_mountflags;*/
 	    current->fs.pwd = current->fs.root = sb->s_mounted;
-	    printk("VFS: Mounted root %D (%s filesystem)%s.\n", ROOT_DEV,
+	    printk("VFS: Mounted root device %04x (%s filesystem)%s.\n", ROOT_DEV,
 		   fsname[fp->type], (sb->s_flags & MS_RDONLY) ? " readonly" : "");
 	    iput(d_inode);
 	    filp->f_count = 0;

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -178,7 +178,7 @@ static void INITPROC kernel_banner(seg_t start, seg_t end, seg_t init, seg_t ext
     printk("8018X machine, ");
 #endif
 
-    printk("syscaps 0x%x, %uK base ram.\n", sys_caps, SETUP_MEM_KBYTES);
+    printk("syscaps %x, %uK base ram\n", sys_caps, SETUP_MEM_KBYTES);
     printk("ELKS kernel %s (%u text, %u ftext, %u data, %u bss, %u heap)\n",
            system_utsname.release,
            (unsigned)_endtext, (unsigned)_endftext, (unsigned)_enddata,

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -16,7 +16,7 @@
  *              %x/%X   hexadecimal with lower/upper case letters
  *              %#x/%#X hexadecimal using 0x alt prefix
  *              %p/%P   pointer - same as %04x/%04X respectively
- *              %D      device name as %#04x
+ *              %D      device name as %04x
  *
  *      All except %% can be followed by a width specifier 1 -> 31 only
  *      and the h/l length specifiers also work where appropriate.
@@ -190,7 +190,6 @@ static void vprintk(const char *fmt, va_list p)
                 break;
             case 'D':
                 c += 'X' - 'D';
-                alt = 1;
             case 'P':
             case 'p':
                 c += 'X' - 'P';

--- a/elkscmd/debug/.gitignore
+++ b/elkscmd/debug/.gitignore
@@ -2,4 +2,5 @@
 nm86
 testsym
 disasm
+hostdisasm
 opcodes

--- a/elkscmd/file_utils/.gitignore
+++ b/elkscmd/file_utils/.gitignore
@@ -10,6 +10,7 @@ grep
 l
 ln
 ls
+md5sum
 mkdir
 mkfifo
 mknod

--- a/elkscmd/test/.gitignore
+++ b/elkscmd/test/.gitignore
@@ -1,6 +1,7 @@
 libc/test_libc
 other/test_exit
 other/test_eth
+other/test_float
 other/test_pty
 other/test_select
 other/test_signal


### PR DESCRIPTION
Standardizes some startup kernel messages for consistency.

Don't use `0x` prefix on device numbers, display as 4-digit hex. Com and network I/O ports displayed as 3-digit hex.
Use capital `K` consistently for disk and ram sizes.


Adds parameter passing documentation for `ia16-elf-gcc` and ELKS.
Updates a few `.gitignore` files.

The latest boot screen:

<img width="832" alt="ELKS new boot screen 1" src="https://github.com/ghaerr/elks/assets/11985637/10b824fd-d5ba-4648-9d17-016f9b7ea37d">
