### PR TITLE
[kernel] Fix to allow booting 2.88M floppy on dosbox

### DIFF
--- a/elks/arch/i86/drivers/block/bios.c
+++ b/elks/arch/i86/drivers/block/bios.c
@@ -225,38 +225,28 @@ int INITPROC bios_gethdinfo(struct drive_infot *drivep) {
 #endif
 
 #ifdef CONFIG_BLK_DEV_BFD_HARD
-/* hard-coded floppy configuration*/
 int INITPROC bios_getfdinfo(struct drive_infot *drivep)
 {
-/* Set this to match your system. Currently it's set to a two drive system:
+/*
+ * Hard-coded floppy configuration
+ * Set below to match your system. For IBM PC, it's set to a two drive system:
  *
  *              720KB as /dev/fd0
  *      and     720KB as /dev/fd1
  *
- * ndrives is number of drives in your system (either 0, 1 or 2)
- */
-
-    int ndrives = FD_DRIVES;
-
-/* drive_info[] should be set *only* for existing drives;
- * comment out drive_info lines if you don't need them
- * (e.g. you have less than 2 drives)
- *
- * Use floppy drive type table below:
- *
- *      Type    Format
- *      ~~~~    ~~~~~~
+ * Drive Type   Format
+ *      ~~~~~   ~~~~~~
  *        0     360 KB
  *        1     1.2 MB
  *        2     720 KB
  *        3     1.44 MB
- *        4     1.232 MB (PC/98 1K sectors)
- *        5     2.88 MB
- *
- * Warning: drive will be reported as 2880 KB at bootup if you've set it
- * as unknown (4). Floppy probe will detect correct floppy format at each
- * change so don't bother with that
+ *        4     2.88 MB (QEMU)
+ *        5     2.88 MB (Dosbox)
+ *        6     1.232 MB (PC/98 1K sectors)
+ * ndrives is number of drives in your system (either 0, 1 or 2)
  */
+
+    int ndrives = FD_DRIVES;
 
 #ifdef CONFIG_ARCH_PC98
 #if defined(CONFIG_IMG_FD1232)
@@ -264,11 +254,11 @@ int INITPROC bios_getfdinfo(struct drive_infot *drivep)
     drivep[1] = fd_types[FD1232];
     drivep[2] = fd_types[FD1232];
     drivep[3] = fd_types[FD1232];
-#elif defined(CONFIG_IMG_FD1440)
+#else
     drivep[0] = fd_types[FD1440];
     drivep[1] = fd_types[FD1440];
     drivep[2] = fd_types[FD1440];
-    drivep[FD1440] = fd_types[FD1440];
+    drivep[3] = fd_types[FD1440];
 #endif
 #endif
 

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -364,7 +364,7 @@ void INITPROC bioshd_init(void)
     /* FIXME perhaps remove for speed on floppy boot*/
     outb_p(0x0C, FDC_DOR);      /* FD motors off, enable IRQ and DMA*/
 
-#ifdef CONFIG_BLK_DEV_BFD
+#if defined(CONFIG_BLK_DEV_BFD) || defined(CONFIG_BLK_DEV_BFD_HARD)
     fd_count = bios_getfdinfo(&drive_info[DRIVE_FD0]);
 #endif
 #ifdef CONFIG_BLK_DEV_BHD

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -53,6 +53,7 @@
 #include <arch/system.h>
 #include <arch/irq.h>
 #include <arch/ports.h>
+#include "bioshd.h"
 
 #define PER_DRIVE_INFO  1       /* =1 for per-line display of drive info at init */
 #define DEBUG_PROBE     0       /* =1 to display more floppy probing information */
@@ -60,21 +61,6 @@
 #define FULL_TRACK      0       /* =1 to read full tracks when track caching */
 //#define IODELAY       5       /* times 10ms, emulated delay for floppy on QEMU */
 #define MAX_ERRS        5       /* maximum sector read/write error retries */
-
-/* the following must match with /dev minor numbering scheme*/
-#define NUM_MINOR       8       /* max minor devices per drive*/
-#define MINOR_SHIFT     3       /* =log2(NUM_MINOR) shift to get drive num*/
-#define MAX_DRIVES      8       /* <=256/NUM_MINOR*/
-#define DRIVE_HD0       0
-#define DRIVE_FD0       4       /* =MAX_DRIVES/2 first floppy drive*/
-
-#define HD_DRIVES       4       /* max hard drives */
-#ifdef CONFIG_ARCH_PC98
-#define FD_DRIVES       4
-#else
-#define FD_DRIVES       2       /* max floppy drives */
-#endif
-#define NUM_DRIVES      (HD_DRIVES+FD_DRIVES) /* max number of drives (<=256/NUM_MINOR) */
 
 #define MAJOR_NR        BIOSHD_MAJOR
 #define BIOSDISK

--- a/elks/arch/i86/drivers/block/bioshd.h
+++ b/elks/arch/i86/drivers/block/bioshd.h
@@ -1,0 +1,19 @@
+#ifndef _BIOSHD_H
+#define _BIOSHD_H
+
+/* the following must match with /dev minor numbering scheme*/
+#define NUM_MINOR       8       /* max minor devices per drive*/
+#define MINOR_SHIFT     3       /* =log2(NUM_MINOR) shift to get drive num*/
+#define MAX_DRIVES      8       /* <=256/NUM_MINOR*/
+#define DRIVE_HD0       0
+#define DRIVE_FD0       4       /* =MAX_DRIVES/2 first floppy drive*/
+
+#define HD_DRIVES       4       /* max hard drives */
+#ifdef CONFIG_ARCH_PC98
+#define FD_DRIVES       4
+#else
+#define FD_DRIVES       2       /* max floppy drives */
+#endif
+#define NUM_DRIVES      (HD_DRIVES+FD_DRIVES) /* max number of drives (<=256/NUM_MINOR) */
+
+#endif

--- a/elks/kernel/sched.c
+++ b/elks/kernel/sched.c
@@ -71,7 +71,7 @@ void schedule(void)
     prev = current;
 
 #ifdef CHECK_SCHED
-    if (intr_count > 0) {
+    if (intr_count) {
         /* Taking a timer IRQ during another IRQ or while in kernel space is
          * quite legal. We just dont switch then */
          panic("SCHED: schedule() called from interrupt, intr_count %d", intr_count);


### PR DESCRIPTION
Testing with `dosbox` revealed ELKS didn't support Dosbox's drive type return value in BL for INT 13h AH=8 (Get Drive Parms). Interestingly, QEMU returns BL=5 for 2880k floppies and DosBox returns BL=6. So we now support both.

Tested on QEMU and Dosbox for IBM PC and PC/98.

