### PR TITLE
[cmds] Speed up the sl choo choo train for slow systems

### DIFF
--- a/elkscmd/tui/curses.c
+++ b/elkscmd/tui/curses.c
@@ -22,7 +22,8 @@ void *stdscr;
 void *initscr()
 {
     tty_init(MouseTracking|CatchISig|FullBuffer);
-    tty_getsize(&COLS, &LINES);
+    if (isatty(1))
+        tty_getsize(&COLS, &LINES);
     return stdout;
 }
 
@@ -85,6 +86,12 @@ void refresh()
 void mvcur(int oy, int ox, int y, int x)
 {
     move(y, x);
+}
+
+int addch(int ch)
+{
+    putchar(ch);
+    return OK;
 }
 
 int mvaddch(int y, int x, int ch)

--- a/elkscmd/tui/curses.h
+++ b/elkscmd/tui/curses.h
@@ -75,3 +75,4 @@ void nodelay(void *,int);
 void refresh();
 void mvcur(int,int,int,int);
 int mvaddch(int,int,int);
+int addch(int);

--- a/elkscmd/tui/sl.c
+++ b/elkscmd/tui/sl.c
@@ -55,14 +55,20 @@ int ACCIDENT  = 0;
 int LOGO      = 0;
 int FLY       = 0;
 int C51       = 0;
+int SLOW      = 0;
 
 int my_mvaddstr(int y, int x, char *str)
 {
+    int startx;
+
     for ( ; x < 0; ++x, ++str)
         if (*str == '\0')  return ERR;
+    startx = x;
     for ( ; *str != '\0'; ++str, ++x) {
         if (x >= COLS) break;
-        if (mvaddch(y, x, *str) == ERR)  return ERR;
+        if (!SLOW && x > startx && x < COLS)
+            addch(*str);
+        else mvaddch(y, x, *str);
     }
     return OK;
 }
@@ -77,6 +83,7 @@ void option(char *str)
             case 'F': FLY      = 1; break;
             case 'l': LOGO     = 1; break;
             case 'c': C51      = 1; break;
+            case 's': SLOW     = 1; break;
             default:                break;
         }
     }


### PR DESCRIPTION
Removes ANSI cursor positioning per character output - runs 40x faster, 0.08 seconds on QEMU!

Adds -s option (`sl -s`) to run in older "slow" mode, useful for testing system performance (and actually seeing the train on QEMU).

Doesn't output ANSI DSR sequence if not a terminal, fixing problems with `sl > file`.