### PR TITLE
[kernel] Cleanup block driver blk_size code

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -86,7 +86,6 @@ struct drive_infot *last_drive;         /* set to last drivep-> used in read/wri
 extern struct drive_infot fd_types[];   /* BIOS floppy formats */
 
 static struct hd_struct hd[NUM_DRIVES << MINOR_SHIFT];  /* partitions start, size*/
-//static int hd_sizes[NUM_DRIVES << MINOR_SHIFT];       /* used only with BDEV_SIZE_CHK*/
 
 static int bioshd_open(struct inode *, struct file *);
 static void bioshd_release(struct inode *, struct file *);
@@ -101,7 +100,6 @@ static struct gendisk bioshd_gendisk = {
     NUM_DRIVES,                 /* maximum number of drives */
     bioshd_geninit,             /* init function */
     hd,                         /* hd struct */
-    0,//hd_sizes,               /* sizes not blocksizes */
     0,                          /* hd drives found */
     drive_info,
     NULL                        /* next */
@@ -715,7 +713,7 @@ next_block:
         start = req->rq_sector;
 
         if (hd[minor].start_sect == -1U || start >= hd[minor].nr_sects) {
-            printk("bioshd: bad partition start=%ld sect=%ld nr_sects=%ld.\n",
+            printk("bioshd: sector %ld access beyond partition (%ld,%ld)\n",
                 start, hd[minor].start_sect, hd[minor].nr_sects);
             end_request(0);
             continue;

--- a/elks/arch/i86/drivers/block/directhd.c
+++ b/elks/arch/i86/drivers/block/directhd.c
@@ -64,7 +64,6 @@ static struct drive_infot {
 } drive_info[4] = { 0, };	/* preset to 0 */
 
 static struct hd_struct hd[4 << 6];
-static int directhd_sizes[4 << 6] = { 0, };
 static void directhd_geninit();
 
 static struct gendisk directhd_gendisk = {
@@ -75,7 +74,6 @@ static struct gendisk directhd_gendisk = {
     4,
     directhd_geninit,		/* init */
     hd,				/* hd struct */
-    directhd_sizes,		/* drive sizes */
     0,
     drive_info,
     NULL

--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -254,7 +254,9 @@ out:
              * be able to bread the block containing the extended
              * partition info.
              */
-            hd->sizes[minor] = (int) (hdp->nr_sects >> (BLOCK_SIZE_BITS - 9));
+#if UNUSED
+            hd->sizes[minor] = hdp->nr_sects >> (BLOCK_SIZE_BITS - 9);
+#endif
             extended_partition(hd, MKDEV(hd->major, minor));
             printk(" >");
             /* prevent someone doing mkfs on an
@@ -276,7 +278,8 @@ out:
             if (!START_SECT_PC98(p98))
                 continue;
 
-            add_partition(hd, minor, first_sector + START_SECT_PC98(p98), NR_SECTS_PC98(p98));
+            add_partition(hd, minor, first_sector + START_SECT_PC98(p98),
+                NR_SECTS_PC98(p98));
         }
     }
 #endif
@@ -337,19 +340,15 @@ void resetup_one_dev(struct gendisk *dev, int drive)
 
 void INITPROC setup_dev(register struct gendisk *dev)
 {
-#ifdef BDEV_SIZE_CHK
-        blk_size[dev->major] = NULL;
-#endif
-
-        //memset((void *)dev->part, 0, sizeof(struct hd_struct)*dev->max_nr*dev->max_p);
-        dev->init(dev);
+    //memset((void *)dev->part, 0, sizeof(struct hd_struct)*dev->max_nr*dev->max_p);
+    dev->init();
 
 #ifdef CONFIG_BLK_DEV_BHD
-        for (int i = 0; i < dev->nr_hd; i++) {
-                unsigned int first_minor = i << dev->minor_shift;
-                current_minor = first_minor + 1;
-                check_partition(dev, MKDEV(dev->major, first_minor));
-        }
+    for (int i = 0; i < dev->nr_hd; i++) {
+        unsigned int first_minor = i << dev->minor_shift;
+        current_minor = first_minor + 1;
+        check_partition(dev, MKDEV(dev->major, first_minor));
+    }
 #endif
 
 }

--- a/elks/arch/i86/drivers/block/ll_rw_blk.c
+++ b/elks/arch/i86/drivers/block/ll_rw_blk.c
@@ -41,19 +41,6 @@ static struct request all_requests[NR_REQUEST];
 /* current request and function pointer for each block device handler */
 struct blk_dev_struct blk_dev[MAX_BLKDEV];      /* initialized by blk_dev_init() */
 
-/*
- * blk_size contains the size of all block-devices in units of 1024 byte
- * sectors:
- *
- * blk_size[MAJOR][MINOR]
- *
- * if (!blk_size[MAJOR]) then no minor size checking is done.
- */
-
-#ifdef BDEV_SIZE_CHK
-int *blk_size[MAX_BLKDEV] = { NULL, NULL, };
-#endif
-
 /* return hardware sector size for passed device */
 int get_sector_size(kdev_t dev)
 {
@@ -185,18 +172,8 @@ static void make_request(unsigned short major, int rw, struct buffer_head *bh)
     struct request *req;
     int max_req;
 
-    //debug_blk("BLK %lu %s %lx:%x\n", buffer_blocknr(bh), rw==READ? "read": "write",
-        //(unsigned long)buffer_seg(bh), buffer_data(bh));
-
-#ifdef BDEV_SIZE_CHK
-    sector_t count = BLOCK_SIZE / SECTOR_SIZE;  /* FIXME must move to lower level*/
-    sector_t sector = buffer_blocknr(bh) * count;
-    if (blk_size[major])
-        if (blk_size[major][MINOR(buffer_dev(bh))] < (sector + count) >> 1) {
-            printk("attempt to access beyond end of device\n");
-            return;
-        }
-#endif
+    debug("BLK %lu %s %lx:%x\n", buffer_blocknr(bh), rw==READ? "read": "write",
+        (unsigned long)buffer_seg(bh), buffer_data(bh));
 
     /* Uhhuh.. Nasty dead-lock possible here.. */
     if (EBH(bh)->b_locked)

--- a/elks/arch/i86/drivers/block/rd.c
+++ b/elks/arch/i86/drivers/block/rd.c
@@ -239,8 +239,8 @@ static void do_rd_request(void)
 	debug("RD: %s dev %d sector %d, ", req->rq_cmd == READ? "read": "write",
 		target, start);
 	if (drive_info[target].valid == 0 || start >= drive_info[target].size) {
-	    debug("RD: bad request on ram%d, size %d, sector %d\n",
-		 target, drive_info[target].size, start);
+	    debug("rd%d: sector %d beyond max %d\n",
+		 target, start, drive_info[target].size);
 	    end_request(0);
 	    continue;
 	}

--- a/elks/arch/i86/drivers/block/ssd.c
+++ b/elks/arch/i86/drivers/block/ssd.c
@@ -112,10 +112,9 @@ void ssd_io_complete(void)
         buf = req->rq_buffer;
         start = req->rq_sector;
 
-        // FIXME move max sector check to to ll_rw_blk level
-        if (start >= (NUM_SECTS-1)) {
-            printk("SSD: bad request sector %lu count %d cmd %d\n", start,
-                req->rq_nr_sectors, req->rq_cmd);
+        if (start + req->rq_nr_sectors >= NUM_SECTS) {
+            printk("ssd: sector %lu+%d beyond max %lu\n", start,
+                req->rq_nr_sectors, NUM_SECTS);
             end_request(0);
             continue;
         }

--- a/elks/include/linuxmt/genhd.h
+++ b/elks/include/linuxmt/genhd.h
@@ -73,9 +73,8 @@ struct gendisk
     int minor_shift;            /* number of times minor is shifted to get real minor */
     int max_p;                  /* maximum partitions per device */
     int max_nr;                 /* maximum number of real devices */
-    void (*init) ();            /* Initialization called before we do our thing */
+    void (*init)(void);         /* Initialization called before we do our thing */
     struct hd_struct *part;     /* partition table */
-    int *sizes;                 /* device size in blocks, copied to blk_size[] */
     int nr_hd;                  /* number of hard drives */
     struct drive_infot *drive_info;
     struct gendisk *next;


### PR DESCRIPTION
Adds better display error if accessing off end of partition attempted.

Fixes potential data corruption when accessing extended partitions (needs testing).

Removes unused ifdef BDEV_SIZE_CHK code.
