### PR TITLE
[kernel] Use outb directly for DMA programming in DF driver

### DIFF
--- a/elks/arch/i86/drivers/block/Makefile
+++ b/elks/arch/i86/drivers/block/Makefile
@@ -58,7 +58,7 @@ endif
 
 # experimental direct fd support
 ifeq ($(CONFIG_BLK_DEV_FD), y)
-OBJS += directfd.o dma.o
+OBJS += directfd.o
 endif
 
 # experimental (and not working) direct hd support


### PR DESCRIPTION
This uses another one of @Mellvik's ideas - that of dropping the relatively large set of DMA access routines and replacing them with programming the DMA chip directly from the DF driver. This saves ~500 bytes of kernel text and works well because no other devices use or will use DMA. (Even the HD direct driver uses programmed I/O).

The DMA programming is done within the `setup_DMA` routine and borrows from the simplicity found from the Minix OS source.