### PR TITLE
[kernel] Improve ^N system inode status listing

### DIFF
--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -83,8 +83,8 @@ static int lastL1map;
 static int xms_enabled;
 static int map_count, remap_count, unmap_count;
 
-#ifdef CHECK_FREECNTS
 static int nr_free_bh, nr_bh;
+#ifdef CHECK_FREECNTS
 #define DCR_COUNT(bh) if(!(--bh->b_count))nr_free_bh++
 #define INR_COUNT(bh) if(!(bh->b_count++))nr_free_bh--
 #define CLR_COUNT(bh) if(bh->b_count)nr_free_bh++
@@ -209,8 +209,8 @@ int INITPROC buffer_init(void)
     int bufs_to_alloc = nr_map_bufs;
 #endif
 
-#ifdef CHECK_FREECNTS
     nr_bh = nr_free_bh = bufs_to_alloc;
+#if defined(CHECK_FREECNTS) && DEBUG_EVENT
     debug_setcallback(1, list_buffer_status);   /* ^O will generate buffer list */
 #endif
 

--- a/elks/fs/inode.c
+++ b/elks/fs/inode.c
@@ -84,9 +84,9 @@ static void list_inode_status(void)
     do {
         if (inode->i_count || inode->i_dev || inode->i_dirt) {
             inode->i_path[sizeof(inode->i_path)-1] = '\0';
-            printk("\n#%2d: dev %p inode %5lu dirty %d count %u %s", i, inode->i_dev,
-                (unsigned long)inode->i_ino, inode->i_dirt, inode->i_count,
-                inode->i_path);
+            printk("\n#%2d: dev %p inode %5lu cnt %2d %c %06o %s", i, inode->i_dev,
+                (unsigned long)inode->i_ino, inode->i_count, inode->i_dirt? 'D':' ',
+                inode->i_mode, S_ISSOCK(inode->i_mode)? " [socket]": inode->i_path);
         }
         i++;
         if (inode->i_count) inuse++;
@@ -103,7 +103,7 @@ void INITPROC inode_init(void)
 	inode->i_next = inode->i_prev = inode;
 	put_last_lru(inode);
     } while (++inode < &inode_block[NR_INODE]);
-#ifdef CHECK_FREECNTS
+#if defined(CHECK_FREECNTS) && DEBUG_EVENT
     debug_setcallback(0, list_inode_status);    /* ^N will generate inode list */
 #endif
 }

--- a/elks/fs/namei.c
+++ b/elks/fs/namei.c
@@ -212,6 +212,16 @@ static int dir_namei(const char *pathname, size_t * namelen,
     return error;
 }
 
+/* saves path for list_inode_status */
+static void save_path(struct inode *inode, const char *pathname)
+{
+#ifdef CHECK_FREECNTS
+    if (!inode->i_path[0])
+        fmemcpyb(inode->i_path, kernel_ds, (void *)pathname, current->t_regs.ds,
+            sizeof(inode->i_path));
+#endif
+}
+
 /*
  *	_namei()
  *
@@ -244,6 +254,7 @@ int _namei(const char *pathname, register struct inode *base, int follow_links,
 	    } else
 		iput(base);
 	    *res_inode = inode;
+            save_path(inode, pathname);
 	} else
 	    iput(base);
     }
@@ -387,11 +398,7 @@ int open_namei(const char *pathname, int flag, int mode,
 	    put_write_access(inode);
 	}
 	*res_inode = inode;
-
-#ifdef CHECK_FREECNTS
-        fmemcpyb(inode->i_path, kernel_ds, (void *)pathname, current->t_regs.ds,
-            sizeof(inode->i_path));
-#endif
+        save_path(inode, pathname);
 
     } else iput(inode);
 #undef inode


### PR DESCRIPTION
Improves display of system inode table displayed by ^N when CONFIG_TRACE=y. Now shows more accurate pathname info as well as socket status.

Here's a listing with networking running along with two `telnet localhost` connections and a `cat > file` running:
```
# 1: dev 0380 inode     9 cnt  1   100755 /bin/cat
# 3: dev 0380 inode   378 cnt  1 D 100644 
# 6: dev 0380 inode   154 cnt 11 D 040755 /root
# 9: dev 0380 inode    76 cnt  3   100755 /bin/sh
#15: dev 0380 inode   364 cnt  1   020644 /dev/ttyp1
#17: dev 0380 inode   357 cnt  1   020644 /dev/ptyp1
#19: dev 0380 inode   356 cnt  1   020644 /dev/ptyp0
#21: dev 0000 inode     0 cnt  1   140000  [socket]
#22: dev 0000 inode     0 cnt  2   140000  [socket]
#23: dev 0380 inode   130 cnt  2   100755 /bin/telnet
#33: dev 0380 inode   363 cnt  1   020644 /dev/ttyp0
#36: dev 0000 inode     0 cnt  2   140000  [socket]
#37: dev 0000 inode     0 cnt  2   140000  [socket]
#41: dev 0000 inode     0 cnt  1   140000  [socket]
#42: dev 0380 inode   368 cnt  3   020600 /dev/console
#44: dev 0000 inode     0 cnt  2   140000  [socket]
#45: dev 0380 inode    84 cnt  1   100755 /bin/ftpd
#49: dev 0000 inode     0 cnt  2   140000  [socket]
#51: dev 0000 inode     0 cnt  2   140000  [socket]
#52: dev 0380 inode    53 cnt  3   100755 /bin/telnetd
#57: dev 0380 inode   375 cnt  1   020644 /dev/ne0
#59: dev 0380 inode   374 cnt  1   020644 /dev/tcpdev
#61: dev 0380 inode   134 cnt  1   100755 /bin/ktcp
#90: dev 0380 inode    98 cnt  1   100755 /bin/getty
#92: dev 0380 inode   369 cnt  1   020644 /dev/ttyS0
#93: dev 0380 inode   360 cnt  1   020644 /dev/tty1
#94: dev 0380 inode   146 cnt  1   100644 /etc/inittab
#95: dev 0380 inode    11 cnt  1   100755 /bin/init
#96: dev 0380 inode     1 cnt 17   040755 
Total inodes inuse 29/96 (67 free)
```
"Dirty" (modified and unwritten) inodes show the letter `D` in the listing.