### PR TITLE
[kernel] Speed up TTY output processing

### DIFF
--- a/elks/fs/read_write.c
+++ b/elks/fs/read_write.c
@@ -90,7 +90,7 @@ int sys_read(unsigned int fd, char *buf, size_t count)
 	fop = file->f_op;
 	if (fop->read) {
 	    retval = (int) fop->read(file->f_inode, file, buf, count);
-	    schedule();
+	    schedule();         // FIXME removing these slows down localhost networking
 	}
     }
     return retval;
@@ -129,7 +129,7 @@ int sys_write(unsigned int fd, char *buf, size_t count)
 
 	    }
 	    written = (int) fop->write(inode, file, buf, count);
-	    schedule();         // FIXME should this be here?
+	    schedule();         // FIXME removing these slows down localhost networking
 	}
     }
     return written;

--- a/elks/include/linuxmt/chqueue.h
+++ b/elks/include/linuxmt/chqueue.h
@@ -1,7 +1,7 @@
-/* chqueue.h (C) 1997 Chad Page, rewritten Greg Haerr Oct 2020 */
-
 #ifndef __LINUXMT_CHQ_H
 #define __LINUXMT_CHQ_H
+
+/* chqueue.h (C) 1997 Chad Page, rewritten Greg Haerr Oct 2020 */
 
 struct ch_queue {
     unsigned char	*base;
@@ -11,15 +11,12 @@ struct ch_queue {
 };
 
 extern void chq_init(register struct ch_queue *,unsigned char *,int);
-/*extern void chq_erase(register struct ch_queue *);*/
 extern int chq_wait_wr(register struct ch_queue *,int);
+extern int chq_wait_rd(register struct ch_queue *,int);
 extern void chq_addch(register struct ch_queue *,unsigned char);
 extern void chq_addch_nowakeup(register struct ch_queue *,unsigned char);
-extern int chq_delch(register struct ch_queue *);
 extern int chq_peekch(register struct ch_queue *);
-/*extern int chq_full(register struct ch_queue *);*/
-
-extern int chq_wait_rd(register struct ch_queue *,int);
 extern int chq_getch(register struct ch_queue *);
+/*extern int chq_full(register struct ch_queue *);*/
 
 #endif


### PR DESCRIPTION
Tested on QEMU, this increases `sl` output by 25-50% on already fast systems. Discussed in https://github.com/ghaerr/elks/issues/1619#issuecomment-1712385485.

It seems @Vutshi has a knack for finding deep rabbit holes. Using the operation of `sl`, testing has found that the output speed varies considerably, based on something I can't pinpoint. I've looked at the scheduler, kernel timers, serial console, and all seem operating correctly. What is being observed is that (especially with this enhancement) `sl` runs fast ~0.45 seconds on QEMU on boot (from ~0.73s - 1.0s before). But after running networking, then stopping it, or running /bin/getty on a serial line, then stopping it, or even just typing ^D a few times to login: on serial, the `sl` output time increases 50% to 0.73s or more, then sometimes drops back to speedy again.

This needs testing on real hardware - I'm very interested to learn how much quicker this change gets us, as well as any slowdowns seen when `init 3` is run opening a /bin/getty on /dev/ttyS0. 