### PR TITLE
[kernel] Show open filenames with ^N kernel inode listing

### DIFF
--- a/elks/fs/inode.c
+++ b/elks/fs/inode.c
@@ -83,8 +83,10 @@ static void list_inode_status(void)
 
     do {
         if (inode->i_count || inode->i_dev || inode->i_dirt) {
-            printk("\n#%2d: dev %p inode %5lu dirty %d count %u", i, inode->i_dev,
-                (unsigned long)inode->i_ino, inode->i_dirt, inode->i_count);
+            inode->i_path[sizeof(inode->i_path)-1] = '\0';
+            printk("\n#%2d: dev %p inode %5lu dirty %d count %u %s", i, inode->i_dev,
+                (unsigned long)inode->i_ino, inode->i_dirt, inode->i_count,
+                inode->i_path);
         }
         i++;
         if (inode->i_count) inuse++;

--- a/elks/fs/namei.c
+++ b/elks/fs/namei.c
@@ -387,6 +387,12 @@ int open_namei(const char *pathname, int flag, int mode,
 	    put_write_access(inode);
 	}
 	*res_inode = inode;
+
+#ifdef CHECK_FREECNTS
+        fmemcpyb(inode->i_path, kernel_ds, (void *)pathname, current->t_regs.ds,
+            sizeof(inode->i_path));
+#endif
+
     } else iput(inode);
 #undef inode
 

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -8,6 +8,7 @@
 #ifdef __KERNEL__
 
 #include <linuxmt/config.h>
+#include <linuxmt/trace.h>
 #include <linuxmt/types.h>
 #include <linuxmt/wait.h>
 #include <linuxmt/kdev_t.h>
@@ -227,6 +228,9 @@ struct inode {
 #endif
                 void * generic_i;
     } u;
+#ifdef CHECK_FREECNTS
+    char                        i_path[16];
+#endif
 };
 
 struct file {


### PR DESCRIPTION
The kernel's in-use inode table now displays the associated pathnames for better understanding of the system:
```
# 7: dev 0380 inode   154 dirty 0 count 2 
#10: dev 0380 inode    76 dirty 0 count 2 /bin/sh
#28: dev 0380 inode   360 dirty 0 count 1 /dev/tty1
#30: dev 0380 inode   146 dirty 0 count 1 /etc/inittab
#60: dev 0380 inode   369 dirty 0 count 1 /dev/ttyS0
#91: dev 0380 inode    11 dirty 0 count 1 /bin/init
#94: dev 0380 inode     1 dirty 0 count 6 
Total inodes inuse 7/96 (89 free)
```
If a pathname is not shown (as in inode 154 above), `fsck -flvv /dev/fd0 | grep 154` can be used to find it.

The ^N inode table display becomes operational when the system is compiled with CONFIG_TRACE=y.