### PR TITLE
[cmds] Enable more to recognize line wrapping

### DIFF
--- a/elkscmd/file_utils/more.c
+++ b/elkscmd/file_utils/more.c
@@ -232,7 +232,7 @@ int main(int argc, char **argv)
 			}
 
 			putchar(ch);
-#if 0
+#if 1
 			if (col >= 80) {
 				col -= 80;
 				line++;


### PR DESCRIPTION
Needed for running things like `fsck -flvv /dev/fd0 | more`.