### PR TITLE
[libc/cmds] Fix time command hour wrapping problem

### DIFF
--- a/elkscmd/misc_utils/time.c
+++ b/elkscmd/misc_utils/time.c
@@ -1,28 +1,39 @@
 /* time command - modified from BSD 4.2 by Greg Haerr*/
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <signal.h>
 #include <sys/types.h>
 #include <sys/time.h>
-#include <sys/times.h>
 #include <sys/wait.h>
 
-static void printt(char * s, long us)
+/* return current time in microseconds */
+clock_t time_usecs(void)
+{
+        struct timeval tv;
+
+        if (gettimeofday(&tv, (void *)0) < 0)
+                return 0;
+
+        return (tv.tv_sec * 1000000LL + tv.tv_usec);
+}
+
+static void print_time(char * s, clock_t us)
 {
 	long mins, secs;
 
-	if (us < 1000L && us > 499L)	/* round up to 1/1000 second*/
-		us = 1000L;
-	mins = us / 60000000L;
+	if (us < 1000 && us > 499)	/* round up to 1/1000 second*/
+		us = 1000;
+	mins = us / 60000000LL;
 	if (mins)
-		us -= mins * 60000000L;
+		us -= mins * 60000000LL;
 
 	secs = us / 1000000L;
 	if (secs)
-		us -= secs * 1000000L;
+		us -= secs * 1000000LL;
 
-	fprintf(stderr, "%s\t%lum%lu.%03lus\n", s, mins, secs, us/1000);
+	fprintf(stderr, "%s\t%lum%lu.%03lus\n", s, mins, secs, (long)us/1000);
 	
 }
 
@@ -30,23 +41,23 @@ static void printt(char * s, long us)
 int main(int argc, char **argv)
 {
 	int status, p;
-	struct tms end, start;
+	clock_t start, end;
 
 	if(argc <= 1) {
 		fprintf(stderr, "Usage: time <program ...>\n");
-		exit(0);
+		return 0;
 	}
 
-	times(&start);
+	start = time_usecs();
 	p = fork();
 	if(p == -1) {
-		fprintf(stderr, "Try again.\n");
-		exit(1);
+		perror(NULL);
+		return 1;
 	}
 	if(p == 0) {
 		execvp(argv[1], &argv[1]);
 		perror(argv[1]);
-		exit(1);
+		return 1;
 	}
 	signal(SIGINT, SIG_IGN);
 	signal(SIGQUIT, SIG_IGN);
@@ -54,8 +65,8 @@ int main(int argc, char **argv)
 		continue;
 	if((status&0377) != 0)
 		fprintf(stderr,"Command terminated abnormally.\n");
-	times(&end);
+	end = time_usecs();
 	fprintf(stderr, "\n");
-	printt("Real", end.tms_cstime - start.tms_cstime);
+	print_time("Real", end - start);
 	exit(status>>8);
 }

--- a/libc/include/sys/times.h
+++ b/libc/include/sys/times.h
@@ -12,10 +12,6 @@ struct tms {
 	clock_t tms_cstime;
 };
 
-__BEGIN_DECLS
-
 clock_t times (struct tms *tp);
-
-__END_DECLS
 
 #endif

--- a/libc/include/time.h
+++ b/libc/include/time.h
@@ -3,12 +3,10 @@
 
 #include <features.h>
 #include <sys/types.h>
+#include <stdint.h>
 #include <stddef.h>
 
-#ifndef _CLOCK_T
-#define _CLOCK_T
-typedef long clock_t;
-#endif
+typedef int64_t clock_t;
 
 #define CLOCKS_PER_SEC	100
 #define CLK_TCK		100	/* That must be the same as HZ ???? */
@@ -42,11 +40,6 @@ struct timezone {
 //extern int daylight;
 extern long timezone;
 
-__BEGIN_DECLS
-
-int	stime (time_t* __tptr);
-
-clock_t	clock(void);
 time_t	time(time_t * __tp);
 #ifndef __HAS_NO_FLOATS__
 double  difftime(time_t __time2, time_t __time1);
@@ -65,7 +58,5 @@ extern int _tz_is_set;
 void __tm_conv(struct tm *tmbuf, const time_t *timep, time_t offset);
 void __asctime(char *buffer, const struct tm *ptm);
 #endif
-
-__END_DECLS
 
 #endif

--- a/libc/system/out.mk
+++ b/libc/system/out.mk
@@ -1,7 +1,7 @@
 include $(TOPDIR)/libc/Makefile.inc
 
 DEFINES	+= -DL_execl -DL_execle -DL_execlp -DL_execlpe \
-	   -DL_sleep -DL_usleep -DL_times
+	   -DL_sleep -DL_usleep
 
 ifneq "$(VPATH)" ""
 	dir	= $(VPATH)/

--- a/libc/system/times.c
+++ b/libc/system/times.c
@@ -2,38 +2,29 @@
 #include <sys/time.h>
 #include <sys/times.h>
 
-#if 0	/* system call not implemented*/
-
+/*
+ * Library version of 'times' since ELKS doesn't implement the system call.
+ * Note: this routine returns the system clock time in microseconds,
+ * not the accumulated CPU time(s) nor in CLK_TCKs.
+ * Thus, it should not be used and has been removed from compilation.
+ */
 clock_t times(struct tms *tp)
 {
-   long rv;
-   __times(tp, &rv);
-   return rv;
+        struct timeval tv;
+
+        if (gettimeofday(&tv, (void *)0) < 0)
+                return -1;
+
+        if (tp) {
+                clock_t usecs = tv.tv_sec * 1000000LL + tv.tv_usec;
+
+                /* return user and system same since ELKS doesn't implement*/
+                tp->tms_utime = usecs;
+                tp->tms_stime = usecs;
+                tp->tms_cutime = usecs;
+                tp->tms_cstime = usecs;
+        }
+
+        return tv.tv_sec;
 }
-
-#else
-
-/* library version of 'times' since ELKS doesn't implement it*/
-clock_t times(struct tms *tp)
-{
-	struct timeval tv;
-
-	if (gettimeofday(&tv, (void *)0) < 0)
-		return -1;
-
-	if (tp) {
-		/* scale down to one hour period to fit in long*/
-		unsigned long usecs = (tv.tv_sec % 3600) * 1000000L + tv.tv_usec;
-
-		/* return user and system same since ELKS doesn't implement*/
-		tp->tms_utime = usecs;
-		tp->tms_stime = usecs;
-		tp->tms_cutime = usecs;
-		tp->tms_cstime = usecs;
-	}
-
-	return tv.tv_sec;
-}
-
-#endif
 #endif	/* L_times*/


### PR DESCRIPTION
Fixes `time` command sometimes displaying incorrect results, reported by @Vutshi in https://github.com/ghaerr/elks/issues/1619#issuecomment-1703364279.

`time` would report incorrect results (e.g. an extremely large number) when a command would execute for a period of time where the number of seconds since Jan , 1970 would "wrap" during a modulo 3600 operation. Long story short, previously `time` used microsecond time calculations with a 32-bit long which was subjected to the improper 3600 second modulo operation approximately every hour GMT. It has been rewritten to use 64-bit arithmetic and is no longer subject to any time modulus.

The `times` C library routine has been removed due to being incorrect, and an alternative method used to get times in `time`.

@Vutshi, `time sl -s` should display properly now, although I don't expect you to actually wait 34 minutes to test it!