### PR TITLE
[directfd] Add support for 2880k discs, multiple open/close

### DIFF
--- a/elks/arch/i86/drivers/block/dma.c
+++ b/elks/arch/i86/drivers/block/dma.c
@@ -17,6 +17,7 @@
 #include <linuxmt/types.h>
 #include <linuxmt/kernel.h>
 #include <linuxmt/errno.h>
+#include <linuxmt/debug.h>
 #include <arch/dma.h>
 #include <arch/system.h>
 
@@ -81,7 +82,7 @@ int request_dma(unsigned char dma, const char *device)
 void free_dma(unsigned char dma)
 {
     if (dma >= MAX_DMA_CHANNELS)
-	printk("Trying to free DMA%u\n", dma);
+	debug("Trying to free DMA%u\n", dma);
     else if (!xchg(&dma_chan_busy[dma].lock, 0)) {
 	printk("Trying to free free DMA%u\n", dma);
 } }				/* free_dma */
@@ -91,7 +92,7 @@ void free_dma(unsigned char dma)
 void enable_dma(unsigned char dma)
 {
     if (dma >= MAX_DMA_CHANNELS)
-	printk("Trying to enable DMA%u\n", dma);
+	debug("Trying to enable DMA%u\n", dma);
     else if (dma <= 3)
 	dma_outb(dma, DMA1_MASK_REG);
     else
@@ -101,7 +102,7 @@ void enable_dma(unsigned char dma)
 void disable_dma(unsigned char dma)
 {
     if (dma >= MAX_DMA_CHANNELS)
-	printk("Trying to disable DMA%u\n", dma);
+	debug("Trying to disable DMA%u\n", dma);
     else if (dma <= 3)
 	dma_outb(dma | 4, DMA1_MASK_REG);
     else
@@ -119,7 +120,7 @@ void disable_dma(unsigned char dma)
 void clear_dma_ff(unsigned char dma)
 {
     if (dma >= MAX_DMA_CHANNELS)
-	printk("Trying to disable DMA%u\n", dma);
+	debug("Trying to disable DMA%u\n", dma);
     else if (dma <= 3)
 	dma_outb(0, DMA1_CLEAR_FF_REG);
     else
@@ -131,7 +132,7 @@ void clear_dma_ff(unsigned char dma)
 void set_dma_mode(unsigned char dma, unsigned char mode)
 {
     if (dma >= MAX_DMA_CHANNELS)
-	printk("Trying to disable DMA%u\n", dma);
+	debug("Trying to disable DMA%u\n", dma);
     else if (dma <= 3)
 	dma_outb(mode | dma, DMA1_MODE_REG);
     else
@@ -237,10 +238,9 @@ int get_dma_list(char *buf)
 
     for (i = 0; i < MAX_DMA_CHANNELS; i++)
 	if (dma_chan_busy[i].lock)
-	    len += sprintf(buf + len, "%2d: %s\n",
-			   i, dma_chan_busy[i].device_id);
+	    len += sprintf(buf + len, "%2d: %s\n", i, dma_chan_busy[i].device_id);
     return len;
-}				/* get_dma_list */
+}
 #endif
 
 #endif

--- a/elks/arch/i86/drivers/block/dma.c
+++ b/elks/arch/i86/drivers/block/dma.c
@@ -64,32 +64,15 @@ static struct dma_chan dma_chan_busy[MAX_DMA_CHANNELS] = {
 	__ret;		   \
 } )
 
-#ifdef ONE_DAY
-
-int get_dma_list(char *buf)
+int request_dma(unsigned char dma, const char *device)
 {
-    int i, len = 0;
-
-    for (i = 0; i < MAX_DMA_CHANNELS; i++)
-	if (dma_chan_busy[i].lock)
-	    len += sprintf(buf + len, "%2d: %s\n",
-			   i, dma_chan_busy[i].device_id);
-    return len;
-}				/* get_dma_list */
-
-#endif
-
-int request_dma(unsigned char dma, void *device)
-{
-    char *device_id = device;
-
     if (dma >= MAX_DMA_CHANNELS)
 	return -EINVAL;
 
     if (xchg(&dma_chan_busy[dma].lock, 1) != 0)
 	return -EBUSY;
 
-    dma_chan_busy[dma].device_id = device_id;
+    dma_chan_busy[dma].device_id = device;
 
     /* old flag was 0, now contains 1 to indicate busy */
     return 0;
@@ -225,6 +208,7 @@ void set_dma_count(unsigned char dma, unsigned int count)
     }
 }
 
+#if UNUSED
 /* Get DMA residue count. After a DMA transfer, this
  * should return zero. Reading this while a DMA transfer is
  * still in progress will return unpredictable results.
@@ -246,5 +230,17 @@ int get_dma_residue(unsigned char dma)
 
     return (dma <= 3) ? count : (count << 1);
 }
+
+int get_dma_list(char *buf)
+{
+    int i, len = 0;
+
+    for (i = 0; i < MAX_DMA_CHANNELS; i++)
+	if (dma_chan_busy[i].lock)
+	    len += sprintf(buf + len, "%2d: %s\n",
+			   i, dma_chan_busy[i].device_id);
+    return len;
+}				/* get_dma_list */
+#endif
 
 #endif

--- a/elks/include/arch/dma.h
+++ b/elks/include/arch/dma.h
@@ -137,7 +137,7 @@ extern void set_dma_page(unsigned char,unsigned char);
 extern void set_dma_addr(unsigned char,unsigned long);
 extern void set_dma_count(unsigned char,unsigned int);
 extern int get_dma_residue(unsigned char);
-extern int request_dma(unsigned char,void *);
+extern int request_dma(unsigned char,const char *);
 extern void free_dma(unsigned char);
 
 #endif

--- a/elks/include/arch/ports.h
+++ b/elks/include/arch/ports.h
@@ -121,5 +121,5 @@
 #define HD1_AT_IRQ	14		/* missing request_irq call*/
 #define HD2_AT_IRQ	15		/* missing request_irq call*/
 
-/* obsolete - experimental floppy drive, floppy.c (won't compile)*/
-#define FLOPPY_IRQ	6		/* missing request_irq call*/
+/* direct floppy driver, directfd.c */
+#define FLOPPY_IRQ	6

--- a/elks/include/linuxmt/devnum.h
+++ b/elks/include/linuxmt/devnum.h
@@ -19,6 +19,8 @@
 #define DEV_FD1     MKDEV(BIOSHD_MAJOR, 40)
 #define DEV_FD2     MKDEV(BIOSHD_MAJOR, 48)
 #define DEV_FD3     MKDEV(BIOSHD_MAJOR, 56)
+#define DEV_DF0     MKDEV(FLOPPY_MAJOR, 0)
+#define DEV_DF1     MKDEV(FLOPPY_MAJOR, 1)
 #define DEV_ROM     MKDEV(ROMFLASH_MAJOR, 0)
 
 /* char devices */

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -260,6 +260,8 @@ static struct dev_name_struct {
 	{ "hdd",     DEV_HDD },
 	{ "fd0",     DEV_FD0 },
 	{ "fd1",     DEV_FD1 },
+	{ "df0",     DEV_DF0 },
+	{ "df1",     DEV_DF1 },
 	{ "ttyS0",   DEV_TTYS0 },
 	{ "ttyS1",   DEV_TTYS1 },
 	{ "tty1",    DEV_TTY1 },

--- a/libc/misc/devname.c
+++ b/libc/misc/devname.c
@@ -29,6 +29,8 @@ static struct dev_name_struct {
     { "hdd",     S_IFBLK,   DEV_HDD             },
     { "fd0",     S_IFBLK,   DEV_FD0             },
     { "fd1",     S_IFBLK,   DEV_FD1             },
+    { "df0",     S_IFBLK,   DEV_DF0             },
+    { "df1",     S_IFBLK,   DEV_DF1             },
     { "ssd",     S_IFBLK,   MKDEV(SSD_MAJOR, 0) },
     { "rd0",     S_IFBLK,   MKDEV(RAM_MAJOR, 0) },
     { "ttyS0",   S_IFCHR,   DEV_TTYS0           },


### PR DESCRIPTION
Adds support for 2.88M floppies to direct FD driver, which are the same as a 1.44M floppy except 36 sectors and a 1M data FDC rate (=3). Using tables from QEMU's SeaBIOS source at https://github.com/coreboot/seabios/blob/master/src/hw/floppy.c.

This allows for a large floppy for extensive I/O testing in emulated environment.

Tested working only on QEMU. Unknown whether floppy gap1/gap2 change or other needed on real hardware.

Separates `floppy_init` a bit, allowing for linking direct FD driver into kernel when booting using bioshd. More work needed there, next step is to request/release IRQ and DMA on driver open/close (the way serial drivers work), rather than all the time. These changes will make direct FD and/or BIOS FD drivers optional and usable dynamically.

From some discussion on https://github.com/Mellvik/TLVC/pull/24.
