### PR TITLE
[cmds] Speed up 'sl' - let her rip full speed

### DIFF
--- a/elkscmd/tui/sl.c
+++ b/elkscmd/tui/sl.c
@@ -60,8 +60,10 @@ int my_mvaddstr(int y, int x, char *str)
 {
     for ( ; x < 0; ++x, ++str)
         if (*str == '\0')  return ERR;
-    for ( ; *str != '\0'; ++str, ++x)
+    for ( ; *str != '\0'; ++str, ++x) {
+        if (x >= COLS) continue;
         if (mvaddch(y, x, *str) == ERR)  return ERR;
+    }
     return OK;
 }
 
@@ -107,11 +109,10 @@ int main(int argc, char *argv[])
         else {
             if (add_D51(x) == ERR) break;
         }
-        //getch();
         refresh();
-        usleep(40000);
+        //usleep(40000);
     }
-    mvcur(0, COLS - 1, LINES - 1, 0);
+    mvcur(0, COLS - 1, LINES - 2, 0);
     endwin();
 
     return 0;

--- a/elkscmd/tui/sl.c
+++ b/elkscmd/tui/sl.c
@@ -61,7 +61,7 @@ int my_mvaddstr(int y, int x, char *str)
     for ( ; x < 0; ++x, ++str)
         if (*str == '\0')  return ERR;
     for ( ; *str != '\0'; ++str, ++x) {
-        if (x >= COLS) continue;
+        if (x >= COLS) break;
         if (mvaddch(y, x, *str) == ERR)  return ERR;
     }
     return OK;


### PR DESCRIPTION
Attempts at "fixing" `sl` on very slow (8088) systems: discussed in https://github.com/ghaerr/elks/issues/1619#issuecomment-1712082339.

`sl` used to cursor position off the screen and continue to draw the entire train. All this output would all appear in the last screen column since an ANSI terminal clips cursor moves to the screen. On faster systems, such drawing wouldn't even be noticeable. Now, portions of the train not on the screen aren't drawn.

After each column of the train was drawn, `sl` would wait 40ms. On very fast systems, this slowed the train down as drawing was extremely quick. On slow systems, this had the effect of slowing the drawing down further. For the time being, this wait is turned off, pending @Vutshi's testing on the Book 8088 and Schneider systems. The proper fix involves timing each column display with millisecond accuracy, and only adding a delay for drawing that takes less than 40ms per cycle.



