### PR TITLE
[df] Add 300k data xfer rate to 360k floppy FDC data

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -712,7 +712,7 @@ next_block:
         count = req->rq_nr_sectors;
         start = req->rq_sector;
 
-        if (hd[minor].start_sect == -1U || start >= hd[minor].nr_sects) {
+        if (hd[minor].start_sect == -1U || start + count > hd[minor].nr_sects) {
             printk("bioshd: sector %ld access beyond partition (%ld,%ld)\n",
                 start, hd[minor].start_sect, hd[minor].nr_sects);
             end_request(0);

--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -76,7 +76,7 @@ extern void resetup_one_dev(struct gendisk *dev, int drive);
 #ifdef FLOPPYDISK
 
 static void floppy_on(int nr);
-static void floppy_off(unsigned int nr);
+static void floppy_off(int nr);
 
 #define DEVICE_NAME "df"
 #define DEVICE_INTR do_floppy

--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -79,7 +79,6 @@ static void floppy_on(int nr);
 static void floppy_off(int nr);
 
 #define DEVICE_NAME "df"
-#define DEVICE_INTR do_floppy
 #define DEVICE_REQUEST do_fd_request
 #define DEVICE_NR(device) ((device) & 3)
 #define DEVICE_ON(device) floppy_on(DEVICE_NR(device))

--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -1172,8 +1172,8 @@ static void redo_fd_request(void)
 	    current_drive = drive;
 	}
 	start = (unsigned int) req->rq_sector;
-	if (start + req->rq_nr_sectors >= floppy->size) {
-            printk("df%d: sector %u beyond max %u\n", start, floppy->size);
+	if (start + req->rq_nr_sectors > floppy->size) {
+            printk("df%d: sector %u beyond max %u\n", drive, start, floppy->size);
 	    request_done(0);
 	    goto repeat;
 	}

--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -1314,7 +1314,7 @@ static void INITPROC config_types(void)
 {
     printk("df: CMOS ");
     base_type[0] = find_base(0, (CMOS_READ(0x10) >> 4) & 0xF);
-    base_type[0] = find_base(0, 1);     /* force 360k FIXME add setup table */
+    //base_type[0] = find_base(0, 1);     /* force 360k FIXME add setup table */
     if (((CMOS_READ(0x14) >> 6) & 1) != 0) {
 	printk(", ");
 	base_type[1] = find_base(1, CMOS_READ(0x10) & 0xF);

--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -1538,8 +1538,6 @@ static int get_fdc_version(void)
     default:
         name = "Unknown";
     }
-type = FDC_TYPE_8272A;
-name = "Special";
     printk("df: direct floppy FDC %s (0x%x), irq %d, dma %d\n",
         name, reply_buffer[0], FLOPPY_IRQ, FLOPPY_DMA);
 

--- a/elks/arch/i86/drivers/block/ll_rw_blk.c
+++ b/elks/arch/i86/drivers/block/ll_rw_blk.c
@@ -220,6 +220,7 @@ static void make_request(unsigned short major, int rw, struct buffer_head *bh)
     req->rq_seg = buffer_seg(bh);
     req->rq_buffer = buffer_data(bh);
     req->rq_bh = bh;
+    req->rq_errors = 0;
 
 #ifdef BLOAT_FS
     req->rq_nr_sectors = count;

--- a/elks/arch/i86/drivers/block/rd.c
+++ b/elks/arch/i86/drivers/block/rd.c
@@ -238,7 +238,8 @@ static void do_rd_request(void)
 	target = DEVICE_NR(req->rq_dev);
 	debug("RD: %s dev %d sector %d, ", req->rq_cmd == READ? "read": "write",
 		target, start);
-	if (drive_info[target].valid == 0 || start >= drive_info[target].size) {
+	if (drive_info[target].valid == 0 ||
+                start + req->rq_nr_sectors > drive_info[target].size) {
 	    debug("rd%d: sector %d beyond max %d\n",
 		 target, start, drive_info[target].size);
 	    end_request(0);

--- a/elks/arch/i86/drivers/block/ssd.c
+++ b/elks/arch/i86/drivers/block/ssd.c
@@ -112,7 +112,7 @@ void ssd_io_complete(void)
         buf = req->rq_buffer;
         start = req->rq_sector;
 
-        if (start + req->rq_nr_sectors >= NUM_SECTS) {
+        if (start + req->rq_nr_sectors > NUM_SECTS) {
             printk("ssd: sector %lu+%d beyond max %lu\n", start,
                 req->rq_nr_sectors, NUM_SECTS);
             end_request(0);

--- a/elks/include/linuxmt/fdreg.h
+++ b/elks/include/linuxmt/fdreg.h
@@ -8,7 +8,6 @@
 
 /* Fd controller regs. S&C, about page 340 */
 #define FD_STATUS	0x3f4   /* (MSR) Main Status Register */
-#define FD_DSR          0x3f4   /* Data Rate Select Register (write) (82072 only) */
 #define FD_DATA		0x3f5   /* Data Register (FIFO) */
 #define FD_DOR		0x3f2	/* Digital Output Register */
 #define FD_DIR		0x3f7	/* Digital Input Register (read) (82077) */
@@ -61,15 +60,17 @@
 #define FD_FORMAT		0x4D	/* format one track */
 #define FD_VERSION		0x10	/* get version code */
 #define FD_CONFIGURE		0x13	/* configure FIFO operation (82072) */
-#define FD_PERPENDICULAR	0x12	/* perpendicular r/w mode (82077) */
 #define FD_DUMPREGS             0x0E    /* dump the contents of the fdc regs (82072) */
+#define FD_PERPENDICULAR	0x12	/* perpendicular r/w mode (82077) */
 
 /* DMA commands */
 #define DMA_READ	0x46
 #define DMA_WRITE	0x4A
 
-/* FDC version return types */
-#define FDC_TYPE_STD	0x80	/* normal 8272A clone FDC */
-#define FDC_TYPE_82077	0x90	/* FIFO + perpendicular support */
+/* FDC chip/adapter types */
+#define FDC_TYPE_8272A      1   /* IBM PC or PC/XT clone w/8272A (or NEC 765) */
+#define FDC_TYPE_8272PC_AT  2   /* IBM PC/AT w/8272A has DIR/CCR on adaptor */
+#define FDC_TYPE_82072      3   /* FDC accepts CONFIGURE, DUMPREGS */
+#define FDC_TYPE_82077      4   /* FDC accepts PERPENDICULAR, LOCK */
 
 #endif

--- a/elks/include/linuxmt/fdreg.h
+++ b/elks/include/linuxmt/fdreg.h
@@ -7,11 +7,12 @@
  */
 
 /* Fd controller regs. S&C, about page 340 */
-#define FD_STATUS	0x3f4
-#define FD_DATA		0x3f5
+#define FD_STATUS	0x3f4   /* (MSR) Main Status Register */
+#define FD_DSR          0x3f4   /* Data Rate Select Register (write) (82072 only) */
+#define FD_DATA		0x3f5   /* Data Register (FIFO) */
 #define FD_DOR		0x3f2	/* Digital Output Register */
-#define FD_DIR		0x3f7	/* Digital Input Register (read) PC/AT only */
-#define FD_DCR		0x3f7	/* Diskette Control Register (write) PC/AT only */
+#define FD_DIR		0x3f7	/* Digital Input Register (read) (82077) */
+#define FD_CCR		0x3f7	/* Configuration Control Register (write) (82077) */
 
 /* Bits of main status register */
 #define STATUS_BUSYMASK	0x0F	/* drive busy mask */
@@ -59,8 +60,9 @@
 #define FD_SPECIFY		0x03	/* specify HUT etc */
 #define FD_FORMAT		0x4D	/* format one track */
 #define FD_VERSION		0x10	/* get version code */
-#define FD_CONFIGURE		0x13	/* configure FIFO operation */
-#define FD_PERPENDICULAR	0x12	/* perpendicular r/w mode */
+#define FD_CONFIGURE		0x13	/* configure FIFO operation (82072) */
+#define FD_PERPENDICULAR	0x12	/* perpendicular r/w mode (82077) */
+#define FD_DUMPREGS             0x0E    /* dump the contents of the fdc regs (82072) */
 
 /* DMA commands */
 #define DMA_READ	0x46

--- a/elks/include/linuxmt/fdreg.h
+++ b/elks/include/linuxmt/fdreg.h
@@ -10,8 +10,8 @@
 #define FD_STATUS	0x3f4
 #define FD_DATA		0x3f5
 #define FD_DOR		0x3f2	/* Digital Output Register */
-#define FD_DIR		0x3f7	/* Digital Input Register (read) */
-#define FD_DCR		0x3f7	/* Diskette Control Register (write) */
+#define FD_DIR		0x3f7	/* Digital Input Register (read) PC/AT only */
+#define FD_DCR		0x3f7	/* Diskette Control Register (write) PC/AT only */
 
 /* Bits of main status register */
 #define STATUS_BUSYMASK	0x0F	/* drive busy mask */

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -391,7 +391,6 @@ extern struct file_operations *get_blkfops(unsigned int);
 extern int register_blkdev(unsigned int,const char *,struct file_operations *);
 extern int unregister_blkdev(void);
 extern int blkdev_open(struct inode *,struct file *);
-
 extern struct file_operations def_blk_fops;
 extern struct inode_operations blkdev_inode_operations;
 
@@ -484,6 +483,7 @@ extern size_t decompress(char *buf, seg_t seg, size_t orig_size, size_t compr_si
 #ifdef BLOAT_FS
 extern int get_write_access(struct inode *);
 extern void put_write_access(struct inode *);
+extern int check_disk_change(kdev_t);
 #else
 #define get_write_access(_a)
 #define put_write_access(_a)

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -391,6 +391,7 @@ extern struct file_operations *get_blkfops(unsigned int);
 extern int register_blkdev(unsigned int,const char *,struct file_operations *);
 extern int unregister_blkdev(void);
 extern int blkdev_open(struct inode *,struct file *);
+
 extern struct file_operations def_blk_fops;
 extern struct inode_operations blkdev_inode_operations;
 

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -18,4 +18,5 @@ wd0=10,0x300,0xCC00,0x80
 #root=hda1 ro		# root hd partition 1 read-only
 #kstack
 #strace
+root=df0
 #console=ttyS0,19200 3


### PR DESCRIPTION
Allows for DF autodetect to use 300K data transfer rate (as well as previous 250K data transfer rate) for floppy probe. This version boots from QEMU and uses the 300K data transfer rate as the first rate to probe from the SeaBIOS tables at https://github.com/coreboot/seabios/blob/master/src/hw/floppy.c.

This PR intentionally hard-wires floppy 0 to be 360k in an attempt at getting @toncho11's Amstrad PC to boot using the DF driver. After seeing results, the PR may be modified.

Also adds more debug display information to see what might be going on.

Continues @toncho11's discussion from https://github.com/ghaerr/elks/pull/1721#issuecomment-1721843677.

@toncho11, here's a prebuilt image for you to test again with, thank you!

[fd360.img.zip](https://github.com/ghaerr/elks/files/12631308/fd360.img.zip)
