### PR TITLE
[build] Update ELKS version to 0.8.0-dev

### DIFF
--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -55,10 +55,10 @@ include $(TOPDIR)/Make.defs
 #########################################################################
 # State the current version of this system.
 
-VERSION 	= 0	# (0-255)
-PATCHLEVEL	= 7	# (0-255)
-SUBLEVEL	= 0	# (0-255)
-PRE		= 0
+VERSION     = 0	# (0-255)
+PATCHLEVEL  = 8	# (0-255)
+SUBLEVEL    = 0	# (0-255)
+PRE         = -dev
 
 #########################################################################
 # Specify the architecture we will use.
@@ -77,14 +77,14 @@ TARGET_NB_IMAGE	= $(TOPDIR)/elks/nbImage
 #########################################################################
 # Define variables directly dependant on the current version number.
 
-ifeq ($(PRE), 0)
+ifeq ($(PRE), )
 
 DIST		= $(shell printf '%u.%u.%u' \
 			$(VERSION) $(PATCHLEVEL) $(SUBLEVEL))
 
 else
 
-DIST		= $(shell printf '%u.%u.%u-pre%u' \
+DIST		= $(shell printf '%u.%u.%u%s' \
 			$(VERSION) $(PATCHLEVEL) $(SUBLEVEL) $(PRE))
 
 endif

--- a/image/ver.pl
+++ b/image/ver.pl
@@ -2,10 +2,10 @@
 #Get the version from the kernel makefile
 
 while (<>) {
-        /^\s*VERSION\s*=\s*(\d+)/	&& ($ver = $1);
-        /^\s*PATCHLEVEL\s*=\s*(\d+)/	&& ($pat = $1);
-        /^\s*SUBLEVEL\s*=\s*(\d+)/	&& ($sub = $1);
-        /^\s*EXTRAVERSION\s*=\s*(.*)/	&& ($ext = $1);
+        /^\s*VERSION\s*=\s*(\d+)/       && ($ver = $1);
+        /^\s*PATCHLEVEL\s*=\s*(\d+)/    && ($pat = $1);
+        /^\s*SUBLEVEL\s*=\s*(\d+)/      && ($sub = $1);
+        /^\s*PRE\s*=\s*(.*)/            && ($pre = $1);
 }
 
-print "\nELKS ${ver}.${pat}.${sub}${ext}\n\n";
+print "\nELKS ${ver}.${pat}.${sub}${pre}\n\n";


### PR DESCRIPTION
This turned out easier than expected; ELKS will now display `ELKS 0.8.0-dev` on boot and can be easily updated by editing `elks/Makefile-rules`.