### PR TITLE
[build] Reformat Applications file

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -1,5 +1,5 @@
 # ELKSCMD Application Installation Table
-#	3/13/20 Greg Haerr
+#   3/13/20 Greg Haerr
 #
 # This file is used to specify when each application in elkscmd/ should
 # be installed to $(DESTDIR).
@@ -16,198 +16,198 @@
 #
 # Following are the current ELKS application packages and description,
 # see Make.install for more details.
-#	Tag			Description									Directory
-#	--------	-----------------------------------------	-----------
-#	:boot		Required for ELKS to boot
-#	:128k		Minimal set of apps to fit on 128k rom image
-#	:192k		Additional apps to fit on 192k rom image
-#	:360k		Minimal set of apps to fit on 360k disks
-#	:720k		Set of apps to fit on 720k disks (includes :net)
-#	:1200k		Set of apps to fit on 1200 disks (almost all of 1440k)
-#	:1440k		All apps selected for 1440k disks
-#	:ash		Ash (bash) shell							ash
-#	:sash		Sash (standalone very small) shell			sash
-#	:defsash	Use sash as default shell                   sash
-#	:sysutil	System utilities							sys_utils
-#	:fileutil	File handling utilies						file_utils
-#	:shutil		Shell utilities								shell_utils
-#	:diskutil	Disk utilities								disk_utils
-#	:miscutil	Miscellaneous utilities						misc_utils
-#	:minix1,2,3	Minix utilities								minix{1,2,3}
+#   Tag         Description                                 Directory
+#   --------    -----------------------------------------   -----------
+#   :boot       Required for ELKS to boot
+#   :128k       Minimal set of apps to fit on 128k rom image
+#   :192k       Additional apps to fit on 192k rom image
+#   :360k       Minimal set of apps to fit on 360k disks
+#   :720k       Set of apps to fit on 720k disks (includes :net)
+#   :1200k      Set of apps to fit on 1200 disks (almost all of 1440k)
+#   :1440k      All apps selected for 1440k disks
+#   :ash        Ash (bash) shell                            ash
+#   :sash       Sash (standalone very small) shell          sash
+#   :defsash    Use sash as default shell                   sash
+#   :sysutil    System utilities                            sys_utils
+#   :fileutil   File handling utilies                       file_utils
+#   :shutil     Shell utilities                             shell_utils
+#   :diskutil   Disk utilities                              disk_utils
+#   :miscutil   Miscellaneous utilities                     misc_utils
+#   :minix1,2,3 Minix utilities                             minix{1,2,3}
 #   :tui        Text user interface library programs        tui
-#	:mtools		MSDOS utilities								mtools
-#	:elvis		Elvis vi editor								elvis
-#	:net		Networking apps								ktcp,inet
-#	:nanox		Nano-X graphical apps						nano-X
-#	:other		Other apps
-#	:busyelks	Busyelks									busyelks
-#	:be-*		File created as symlink if busyelks option 'B' set
-#	::path/file	path/file to install file as on $(DESTDIR)
+#   :mtools     MSDOS utilities                             mtools
+#   :elvis      Elvis vi editor                             elvis
+#   :net        Networking apps                             ktcp,inet
+#   :nanox      Nano-X graphical apps                       nano-X
+#   :other      Other apps
+#   :busyelks   Busyelks                                    busyelks
+#   :be-*       File created as symlink if busyelks option 'B' set
+#   ::path/file path/file to install file as on $(DESTDIR)
 # 
-# -------------	----------------------------------------------------------
-sys_utils/init			:boot	:sysutil    :128k
-#sys_utils/min_init ::bin/init :boot	:sysutil    :128k
-sys_utils/getty			:boot	:sysutil    :128k
-sys_utils/login			:boot	:sysutil    :128k
-sash/sash	::bin/sh	    	:defsash	# install as /bin/sh
-ash/ash		::bin/sh	:boot	:ash	    # install as /bin/sh (must follow :defsash)
-sash/sash		    	        :sash                   :1200k  :1440k
-sys_utils/mount			:boot	:sysutil    :128k
-sys_utils/umount		:boot	:sysutil    :128k
-sys_utils/clock			:boot	:sysutil    :128k
-sys_utils/shutdown		:boot	:sysutil    :128k
-sh_utils/uname			:boot	:be-shutil  :128k
-sh_utils/date           :boot	:be-shutil  :128k
-file_utils/cat			:boot	:be-fileutil    :128k
-file_utils/chgrp				:be-fileutil			:1200k	:1440k
-file_utils/chmod				:be-fileutil    :360k
-file_utils/chown				:be-fileutil			:1200k	:1440k
-file_utils/cmp					:be-fileutil			:1200k	:1440k
-file_utils/cp					:be-fileutil	:360k
-file_utils/dd					:be-fileutil			:1200k	:1440k
-file_utils/md5sum				:fileutil
-file_utils/mkdir				:fileutil		:360k
-file_utils/mknod				:fileutil		:360k
-#file_utils/mkfifo				:fileutil				:1200k	:1440k
-file_utils/more					:fileutil		:360k	:128k
-file_utils/mv					:fileutil		:360k
-file_utils/ln					:fileutil			:720k
-file_utils/ls					:fileutil		:360k   :128k
-file_utils/rm					:fileutil		:360k
-file_utils/rmdir				:fileutil		:360k
-file_utils/split				:fileutil		         :1200k
-file_utils/sync					:fileutil		:360k
-file_utils/touch				:fileutil			:720k
-sys_utils/chmem					:sysutil			:720k
-sys_utils/kill					:sysutil			:720k
-sys_utils/ps			:sash	:sysutil		:360k   :128k
+# ------------- ----------------------------------------------------------
+sys_utils/init          :boot   :sysutil    :128k
+#sys_utils/min_init ::bin/init :boot    :sysutil    :128k
+sys_utils/getty         :boot   :sysutil    :128k
+sys_utils/login         :boot   :sysutil    :128k
+sash/sash   ::bin/sh            :defsash    # install as /bin/sh
+ash/ash     ::bin/sh    :boot   :ash        # install as /bin/sh (must follow :defsash)
+sash/sash                       :sash                   :1200k  :1440k
+sys_utils/mount         :boot   :sysutil    :128k
+sys_utils/umount        :boot   :sysutil    :128k
+sys_utils/clock         :boot   :sysutil    :128k
+sys_utils/shutdown      :boot   :sysutil    :128k
+sh_utils/uname          :boot   :be-shutil  :128k
+sh_utils/date           :boot   :be-shutil  :128k
+file_utils/cat          :boot   :be-fileutil    :128k
+file_utils/chgrp                :be-fileutil            :1200k  :1440k
+file_utils/chmod                :be-fileutil    :360k
+file_utils/chown                :be-fileutil            :1200k  :1440k
+file_utils/cmp                  :be-fileutil            :1200k  :1440k
+file_utils/cp                   :be-fileutil    :360k
+file_utils/dd                   :be-fileutil            :1200k  :1440k
+file_utils/md5sum               :fileutil
+file_utils/mkdir                :fileutil       :360k
+file_utils/mknod                :fileutil       :360k
+#file_utils/mkfifo              :fileutil               :1200k  :1440k
+file_utils/more                 :fileutil       :360k   :128k
+file_utils/mv                   :fileutil       :360k
+file_utils/ln                   :fileutil           :720k
+file_utils/ls                   :fileutil       :360k   :128k
+file_utils/rm                   :fileutil       :360k
+file_utils/rmdir                :fileutil       :360k
+file_utils/split                :fileutil                :1200k
+file_utils/sync                 :fileutil       :360k
+file_utils/touch                :fileutil           :720k
+sys_utils/chmem                 :sysutil            :720k
+sys_utils/kill                  :sysutil            :720k
+sys_utils/ps            :sash   :sysutil        :360k   :128k
 sys_utils/ps :::uptime          :sysutil                        :1440k  :128k
-sys_utils/reboot				:sysutil		:360k   :128k
-sys_utils/makeboot				:sysutil		:360k
-sys_utils/man					:sysutil				:1200k	:1440k
-sys_utils/meminfo		:sash	:sysutil		:360k   :128k
-sys_utils/mouse					:sysutil				:1200k	:1440k
-sys_utils/passwd				:sysutil				:1200k	:1440k
-sys_utils/poweroff				:sysutil			:720k
-sys_utils/sercat				:sysutil				:1200k	:1440k
-sys_utils/console				:sysutil				:1200k	:1440k
-#sys_utils/who					:sysutil				:1200k	:1440k
-sys_utils/unreal16				:sysutil
-screen/screen					:screen					:1200k	:1440k
-cron/cron   					:cron					:1200k	:1440k
-cron/crontab   					:cron					:1200k	:1440k
-sh_utils/basename				:be-shutil			:720k
-sh_utils/clear					:shutil					:1200k	:1440k
-sh_utils/dirname				:be-shutil			:720k
-sh_utils/echo			        :be-shutil              :1200k  :1440k
-#sh_utils/test			        :shutil                 :1200k  :1440k
-#sh_utils/false					:be-shutil				:1200k	:1440k
-#sh_utils/true					:be-shutil				:1200k	:1440k
-#sh_utils/logname				:shutil					:1200k	:1440k
-#sh_utils/mesg					:shutil					:1200k	:1440k
-sh_utils/stty					:shutil					:1200k	:1440k  :192k
-sh_utils/printenv				:shutil		    :360k   :128k
-sh_utils/pwd					:shutil			:360k   :128k
-sh_utils/tr						:shutil				:720k
-#sh_utils/which					:shutil					:1200k	:1440k
-#sh_utils/whoami				:shutil					:1200k	:1440k
-sh_utils/xargs					:shutil					:1200k	:1440k
-sh_utils/yes					:shutil				:720k
-misc_utils/compress				:miscutil						:1440k
-misc_utils/miniterm				:miscutil			:720k
-misc_utils/fdtest				:miscutil				:1200k	:1440k
-misc_utils/tar					:miscutil				:1200k	:1440k
-misc_utils/od					:miscutil				:1200k	:1440k
-misc_utils/hd					:miscutil				:1200k	:1440k
-misc_utils/time					:miscutil			:720k
-misc_utils/kilo					:miscutil				:1200k	:1440k
-misc_utils/mined ::bin/edit		:miscutil		:360k	:1200k	:1440k
-misc_utils/sleep				:miscutil				:1200k	:1440k
-misc_utils/tty					:miscutil				:1200k	:1440k
-misc_utils/uuencode				:miscutil				:1200k	:1440k
-misc_utils/uudecode				:miscutil				:1200k	:1440k
-#misc_utils/ed					:be-miscutil		:720k
-elvis/elvis	::bin/vi			:elvis				:720k
-minix1/banner					:minix1					:1200k	:1440k
-#minix1/decomp16				:minix1					:1440k
-#minix1/fgrep					:minix1					:1200k	:1440k
-minix1/grep						:minix1			:360k
-minix1/sum						:minix1					:1200k	:1440k
-minix1/uniq						:minix1				:720k
-minix1/wc						:minix1					:1200k	:1440k
-#minix1/proto					:minix1					:1200k	:1440k
-minix1/cut						:be-minix1			:720k
-#minix1/cksum					:be-minix1				:1200k	:1440k
-minix1/du						:be-minix1				:1200k	:1440k
-#minix2/env						:minix2					:1200k	:1440k
-#minix2/lp						:minix2					:1200k	:1440k
-#minix2/pwdauth					:minix2							:1440k
-minix2/remsync					:other
-minix2/synctree					:other
-#minix2/tget					:minix2							:1440k
-#minix2/man						:minix2					:1200k	:1440k
-minix3/sed						:minix3				:720k
-minix3/file						:minix3				:720k
-minix3/head						:minix3				:720k
-minix3/sort						:minix3				:720k
-minix3/tail						:minix3				:720k
-minix3/tee						:minix3					:1200k	:1440k
-minix3/cal						:be-minix3				:1200k	:1440k
-minix3/diff						:be-minix3			:720k
-minix3/find						:be-minix3			:720k
-minix3/mail						:minix3                         :other
-disk_utils/df					:diskutil       :360k
-disk_utils/fsck					:diskutil		:360k   :1200k	:1440k
-disk_utils/mkfs					:diskutil		:360k
-disk_utils/mkfat				:diskutil		:360k
-disk_utils/partype				:diskutil				:1200k	:1440k
-disk_utils/ramdisk				:diskutil				:1200k	:1440k
-disk_utils/fdisk				:be-diskutil	:360k
+sys_utils/reboot                :sysutil        :360k   :128k
+sys_utils/makeboot              :sysutil        :360k
+sys_utils/man                   :sysutil                :1200k  :1440k
+sys_utils/meminfo       :sash   :sysutil        :360k   :128k
+sys_utils/mouse                 :sysutil                :1200k  :1440k
+sys_utils/passwd                :sysutil                :1200k  :1440k
+sys_utils/poweroff              :sysutil            :720k
+sys_utils/sercat                :sysutil                :1200k  :1440k
+sys_utils/console               :sysutil                :1200k  :1440k
+#sys_utils/who                  :sysutil                :1200k  :1440k
+sys_utils/unreal16              :sysutil
+screen/screen                   :screen                 :1200k  :1440k
+cron/cron                       :cron                   :1200k  :1440k
+cron/crontab                    :cron                   :1200k  :1440k
+sh_utils/basename               :be-shutil          :720k
+sh_utils/clear                  :shutil                 :1200k  :1440k
+sh_utils/dirname                :be-shutil          :720k
+sh_utils/echo                   :be-shutil              :1200k  :1440k
+#sh_utils/test                  :shutil                 :1200k  :1440k
+#sh_utils/false                 :be-shutil              :1200k  :1440k
+#sh_utils/true                  :be-shutil              :1200k  :1440k
+#sh_utils/logname               :shutil                 :1200k  :1440k
+#sh_utils/mesg                  :shutil                 :1200k  :1440k
+sh_utils/stty                   :shutil                 :1200k  :1440k  :192k
+sh_utils/printenv               :shutil         :360k   :128k
+sh_utils/pwd                    :shutil         :360k   :128k
+sh_utils/tr                     :shutil             :720k
+#sh_utils/which                 :shutil                 :1200k  :1440k
+#sh_utils/whoami                :shutil                 :1200k  :1440k
+sh_utils/xargs                  :shutil                 :1200k  :1440k
+sh_utils/yes                    :shutil             :720k
+misc_utils/compress             :miscutil                       :1440k
+misc_utils/miniterm             :miscutil           :720k
+misc_utils/fdtest               :miscutil               :1200k  :1440k
+misc_utils/tar                  :miscutil               :1200k  :1440k
+misc_utils/od                   :miscutil               :1200k  :1440k
+misc_utils/hd                   :miscutil               :1200k  :1440k
+misc_utils/time                 :miscutil           :720k
+misc_utils/kilo                 :miscutil               :1200k  :1440k
+misc_utils/mined ::bin/edit     :miscutil       :360k   :1200k  :1440k
+misc_utils/sleep                :miscutil               :1200k  :1440k
+misc_utils/tty                  :miscutil               :1200k  :1440k
+misc_utils/uuencode             :miscutil               :1200k  :1440k
+misc_utils/uudecode             :miscutil               :1200k  :1440k
+#misc_utils/ed                  :be-miscutil        :720k
+elvis/elvis ::bin/vi            :elvis              :720k
+minix1/banner                   :minix1                 :1200k  :1440k
+#minix1/decomp16                :minix1                 :1440k
+#minix1/fgrep                   :minix1                 :1200k  :1440k
+minix1/grep                     :minix1         :360k
+minix1/sum                      :minix1                 :1200k  :1440k
+minix1/uniq                     :minix1             :720k
+minix1/wc                       :minix1                 :1200k  :1440k
+#minix1/proto                   :minix1                 :1200k  :1440k
+minix1/cut                      :be-minix1          :720k
+#minix1/cksum                   :be-minix1              :1200k  :1440k
+minix1/du                       :be-minix1              :1200k  :1440k
+#minix2/env                     :minix2                 :1200k  :1440k
+#minix2/lp                      :minix2                 :1200k  :1440k
+#minix2/pwdauth                 :minix2                         :1440k
+minix2/remsync                  :other
+minix2/synctree                 :other
+#minix2/tget                    :minix2                         :1440k
+#minix2/man                     :minix2                 :1200k  :1440k
+minix3/sed                      :minix3             :720k
+minix3/file                     :minix3             :720k
+minix3/head                     :minix3             :720k
+minix3/sort                     :minix3             :720k
+minix3/tail                     :minix3             :720k
+minix3/tee                      :minix3                 :1200k  :1440k
+minix3/cal                      :be-minix3              :1200k  :1440k
+minix3/diff                     :be-minix3          :720k
+minix3/find                     :be-minix3          :720k
+minix3/mail                     :minix3                         :other
+disk_utils/df                   :diskutil       :360k
+disk_utils/fsck                 :diskutil       :360k   :1200k  :1440k
+disk_utils/mkfs                 :diskutil       :360k
+disk_utils/mkfat                :diskutil       :360k
+disk_utils/partype              :diskutil               :1200k  :1440k
+disk_utils/ramdisk              :diskutil               :1200k  :1440k
+disk_utils/fdisk                :be-diskutil    :360k
 tui/fm                          :tui                            :1440k
 tui/matrix                      :tui                            :1440k
 tui/cons                        :tui                            :1440k
 tui/ttyinfo                     :tui                            :1440k
 tui/sl                          :tui
-busyelks/busyelks				:busyelks
-inet/httpd/sample_index.html	::var/www/index.html	:net
-ktcp/ktcp						:net
-inet/nettools/netstat			:net
-inet/nettools/nslookup			:net
-inet/nettools/arp				:net
-inet/telnet/telnet				:net
-inet/telnetd/telnetd			:net
-inet/httpd/httpd				:net
-inet/ftp/ftp					:net
-inet/ftp/ftpd					:net
-inet/tinyirc/tinyirc			:other
-inet/urlget/urlget				:net
-inet/urlget/urlget :::ftpget	:net
-inet/urlget/urlget :::ftpput	:net
-inet/urlget/urlget :::httpget	:net
-bc/bc							:other
-test/libc/test_libc				:test
-test/other/test_float			:test
-#nano/nano-2.0.6/src/nano		:other					:1440k
-#mtools/mcopy					:other
-#mtools/mdel					:other
-#mtools/mdir					:other
-#mtools/mkdfs					:other
-#mtools/mmd						:other
-#mtools/mrd						:other
-#mtools/mread					:other
-#mtools/mren					:other
-#mtools/mtype					:other
-#mtools/mwrite					:other
-#m4/m4							:other
-#prems/pres/pres				:other
-nano-X/bin/nxclock				:other
-nano-X/bin/nxdemo				:other
-nano-X/bin/nxtest				:other
-nano-X/bin/nxtetris				:nanox
-nano-X/bin/nxlandmine			:nanox				:1200k
-nano-X/bin/nxterm				:nanox
-nano-X/bin/nxworld				:nanox
-nano-X/bin/nxworld.map	::lib/nxworld.map	:nanox
-basic/basic						:basic              :1200k
-advent/advent					:other
-advent/advent.db	::lib/advent.db	:other
+busyelks/busyelks               :busyelks
+inet/httpd/sample_index.html    ::var/www/index.html    :net
+ktcp/ktcp                       :net
+inet/nettools/netstat           :net
+inet/nettools/nslookup          :net
+inet/nettools/arp               :net
+inet/telnet/telnet              :net
+inet/telnetd/telnetd            :net
+inet/httpd/httpd                :net
+inet/ftp/ftp                    :net
+inet/ftp/ftpd                   :net
+inet/tinyirc/tinyirc            :other
+inet/urlget/urlget              :net
+inet/urlget/urlget :::ftpget    :net
+inet/urlget/urlget :::ftpput    :net
+inet/urlget/urlget :::httpget   :net
+bc/bc                           :other
+test/libc/test_libc             :test
+test/other/test_float           :test
+#nano/nano-2.0.6/src/nano       :other                  :1440k
+#mtools/mcopy                   :other
+#mtools/mdel                    :other
+#mtools/mdir                    :other
+#mtools/mkdfs                   :other
+#mtools/mmd                     :other
+#mtools/mrd                     :other
+#mtools/mread                   :other
+#mtools/mren                    :other
+#mtools/mtype                   :other
+#mtools/mwrite                  :other
+#m4/m4                          :other
+#prems/pres/pres                :other
+nano-X/bin/nxclock              :other
+nano-X/bin/nxdemo               :other
+nano-X/bin/nxtest               :other
+nano-X/bin/nxtetris             :nanox
+nano-X/bin/nxlandmine           :nanox              :1200k
+nano-X/bin/nxterm               :nanox
+nano-X/bin/nxworld              :nanox
+nano-X/bin/nxworld.map  ::lib/nxworld.map   :nanox
+basic/basic                     :basic              :1200k
+advent/advent                   :other
+advent/advent.db    ::lib/advent.db :other

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -24,7 +24,7 @@
 #   :360k       Minimal set of apps to fit on 360k disks
 #   :720k       Set of apps to fit on 720k disks (includes :net)
 #   :1200k      Set of apps to fit on 1200 disks (almost all of 1440k)
-#   :1440k      All apps selected for 1440k disks
+#   :1440k      Set of apps to fit on 1440k disks
 #   :ash        Ash (bash) shell                            ash
 #   :sash       Sash (standalone very small) shell          sash
 #   :defsash    Use sash as default shell                   sash
@@ -46,33 +46,33 @@
 # 
 # ------------- ----------------------------------------------------------
 sys_utils/init          :boot   :sysutil    :128k
-#sys_utils/min_init ::bin/init :boot    :sysutil    :128k
+#sys_utils/min_init ::bin/init :boot :sysutil :128k
 sys_utils/getty         :boot   :sysutil    :128k
 sys_utils/login         :boot   :sysutil    :128k
 sash/sash   ::bin/sh            :defsash    # install as /bin/sh
 ash/ash     ::bin/sh    :boot   :ash        # install as /bin/sh (must follow :defsash)
-sash/sash                       :sash                   :1200k  :1440k
+sash/sash                       :sash                   :1200k
 sys_utils/mount         :boot   :sysutil    :128k
 sys_utils/umount        :boot   :sysutil    :128k
 sys_utils/clock         :boot   :sysutil    :128k
 sys_utils/shutdown      :boot   :sysutil    :128k
 sh_utils/uname          :boot   :be-shutil  :128k
 sh_utils/date           :boot   :be-shutil  :128k
-file_utils/cat          :boot   :be-fileutil    :128k
-file_utils/chgrp                :be-fileutil            :1200k  :1440k
+file_utils/cat          :boot   :be-fileutil :128k
+file_utils/chgrp                :be-fileutil            :1200k
 file_utils/chmod                :be-fileutil    :360k
-file_utils/chown                :be-fileutil            :1200k  :1440k
-file_utils/cmp                  :be-fileutil            :1200k  :1440k
+file_utils/chown                :be-fileutil            :1200k
+file_utils/cmp                  :be-fileutil            :1200k
 file_utils/cp                   :be-fileutil    :360k
-file_utils/dd                   :be-fileutil            :1200k  :1440k
+file_utils/dd                   :be-fileutil            :1200k
 file_utils/md5sum               :fileutil
 file_utils/mkdir                :fileutil       :360k
 file_utils/mknod                :fileutil       :360k
-#file_utils/mkfifo              :fileutil               :1200k  :1440k
-file_utils/more                 :fileutil       :360k   :128k
+#file_utils/mkfifo              :fileutil               :1200k
+file_utils/more                 :fileutil       :360k           :128k
 file_utils/mv                   :fileutil       :360k
 file_utils/ln                   :fileutil           :720k
-file_utils/ls                   :fileutil       :360k   :128k
+file_utils/ls                   :fileutil       :360k           :128k
 file_utils/rm                   :fileutil       :360k
 file_utils/rmdir                :fileutil       :360k
 file_utils/split                :fileutil                :1200k
@@ -80,88 +80,88 @@ file_utils/sync                 :fileutil       :360k
 file_utils/touch                :fileutil           :720k
 sys_utils/chmem                 :sysutil            :720k
 sys_utils/kill                  :sysutil            :720k
-sys_utils/ps            :sash   :sysutil        :360k   :128k
-sys_utils/ps :::uptime          :sysutil                        :1440k  :128k
-sys_utils/reboot                :sysutil        :360k   :128k
+sys_utils/ps            :sash   :sysutil        :360k           :128k
+sys_utils/ps :::uptime          :sysutil                        :128k   :1440k
+sys_utils/reboot                :sysutil        :360k           :128k
 sys_utils/makeboot              :sysutil        :360k
-sys_utils/man                   :sysutil                :1200k  :1440k
-sys_utils/meminfo       :sash   :sysutil        :360k   :128k
-sys_utils/mouse                 :sysutil                :1200k  :1440k
-sys_utils/passwd                :sysutil                :1200k  :1440k
+sys_utils/man                   :sysutil                :1200k
+sys_utils/meminfo       :sash   :sysutil        :360k           :128k
+sys_utils/mouse                 :sysutil                :1200k
+sys_utils/passwd                :sysutil                :1200k
 sys_utils/poweroff              :sysutil            :720k
-sys_utils/sercat                :sysutil                :1200k  :1440k
-sys_utils/console               :sysutil                :1200k  :1440k
-#sys_utils/who                  :sysutil                :1200k  :1440k
+sys_utils/sercat                :sysutil                :1200k
+sys_utils/console               :sysutil                :1200k
+#sys_utils/who                  :sysutil                :1200k
 sys_utils/unreal16              :sysutil
-screen/screen                   :screen                 :1200k  :1440k
-cron/cron                       :cron                   :1200k  :1440k
-cron/crontab                    :cron                   :1200k  :1440k
+screen/screen                   :screen                 :1200k
+cron/cron                       :cron                   :1200k
+cron/crontab                    :cron                   :1200k
 sh_utils/basename               :be-shutil          :720k
-sh_utils/clear                  :shutil                 :1200k  :1440k
+sh_utils/clear                  :shutil                 :1200k
 sh_utils/dirname                :be-shutil          :720k
-sh_utils/echo                   :be-shutil              :1200k  :1440k
-#sh_utils/test                  :shutil                 :1200k  :1440k
-#sh_utils/false                 :be-shutil              :1200k  :1440k
-#sh_utils/true                  :be-shutil              :1200k  :1440k
-#sh_utils/logname               :shutil                 :1200k  :1440k
-#sh_utils/mesg                  :shutil                 :1200k  :1440k
-sh_utils/stty                   :shutil                 :1200k  :1440k  :192k
-sh_utils/printenv               :shutil         :360k   :128k
-sh_utils/pwd                    :shutil         :360k   :128k
+sh_utils/echo                   :be-shutil              :1200k
+#sh_utils/test                  :shutil                 :1200k
+#sh_utils/false                 :be-shutil              :1200k
+#sh_utils/true                  :be-shutil              :1200k
+#sh_utils/logname               :shutil                 :1200k
+#sh_utils/mesg                  :shutil                 :1200k
+sh_utils/stty                   :shutil                 :1200k  :192k
+sh_utils/printenv               :shutil         :360k           :128k
+sh_utils/pwd                    :shutil         :360k           :128k
 sh_utils/tr                     :shutil             :720k
-#sh_utils/which                 :shutil                 :1200k  :1440k
-#sh_utils/whoami                :shutil                 :1200k  :1440k
-sh_utils/xargs                  :shutil                 :1200k  :1440k
+#sh_utils/which                 :shutil                 :1200k
+#sh_utils/whoami                :shutil                 :1200k
+sh_utils/xargs                  :shutil                 :1200k
 sh_utils/yes                    :shutil             :720k
 misc_utils/compress             :miscutil                       :1440k
 misc_utils/miniterm             :miscutil           :720k
-misc_utils/fdtest               :miscutil               :1200k  :1440k
-misc_utils/tar                  :miscutil               :1200k  :1440k
-misc_utils/od                   :miscutil               :1200k  :1440k
-misc_utils/hd                   :miscutil               :1200k  :1440k
+misc_utils/fdtest               :miscutil               :1200k
+misc_utils/tar                  :miscutil               :1200k
+misc_utils/od                   :miscutil               :1200k
+misc_utils/hd                   :miscutil               :1200k
 misc_utils/time                 :miscutil           :720k
-misc_utils/kilo                 :miscutil               :1200k  :1440k
-misc_utils/mined ::bin/edit     :miscutil       :360k   :1200k  :1440k
-misc_utils/sleep                :miscutil               :1200k  :1440k
-misc_utils/tty                  :miscutil               :1200k  :1440k
-misc_utils/uuencode             :miscutil               :1200k  :1440k
-misc_utils/uudecode             :miscutil               :1200k  :1440k
+misc_utils/kilo                 :miscutil               :1200k
+misc_utils/mined ::bin/edit     :miscutil       :360k   :1200k
+misc_utils/sleep                :miscutil               :1200k
+misc_utils/tty                  :miscutil               :1200k
+misc_utils/uuencode             :miscutil               :1200k
+misc_utils/uudecode             :miscutil               :1200k
 #misc_utils/ed                  :be-miscutil        :720k
 elvis/elvis ::bin/vi            :elvis              :720k
-minix1/banner                   :minix1                 :1200k  :1440k
-#minix1/decomp16                :minix1                 :1440k
-#minix1/fgrep                   :minix1                 :1200k  :1440k
+minix1/banner                   :minix1                 :1200k
+#minix1/decomp16                :minix1                         :1440k
+#minix1/fgrep                   :minix1                 :1200k
 minix1/grep                     :minix1         :360k
-minix1/sum                      :minix1                 :1200k  :1440k
+minix1/sum                      :minix1                 :1200k
 minix1/uniq                     :minix1             :720k
-minix1/wc                       :minix1                 :1200k  :1440k
-#minix1/proto                   :minix1                 :1200k  :1440k
+minix1/wc                       :minix1                 :1200k
+#minix1/proto                   :minix1                 :1200k
 minix1/cut                      :be-minix1          :720k
-#minix1/cksum                   :be-minix1              :1200k  :1440k
-minix1/du                       :be-minix1              :1200k  :1440k
-#minix2/env                     :minix2                 :1200k  :1440k
-#minix2/lp                      :minix2                 :1200k  :1440k
+#minix1/cksum                   :be-minix1              :1200k
+minix1/du                       :be-minix1              :1200k
+#minix2/env                     :minix2                 :1200k
+#minix2/lp                      :minix2                 :1200k
 #minix2/pwdauth                 :minix2                         :1440k
 minix2/remsync                  :other
 minix2/synctree                 :other
 #minix2/tget                    :minix2                         :1440k
-#minix2/man                     :minix2                 :1200k  :1440k
+#minix2/man                     :minix2                 :1200k
 minix3/sed                      :minix3             :720k
 minix3/file                     :minix3             :720k
 minix3/head                     :minix3             :720k
 minix3/sort                     :minix3             :720k
 minix3/tail                     :minix3             :720k
-minix3/tee                      :minix3                 :1200k  :1440k
-minix3/cal                      :be-minix3              :1200k  :1440k
+minix3/tee                      :minix3                 :1200k
+minix3/cal                      :be-minix3              :1200k
 minix3/diff                     :be-minix3          :720k
 minix3/find                     :be-minix3          :720k
 minix3/mail                     :minix3                         :other
 disk_utils/df                   :diskutil       :360k
-disk_utils/fsck                 :diskutil       :360k   :1200k  :1440k
+disk_utils/fsck                 :diskutil       :360k   :1200k
 disk_utils/mkfs                 :diskutil       :360k
 disk_utils/mkfat                :diskutil       :360k
-disk_utils/partype              :diskutil               :1200k  :1440k
-disk_utils/ramdisk              :diskutil               :1200k  :1440k
+disk_utils/partype              :diskutil               :1200k
+disk_utils/ramdisk              :diskutil               :1200k
 disk_utils/fdisk                :be-diskutil    :360k
 tui/fm                          :tui                            :1440k
 tui/matrix                      :tui                            :1440k
@@ -169,7 +169,7 @@ tui/cons                        :tui                            :1440k
 tui/ttyinfo                     :tui                            :1440k
 tui/sl                          :tui
 busyelks/busyelks               :busyelks
-inet/httpd/sample_index.html    ::var/www/index.html    :net
+inet/httpd/sample_index.html ::var/www/index.html :net
 ktcp/ktcp                       :net
 inet/nettools/netstat           :net
 inet/nettools/nslookup          :net
@@ -207,7 +207,7 @@ nano-X/bin/nxtetris             :nanox
 nano-X/bin/nxlandmine           :nanox              :1200k
 nano-X/bin/nxterm               :nanox
 nano-X/bin/nxworld              :nanox
-nano-X/bin/nxworld.map  ::lib/nxworld.map   :nanox
+nano-X/bin/nxworld.map ::lib/nxworld.map :nanox
 basic/basic                     :basic              :1200k
 advent/advent                   :other
-advent/advent.db    ::lib/advent.db :other
+advent/advent.db ::lib/advent.db :other


### PR DESCRIPTION
Reformats and removes redundant `:1440k` tags on `:1200k` items as suggested by @ccoffing.