### PR TITLE
[kernel] Add @Mellvik's direct floppy driver

### DIFF
--- a/elks/arch/i86/defconfig
+++ b/elks/arch/i86/defconfig
@@ -102,7 +102,6 @@ CONFIG_BLK_DEV_BHD=y
 CONFIG_IDE_PROBE=y
 # CONFIG_BLK_DEV_FD is not set
 # CONFIG_BLK_DEV_HD is not set
-# CONFIG_DMA is not set
 
 #
 # Additional block devices

--- a/elks/arch/i86/drivers/block/Makefile
+++ b/elks/arch/i86/drivers/block/Makefile
@@ -56,13 +56,14 @@ ifeq ($(CONFIG_BLK_DEV_SSD_SD8018X), y)
 	OBJS += ssd.o ssd-sd.o spi-8018x.o
 endif
 
+# experimental direct fd support
+ifeq ($(CONFIG_BLK_DEV_FD), y)
+OBJS += directfd.o
+endif
+
 # experimental (and not working) direct hd support
 ifeq ($(CONFIG_BLK_DEV_HD), y)
 OBJS += directhd.o
-endif
-# experimental (and not compiling) direct fd support
-ifeq ($(CONFIG_BLK_DEV_FD), y)
-OBJS += directfd.o
 endif
 
 #########################################################################

--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -19,6 +19,7 @@ struct request {
     ramdesc_t rq_seg;           /* L1 or L2 ext/xms buffer segment */
     struct buffer_head *rq_bh;  /* system buffer head for notifications and locking */
     struct request *rq_next;    /* next request, used when async I/O */
+    int rq_errors;              /* only used by direct floppy driver */
 };
 
 #define RQ_INACTIVE     0
@@ -74,10 +75,10 @@ extern void resetup_one_dev(struct gendisk *dev, int drive);
 
 #ifdef FLOPPYDISK
 
-static void floppy_on(unsigned int nr);
+static void floppy_on(int nr);
 static void floppy_off(unsigned int nr);
 
-#define DEVICE_NAME "fd"
+#define DEVICE_NAME "df"
 #define DEVICE_INTR do_floppy
 #define DEVICE_REQUEST do_fd_request
 #define DEVICE_NR(device) ((device) & 3)
@@ -146,7 +147,7 @@ static void end_request(int uptodate)
     mark_buffer_uptodate(bh, uptodate);
     unlock_buffer(bh);
 
-    DEVICE_OFF(req->dev);
+    DEVICE_OFF(req->rq_dev);
     CURRENT = req->rq_next;
     req->rq_status = RQ_INACTIVE;
 

--- a/elks/arch/i86/drivers/block/config.in
+++ b/elks/arch/i86/drivers/block/config.in
@@ -32,13 +32,9 @@ mainmenu_option next_comment
 	    bool '  IDE hard drive CHS probe'	CONFIG_IDE_PROBE	y
 	fi
 
-	if [ "$CONFIG_BLK_DEV_FD" = "y" ]; then
-	    define_bool CONFIG_DMA y
-	else
-	    define_bool CONFIG_DMA n
-	fi
-
 	comment 'Additional block devices'
+	bool 'Direct floppy driver (experimental)' CONFIG_BLK_DEV_FD   n
+
 	bool 'RAM disk support'			CONFIG_BLK_DEV_RAM	y
 	if [ "$CONFIG_BLK_DEV_RAM" == "y" ]; then
 		hex 'Preload RAM disk segment address' CONFIG_RAMDISK_SEGMENT 0

--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -1,7 +1,4 @@
 /*
- * NOTE: experimental direct fd driver - NOT COMPILING
- *
- * linux/kernel/floppy.c
  * Copyright (C) 1991, 1992  Linus Torvalds
  *
  * 02.12.91 - Changed to static variables to indicate need for reset
@@ -52,64 +49,80 @@
  *
  * 1996/3/27 -- trp@cyberoptics.com
  * began port to linux-8086
- *
  * removed volatile and fixed function definitions
+ *
+ * 2023/03/10 -- helge@skrivervik.com
+ * rewritten for TLVC - imported DMA setup from Minix for simplicity and
+ * compactness. Added fix for bioses that do motor timeout on their own.
+ * Now compiles - and works.
  */
 
-#define TRP_TIMER
-#define TRP_SIG
-
-#define REALLY_SLOW_IO
-#define FLOPPY_DMA 2
+/*
+ * TODO (HS 2023):
+ * - Change read buffer logic to allow small floppies (720k and less) to fill 
+ *   the track buffer (full cylinder)
+ * - When XMS buffers are active, the BIOS hd driver will use DMASEG as a bounce buffer
+ *   thus colliding with the usage here. This is a problem only in the odd case 
+ *   that we're using BIOS HD + DIRECT FD + XMS buffers + TRACK cache, 
+ *   which really should not happen. IOW - use either BIOS block IO or DIRECT block IO,
+ *   don't mix!!
+ * - Update DMA code
+ * - Test density detection logic & floppy change detection
+ * - Clean up debug output
+ */
 
 #include <linuxmt/config.h>
 #include <linuxmt/sched.h>
 #include <linuxmt/fs.h>
 #include <linuxmt/kernel.h>
-/*#include <linuxmt/timer.h>*/
+#include <linuxmt/timer.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/signal.h>
 #include <linuxmt/fdreg.h>
 #include <linuxmt/fd.h>
 #include <linuxmt/errno.h>
+#include <linuxmt/string.h>
+#include <linuxmt/debug.h>
+#include <linuxmt/memory.h>	/* for peek/poke */
 
 #include <arch/dma.h>
 #include <arch/system.h>
 #include <arch/io.h>
 #include <arch/segment.h>
-
+#include <arch/ports.h>
+#include <arch/hdreg.h>		/* for ioctl GETGEO */
 
 #define FLOPPYDISK
 #define MAJOR_NR FLOPPY_MAJOR
-#include "blk.h"
+#define MINOR_SHIFT	5	/* shift to get drive num */
+#define FLOPPY_DMA 2		/* hardwired on old PCs */
 
-#ifdef DEVICE_INTR
+#include "blk.h"		/* ugly - blk.h contains code */
+
+/* This is confusing. DEVICE_INTR is the do_floppy variable.
+ * The code is sometimes using the macro, some times the variable.
+ * It may seem this is a trick to get GCC to shut up ...
+ */
+#ifdef DEVICE_INTR	/* from blk.h */
 void (*DEVICE_INTR) () = NULL;
-#endif
 
-#ifdef DEVICE_TIMEOUT
-
-#define SET_TIMER \
-		((timer_table[DEVICE_TIMEOUT].expires = jiffies + TIMEOUT_VALUE), \
-		(timer_active |= 1<<DEVICE_TIMEOUT))
-
-#define CLEAR_TIMER	timer_active &= ~(1<<DEVICE_TIMEOUT)
-
-#define SET_INTR(x)	if ((DEVICE_INTR = (x)) != NULL) \
-			SET_TIMER; \
-			else \
-			CLEAR_TIMER;
-#else
 #define SET_INTR(x) (DEVICE_INTR = (x))
-#endif
-
-#ifdef DEVICE_INTR
 #define CLEAR_INTR SET_INTR(NULL)
 #else
 #define CLEAR_INTR
 #endif
 
-static unsigned int changed_floppies = 0, fake_change = 0;
+#define _MK_LINADDR(seg, offs) ((unsigned long)((((unsigned long)(seg)) << 4) + (unsigned)(offs)))
+
+//#define dfd_debug
+#ifdef dfd_debug
+#define DEBUG printk
+#else
+#define DEBUG(...)
+#endif
+
+/* Formatting code is currently untested, don't waste the space */
+//#define INCLUDE_FD_FORMATTING
 
 static int initial_reset_flag = 0;
 static int need_configure = 1;	/* for 82077 */
@@ -118,11 +131,21 @@ static int reset = 0;
 static int recover = 0;		/* recalibrate immediately after resetting */
 static int seek = 0;
 
-static unsigned char current_DOR = 0x0C;
-static unsigned char running = 0;
+#ifdef CONFIG_BLK_DEV_CHAR
+static int nr_sectors;		/* only when raw access */
+#endif
 
-#define TYPE(x) ((x)>>2)
-#define DRIVE(x) ((x)&0x03)
+/* Should use poke() for this!! No, turns out the far pointer is better. HS */
+static unsigned char __far *fl_timeout = (void __far *)0x440L; /* BIOS floppy motor timeout counter*/
+					/* On some machines always active, must be
+					 * reset to avoid random motor shutoff.
+					 * Ihis variant takes 10 bytes */
+
+static unsigned char current_DOR = 0x0C;
+static unsigned char running = 0; /* keep track of motors already running */
+/* NOTE: current_DOR tells which motor(s) have been commanded to run,
+ * 'running' tells which ones are actually running. The difference is subtle - 
+ * the spinup time, typical .5 secs */
 
 /*
  * Note that MAX_ERRORS=X doesn't imply that we retry every bad read
@@ -151,7 +174,7 @@ static unsigned char running = 0;
  * driver otherwise. It doesn't matter much for performance anyway, as most
  * floppy accesses go through the track buffer.
  */
-#define LAST_DMA_ADDR	(0x100000 - BLOCK_SIZE)
+#define LAST_DMA_ADDR	(0x100000L - BLOCK_SIZE)
 
 /*
  * globals used by 'result()'
@@ -179,12 +202,14 @@ static struct floppy_struct floppy_type[] = {
     {720, 9, 2, 40, 1, 0x23, 0x01, 0xDF, 0x50, NULL},	/* 360kB in 1.2MB drive */
     {1440, 9, 2, 80, 0, 0x23, 0x01, 0xDF, 0x50, NULL},	/* 720kB in 1.2MB drive */
     {2880, 18, 2, 80, 0, 0x1B, 0x00, 0xCF, 0x6C, NULL},	/* 1.44MB diskette */
+    /* totSectors/secPtrack/heads/tracks/stretch/gap/Drate/S&Hrates/fmtGap/nm/  */
 };
 
 /*
  * Auto-detection. Each drive type has a pair of formats which are
  * used in succession to try to read the disk. If the FDC cannot lock onto
  * the disk, the next format is tried. This uses the variable 'probing'.
+ * NOTE: Ignore the duplicates, they're there for a reason.
  */
 static struct floppy_struct floppy_types[] = {
     {720, 9, 2, 40, 0, 0x2A, 0x02, 0xDF, 0x50, "360k/PC"},	/* 360kB PC diskettes */
@@ -207,8 +232,11 @@ struct floppy_struct *base_type[4];
  * User-provided type information. current_type points to
  * the respective entry of this array.
  */
+#ifdef HAS_IOCTL
 struct floppy_struct user_params[4];
+#endif
 
+#ifdef BDEV_SIZE_CHK
 static int floppy_sizes[] = {
     MAX_DISK_SIZE, MAX_DISK_SIZE, MAX_DISK_SIZE, MAX_DISK_SIZE,
     360, 360, 360, 360,
@@ -219,6 +247,7 @@ static int floppy_sizes[] = {
     720, 720, 720, 720,
     1440, 1440, 1440, 1440
 };
+#endif
 
 /*
  * The driver is trying to determine the correct media format
@@ -239,12 +268,14 @@ static int keep_data[4] = { 0, 0, 0, 0 };
  * disk changes.
  * Also used to enable/disable printing of overrun warnings.
  */
-static ftd_msg[4] = { 0, 0, 0, 0 };
+static int ftd_msg[4] = { 0, 0, 0, 0 };
 
 /* Prevent "aliased" accesses. */
 
-static fd_ref[4] = { 0, 0, 0, 0 };
-static fd_device[4] = { 0, 0, 0, 0 };
+static int fd_ref[4] = { 0, 0, 0, 0 };	/* device reference counter */
+static int fd_device[4] = { 0, 0, 0, 0 }; /* has the i_rdev used in the last access,
+					   * used to detect multiple opens 
+					   * via different devices (minor numbers) */
 
 /* Synchronization of FDC access. */
 static int format_status = FORMAT_NONE, fdc_busy = 0;
@@ -261,11 +292,11 @@ static struct format_descr format_req;
  * format request descriptor.
  */
 #define CURRENT_DEVICE (format_status == FORMAT_BUSY ? format_req.device : \
-   (CURRENT->dev))
+   (CURRENT->rq_dev))
 
 /* Current error count. */
 #define CURRENT_ERRORS (format_status == FORMAT_BUSY ? format_errors : \
-    (CURRENT->errors))
+    (CURRENT->rq_errors))
 
 /*
  * Threshold for reporting FDC errors to the console.
@@ -277,23 +308,28 @@ static unsigned short min_report_error_cnt[4] = { 2, 2, 2, 2 };
 /*
  * Rate is 0 for 500kb/s, 1 for 300kbps, 2 for 250kbps
  * Spec1 is 0xSH, where S is stepping rate (F=1ms, E=2ms, D=3ms etc),
- * H is head unload time (1=16ms, 2=32ms, etc)
+ * H is head unload time, time the FDC will wait before unloading
+ * the head after a command that accesses the disk (1=16ms, 2=32ms, etc)
  *
  * Spec2 is (HLD<<1 | ND), where HLD is head load time (1=2ms, 2=4 ms etc)
  * and ND is set means no DMA. Hardcoded to 6 (HLD=6ms, use DMA).
  */
 
 /*
- * Track buffer and block buffer (in case track buffering doesn't work).
- * Because these are written to by the DMA controller, they must
- * not contain a 64k byte boundary crossing, or data will be
- * corrupted/lost. Alignment of these is enforced in boot/head.s.
- * Note that you must not change the sizes below without updating head.s.
+ * The block buffer is used for all writes, for formatting and for reads
+ * in case track buffering doesn't work or has been turned off.
  */
-extern char tmp_floppy_area[BLOCK_SIZE];
-extern char floppy_track_buffer[512 * 2 * MAX_BUFFER_SECTORS];
+static char tmp_floppy_area[BLOCK_SIZE]; /* for now FIXME to be removed */
+
+#ifdef CHECK_DISK_CHANGE
+#define buffer_dirty(b)	((b)->b_dirty)
+int check_disk_change(kdev_t);
+#endif
 
 static void redo_fd_request(void);
+static void recal_interrupt(void);
+static void floppy_shutdown(void);
+static void motor_off_callback(int);
 
 /*
  * These are global variables, as that's the easiest way to give
@@ -302,7 +338,7 @@ static void redo_fd_request(void);
  */
 #define NO_TRACK 255
 
-static int read_track = 0;	/* flag to indicate if we want to read entire track */
+static int read_track = 0;	/* set to read entire track */
 static int buffer_track = -1;
 static int buffer_drive = -1;
 static int cur_spec1 = -1;
@@ -317,75 +353,86 @@ static unsigned char current_track = NO_TRACK;
 static unsigned char command = 0;
 static unsigned char fdc_version = FDC_TYPE_STD;	/* FDC version code */
 
+void ll_rw_block(int, int, struct buffer_head **);
 static void floppy_ready(void);
 
 static void delay_loop(int cnt)
 {
-    while (cnt > 0) {
-	asm("nop");
-	cnt--;
-    }
+    while (cnt-- > 0) asm("nop");
 }
 
-#ifdef TRP_ASM
-#define copy_buffer(from,to) \
-asm("cld ; rep ; movsl" \
-	: \
-	:"c" (BLOCK_SIZE/4),"S" ((long)(from)),"D" ((long)(to)) \
-	:"cx","di","si")
-#else
-static void copy_buffer(void *from, void *to)
+static void select_callback(int unused)
 {
-    memcpy(to, from, BLOCK_SIZE);
-}
-#endif
-
-static void select_callback(unsigned long unused)
-{
+    DEBUG("SC;");
     floppy_ready();
 }
 
+static struct timer_list select = { NULL, 0, 0, select_callback };
+/*
+ * Select drive for this op - always one at a time, leave motor_on alone,
+ * several drives can have the motor running at the same time. A drive cannot
+ * be selected unless the motor is on, they can be set concurrently.
+ */
+/*
+ * NOTE: The argument (nr) is silently ignored, current_drive being used instead.
+ * is this OK?
+  */
 static void floppy_select(unsigned int nr)
 {
-#ifndef TRP_TIMER
-    static struct timer_list select = { NULL, NULL, 0, 0, select_callback };
-#endif
-
+    DEBUG("sel0x%x-", current_DOR);
     if (current_drive == (current_DOR & 3)) {
+	/* Drive already selected, we're ready to go */
 	floppy_ready();
 	return;
     }
+    /* activate a different drive */
     seek = 1;
     current_track = NO_TRACK;
+    /* 
+     * NOTE: This is drive select, not motor on/off
+     * Unless the motor is turned on, select will fail 
+     * Setting them concurrently is OK
+     */
     current_DOR &= 0xFC;
     current_DOR |= current_drive;
     outb(current_DOR, FD_DOR);
 
-#ifndef TRP_TIMER
+    /* It is not obvious why select should take any time at all ... HS */
+    /* The select_callback calls floppy_ready() */
+    /* The callback is NEVER called unless several drives are active concurrently */
     del_timer(&select);
-    select.expires = 2;
+    select.tl_expires = jiffies + 2;
     add_timer(&select);
-#endif
 }
 
-static void motor_on_callback(unsigned long nr)
+static void motor_on_callback(int nr)
 {
+    DEBUG("mON,");
+    clr_irq();	// Experimental
     running |= 0x10 << nr;
+    set_irq();
     floppy_select(nr);
 }
 
-#ifndef TRP_TIMER
 static struct timer_list motor_on_timer[4] = {
-    {NULL, NULL, 0, 0, motor_on_callback},
-    {NULL, NULL, 0, 1, motor_on_callback},
-    {NULL, NULL, 0, 2, motor_on_callback},
-    {NULL, NULL, 0, 3, motor_on_callback}
+    {NULL, 0, 0, motor_on_callback},
+    {NULL, 0, 1, motor_on_callback},
+    {NULL, 0, 2, motor_on_callback},
+    {NULL, 0, 3, motor_on_callback}
 };
-#endif
+static struct timer_list motor_off_timer[4] = {
+    {NULL, 0, 0, motor_off_callback},
+    {NULL, 0, 1, motor_off_callback},
+    {NULL, 0, 2, motor_off_callback},
+    {NULL, 0, 3, motor_off_callback}
+};
+static struct timer_list fd_timeout = {NULL, 0, 0, floppy_shutdown};
 
-static void motor_off_callback(unsigned long nr)
+static void motor_off_callback(int nr)
 {
     unsigned char mask = ~(0x10 << nr);
+
+    DEBUG("[%u]MOF%d", (unsigned int)jiffies, nr);
     clr_irq();
     running &= mask;
     current_DOR &= mask;
@@ -393,60 +440,82 @@ static void motor_off_callback(unsigned long nr)
     set_irq();
 }
 
-#ifndef TRP_TIMER
-static struct timer_list motor_off_timer[4] = {
-    {NULL, NULL, 0, 0, motor_off_callback},
-    {NULL, NULL, 0, 1, motor_off_callback},
-    {NULL, NULL, 0, 2, motor_off_callback},
-    {NULL, NULL, 0, 3, motor_off_callback}
-};
-#endif
-
-static void floppy_on(unsigned int nr)
+/*
+ * floppy_on: turn on motor. If already running, call floppy_select
+ * otherwise start motor and set timer to continue (motor_on_callback).
+ * In the latter case, motor_on_callback will call floppy_select();
+ *
+ * DOR (Data Output Register) is |MOTD|MOTC|MOTB|MOTA|DMA|/RST|DR1|DR0|
+ */
+static void floppy_on(int nr)
 {
-    unsigned char mask = 0x10 << nr;
+    unsigned char mask = 0x10 << nr;	/* motor on select */
 
-#ifndef TRP_TIMER
-    del_timer(motor_off_timer + nr);
-#endif
+    DEBUG("flpON");
+    *fl_timeout = 0;	/* Reset BIOS motor timeout counter, neccessary on some machines */
+    			/* Don't ask how I found out. HS */
+    //pokeb(0x40, 0x40, 0);	/* this variant is 10 bytes of code too, but slower than */
+				/* using the far pointer above */
+    del_timer(&motor_off_timer[nr]);
 
-    if (mask & running)
+    if (mask & running) {
 	floppy_select(nr);
-#ifndef TRP_TIMER
-    if (!(mask & current_DOR)) {
-	del_timer(motor_on_timer + nr);
-	motor_on_timer[nr].expires = HZ;
-	add_timer(motor_on_timer + nr);
+	DEBUG("#%x;",current_DOR);
+	return;	
     }
-#endif
-    current_DOR &= 0xFC;
-    current_DOR |= mask;
-    current_DOR |= nr;
-    outb(current_DOR, FD_DOR);
+
+    if (!(mask & current_DOR)) {	/* motor not running yet */
+	del_timer(&motor_on_timer[nr]);
+	motor_on_timer[nr].tl_expires = jiffies + HZ/2;	/* TEAC 1.44M says 'waiting time' 505ms,
+							 * may be too little for 5.25in drives. */
+	add_timer(&motor_on_timer[nr]);
+
+	current_DOR &= 0xFC;	/* remove drive select */
+	current_DOR |= mask;	/* set motor select */
+	current_DOR |= nr;	/* set drive select */
+	outb(current_DOR, FD_DOR);
+    }	// EXPERIMENTAL - moved this one ...
+
+    DEBUG("flpON0x%x;", current_DOR);
 }
 
+/* floppy_off (and floppy_on) are called from upper layer routines when a
+ * block request is started or ended respectively. It's extremely important
+ * that the motor off timer is slow enough not to affect performance. 3 
+ * seconds is a fair compromise.
+ */
 static void floppy_off(unsigned int nr)
 {
-#ifndef TRP_TIMER
-    del_timer(motor_off_timer + nr);
-    motor_off_timer[nr].expires = 3 * HZ;
-    add_timer(motor_off_timer + nr);
-#endif
+    del_timer(&motor_off_timer[nr]);
+    motor_off_timer[nr].tl_expires = jiffies + 3 * HZ;
+    add_timer(&motor_off_timer[nr]);
+    DEBUG("flpOFF-\n");
 }
 
 void request_done(int uptodate)
 {
-#ifndef TRP_TIMER
-    timer_active &= ~(1 << FLOPPY_TIMER);
-#endif
+    /* FIXME: Is this the right place to delete this timer? */
+    del_timer(&fd_timeout);
 
+#ifdef INCLUDE_FD_FORMATTING
     if (format_status != FORMAT_BUSY)
 	end_request(uptodate);
     else {
 	format_status = uptodate ? FORMAT_OKAY : FORMAT_ERROR;
 	wake_up(&format_done);
     }
+#else
+    end_request(uptodate);
+#endif
 }
+
+#ifdef CHECK_DISK_CHANGE
+/*
+ * The check_media_change entry in struct file_operations (fs.h) is not
+ * part of the 'normal' setup (only BLOAT_FS), so we're ignoring it for now,
+ * assuming the user is smart enough to umount before media changes - or
+ * ready for the consequences.
+ */ 
 
 /*
  * floppy-change is never called from an interrupt, so we can relax a bit
@@ -454,12 +523,14 @@ void request_done(int uptodate)
  * to the desired drive, but it will probably not survive the sleep if
  * several floppies are used at the same time: thus the loop.
  */
+static unsigned int changed_floppies = 0, fake_change = 0;
+
 int floppy_change(struct buffer_head *bh)
 {
-    unsigned int mask = 1 << (bh->b_dev & 0x03);
+    unsigned int mask = 1 << ((bh->b_dev & 0x03) >> MINOR_SHIFT;
 
     if (MAJOR(bh->b_dev) != MAJOR_NR) {
-	printk("floppy_changed: not a floppy\n");
+	printk("floppy_change: not a floppy\n");
 	return 0;
     }
     if (fake_change & mask) {
@@ -492,38 +563,51 @@ int floppy_change(struct buffer_head *bh)
     }
     return 0;
 }
+#endif
 
 static void setup_DMA(void)
 {
-    unsigned long addr, count;
-    unsigned char dma_code;
+    unsigned long dma_addr;
+    unsigned int count;
 
-    dma_code = DMA_WRITE;
-    if (command == FD_READ)
-	dma_code = DMA_READ;
+#ifdef CONFIG_FS_XMS_BUFFER
+    dma_addr = LAST_DMA_ADDR + 1;	/* force use of bounce buffer */
+#else
+    dma_addr = _MK_LINADDR(CURRENT->rq_seg, CURRENT->rq_buffer);
+#endif
+
+#ifdef CONFIG_BLK_DEV_CHAR
+    count = nr_sectors ? nr_sectors<<9 : BLOCK_SIZE;
+#else
+    count = BLOCK_SIZE;
+#endif
+    DEBUG("setupDMA ");
     if (command == FD_FORMAT) {
-	addr = (long) tmp_floppy_area;
+	dma_addr = _MK_LINADDR(kernel_ds, tmp_floppy_area);
 	count = floppy->sect * 4;
-    } else {
-	addr = (long) CURRENT->buffer;
-	count = 1024;
     }
-    if (read_track) {
-/* mark buffer-track bad, in case all this fails.. */
+    if (read_track) {	/* mark buffer-track bad, in case all this fails.. */
 	buffer_drive = buffer_track = -1;
-	count = floppy->sect * floppy->head * 512;
-	addr = (long) floppy_track_buffer;
-    } else if (addr >= LAST_DMA_ADDR) {
-	addr = (long) tmp_floppy_area;
-	if (command == FD_WRITE)
-	    copy_buffer(CURRENT->buffer, tmp_floppy_area);
+	count = floppy->sect << 9;	/* sects/trk (one side) times 512 */
+	if (floppy->sect & 1 && !head) count += 512; /* add one if head=0 && sector count is odd */
+	dma_addr = _MK_LINADDR(DMASEG, 0);
+    } else if (dma_addr >= LAST_DMA_ADDR) {
+	dma_addr = _MK_LINADDR(kernel_ds, tmp_floppy_area); /* use bounce buffer */
+	if (command == FD_WRITE) {
+#ifdef CONFIG_FS_XMS_BUFFER
+	    xms_fmemcpyw(tmp_floppy_area, kernel_ds, CURRENT->rq_buffer, CURRENT->rq_seg, BLOCK_SIZE/2);
+#else
+	    fmemcpyw(tmp_floppy_area, kernel_ds, CURRENT->rq_buffer, CURRENT->rq_seg, BLOCK_SIZE/2);
+#endif
+	}
     }
+    DEBUG("%d/%lx;", count, dma_addr);
     clr_irq();
     disable_dma(FLOPPY_DMA);
     clear_dma_ff(FLOPPY_DMA);
     set_dma_mode(FLOPPY_DMA,
 		 (command == FD_READ) ? DMA_MODE_READ : DMA_MODE_WRITE);
-    set_dma_addr(FLOPPY_DMA, addr);
+    set_dma_addr(FLOPPY_DMA, dma_addr);
     set_dma_count(FLOPPY_DMA, count);
     enable_dma(FLOPPY_DMA);
     set_irq();
@@ -556,7 +640,7 @@ static int result(void)
 	return -1;
     for (counter = 0; counter < 10000; counter++) {
 	status = inb_p(FD_STATUS) & (STATUS_DIR | STATUS_READY | STATUS_BUSY);
-	if (status == STATUS_READY) {
+	if (status == STATUS_READY) {	/* done, no more result bytes */
 	    return i;
 	}
 	if (status == (STATUS_DIR | STATUS_READY | STATUS_BUSY)) {
@@ -569,7 +653,7 @@ static int result(void)
     }
     reset = 1;
     current_track = NO_TRACK;
-    printk("Getstatus times out\n");
+    printk("Getstatus timed out\n");
     return -1;
 }
 
@@ -577,15 +661,19 @@ static void bad_flp_intr(void)
 {
     int errors;
 
+    DEBUG("bad_flpI-");
     current_track = NO_TRACK;
+#ifdef INCLUDE_FD_FORMATTING
     if (format_status == FORMAT_BUSY)
 	errors = ++format_errors;
-    else if (!CURRENT) {
+    else 
+#endif
+    if (!CURRENT) {
 	printk("%s: no current request\n", DEVICE_NAME);
 	reset = recalibrate = 1;
 	return;
     } else
-	errors = ++CURRENT->errors;
+	errors = ++CURRENT->rq_errors;
     if (errors > MAX_ERRORS) {
 	request_done(0);
     }
@@ -633,6 +721,7 @@ static void perpendicular_mode(unsigned char rate)
  */
 static void configure_fdc_mode(void)
 {
+#ifdef FDC_FIFO_UNTESTED
     if (need_configure && (fdc_version == FDC_TYPE_82077)) {
 	/* Enhanced version with FIFO & vertical recording. */
 	output_byte(FD_CONFIGURE);
@@ -642,6 +731,7 @@ static void configure_fdc_mode(void)
 	need_configure = 0;
 	printk("%s: FIFO enabled\n", DEVICE_NAME);
     }
+#endif
     if (cur_spec1 != floppy->spec1) {
 	cur_spec1 = floppy->spec1;
 	output_byte(FD_SPECIFY);
@@ -672,23 +762,27 @@ static void tell_sector(int nr)
  */
 static void rw_interrupt(void)
 {
-    char *buffer_area;
+    unsigned char *buffer_area;
     int nr;
     char bad;
 
     nr = result();
+    /* NOTE: If read_track is active and sector count is uneven, ST0 will
+     * always show HD1 as selected at this point. */
+    DEBUG("rwI%x|%x|%x-", ST0,ST1,ST2);
+
     /* check IC to find cause of interrupt */
     switch ((ST0 & ST0_INTR) >> 6) {
     case 1:			/* error occured during command execution */
 	bad = 1;
 	if (ST1 & ST1_WP) {
-	    printk("%s: Drive %d is write protected\n", DEVICE_NAME,
+	    printk("%s: Drive %d is write protected", DEVICE_NAME,
 		   current_drive);
 	    request_done(0);
 	    bad = 0;
 	} else if (ST1 & ST1_OR) {
 	    if (ftd_msg[ST0 & ST0_DS])
-		printk("%s: Over/Under-run - retrying\n", DEVICE_NAME);
+		printk("%s: Over/Under-run - retrying", DEVICE_NAME);
 	    /* could continue from where we stopped, but ... */
 	    bad = 0;
 	} else if (CURRENT_ERRORS > min_report_error_cnt[ST0 & ST0_DS]) {
@@ -712,12 +806,15 @@ static void rw_interrupt(void)
 	    } else if (ST2 & ST2_BC) {	/* cylinder marked as bad */
 		printk("bad cylinder");
 	    } else {
-		printk("unknown error. ST[0..3] are: 0x%x 0x%x 0x%x 0x%x\n",
+		printk("unknown error. ST[0-3]: 0x%x 0x%x 0x%x 0x%x",
 		       ST0, ST1, ST2, ST3);
 	    }
-	    printk("\n");
-
+	    CURRENT->rq_errors++; /* may want to increase this even more, doesn't make 
+	    		 * sense to re-try most of these conditions more 
+			 * than the reporting threshold. */
+			/* FIXME: Need smarter retry/error reporting scheme */
 	}
+	printk("\n");
 	if (bad)
 	    bad_flp_intr();
 	redo_fd_request();
@@ -736,25 +833,46 @@ static void rw_interrupt(void)
     }
 
     if (probing) {
-	int drive = MINOR(CURRENT->dev);
+	int drive = (MINOR(CURRENT->rq_dev) >> MINOR_SHIFT) & 3;
 
 	if (ftd_msg[drive])
-	    printk("Auto-detected floppy type %s in fd%d\n",
+	    printk("Auto-detected floppy type %s in df%d\n",
 		   floppy->name, drive);
 	current_type[drive] = floppy;
+#ifdef BDEV_SIZE_CHK
 	floppy_sizes[drive] = floppy->size >> 1;
+#endif
 	probing = 0;
     }
     if (read_track) {
-	buffer_track = seek_track;
+	buffer_track = (seek_track << 1) + head;	/* This encoding is ugly, should
+							 * save block-start, block-end instead */
 	buffer_drive = current_drive;
-	buffer_area = floppy_track_buffer +
-	    ((sector - 1 + head * floppy->sect) << 9);
-	copy_buffer(buffer_area, CURRENT->buffer);
-    } else if (command == FD_READ &&
-	       (unsigned long) (CURRENT->buffer) >= LAST_DMA_ADDR)
-	    copy_buffer(tmp_floppy_area, CURRENT->buffer);
+	buffer_area = (unsigned char *)(sector << 9);
+#ifdef CONFIG_FS_XMS_BUFFER
+	DEBUG("rd:%lx:%04x->%lx:%04x;", DMASEG, buffer_area, CURRENT->rq_seg, CURRENT->rq_buffer);
+	xms_fmemcpyw(CURRENT->rq_buffer, CURRENT->rq_seg, buffer_area, DMASEG, BLOCK_SIZE/2);
+#else
+	DEBUG("rd:%04x:%04x->%04x:%04x;", DMASEG, buffer_area, CURRENT->rq_seg, CURRENT->rq_buffer);
+	fmemcpyw(CURRENT->rq_buffer, CURRENT->rq_seg, buffer_area, DMASEG, BLOCK_SIZE/2);
+#endif
+    } else if (command == FD_READ 
+#ifndef CONFIG_FS_XMS_BUFFER
+	   && _MK_LINADDR(CURRENT->rq_seg, CURRENT->rq_buffer) >= LAST_DMA_ADDR
+#endif
+	) {
+	/* if the dest buffer is out of reach for DMA (always the case if using
+	 * XMS buffers) we need to read/write via the bounce buffer */
+#ifdef CONFIG_FS_XMS_BUFFER
+	xms_fmemcpyw(CURRENT->rq_buffer, CURRENT->rq_seg, tmp_floppy_area, kernel_ds, BLOCK_SIZE/2);
+#else
+	fmemcpyw(CURRENT->rq_buffer, CURRENT->rq_seg, tmp_floppy_area, kernel_ds, BLOCK_SIZE/2);
+#endif
+	printk("directfd: illegal buffer usage, rq_buffer %04x:%04x\n", 
+		CURRENT->rq_seg, CURRENT->rq_buffer);
+    }
     request_done(1);
+    //printk("RQOK;");
     redo_fd_request();
 }
 
@@ -762,32 +880,39 @@ static void rw_interrupt(void)
  * We try to read tracks, but if we get too many errors, we go back to
  * reading just one sector at a time. This means we should be able to
  * read a sector even if there are other bad sectors on this track.
+ *
+ * The FDC will start read/write at the specified sector, then continues
+ * until the DMA controller tells it to stop ... as long as we're on the same cyl.
+ * Notably: If the # of sectors per track is odd, we read sectors + 1 if head = 0
+ * to ensure we have full blocks in the buffer.
+ *
+ * From the Intel 8272A app note: "The 8272A always operates in a multi-sector 
+ * transfer mode. It continues to transfer data until the TC input is active."
+ * IOW: We tell the FDC where to start, and the DMA controller where to stop.
  */
 void setup_rw_floppy(void)
 {
+    DEBUG("setup_rw-");
     setup_DMA();
     do_floppy = rw_interrupt;
     output_byte(command);
+    output_byte(head << 2 | current_drive);
+
     if (command != FD_FORMAT) {
-	if (read_track) {
-	    output_byte(current_drive);
-	    output_byte(track);
-	    output_byte(0);
-	    output_byte(1);
-	} else {
-	    output_byte(head << 2 | current_drive);
-	    output_byte(track);
-	    output_byte(head);
-	    output_byte(sector);
-	}
+	output_byte(track);
+	output_byte(head);
+	if (read_track)
+	    output_byte(1);	/* always start at 1 */
+	else
+	    output_byte(sector+1); 
+
 	output_byte(2);		/* sector size = 512 */
 	output_byte(floppy->sect);
 	output_byte(floppy->gap);
-	output_byte(0xFF);	/* sector size (0xff when n!=0 ?) */
+	output_byte(0xFF);	/* sector size, 0xff unless sector size==0 (128b) */
     } else {
-	output_byte(head << 2 | current_drive);
-	output_byte(2);
-	output_byte(floppy->sect);
+	output_byte(2);		/* sector size = 512 */
+	output_byte(floppy->sect * 2); /* sectors per cyl */
 	output_byte(floppy->fmt_gap);
 	output_byte(FD_FILL_BYTE);
     }
@@ -803,9 +928,10 @@ void setup_rw_floppy(void)
 static void seek_interrupt(void)
 {
     /* sense drive status */
+    DEBUG("seekI-");
     output_byte(FD_SENSEI);
     if (result() != 2 || (ST0 & 0xF8) != 0x20 || ST1 != seek_track) {
-	printk("%s: seek failed\n", DEVICE_NAME);
+	printk("%s%d: seek failed\n", DEVICE_NAME, current_drive);
 	recalibrate = 1;
 	bad_flp_intr();
 	redo_fd_request();
@@ -818,14 +944,18 @@ static void seek_interrupt(void)
 /*
  * This routine is called when everything should be correctly set up
  * for the transfer (ie floppy motor is on and the correct floppy is
- * selected).
+ * selected, error conditions cleared).
  */
 static void transfer(void)
 {
+#ifdef CONFIG_TRACK_CACHE
     read_track = (command == FD_READ) && (CURRENT_ERRORS < 4) &&
 	(floppy->sect <= MAX_BUFFER_SECTORS);
+#endif
+    DEBUG("trns%d-", read_track);
 
-    configure_fdc_mode();
+    configure_fdc_mode();	/* FIXME: Why are we doing this here??? 
+    				 * should be done once per media change ... */
 
     if (reset) {
 	redo_fd_request();
@@ -836,24 +966,28 @@ static void transfer(void)
 	return;
     }
 
+    /* OK; need to change tracks ... */
     do_floppy = seek_interrupt;
+    DEBUG("sk%d;",seek_track);
     output_byte(FD_SEEK);
-    if (read_track)
-	output_byte(current_drive);
-    else
-	output_byte((head << 2) | current_drive);
+    output_byte((head << 2) | current_drive);
     output_byte(seek_track);
-    if (reset)
-	redo_fd_request();
+    //if (reset)	/* We already did this */
+	//redo_fd_request();
 }
 
 static void recalibrate_floppy(void)
 {
+    DEBUG("recal-");
     recalibrate = 0;
     current_track = 0;
     do_floppy = recal_interrupt;
     output_byte(FD_RECALIBRATE);
-    output_byte(head << 2 | current_drive);
+    output_byte(current_drive);
+
+    /* this may not make sense: We're waiting for recal_interrupt
+     * why redo_request here when recal_interrupt is doing it ??? */
+    /* 'reset' gets set in recal_interrupt, maybe that's it ??? */
     if (reset)
 	redo_fd_request();
 }
@@ -866,11 +1000,13 @@ static void recal_interrupt(void)
 {
     output_byte(FD_SENSEI);
     current_track = NO_TRACK;
-    if (result() != 2 || (ST0 & 0xE0) == 0x60)
+    if (result() != 2 || (ST0 & 0xE0) == 0x60) /* look for SEEK END and ABN TERMINATION*/
 	reset = 1;
+    DEBUG("recalI-%x", ST0);	/* Should be 0x20, Seek End */
     /* Recalibrate until track 0 is reached. Might help on some errors. */
-    if ((ST0 & 0x10) == 0x10)
-	recalibrate_floppy();	/* FIXME: should limit nr of recalibrates */
+    if (ST0 & 0x10)		/* Look for UnitCheck, which will happen regularly
+    				 * on 80 track drives because RECAL only steps 77 times */
+	recalibrate_floppy();	/* FIXME: may loop, should limit nr of recalibrates */
     else
 	redo_fd_request();
 }
@@ -893,13 +1029,16 @@ static void reset_interrupt(void)
 {
     short i;
 
+    DEBUG("rstI-");
     for (i = 0; i < 4; i++) {
 	output_byte(FD_SENSEI);
 	(void) result();
     }
+    //DEBUG("1-");
     output_byte(FD_SPECIFY);
     output_byte(cur_spec1);	/* hut etc */
     output_byte(6);		/* Head load time =6ms, DMA */
+    //DEBUG("2-");
     configure_fdc_mode();	/* reprogram fdc */
     if (initial_reset_flag) {
 	initial_reset_flag = 0;
@@ -920,8 +1059,8 @@ static void reset_interrupt(void)
  */
 static void reset_floppy(void)
 {
-    int i;
 
+    DEBUG("[%u]rst-", (unsigned int)jiffies);
     do_floppy = reset_interrupt;
     reset = 0;
     current_track = NO_TRACK;
@@ -940,45 +1079,55 @@ static void reset_floppy(void)
 
 static void floppy_shutdown(void)
 {
-    clr_irq();
+    printk("[%u]shtdwn0x%x|%x-", (unsigned int)jiffies, current_DOR, running);
     do_floppy = NULL;
     request_done(0);
     recover = 1;
     reset_floppy();
-    set_irq();
     redo_fd_request();
 }
 
 static void shake_done(void)
 {
+    /* Need SENSEI to clear the interrupt per spec, required by QEMU, not by
+     * real hardware	*/
+    output_byte(FD_SENSEI);	/* TESTING FIXME */
+    result();
+    DEBUG("shD0x%x-", ST0);
     current_track = NO_TRACK;
-    if (inb(FD_DIR) & 0x80)
-	request_done(0);
-    redo_fd_request();
+    if (inb(FD_DIR) & 0x80 || ST0 & 0xC0)
+	request_done(0);	/* still errors: just fail */
+    else
+	redo_fd_request();
 }
 
-
+/*
+ * The result byte after the SENSEI cmd is ST3, not ST0
+ */
 static int retry_recal(void (*proc)())
 {
+    DEBUG("rrecal-");
     output_byte(FD_SENSEI);
-    if (result() == 2 && (ST0 & 0x10) != 0x10)
-	return 0;
-    do_floppy = proc;
+    if (result() == 2 && (ST0 & 0x10) != 0x10) /* track 0 test */
+	return 0;		/* No 'unit check': We're OK */
+    do_floppy = proc;		/* otherwise recalibrate */
     output_byte(FD_RECALIBRATE);
-    output_byte(head << 2 | current_drive);
+    output_byte(current_drive);
     return 1;
 }
 
 static void shake_zero(void)
 {
+    DEBUG("sh0-");
     if (!retry_recal(shake_zero))
 	shake_done();
 }
 
 static void shake_one(void)
 {
+    DEBUG("sh1-");
     if (retry_recal(shake_one))
-	return;
+	return;	/* just return if retry_recal initiated a RECAL */
     do_floppy = shake_done;
     output_byte(FD_SEEK);
     output_byte(head << 2 | current_drive);
@@ -987,21 +1136,30 @@ static void shake_one(void)
 
 static void floppy_ready(void)
 {
-    if (inb(FD_DIR) & 0x80) {
+    DEBUG("RDY0x%x,%d,%d-", inb(FD_DIR), reset, recalibrate);
+    if (inb(FD_DIR) & 0x80) {	/* set if disk changed since last cmd (AT ++) */
+#ifdef CHECK_DISK_CHANGE
 	changed_floppies |= 1 << current_drive;
+#endif
 	buffer_track = -1;
 	if (keep_data[current_drive]) {
 	    if (keep_data[current_drive] > 0)
 		keep_data[current_drive]--;
 	} else {
+		/* FIXME: this is non sensical: Need to assume that a medium change
+		 * means a new medium of the same format as the prev until it fails.
+		 */
 	    if (ftd_msg[current_drive] && current_type[current_drive] != NULL)
-		printk("Disk type is undefined after disk change in fd%d\n",
+		printk("Disk type is undefined after disk change in df%d\n",
 		       current_drive);
 	    current_type[current_drive] = NULL;
+#ifdef BDEV_SIZE_CHK
 	    floppy_sizes[current_drive] = MAX_DISK_SIZE;
+#endif
 	}
 	/* Forcing the drive to seek makes the "media changed" condition go
 	 * away. There should be a cleaner solution for that ...
+	 * FIXME: This is way too slow and recal is not seek ...
 	 */
 	if (!reset && !recalibrate) {
 	    if (current_track && current_track != NO_TRACK)
@@ -1009,10 +1167,11 @@ static void floppy_ready(void)
 	    else
 		do_floppy = shake_one;
 	    output_byte(FD_RECALIBRATE);
-	    output_byte(head << 2 | current_drive);
+	    output_byte(current_drive);
 	    return;
 	}
     }
+
     if (reset) {
 	reset_floppy();
 	return;
@@ -1048,18 +1207,20 @@ static void setup_format_params(void)
 
 static void redo_fd_request(void)
 {
-    unsigned int block;
-    char *buffer_area;
-    int device;
+    unsigned int start;
+    struct request *req;
+    int device, drive;
 
-    if (CURRENT && CURRENT->dev < 0)
+    /* cannot use the INIT_REQUEST macro since req=NULL is OK */
+
+    if (CURRENT && ((int)CURRENT->rq_dev == -1U))
 	return;
-
   repeat:
+    req = CURRENT;
     if (format_status == FORMAT_WAIT)
 	format_status = FORMAT_BUSY;
     if (format_status != FORMAT_BUSY) {
-	if (!CURRENT) {
+	if (!req) {
 	    if (!fdc_busy)
 		printk("FDC access conflict!");
 	    fdc_busy = 0;
@@ -1067,23 +1228,24 @@ static void redo_fd_request(void)
 	    CLEAR_INTR;
 	    return;
 	}
-	if (MAJOR(CURRENT->dev) != MAJOR_NR)
+	if (MAJOR(req->rq_dev) != MAJOR_NR)
 	    panic("%s: request list destroyed", DEVICE_NAME);
-	if (CURRENT->bh) {
-	    if (!(CURRENT->bh)->b_locked)
+	if (req->rq_bh) {
+	    if (!EBH(req->rq_bh)->b_locked)
 		panic("%s: block not locked", DEVICE_NAME);
 	}
     }
     seek = 0;
     probing = 0;
-    device = MINOR(CURRENT_DEVICE);
+    device = MINOR(CURRENT_DEVICE) >> MINOR_SHIFT;
+    drive = device & 3;
     if (device > 3)
 	floppy = (device >> 2) + floppy_type;
     else {			/* Auto-detection */
-	floppy = current_type[device & 3];
+	floppy = current_type[drive];
 	if (!floppy) {
 	    probing = 1;
-	    floppy = base_type[device & 3];
+	    floppy = base_type[drive];
 	    if (!floppy) {
 		request_done(0);
 		goto repeat;
@@ -1092,31 +1254,43 @@ static void redo_fd_request(void)
 		floppy++;
 	}
     }
+    DEBUG("[%u]redo-%c %d(%s) bl %u;", (unsigned int)jiffies, 
+		req->rq_cmd == WRITE? 'W':'R', device, floppy->name, req->rq_blocknr);
+    debug_blkdrv("df[%04x]: %c blk %ld\n", CURRENT_DEVICE, req->rq_cmd==WRITE? 'W' : 'R', req->rq_blocknr);
     if (format_status != FORMAT_BUSY) {
-	if (current_drive != CURRENT_DEV) {
+    	unsigned int tmp;
+	if (current_drive != drive) {
 	    current_track = NO_TRACK;
-	    current_drive = CURRENT_DEV;
+	    current_drive = drive;
 	}
-	block = CURRENT->sector;
-	if (block + 2 > floppy->size) {
+	/* rq_blocknr is ALWAYS sectors */
+	start = (unsigned int) req->rq_blocknr;
+	if (start + 2 > floppy->size) {
 	    request_done(0);
-	    goto repeat;
+	    goto repeat;	/* FIXME: Should probably exit here */
+				/* or at least increment an error counter */
 	}
-	sector = block % floppy->sect;
-	block /= floppy->sect;
-	head = block % floppy->head;
-	track = block / floppy->head;
+#ifdef CONFIG_BLK_DEV_CHAR
+	nr_sectors = req->rq_nr_sectors;	/* non-zero if raw io */
+#endif
+	sector = start % floppy->sect;
+	tmp = start / floppy->sect;
+	head = tmp % floppy->head;
+	track = tmp / floppy->head;
 	seek_track = track << floppy->stretch;
-	if (CURRENT->cmd == READ)
+	DEBUG("%d:%d:%d:%d; ", start, sector, head, track);
+	if (req->rq_cmd == READ)
 	    command = FD_READ;
-	else if (CURRENT->cmd == WRITE)
+	else if (req->rq_cmd == WRITE)
 	    command = FD_WRITE;
 	else {
-	    printk("do_fd_request: unknown command\n");
+	    printk("redo_fd_request: unknown command\n");
 	    request_done(0);
 	    goto repeat;
 	}
-    } else {
+    }
+#ifdef INCLUDE_FD_FORMATTING
+    else {	/* Format drive */
 	if (current_drive != (format_req.device & 3))
 	    current_track = NO_TRACK;
 	current_drive = format_req.device & 3;
@@ -1128,55 +1302,98 @@ static void redo_fd_request(void)
 	head = format_req.head;
 	track = format_req.track;
 	seek_track = track << floppy->stretch;
-	if (seek_track == buffer_track)
+	if ((seek_track << 1) + head == buffer_track)
 	    buffer_track = -1;
 	command = FD_FORMAT;
 	setup_format_params();
     }
-#ifndef TRP_TIMER
-    timer_table[FLOPPY_TIMER].expires = jiffies + 10 * HZ;
-    timer_active |= 1 << FLOPPY_TIMER;
 #endif
-    if ((seek_track == buffer_track) && (current_drive == buffer_drive)) {
-	buffer_area = floppy_track_buffer +
-	    ((sector + head * floppy->sect) << 9);
-	if (command == FD_READ) {
-	    copy_buffer(buffer_area, CURRENT->buffer);
+
+    /* timer for hung operations, 6 secs probably too long ... */
+    del_timer(&fd_timeout);
+    fd_timeout.tl_expires = jiffies + 6 * HZ;
+    add_timer(&fd_timeout);
+
+    DEBUG("prep %d|%d,%d|%d-", buffer_track, seek_track, buffer_drive, current_drive);
+
+    if ((((seek_track << 1) + head) == buffer_track) && (current_drive == buffer_drive)) {
+	/* Requested block is in the buffer. If reading, go get it.
+	 * If the sector count is odd, we buffer sectors+1 when head=0 to get an even
+	 * number of sectors (full blocks). When head=1 we read the entire track
+	 * and ignore the first sector.
+	 */
+	DEBUG("bufrd tr/h/s %d/%d/%d\n", seek_track, head, sector);
+	char *buf_ptr = (char *) (sector << 9);
+	if (command == FD_READ) {	/* requested data is in buffer */
+#ifdef CONFIG_FS_XMS_BUFFER
+	    xms_fmemcpyw(req->rq_buffer, req->rq_seg, buf_ptr, DMASEG, BLOCK_SIZE/2);
+#else
+	    fmemcpyw(req->rq_buffer, req->rq_seg, buf_ptr, DMASEG, BLOCK_SIZE/2);
+#endif
 	    request_done(1);
 	    goto repeat;
-	} else if (command == FD_WRITE)
-	    copy_buffer(CURRENT->buffer, buffer_area);
-    }
+    	} else if (command == FD_WRITE)	/* update track buffer */
+#ifdef CONFIG_FS_XMS_BUFFER
+	    xms_fmemcpyw(buf_ptr, DMASEG, req->rq_buffer, req->rq_seg, BLOCK_SIZE/2);
+#else
+	    fmemcpyw(buf_ptr, DMASEG, req->rq_buffer, req->rq_seg, BLOCK_SIZE/2);
+#endif
+    } 
+
     if (seek_track != current_track)
 	seek = 1;
-    sector++;
-#ifndef TRP_TIMER
-    del_timer(motor_off_timer + current_drive);
-#endif
+
     floppy_on(current_drive);
 }
 
 void do_fd_request(void)
 {
-    clr_irq();
+    DEBUG("fdrq:");
+    if (CURRENT) CURRENT->rq_errors = 0;	// EXPERIMENTAL
+    //clr_irq();
     while (fdc_busy)
 	sleep_on(&fdc_wait);
     fdc_busy = 1;
-    set_irq();
+    //set_irq();
     redo_fd_request();
 }
 
 static int fd_ioctl(struct inode *inode,
-		    struct file *filp, unsigned int cmd, unsigned long param)
+		    struct file *filp, unsigned int cmd, unsigned int param)
 {
+/* FIXME: Get this back in when everything else is working */
+/* Needs a big cleanup */
     struct floppy_struct *this_floppy;
-    int i, drive, cnt, okay;
+    int drive, err = -EINVAL;
+    struct hd_geometry *loc = (struct hd_geometry *) param;
 
+#if 0 /* what is this ? */
     switch (cmd) {
 	RO_IOCTLS(inode->i_rdev, param);
     }
-    drive = MINOR(inode->i_rdev);
+#endif
+    if (!inode || !inode->i_rdev)
+	return -EINVAL;
+    drive = MINOR(inode->i_rdev) >> MINOR_SHIFT;
+    if (drive > 3)
+	this_floppy = &floppy_type[drive >> 2];
+    else if ((this_floppy = current_type[drive & 3]) == NULL)
+	return -ENODEV;
+
     switch (cmd) {
+    case HDIO_GETGEO:	/* need this one for the sys/makeboot command */
+    case FDGETPRM:
+	err = verify_area(VERIFY_WRITE, (void *) param, sizeof(struct hd_geometry));
+	if (!err) {
+	    put_user_char(this_floppy->head, &loc->heads);
+	    put_user_char(this_floppy->sect, &loc->sectors);
+	    put_user(this_floppy->track, &loc->cylinders);
+	    put_user_long(0L, &loc->start);
+	}
+	//return verified_memcpy_tofs((char *)param,
+	//	    (char *)this_floppy, sizeof(struct floppy_struct));
+	return err;
+#ifdef INCLUDE_FD_FORMATTING
     case FDFMTBEG:
 	if (!suser())
 	    return -EPERM;
@@ -1190,13 +1407,6 @@ static int fd_ioctl(struct inode *inode,
 	drive &= 3;
 	cmd = FDCLRPRM;
 	break;
-    case FDGETPRM:
-	if (drive > 3)
-	    this_floppy = &floppy_type[drive >> 2];
-	else if ((this_floppy = current_type[drive & 3]) == NULL)
-	    return -ENODEV;
-	return verified_memcpy_tofs((char *)param,
-		    (char *)this_floppy, sizeof(struct floppy_struct));
     case FDFMTTRK:
 	if (!suser())
 	    return -EPERM;
@@ -1207,7 +1417,7 @@ static int fd_ioctl(struct inode *inode,
 	    sleep_on(&format_done);
 	memcpy_fromfs((char *)(&format_req),
 		    (char *)param, sizeof(struct format_descr));
-	format_req.device = drive;
+	format_req.device = drive; 	/* Should this be a full device ID? */
 	format_status = FORMAT_WAIT;
 	format_errors = 0;
 	while (format_status != FORMAT_OKAY && format_status != FORMAT_ERROR) {
@@ -1221,11 +1431,11 @@ static int fd_ioctl(struct inode *inode,
 	while (format_status != FORMAT_OKAY && format_status != FORMAT_ERROR)
 	    sleep_on(&format_done);
 	set_irq();
-	okay = format_status == FORMAT_OKAY;
+	err = format_status == FORMAT_OKAY;
 	format_status = FORMAT_NONE;
 	floppy_off(drive & 3);
 	wake_up(&format_done);
-	return okay ? 0 : -EIO;
+	return err ? 0 : -EIO;
     case FDFLUSH:
 	if (!permission(inode, 2))
 	    return -EPERM;
@@ -1242,7 +1452,9 @@ static int fd_ioctl(struct inode *inode,
     switch (cmd) {
     case FDCLRPRM:
 	current_type[drive] = NULL;
+#ifdef BDEV_SIZE_CHK
 	floppy_sizes[drive] = MAX_DISK_SIZE;
+#endif
 	keep_data[drive] = 0;
 	break;
     case FDSETPRM:
@@ -1250,7 +1462,9 @@ static int fd_ioctl(struct inode *inode,
 	memcpy_fromfs(user_params + drive,
 		      (void *) param, sizeof(struct floppy_struct));
 	current_type[drive] = &user_params[drive];
+#ifdef BDEV_SIZE_CHK
 	floppy_sizes[drive] = user_params[drive].size >> 1;
+#endif
 	if (cmd == FDDEFPRM)
 	    keep_data[drive] = -1;
 	else {
@@ -1279,10 +1493,11 @@ static int fd_ioctl(struct inode *inode,
     case FDSETEMSGTRESH:
 	min_report_error_cnt[drive] = (unsigned short) (param & 0x0f);
 	break;
+#endif
     default:
 	return -EINVAL;
     }
-    return 0;
+    return err;
 }
 
 #ifdef TRP_ASM
@@ -1291,7 +1506,7 @@ outb_p(addr,0x70); \
 inb_p(0x71); \
 })
 #else
-int CMOS_READ(long addr)
+int CMOS_READ(int addr)
 {
     outb_p(addr, 0x70);
     return inb_p(0x71);
@@ -1304,22 +1519,22 @@ static struct floppy_struct *find_base(int drive, int code)
 
     if (code > 0 && code < 5) {
 	base = &floppy_types[(code - 1) * 2];
-	printk("fd%d is %s", drive, base->name);
+	printk("df%d is %s (%d)", drive, base->name, code);
 	return base;
     }
-    printk("fd%d is unknown type %d", drive, code);
+    printk("df%d is unknown type %d", drive, code);
     return NULL;
 }
 
 static void config_types(void)
 {
-    printk("Floppy drive(s): ");
-    base_type[0] = find_base(0, (CMOS_READ(0x10) >> 4) & 15);
+    printk("Floppy drive(s) [CMOS]: ");
+    base_type[0] = find_base(0, (CMOS_READ(0x10) >> 4) & 0xF);
     if (((CMOS_READ(0x14) >> 6) & 1) == 0)
 	base_type[1] = NULL;
     else {
 	printk(", ");
-	base_type[1] = find_base(1, CMOS_READ(0x10) & 15);
+	base_type[1] = find_base(1, CMOS_READ(0x10) & 0xF);
     }
     base_type[2] = base_type[3] = NULL;
     printk("\n");
@@ -1332,45 +1547,59 @@ static void config_types(void)
  */
 static int floppy_open(struct inode *inode, struct file *filp)
 {
-    int drive, old_dev, device;
+    int drive, old_dev, dev;
 
-    drive = inode->i_rdev & 3;
-    old_dev = fd_device[drive];
-    if (fd_ref[drive])
-	if (old_dev != inode->i_rdev)
-	    return -EBUSY;
-    fd_ref[drive]++;
-    fd_device[drive] = inode->i_rdev;
-    buffer_drive = buffer_track = -1;
+    drive = MINOR(inode->i_rdev) >> MINOR_SHIFT;
+    dev = drive & 3;
+    old_dev = fd_device[dev];
     if (old_dev && old_dev != inode->i_rdev)
+	    return -EBUSY;	/* no reopens using differen minor */
+    fd_ref[dev]++;
+    fd_device[dev] = inode->i_rdev;
+    buffer_drive = buffer_track = -1;	/* FIXME: Don't invalidate buffer if
+					 * this is a reopen of the currently
+					 * bufferd drive. */
+
+    if (fd_ref[dev] == 1) invalidate_buffers(inode->i_rdev);	/* EXPERIMENTAL */
+#if 0
+    if (old_dev && old_dev != inode->i_rdev)	/* FIXME: Delete. This cannot happen */
+						/* same test cause return EBUSY above */
 	invalidate_buffers(old_dev);
+#endif
+#ifdef CHECK_DISK_CHANGE
     if (filp && filp->f_mode)
 	check_disk_change(inode->i_rdev);
+#endif
 
-/* FIXME: Put the correct value for inode->i_size */
-    device = MINOR(inode->i_rdev);
-    if (device > 3)
-	floppy = (device >> 2) + floppy_type;
+    if (drive > 3)		/* forced floppy type */
+	floppy = (drive >> 2) + floppy_type;
     else {			/* Auto-detection */
-	floppy = current_type[device & 3];
+	floppy = current_type[dev];
 	if (!floppy) {
 	    probing = 1;
-	    floppy = base_type[device & 3];
+	    floppy = base_type[dev];
 	    if (!floppy)
 		return -ENXIO;
 	}
     }
-    inode->i_size = ((sector_t)(floppy->size)) << 9;
+    inode->i_size = ((sector_t)(floppy->size)) << 9;	/* NOTE: assumes sector size 512 */
+    debug_blkdrv("df%d: open dv %x, sz %lu, %s\n", drive,
+		inode->i_rdev, inode->i_size, floppy->name);
 
     return 0;
 }
 
 static void floppy_release(struct inode *inode, struct file *filp)
 {
+    int drive = MINOR(inode->i_rdev) >> MINOR_SHIFT;
+
+    DEBUG("df%d release", drive);
     sync_dev(inode->i_rdev);
-    if (!fd_ref[inode->i_rdev & 3]--) {
+    DEBUG("\n");
+    invalidate_buffers(inode->i_rdev);
+    if (!fd_ref[drive & 3]--) {
 	printk("floppy_release with fd_ref == 0");
-	fd_ref[inode->i_rdev & 3] = 0;
+	fd_ref[drive & 3] = 0;
     }
 }
 
@@ -1381,7 +1610,6 @@ static struct file_operations floppy_fops = {
     NULL,			/* readdir - bad */
     NULL,			/* select */
     fd_ioctl,			/* ioctl */
-    NULL,			/* mmap */
     floppy_open,		/* open */
     floppy_release,		/* release */
 };
@@ -1401,49 +1629,44 @@ static void ignore_interrupt(void)
     CLEAR_INTR;			/* ignore only once */
 }
 
-static void floppy_interrupt(int unused)
+static void floppy_interrupt(int unused, struct pt_regs *unused1)
 {
     void (*handler) () = DEVICE_INTR;
 
     DEVICE_INTR = NULL;
     if (!handler)
 	handler = unexpected_floppy_interrupt;
+    //printk("$");
     handler();
 }
 
-/*
- * This is the floppy IRQ description. The SA_INTERRUPT in sa_flags
- * means we run the IRQ-handler with interrupts disabled.
- */
-static struct sigaction floppy_sigaction = {
-    floppy_interrupt,
-    0,
-    SA_INTERRUPT,
-    NULL
-};
-
-void floppy_init(void)
+void INITPROC floppy_init(void)
 {
-    extern int blk_size[];
+#ifdef BDEV_SIZE_CHK
+    extern int *blk_size[];
+#endif
+    int err;
 
-    outb(current_DOR, FD_DOR);
-    if (register_blkdev(MAJOR_NR, "fd", &floppy_fops)) {
+    outb(current_DOR, FD_DOR);	/* all motors off, DMA, /RST  (0x0c) */
+    if (register_blkdev(MAJOR_NR, DEVICE_NAME, &floppy_fops)) {
 	printk("Unable to get major %d for floppy\n", MAJOR_NR);
 	return;
     }
+#ifdef BDEV_SIZE_CHK
     blk_size[MAJOR_NR] = floppy_sizes;
+#endif
     blk_dev[MAJOR_NR].request_fn = DEVICE_REQUEST;
-#ifndef TRP_TIMER
-    timer_table[FLOPPY_TIMER].fn = floppy_shutdown;
-    timer_active &= ~(1 << FLOPPY_TIMER);
-#endif
+
     config_types();
-#ifdef TRP_SIG
-    if (irqaction(FLOPPY_IRQ, &floppy_sigaction))
+    err = request_irq(FLOPPY_IRQ, floppy_interrupt, INT_GENERIC);
+    if (err) {
 	printk("Unable to grab IRQ%d for the floppy driver\n", FLOPPY_IRQ);
-#endif
-    if (request_dma(FLOPPY_DMA))
+	return;	/* should be able to signal failure back to the caller */
+    }
+
+    if (request_dma(FLOPPY_DMA, (void *)DEVICE_NAME))
 	printk("Unable to grab DMA%d for the floppy driver\n", FLOPPY_DMA);
+
     /* Try to determine the floppy controller type */
     DEVICE_INTR = ignore_interrupt;	/* don't ask ... */
     output_byte(FD_VERSION);	/* get FDC version code */
@@ -1453,7 +1676,8 @@ void floppy_init(void)
     } else
 	fdc_version = reply_buffer[0];
     if (fdc_version != FDC_TYPE_STD)
-	printk("%s: FDC version 0x%x\n", DEVICE_NAME, fdc_version);
+	printk("%s: Direct floppy driver, FDC (%s) @ irq %d, DMA %d\n", DEVICE_NAME, 
+		fdc_version == 0x80 ? "8272A" : "82077", FLOPPY_IRQ, FLOPPY_DMA);
 #ifndef FDC_FIFO_UNTESTED
     fdc_version = FDC_TYPE_STD;	/* force std fdc type; can't test other. */
 #endif
@@ -1462,9 +1686,41 @@ void floppy_init(void)
      * properly, so force a reset for the standard FDC clones,
      * to avoid interrupt garbage.
      */
-
+#if 1	/* testing FIXME --  the FDC has just been reset by the BIOS, do we need this? */
     if (fdc_version == FDC_TYPE_STD) {
 	initial_reset_flag = 1;
 	reset_floppy();
     }
+#endif
 }
+
+#if 0
+/* replace separate DMA handler later - this is much more compact and efficient */
+
+/*===========================================================================*
+ *				dma_setup (from minix driver)		     *
+ *===========================================================================*/
+static void dma_setup(int opcode)
+{
+/* The IBM PC can perform DMA operations by using the DMA chip.  To use it,
+ * the DMA (Direct Memory Access) chip is loaded with the 20-bit memory address
+ * to be read from or written to, the byte count minus 1, and a read or write
+ * opcode.  This routine sets up the DMA chip.  Note that the chip is not
+ * capable of doing a DMA across a 64K boundary (e.g., you can't read a
+ * 512-byte block starting at physical address 65520).
+ */
+
+  /* Set up the DMA registers.  (The comment on the reset is a bit strong,
+   * it probably only resets the floppy channel.)
+   */
+  outb(DMA_INIT, DMA_RESET_VAL);	/* reset the dma controller */
+  outb(DMA_FLIPFLOP, 0);		/* write anything to reset it */
+  outb(DMA_MODE, opcode == DEV_SCATTER ? DMA_WRITE : DMA_READ);
+  outb(DMA_ADDR, (unsigned) tmp_phys >>  0);
+  outb(DMA_ADDR, (unsigned) tmp_phys >>  8);
+  outb(DMA_TOP, (unsigned) (tmp_phys >> 16));
+  outb(DMA_COUNT, (SECTOR_SIZE - 1) >> 0);
+  outb(DMA_COUNT, (SECTOR_SIZE - 1) >> 8);
+  outb(DMA_INIT, 2);			/* some sort of enable */
+}
+#endif

--- a/elks/include/linuxmt/fd.h
+++ b/elks/include/linuxmt/fd.h
@@ -33,7 +33,7 @@ struct floppy_struct {
 	rate,			/* data rate. |= 0x40 for perpendicular */
 	spec1,			/* stepping rate, head unload time */
 	fmt_gap;		/* gap2 size */
-    char *name; 		/* used only for predefined formats */
+    const char *name; 		/* used only for predefined formats */
 };
 
 struct format_descr {

--- a/elks/include/linuxmt/init.h
+++ b/elks/include/linuxmt/init.h
@@ -47,7 +47,7 @@ extern int INITPROC bios_getfdinfo(struct drive_infot *);
 extern dev_t INITPROC bios_conv_bios_drive(unsigned int biosdrive);
 extern int INITPROC get_ide_data(int, struct drive_infot *);
 extern int directhd_init(void);
-extern void floppy_init(void);
+extern void INITPROC floppy_init(void);
 extern void INITPROC rd_init(void);
 extern void INITPROC ssd_init(void);
 extern void romflash_init(void);

--- a/elks/include/linuxmt/major.h
+++ b/elks/include/linuxmt/major.h
@@ -21,7 +21,7 @@
  *  1 - /dev/mem               /dev/rd[01]            char mem, block ramdisk
  *  2 - /dev/ptyp*             /dev/ssd               char pty master, block ssd
  *  3 -                        /dev/{fd*,hd*}         block BIOS fd/hd
- *  4 - /dev/tty*,ttyp*,ttyS*                         char tty, pty slave, serial
+ *  4 - /dev/tty*,ttyp*,ttyS*  /dev/f{0,1}            char tty, pty slave, serial, block fd
  *  5 -
  *  6 - /dev/lp                /dev/rom               char lp, block romflash
  *  7 - /dev/ucd               /dev/ubd               meta UDD user device drivers
@@ -48,10 +48,9 @@
 /* These are the block devices */
 
 #define RAM_MAJOR         1
-#define FLOPPY_MAJOR      2  /* experimental*/
 #define SSD_MAJOR         2
 #define BIOSHD_MAJOR      3
-                             /* 4 unused*/
+#define FLOPPY_MAJOR      4  /* experimental*/
 #define ATHD_MAJOR        5  /* experimental*/
 #define ROMFLASH_MAJOR    6
 

--- a/elks/kernel/Makefile
+++ b/elks/kernel/Makefile
@@ -36,9 +36,8 @@ include $(BASEDIR)/Makefile-rules
 # Objects to compile.
 # unused: wait.o lock.o
 
-UNUSED = dma.o
 OBJS  = sched.o printk.o sleepwake.o version.o sys.o sys2.o fork.o \
-	exit.o time.o signal.o
+	exit.o time.o signal.o dma.o
 
 #########################################################################
 # Commands:

--- a/elks/kernel/dma.c
+++ b/elks/kernel/dma.c
@@ -42,7 +42,7 @@
 
 struct dma_chan {
     int lock;
-    char *device_id;
+    const char *device_id;
 };
 
 static struct dma_chan dma_chan_busy[MAX_DMA_CHANNELS] = {
@@ -55,6 +55,14 @@ static struct dma_chan dma_chan_busy[MAX_DMA_CHANNELS] = {
     {0, 0},
     {0, 0}
 };
+
+#define xchg(op, arg) \
+( {			   \
+	typeof(arg) __ret; \
+	__ret = *op;	   \
+	*op = arg;	   \
+	__ret;		   \
+} )
 
 #ifdef ONE_DAY
 
@@ -73,7 +81,7 @@ int get_dma_list(char *buf)
 
 int request_dma(unsigned char dma, void *device)
 {
-    unsigned char *device_id = device;
+    unsigned char *device_id = (unsigned char *)device;
 
     if (dma >= MAX_DMA_CHANNELS)
 	return -EINVAL;
@@ -186,7 +194,7 @@ void set_dma_page(unsigned char dma, unsigned char page)
 
 void set_dma_addr(unsigned char dma, unsigned long addr)
 {
-    set_dma_page(dma, addr >> 16);
+    set_dma_page(dma, (long)addr >> 16);
     if (dma <= 3) {
 	dma_outb(addr & 0xff, (dma << 1) + IO_DMA1_BASE);
 	dma_outb((addr >> 8) & 0xff, (dma << 1) + IO_DMA1_BASE);

--- a/elks/kernel/dma.c
+++ b/elks/kernel/dma.c
@@ -12,7 +12,7 @@
 
 #include <linuxmt/config.h>
 
-#ifdef CONFIG_DMA
+#ifdef CONFIG_BLK_DEV_FD
 
 #include <linuxmt/types.h>
 #include <linuxmt/kernel.h>

--- a/image/Make.devices
+++ b/image/Make.devices
@@ -60,6 +60,11 @@ devices:
 	$(MKDEV) /dev/fd1  b 3 40
 
 ##############################################################################
+# Direct floppy devices.
+	$(MKDEV) /dev/df0  b 4 0
+	$(MKDEV) /dev/df1  b 4 1
+
+##############################################################################
 # Pseudo-TTY master devices. 
 
 	$(MKDEV) /dev/ptyp0 c 2 8


### PR DESCRIPTION
@Mellvik took Linus's original direct floppy driver from ELKS and got it working using async I/O on his TLVC fork.

I was able to import @Mellvik's code back into ELKS and got it integrated and running in about half an hour. Nice work @Mellvik!!

The driver is currently experimental-only for ELKS and requires CONFIG_ASYNCIO=y to also be set. For testing, QEMU is being used (no real hardware yet), and the system is booted via the BIOS driver hard drive on /dev/hda. Then, `mount /dev/df0 /mnt` is used to open the direct FD driver and mount a 1200k floppy. (QEMU is reporting a 1200k floppy in CMOS even when a 360k floppy image is attached, so using 1200k only for now). `ls -l /mnt`, etc works for a while, then the floppy system becomes heavily corrupted in RAM, for reasons unknown.

This will likely be committed so that some other modifications can be made to ELKS, for instance to disable track caching for hard drives, which will then allow DMASEG to be used for (all) floppy I/O, without worries for DMA 64k boundary overruns and eventual sharing of the BIOS track caching code. I will then continue to investigate the issues seen to determine whether they are ELKS kernel issues with async I/O or with the FD driver.

