### PR TITLE
[kernel] Misc cleanups

### DIFF
--- a/elks/arch/i86/drivers/block/Makefile
+++ b/elks/arch/i86/drivers/block/Makefile
@@ -58,7 +58,7 @@ endif
 
 # experimental direct fd support
 ifeq ($(CONFIG_BLK_DEV_FD), y)
-OBJS += directfd.o
+OBJS += directfd.o dma.o
 endif
 
 # experimental (and not working) direct hd support

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -110,6 +110,7 @@ static void set_cache_invalid(void)
     cache_drive = NULL;
 }
 
+#ifdef CONFIG_BLK_DEV_BFD
 static int read_sector(int drive, int cylinder, int sector)
 {
     int count = 2;              /* one retry on probe or boot sector read */
@@ -129,7 +130,6 @@ static int read_sector(int drive, int cylinder, int sector)
     return 1;                   /* error */
 }
 
-#ifdef CONFIG_BLK_DEV_BFD
 static void probe_floppy(int target, struct hd_struct *hdp)
 {
     /* Check for disk type */

--- a/elks/arch/i86/drivers/block/dma.c
+++ b/elks/arch/i86/drivers/block/dma.c
@@ -81,7 +81,7 @@ int get_dma_list(char *buf)
 
 int request_dma(unsigned char dma, void *device)
 {
-    unsigned char *device_id = (unsigned char *)device;
+    char *device_id = device;
 
     if (dma >= MAX_DMA_CHANNELS)
 	return -EINVAL;

--- a/elks/include/linuxmt/limits.h
+++ b/elks/include/linuxmt/limits.h
@@ -26,7 +26,7 @@
 #define NR_MAPBUFS      8       /* Number of internal L1 buffers */
 
 #ifdef CONFIG_ASYNCIO
-#define NR_REQUEST      4       /* Number of async I/O request headers */
+#define NR_REQUEST      12      /* Number of async I/O request headers */
 #else
 #define NR_REQUEST      1       /* only 1 is required for non-async I/O */
 #endif

--- a/elks/kernel/Makefile
+++ b/elks/kernel/Makefile
@@ -34,10 +34,10 @@ include $(BASEDIR)/Makefile-rules
 
 #########################################################################
 # Objects to compile.
-# unused: wait.o lock.o
 
+# unused: wait.o lock.o
 OBJS  = sched.o printk.o sleepwake.o version.o sys.o sys2.o fork.o \
-	exit.o time.o signal.o dma.o
+	exit.o time.o signal.o
 
 #########################################################################
 # Commands:


### PR DESCRIPTION
Moves dma.c to elks/arch/i86/drivers/block/dma.c.

Increases NR_REQUESTS to 12 for better async I/O testing with direct FD driver.

