### PR TITLE
[kernel] Disable track caching for hard drives

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -722,10 +722,12 @@ next_block:
 
         buf = req->rq_buffer;
         while (count > 0) {
-            int num_sectors;
+            int num_sectors = 0;
 #ifdef CONFIG_TRACK_CACHE
-            /* first try reading track cache*/
-            num_sectors = do_cache_read(drivep, start, buf, req->rq_seg, req->rq_cmd);
+            if (drivep - drive_info >= DRIVE_FD0) {
+                /* first try reading track cache*/
+                num_sectors = do_cache_read(drivep, start, buf, req->rq_seg, req->rq_cmd);
+            }
             if (!num_sectors)
 #endif
                 /* then fallback with retries if required*/

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -180,7 +180,7 @@ static void INITPROC kernel_banner(seg_t start, seg_t end, seg_t init, seg_t ext
 #endif
 
     printk("syscaps %x, %uK base ram\n", sys_caps, SETUP_MEM_KBYTES);
-    printk("ELKS kernel %s (%u text, %u ftext, %u data, %u bss, %u heap)\n",
+    printk("ELKS %s (%u text, %u ftext, %u data, %u bss, %u heap)\n",
            system_utsname.release,
            (unsigned)_endtext, (unsigned)_endftext, (unsigned)_enddata,
            (unsigned)_endbss - (unsigned)_enddata, heapsize);


### PR DESCRIPTION
Track caching will only be performed for floppy drives. This will allow for better performance since the floppy track cache won't be invalidated when/if a hard drive access is made. 

This also allows the experimental direct floppy driver to always use DMASEG for simplification.