### PR TITLE
[cmds] Add accurate train timing to sl

### DIFF
--- a/elkscmd/tui/sl.c
+++ b/elkscmd/tui/sl.c
@@ -95,7 +95,7 @@ void option(char *str)
 
 void cycle(unsigned long usecs)
 {
-    long elapsed;
+    unsigned long elapsed;
     struct timeval now;
     static long start;
 

--- a/elkscmd/tui/sl.c
+++ b/elkscmd/tui/sl.c
@@ -41,6 +41,8 @@
 #include "curses.h"
 #include <signal.h>
 #include <unistd.h>
+#include <time.h>
+#include <sys/time.h>
 #include "sl.h"
 
 void add_smoke(int y, int x);
@@ -56,6 +58,7 @@ int LOGO      = 0;
 int FLY       = 0;
 int C51       = 0;
 int SLOW      = 0;
+int FAST      = 0;
 
 int my_mvaddstr(int y, int x, char *str)
 {
@@ -84,9 +87,27 @@ void option(char *str)
             case 'l': LOGO     = 1; break;
             case 'c': C51      = 1; break;
             case 's': SLOW     = 1; break;
+            case 'f': FAST     = 1; break;
             default:                break;
         }
     }
+}
+
+void cycle(unsigned long usecs)
+{
+    long elapsed;
+    struct timeval now;
+    static long start;
+
+    if (usecs == 0) {
+        gettimeofday(&now, NULL);
+        start = now.tv_sec * 1000000L + now.tv_usec;
+        return;
+    }
+    gettimeofday(&now, NULL);
+    elapsed = now.tv_sec * 1000000L + now.tv_usec - start;
+    if (elapsed < usecs)
+        usleep(usecs - elapsed);
 }
 
 int main(int argc, char *argv[])
@@ -107,6 +128,9 @@ int main(int argc, char *argv[])
     scrollok(stdscr, FALSE);
 
     for (x = COLS - 1; ; --x) {
+        if (!FAST && !SLOW) {
+            cycle(0);
+        }
         if (LOGO == 1) {
             if (add_sl(x) == ERR) break;
         }
@@ -117,7 +141,9 @@ int main(int argc, char *argv[])
             if (add_D51(x) == ERR) break;
         }
         refresh();
-        //usleep(40000);
+        if (!FAST && !SLOW) {
+            cycle(40000);
+        }
     }
     mvcur(0, COLS - 1, LINES - 2, 0);
     endwin();


### PR DESCRIPTION
Adds an accurate 40ms "cycle time" between each train re-display, so that the `sl` train should always chug along at a constant speed on all systems (or at least as fast as possible on slower systems). `sl` now calculates a minimum cycle of 40 ms and will add a delay if the last display cycle was quicker than that. This now helps the illusion that all trains have equal conductors (yes, I'm talking about your 8088 systems @Vutshi).

In order to continue to use `sl` as an indicator of how fast or slow your system may actually be without a delay, a new `-f` option was added: `sl -f` will run the trains off the tracks if your system is fast enough (which is the same as `sl` previously with no option).

To summarize our steam powered evolution:
```
sl     # train running at 40ms/frame or slower on all systems
sl -s  # this train emits more ANSI sequences than slow systems can handle
sl -f  # this train doesn't delay or stop for anybody
```

This finalizes all of the reported problems in #1619.