### PR TITLE
[boot] Remove /bootopts requirement for booting from direct floppy driver

### DIFF
--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -93,14 +93,14 @@
 #include <arch/io.h>
 #include <arch/segment.h>
 #include <arch/ports.h>
-#include <arch/hdreg.h>		/* for ioctl GETGEO */
+#include <arch/hdreg.h>         /* for ioctl GETGEO */
 
 #define FLOPPYDISK
 #define MAJOR_NR FLOPPY_MAJOR
-#define MINOR_SHIFT	0	/* shift to get drive num */
-#define FLOPPY_DMA 2		/* hardwired on old PCs */
+#define MINOR_SHIFT     0       /* shift to get drive num */
+#define FLOPPY_DMA 2            /* hardwired on old PCs */
 
-#include "blk.h"		/* ugly - blk.h contains code */
+#include "blk.h"                /* ugly - blk.h contains code */
 
 /*
  * The original 8272A doesn't have FD_DOR, FD_DIR or FD_CCR registers,
@@ -125,10 +125,10 @@
 
 static void (*do_floppy)();     /* interrupt routine to call */
 static int initial_reset_flag;
-static int need_configure = 1;	/* for 82077 */
+static int need_configure = 1;  /* for 82077 */
 static int recalibrate;
 static int reset;
-static int recover;		/* recalibrate immediately after resetting */
+static int recover;             /* recalibrate immediately after resetting */
 static int seek;
 
 /* BIOS floppy motor timeout counter - FIXME leave this while BIOS driver present */
@@ -159,7 +159,7 @@ static unsigned char running = 0; /* keep track of motors already running */
  * 2nd DMA controller transfers words only, not bytes and thus up to 128k bytes
  * in one 'swoop'.
  */
-#define LAST_DMA_ADDR	(0x100000L - BLOCK_SIZE) /* stick to the 1M limit */
+#define LAST_DMA_ADDR   (0x100000L - BLOCK_SIZE) /* stick to the 1M limit */
 
 #define _MK_LINADDR(seg, offs) ((unsigned long)((((unsigned long)(seg)) << 4) + (unsigned)(offs)))
 
@@ -214,7 +214,7 @@ static struct floppy_struct minor_types[] = {
 /*2*/ {2400, 15, 2, 80, 0, 0x1B, 0x00, 0xDF, 0x54, "1.2M"},     /* 1.2 MB AT-diskettes */
 /*3*/ { 720,  9, 2, 40, 1, 0x2A, 0x02, 0xDF, 0x50, "360k/AT3"}, /* 360kB in 720kB drive */
 /*4*/ {1440,  9, 2, 80, 0, 0x2A, 0x02, 0xDF, 0x50, "720k"},     /* 3.5" 720kB diskette */
-/*5*/ { 720,  9, 2, 40, 1, 0x23, 0x01, 0xDF, 0x50, "360k/AT"},	/* 360kB in 1.2MB drive */
+/*5*/ { 720,  9, 2, 40, 1, 0x23, 0x01, 0xDF, 0x50, "360k/AT"},  /* 360kB in 1.2MB drive */
 /*6*/ {1440,  9, 2, 80, 0, 0x23, 0x01, 0xDF, 0x50, "720k/1.2M"},/* 720kB in 1.2MB drive */
 /*7*/ {2880, 18, 2, 80, 0, 0x1B, 0x00, 0xCF, 0x6C, "1.44M"},    /* 3.5" 1.44MB diskette */
 /*8*/ {5760, 36, 2, 80, 0, 0x1B, 0x43, 0xAF, 0x28, "2.88M"},    /* 3.5" 2.88MB diskette */
@@ -277,7 +277,7 @@ static char tmp_floppy_area[BLOCK_SIZE] WORD_ALIGNED; /* for now FIXME to be rem
  */
 #define NO_TRACK 255
 
-static int read_track;	        /* set to read entire track */
+static int read_track;          /* set to read entire track */
 static int buffer_track = -1;
 static int buffer_drive = -1;
 static int cur_spec1 = -1;
@@ -326,9 +326,9 @@ static void DFPROC floppy_select(unsigned int nr)
 {
     DEBUG("sel0x%x-", current_DOR);
     if (current_drive == (current_DOR & 3)) {
-	/* Drive already selected, we're ready to go */
-	floppy_ready();
-	return;
+        /* Drive already selected, we're ready to go */
+        floppy_ready();
+        return;
     }
     /* activate a different drive */
     seek = 1;
@@ -351,7 +351,7 @@ static void DFPROC floppy_select(unsigned int nr)
 static void motor_on_callback(int nr)
 {
     DEBUG("mON,");
-    clr_irq();	// Experimental
+    clr_irq();  // Experimental
     running |= 0x10 << nr;
     set_irq();
     floppy_select(nr);
@@ -392,28 +392,28 @@ static void motor_off_callback(int nr)
  */
 static void DFPROC floppy_on(int nr)
 {
-    unsigned char mask = 0x10 << nr;	/* motor on select */
+    unsigned char mask = 0x10 << nr;    /* motor on select */
 
     DEBUG("flpON");
     *fl_timeout = 0; /* Reset BIOS motor timeout counter, neccessary on some machines */
     del_timer(&motor_off_timer[nr]);
 
     if (mask & running) {
-	floppy_select(nr);
-	DEBUG("#%x;",current_DOR);
-	return;	
+        floppy_select(nr);
+        DEBUG("#%x;",current_DOR);
+        return;
     }
 
-    if (!(mask & current_DOR)) {	/* motor not running yet */
-	del_timer(&motor_on_timer[nr]);
+    if (!(mask & current_DOR)) {        /* motor not running yet */
+        del_timer(&motor_on_timer[nr]);
         /* TEAC 1.44M says 'waiting time' 505ms, may be too little for 5.25in drives. */
-	motor_on_timer[nr].tl_expires = jiffies + HZ/2;
-	add_timer(&motor_on_timer[nr]);
+        motor_on_timer[nr].tl_expires = jiffies + HZ/2;
+        add_timer(&motor_on_timer[nr]);
 
-	current_DOR &= 0xFC;	        /* remove drive select */
-	current_DOR |= mask;	        /* set motor select */
-	current_DOR |= nr;	        /* set drive select */
-	outb(current_DOR, FD_DOR);
+        current_DOR &= 0xFC;            /* remove drive select */
+        current_DOR |= mask;            /* set motor select */
+        current_DOR |= nr;              /* set drive select */
+        outb(current_DOR, FD_DOR);
     }
 
     DEBUG("flpON0x%x;", current_DOR);
@@ -457,36 +457,36 @@ int floppy_change(struct buffer_head *bh)
     unsigned int mask = 1 << (bh->b_dev & 0x03);
 
     if (MAJOR(bh->b_dev) != MAJOR_NR) {
-	printk("floppy_change: not a floppy\n");
-	return 0;
+        printk("floppy_change: not a floppy\n");
+        return 0;
     }
     if (fake_change & mask) {
-	buffer_track = -1;
-	fake_change &= ~mask;
+        buffer_track = -1;
+        fake_change &= ~mask;
         /* omitting the next line breaks formatting in a horrible way ... */
-	changed_floppies &= ~mask;
-	return 1;
+        changed_floppies &= ~mask;
+        return 1;
     }
     if (changed_floppies & mask) {
-	buffer_track = -1;
-	changed_floppies &= ~mask;
-	recalibrate = 1;
-	return 1;
+        buffer_track = -1;
+        changed_floppies &= ~mask;
+        recalibrate = 1;
+        return 1;
     }
     if (!bh)
-	return 0;
+        return 0;
     if (EBH(bh)->b_dirty)
-	ll_rw_blk(WRITE, bh);
+        ll_rw_blk(WRITE, bh);
     else {
-	buffer_track = -1;
-	mark_buffer_uptodate(bh, 0);
-	ll_rw_blk(READ, bh);
+        buffer_track = -1;
+        mark_buffer_uptodate(bh, 0);
+        ll_rw_blk(READ, bh);
     }
     wait_on_buffer(bh);
     if (changed_floppies & mask) {
-	changed_floppies &= ~mask;
-	recalibrate = 1;
-	return 1;
+        changed_floppies &= ~mask;
+        recalibrate = 1;
+        return 1;
     }
     return 0;
 }
@@ -520,24 +520,24 @@ static void DFPROC setup_DMA(void)
     /* FIXME req->rq_nr_sectors will be 0 for TLVC only */
     count = req->rq_nr_sectors? (unsigned)req->rq_nr_sectors << 9: BLOCK_SIZE;
     if (use_xms || (physaddr + count) < physaddr)
-	dma_addr = LAST_DMA_ADDR + 1;	/* force use of bounce buffer */
+        dma_addr = LAST_DMA_ADDR + 1;   /* force use of bounce buffer */
     else
-	dma_addr = _MK_LINADDR(req->rq_seg, req->rq_buffer);
+        dma_addr = _MK_LINADDR(req->rq_seg, req->rq_buffer);
 
     DEBUG("setupDMA ");
 
-    if (read_track) {	/* mark buffer-track bad, in case all this fails.. */
-	buffer_drive = buffer_track = -1;
-	count = floppy->sect << 9;	/* sects/trk (one side) times 512 */
-	if (floppy->sect & 1 && !head)
-	    count += 512; /* add one if head=0 && sector count is odd */
-	dma_addr = _MK_LINADDR(DMASEG, 0);
+    if (read_track) {   /* mark buffer-track bad, in case all this fails.. */
+        buffer_drive = buffer_track = -1;
+        count = floppy->sect << 9;      /* sects/trk (one side) times 512 */
+        if (floppy->sect & 1 && !head)
+            count += 512; /* add one if head=0 && sector count is odd */
+        dma_addr = _MK_LINADDR(DMASEG, 0);
     } else if (dma_addr >= LAST_DMA_ADDR) {
-	dma_addr = _MK_LINADDR(kernel_ds, tmp_floppy_area); /* use bounce buffer */
-	if (command == FD_WRITE) {
-	    xms_fmemcpyw(tmp_floppy_area, kernel_ds, CURRENT->rq_buffer,
+        dma_addr = _MK_LINADDR(kernel_ds, tmp_floppy_area); /* use bounce buffer */
+        if (command == FD_WRITE) {
+            xms_fmemcpyw(tmp_floppy_area, kernel_ds, CURRENT->rq_buffer,
                 CURRENT->rq_seg, BLOCK_SIZE/2);
-	}
+        }
     }
     DEBUG("%d/%lx;", count, dma_addr);
 
@@ -561,13 +561,13 @@ static void DFPROC output_byte(char byte)
     unsigned char status;
 
     if (reset)
-	return;
+        return;
     for (counter = 0; counter < 10000; counter++) {
-	status = inb_p(FD_STATUS) & (STATUS_READY | STATUS_DIR);
-	if (status == STATUS_READY) {
-	    outb(byte, FD_DATA);
-	    return;
-	}
+        status = inb_p(FD_STATUS) & (STATUS_READY | STATUS_DIR);
+        if (status == STATUS_READY) {
+            outb(byte, FD_DATA);
+            return;
+        }
     }
     current_track = NO_TRACK;
     reset = 1;
@@ -579,19 +579,19 @@ static int DFPROC result(void)
     int i = 0, counter, status;
 
     if (reset)
-	return -1;
+        return -1;
     for (counter = 0; counter < 10000; counter++) {
-	status = inb_p(FD_STATUS) & (STATUS_DIR | STATUS_READY | STATUS_BUSY);
-	if (status == STATUS_READY) {	/* done, no more result bytes */
-	    return i;
-	}
-	if (status == (STATUS_DIR | STATUS_READY | STATUS_BUSY)) {
-	    if (i >= MAX_REPLIES) {
-		printk("floppy_stat reply overrun\n");
-		break;
-	    }
-	    reply_buffer[i++] = inb_p(FD_DATA);
-	}
+        status = inb_p(FD_STATUS) & (STATUS_DIR | STATUS_READY | STATUS_BUSY);
+        if (status == STATUS_READY) {   /* done, no more result bytes */
+            return i;
+        }
+        if (status == (STATUS_DIR | STATUS_READY | STATUS_BUSY)) {
+            if (i >= MAX_REPLIES) {
+                printk("floppy_stat reply overrun\n");
+                break;
+            }
+            reply_buffer[i++] = inb_p(FD_DATA);
+        }
     }
     reset = 1;
     current_track = NO_TRACK;
@@ -620,9 +620,9 @@ static void DFPROC bad_flp_intr(void)
         return;
     }
     if (errors >= MAX_ERRORS / 2)
-	reset = 1;
+        reset = 1;
     else
-	recalibrate = 1;
+        recalibrate = 1;
 }
 
 /* Set perpendicular mode as required, based on data rate, if supported.
@@ -632,60 +632,60 @@ static void DFPROC bad_flp_intr(void)
 static void DFPROC perpendicular_mode(unsigned char rate)
 {
     if (fdc_version >= FDC_TYPE_82077) {
-	output_byte(FD_PERPENDICULAR);
-	if (rate & 0x40) {
-	    unsigned char r = rate & 0x03;
-	    if (r == 0)
-		output_byte(2);	/* perpendicular, 500 kbps */
-	    else if (r == 3)
-		output_byte(3);	/* perpendicular, 1Mbps */
-	    else {
-		printk("df: Invalid data rate for perpendicular mode!\n");
-		reset = 1;
-	    }
-	} else
-	    output_byte(0);	/* conventional mode */
+        output_byte(FD_PERPENDICULAR);
+        if (rate & 0x40) {
+            unsigned char r = rate & 0x03;
+            if (r == 0)
+                output_byte(2); /* perpendicular, 500 kbps */
+            else if (r == 3)
+                output_byte(3); /* perpendicular, 1Mbps */
+            else {
+                printk("df: Invalid data rate for perpendicular mode!\n");
+                reset = 1;
+            }
+        } else
+            output_byte(0);     /* conventional mode */
     } else {
-	if (rate & 0x40) {
-	    printk("df: need 82077 FDC for disc\n");
-	    reset = 1;
-	}
+        if (rate & 0x40) {
+            printk("df: need 82077 FDC for disc\n");
+            reset = 1;
+        }
     }
-}				/* perpendicular_mode */
+}                               /* perpendicular_mode */
 
 static void DFPROC configure_fdc_mode(void)
 {
     if (need_configure && (fdc_version >= FDC_TYPE_82072)) {
-	/* Enhanced version with FIFO & write precompensation */
-	output_byte(FD_CONFIGURE);
-	output_byte(0);
-	output_byte(0x1A);	/* FIFO on, polling off, 10 byte threshold */
-	output_byte(0);		/* precompensation from track 0 upwards */
-	need_configure = 0;
-	printk("df: FIFO enabled\n");
+        /* Enhanced version with FIFO & write precompensation */
+        output_byte(FD_CONFIGURE);
+        output_byte(0);
+        output_byte(0x1A);      /* FIFO on, polling off, 10 byte threshold */
+        output_byte(0);         /* precompensation from track 0 upwards */
+        need_configure = 0;
+        printk("df: FIFO enabled\n");
     }
     if (cur_spec1 != floppy->spec1) {
-	cur_spec1 = floppy->spec1;
-	output_byte(FD_SPECIFY);
-	output_byte(cur_spec1);	/* hut etc */
-	output_byte(6);		/* Head load time =6ms, DMA */
+        cur_spec1 = floppy->spec1;
+        output_byte(FD_SPECIFY);
+        output_byte(cur_spec1); /* hut etc */
+        output_byte(6);         /* Head load time =6ms, DMA */
     }
     if (cur_rate != floppy->rate) {
-	/* use bit 6 of floppy->rate to indicate perpendicular mode */
-	perpendicular_mode(floppy->rate);
-	outb_p((cur_rate = (floppy->rate)) & ~0x40, FD_CCR);
+        /* use bit 6 of floppy->rate to indicate perpendicular mode */
+        perpendicular_mode(floppy->rate);
+        outb_p((cur_rate = (floppy->rate)) & ~0x40, FD_CCR);
     }
-}				/* configure_fdc_mode */
+}                               /* configure_fdc_mode */
 
 static void DFPROC tell_sector(int nr)
 {
     if (nr != 7) {
-	printk(" -- FDC reply error");
-	reset = 1;
+        printk(" -- FDC reply error");
+        reset = 1;
     } else
-	printk(": track %d, head %d, sector %d", reply_buffer[3],
-	       reply_buffer[4], reply_buffer[5]);
-}				/* tell_sector */
+        printk(": track %d, head %d, sector %d", reply_buffer[3],
+               reply_buffer[4], reply_buffer[5]);
+}                               /* tell_sector */
 
 /*
  * Ok, this interrupt is called after a DMA read/write has succeeded
@@ -704,81 +704,81 @@ static void rw_interrupt(void)
 
     /* check IC to find cause of interrupt */
     switch ((ST0 & ST0_INTR) >> 6) {
-    case 1:			/* error occured during command execution */
-	bad = 1;
-	printk("df%d: ", ST0 & ST0_DS);
-	if (ST1 & ST1_WP) {
-	    printk(" write protected");
-	    request_done(0);
-	    bad = 0;
-	} else if (ST1 & ST1_OR) {
-	    printk("data overrun");
-	    /* could continue from where we stopped, but ... */
-	    bad = 0;
-	} else if (CURRENT->rq_errors >= MIN_ERRORS) {
-	    if (ST0 & ST0_ECE) {
-		printk("recalibrate failed");
-	    } else if (ST2 & ST2_CRC) {
-		printk("data CRC error");
-		tell_sector(nr);
-	    } else if (ST1 & ST1_CRC) {
-		printk("CRC error");
-		tell_sector(nr);
-	    } else if ((ST1 & (ST1_MAM | ST1_ND)) || (ST2 & ST2_MAM)) {
-		if (!probing) {
-		    printk("sector not found");
-		    tell_sector(nr);
-		} else
-		    printk("probe failed on %s", floppy->name);
-	    } else if (ST2 & ST2_WC) {	/* seek error */
-		printk("wrong cylinder");
-	    } else if (ST2 & ST2_BC) {	/* cylinder marked as bad */
-		printk("bad cylinder");
-	    } else {
-		printk("unknown error, %x %x %x %x", ST0, ST1, ST2, ST3);
-	    }
-	}
-	printk("\n");
-	if (bad)
-	    bad_flp_intr();
-	redo_fd_request();
-	return;
-    case 2:			/* invalid command given */
-	printk("df: Invalid FDC command\n");
-	request_done(0);
-	return;
+    case 1:                     /* error occured during command execution */
+        bad = 1;
+        printk("df%d: ", ST0 & ST0_DS);
+        if (ST1 & ST1_WP) {
+            printk(" write protected");
+            request_done(0);
+            bad = 0;
+        } else if (ST1 & ST1_OR) {
+            printk("data overrun");
+            /* could continue from where we stopped, but ... */
+            bad = 0;
+        } else if (CURRENT->rq_errors >= MIN_ERRORS) {
+            if (ST0 & ST0_ECE) {
+                printk("recalibrate failed");
+            } else if (ST2 & ST2_CRC) {
+                printk("data CRC error");
+                tell_sector(nr);
+            } else if (ST1 & ST1_CRC) {
+                printk("CRC error");
+                tell_sector(nr);
+            } else if ((ST1 & (ST1_MAM | ST1_ND)) || (ST2 & ST2_MAM)) {
+                if (!probing) {
+                    printk("sector not found");
+                    tell_sector(nr);
+                } else
+                    printk("probe failed on %s", floppy->name);
+            } else if (ST2 & ST2_WC) {  /* seek error */
+                printk("wrong cylinder");
+            } else if (ST2 & ST2_BC) {  /* cylinder marked as bad */
+                printk("bad cylinder");
+            } else {
+                printk("unknown error, %x %x %x %x", ST0, ST1, ST2, ST3);
+            }
+        }
+        printk("\n");
+        if (bad)
+            bad_flp_intr();
+        redo_fd_request();
+        return;
+    case 2:                     /* invalid command given */
+        printk("df: Invalid FDC command\n");
+        request_done(0);
+        return;
     case 3:
-	printk("df: Abnormal cmd termination\n");
-	bad_flp_intr();
-	redo_fd_request();
-	return;
-    default:			/* (0) Normal command termination */
-	break;
+        printk("df: Abnormal cmd termination\n");
+        bad_flp_intr();
+        redo_fd_request();
+        return;
+    default:                    /* (0) Normal command termination */
+        break;
     }
 
     if (probing) {
-	open_inode->i_size = (sector_t)floppy->size << 9;
-	nr = DEVICE_NR(CURRENT->rq_dev);
-	printk("df%d: Auto-detected floppy type %s\n", nr, floppy->name);
-	current_type[nr] = floppy;
-	probing = 0;
+        open_inode->i_size = (sector_t)floppy->size << 9;
+        nr = DEVICE_NR(CURRENT->rq_dev);
+        printk("df%d: Auto-detected floppy type %s\n", nr, floppy->name);
+        current_type[nr] = floppy;
+        probing = 0;
     }
     if (read_track) {
         /* This encoding is ugly, should use block-start, block-end instead */
-	buffer_track = (seek_track << 1) + head;
-	buffer_drive = current_drive;
-	buffer_area = (unsigned char *)(sector << 9);
-	DEBUG("rd:%04x:%08lx->%04x:%04x;", DMASEG, buffer_area,
-		(unsigned long)CURRENT->rq_seg, CURRENT->rq_buffer);
-	xms_fmemcpyw(CURRENT->rq_buffer, CURRENT->rq_seg, buffer_area,
+        buffer_track = (seek_track << 1) + head;
+        buffer_drive = current_drive;
+        buffer_area = (unsigned char *)(sector << 9);
+        DEBUG("rd:%04x:%08lx->%04x:%04x;", DMASEG, buffer_area,
+                (unsigned long)CURRENT->rq_seg, CURRENT->rq_buffer);
+        xms_fmemcpyw(CURRENT->rq_buffer, CURRENT->rq_seg, buffer_area,
             DMASEG, BLOCK_SIZE/2);
     } else if (command == FD_READ 
 #ifndef CONFIG_FS_XMS_BUFFER
-	   && _MK_LINADDR(CURRENT->rq_seg, CURRENT->rq_buffer) >= LAST_DMA_ADDR
+           && _MK_LINADDR(CURRENT->rq_seg, CURRENT->rq_buffer) >= LAST_DMA_ADDR
 #endif
-	                            ) {
-	/* if the dest buffer is out of reach for DMA (always the case if using
-	 * XMS buffers) we need to read/write via the bounce buffer */
+                                    ) {
+        /* if the dest buffer is out of reach for DMA (always the case if using
+         * XMS buffers) we need to read/write via the bounce buffer */
         xms_fmemcpyw(CURRENT->rq_buffer, CURRENT->rq_seg, tmp_floppy_area,
             kernel_ds, BLOCK_SIZE/2);
         printk("fd: illegal buffer usage, rq_buffer %04x:%04x\n",
@@ -786,7 +786,7 @@ static void rw_interrupt(void)
     }
     request_done(1);
     //printk("RQOK;");
-    redo_fd_request();	/* Continue with the next request - if any */
+    redo_fd_request();  /* Continue with the next request - if any */
 }
 
 /*
@@ -813,13 +813,13 @@ static void DFPROC setup_rw_floppy(void)
     output_byte(track);
     output_byte(head);
     if (read_track)
-        output_byte(1);	        /* always start at 1 */
+        output_byte(1);         /* always start at 1 */
     else
         output_byte(sector+1);
-    output_byte(2);		/* sector size = 512 */
+    output_byte(2);             /* sector size = 512 */
     output_byte(floppy->sect);
     output_byte(floppy->gap);
-    output_byte(0xFF);	/* sector size, 0xff unless sector size==0 (128b) */
+    output_byte(0xFF);  /* sector size, 0xff unless sector size==0 (128b) */
     if (reset)
         redo_fd_request();
 }
@@ -835,11 +835,11 @@ static void seek_interrupt(void)
     DEBUG("seekI-");
     output_byte(FD_SENSEI);
     if (result() != 2 || (ST0 & 0xF8) != 0x20 || ST1 != seek_track) {
-	printk("df%d: seek failed %x %x %x\n", current_drive, ST0, ST1, seek_track);
-	recalibrate = 1;
-	bad_flp_intr();
-	redo_fd_request();
-	return;
+        printk("df%d: seek failed %x %x %x\n", current_drive, ST0, ST1, seek_track);
+        recalibrate = 1;
+        bad_flp_intr();
+        redo_fd_request();
+        return;
     }
     current_track = ST1;
     setup_rw_floppy();
@@ -854,20 +854,20 @@ static void DFPROC transfer(void)
 {
 #ifdef CONFIG_TRACK_CACHE
     read_track = (command == FD_READ) && (CURRENT->rq_errors < 4) &&
-	(floppy->sect <= MAX_BUFFER_SECTORS);
+        (floppy->sect <= MAX_BUFFER_SECTORS);
 #endif
     DEBUG("trns%d-", read_track);
 
-    configure_fdc_mode();	/* FIXME: Why are we doing this here??? 
-    				 * should be done once per media change ... */
+    configure_fdc_mode();       /* FIXME: Why are we doing this here???
+                                 * should be done once per media change ... */
 
     if (reset) {
-	redo_fd_request();
-	return;
+        redo_fd_request();
+        return;
     }
     if (!seek) {
-	setup_rw_floppy();
-	return;
+        setup_rw_floppy();
+        return;
     }
 
     /* OK; need to change tracks ... */
@@ -876,8 +876,8 @@ static void DFPROC transfer(void)
     output_byte(FD_SEEK);
     output_byte((head << 2) | current_drive);
     output_byte(seek_track);
-    if (reset)	                /* error in output_byte() */
-	redo_fd_request();
+    if (reset)                  /* error in output_byte() */
+        redo_fd_request();
 }
 
 static void DFPROC recalibrate_floppy(void)
@@ -893,7 +893,7 @@ static void DFPROC recalibrate_floppy(void)
      * why redo_fd_request here when recal_interrupt is doing it ???
      * 'reset' gets set in recal_interrupt, maybe that's it ???  */
     if (reset)
-	redo_fd_request();
+        redo_fd_request();
 }
 
 /*
@@ -905,14 +905,14 @@ static void recal_interrupt(void)
     output_byte(FD_SENSEI);
     current_track = NO_TRACK;
     if (result() != 2 || (ST0 & 0xE0) == 0x60) /* look for SEEK END and ABN TERMINATION*/
-	reset = 1;
-    DEBUG("recalI-%x", ST0);	/* Should be 0x20, Seek End */
+        reset = 1;
+    DEBUG("recalI-%x", ST0);    /* Should be 0x20, Seek End */
     /* Recalibrate until track 0 is reached. Might help on some errors. */
     if (ST0 & 0x10) {           /* Look for UnitCheck, which will happen regularly
-    				 * on 80 track drives because RECAL only steps 77 times */
-	recalibrate_floppy();	/* FIXME: may loop, should limit nr of recalibrates */
+                                 * on 80 track drives because RECAL only steps 77 times */
+        recalibrate_floppy();   /* FIXME: may loop, should limit nr of recalibrates */
     } else
-	redo_fd_request();
+        redo_fd_request();
 }
 
 static void unexpected_floppy_interrupt(void)
@@ -921,9 +921,9 @@ static void unexpected_floppy_interrupt(void)
     current_track = NO_TRACK;
     output_byte(FD_SENSEI);
     if (result() != 2 || (ST0 & 0xE0) == 0x60)
-	reset = 1;
+        reset = 1;
     else
-	recalibrate = 1;
+        recalibrate = 1;
 }
 
 /*
@@ -935,24 +935,24 @@ static void reset_interrupt(void)
 
     DEBUG("rstI-");
     for (i = 0; i < 4; i++) {
-	output_byte(FD_SENSEI);
-	(void) result();
+        output_byte(FD_SENSEI);
+        (void) result();
     }
     output_byte(FD_SPECIFY);
-    output_byte(cur_spec1);	/* hut etc */
-    output_byte(6);		/* Head load time =6ms, DMA */
-    configure_fdc_mode();	/* reprogram fdc */
+    output_byte(cur_spec1);     /* hut etc */
+    output_byte(6);             /* Head load time =6ms, DMA */
+    configure_fdc_mode();       /* reprogram fdc */
     if (initial_reset_flag) {
-	initial_reset_flag = 0;
-	recalibrate = 1;
-	reset = 0;
-	return;
+        initial_reset_flag = 0;
+        recalibrate = 1;
+        reset = 0;
+        return;
     }
     if (!recover)
-	redo_fd_request();
+        redo_fd_request();
     else {
-	recalibrate_floppy();
-	recover = 0;
+        recalibrate_floppy();
+        recover = 0;
     }
 }
 
@@ -970,7 +970,7 @@ static void DFPROC reset_floppy(void)
     recalibrate = 1;
     need_configure = 1;
     if (!initial_reset_flag)
-	printk("df: reset_floppy\n");
+        printk("df: reset_floppy\n");
     clr_irq();              /* FIXME don't busyloop with interrupts off, use timer */
     outb_p(current_DOR & ~0x04, FD_DOR);
     delay_loop(1000);
@@ -993,18 +993,18 @@ static void floppy_shutdown(void)
 static void shake_done(void)
 {
     /* Need SENSEI to clear the interrupt per spec, required by QEMU, not by
-     * real hardware	*/
-    output_byte(FD_SENSEI);	/* TESTING FIXME */
+     * real hardware    */
+    output_byte(FD_SENSEI);     /* TESTING FIXME */
     result();
     DEBUG("shD0x%x-", ST0);
     current_track = NO_TRACK;
     if (inb(FD_DIR) & 0x80) {
         printk("df%d: disk changed, aborting\n", current_drive);
-	request_done(0);
+        request_done(0);
     }
     if (ST0 & 0xC0) {
         printk("df%d: error %02x after SENSEI\n", current_drive, ST0 & 0xC0);
-	//request_done(0);
+        //request_done(0);
     }
     redo_fd_request();
 }
@@ -1017,8 +1017,8 @@ static int DFPROC retry_recal(void (*proc)())
     DEBUG("rrecal-");
     output_byte(FD_SENSEI);
     if (result() == 2 && (ST0 & 0x10) != 0x10) /* track 0 test */
-	return 0;		/* No 'unit check': We're OK */
-    do_floppy = proc;		/* otherwise recalibrate */
+        return 0;               /* No 'unit check': We're OK */
+    do_floppy = proc;           /* otherwise recalibrate */
     output_byte(FD_RECALIBRATE);
     output_byte(current_drive);
     return 1;
@@ -1028,14 +1028,14 @@ static void shake_zero(void)
 {
     DEBUG("sh0-");
     if (!retry_recal(shake_zero))
-	shake_done();
+        shake_done();
 }
 
 static void shake_one(void)
 {
     DEBUG("sh1-");
     if (retry_recal(shake_one))
-	return;	                /* just return if retry_recal initiated a RECAL */
+        return;                 /* just return if retry_recal initiated a RECAL */
     do_floppy = shake_done;
     output_byte(FD_SEEK);
     output_byte(head << 2 | current_drive);
@@ -1059,43 +1059,43 @@ static void DFPROC floppy_ready(void)
     if (fdc_version >= FDC_TYPE_8272PC_AT && (inb(FD_DIR) & 0x80)) {
 
 #if CHECK_DISK_CHANGE
-	changed_floppies |= 1 << current_drive;
+        changed_floppies |= 1 << current_drive;
 #endif
-	buffer_track = -1;
-	if (keep_data[current_drive]) {
-	    if (keep_data[current_drive] > 0)
-		keep_data[current_drive]--;
-	} else {
-		/* FIXME: this is non sensical: Need to assume that a medium change
-		 * means a new medium of the same format as the prev until it fails.
-		 */
-	    if (current_type[current_drive] != NULL)
-		printk("df%d: Disk type undefined after disk change\n", current_drive);
-	    current_type[current_drive] = NULL;
-	}
-	/* Forcing the drive to seek makes the "media changed" condition go
-	 * away. There should be a cleaner solution for that ...
-	 * FIXME: This is way too slow and recal is not seek ...
-	 */
-	if (!reset && !recalibrate) {
-	    if (current_track && current_track != NO_TRACK)
-		do_floppy = shake_zero;
-	    else
-		do_floppy = shake_one;
-	    output_byte(FD_RECALIBRATE);
-	    output_byte(current_drive);
-	    return;
-	}
+        buffer_track = -1;
+        if (keep_data[current_drive]) {
+            if (keep_data[current_drive] > 0)
+                keep_data[current_drive]--;
+        } else {
+                /* FIXME: this is non sensical: Need to assume that a medium change
+                 * means a new medium of the same format as the prev until it fails.
+                 */
+            if (current_type[current_drive] != NULL)
+                printk("df%d: Disk type undefined after disk change\n", current_drive);
+            current_type[current_drive] = NULL;
+        }
+        /* Forcing the drive to seek makes the "media changed" condition go
+         * away. There should be a cleaner solution for that ...
+         * FIXME: This is way too slow and recal is not seek ...
+         */
+        if (!reset && !recalibrate) {
+            if (current_track && current_track != NO_TRACK)
+                do_floppy = shake_zero;
+            else
+                do_floppy = shake_one;
+            output_byte(FD_RECALIBRATE);
+            output_byte(current_drive);
+            return;
+        }
     }
 #endif
 
     if (reset) {
-	reset_floppy();
-	return;
+        reset_floppy();
+        return;
     }
     if (recalibrate) {
-	recalibrate_floppy();
-	return;
+        recalibrate_floppy();
+        return;
     }
     transfer();
 }
@@ -1122,10 +1122,10 @@ static void DFPROC redo_fd_request(void)
     type = MINOR(req->rq_dev) >> MINOR_SHIFT;
     drive = DEVICE_NR(req->rq_dev);
     if (type > 3)
-	floppy = &minor_types[type >> 2];
-    else {			/* Auto-detection */
-	floppy = current_type[drive];
-	if (!floppy) {
+        floppy = &minor_types[type >> 2];
+    else {                      /* Auto-detection */
+        floppy = current_type[drive];
+        if (!floppy) {
             tmp = probing? base_type[drive][probing-1]: base_type[drive][0];
             if (!tmp) {
                 printk("df%d: Unable to determine drive type\n", drive);
@@ -1139,7 +1139,7 @@ static void DFPROC redo_fd_request(void)
         }
     }
     DEBUG("[%u]redo-%c %d(%s) bl %u;", (unsigned int)jiffies, 
-	req->rq_cmd == WRITE? 'W':'R', device, floppy->name, req->rq_sector);
+        req->rq_cmd == WRITE? 'W':'R', device, floppy->name, req->rq_sector);
 
     if (current_drive != drive) {
         current_track = NO_TRACK;
@@ -1173,23 +1173,23 @@ static void DFPROC redo_fd_request(void)
     DEBUG("prep %d|%d,%d|%d-", buffer_track, seek_track, buffer_drive, current_drive);
 
     if ((((seek_track << 1) + head) == buffer_track) && (current_drive == buffer_drive)) {
-	/* Requested block is in the buffer. If reading, go get it.
-	 * If the sector count is odd, we buffer sectors+1 when head=0 to get an even
-	 * number of sectors (full blocks). When head=1 we read the entire track
-	 * and ignore the first sector.
-	 */
-	DEBUG("bufrd chs %d/%d/%d\n", seek_track, head, sector);
-	char *buf_ptr = (char *) (sector << 9);
-	if (command == FD_READ) {	/* requested data is in buffer */
-	    xms_fmemcpyw(req->rq_buffer, req->rq_seg, buf_ptr, DMASEG, BLOCK_SIZE/2);
-	    request_done(1);
-	    goto repeat;
-    	} else if (command == FD_WRITE)	/* update track buffer */
-	    xms_fmemcpyw(buf_ptr, DMASEG, req->rq_buffer, req->rq_seg, BLOCK_SIZE/2);
+        /* Requested block is in the buffer. If reading, go get it.
+         * If the sector count is odd, we buffer sectors+1 when head=0 to get an even
+         * number of sectors (full blocks). When head=1 we read the entire track
+         * and ignore the first sector.
+         */
+        DEBUG("bufrd chs %d/%d/%d\n", seek_track, head, sector);
+        char *buf_ptr = (char *) (sector << 9);
+        if (command == FD_READ) {       /* requested data is in buffer */
+            xms_fmemcpyw(req->rq_buffer, req->rq_seg, buf_ptr, DMASEG, BLOCK_SIZE/2);
+            request_done(1);
+            goto repeat;
+        } else if (command == FD_WRITE) /* update track buffer */
+            xms_fmemcpyw(buf_ptr, DMASEG, req->rq_buffer, req->rq_seg, BLOCK_SIZE/2);
     } 
 
     if (seek_track != current_track)
-	seek = 1;
+        seek = 1;
 
     floppy_on(current_drive);
 }
@@ -1199,7 +1199,7 @@ void do_fd_request(void)
     DEBUG("fdrq:");
     while (fdc_busy) {
         printk("df: add_request error!\n");
-	sleep_on(&fdc_wait);
+        sleep_on(&fdc_wait);
     }
     fdc_busy = 1;
     redo_fd_request();
@@ -1213,108 +1213,108 @@ static int fd_ioctl(struct inode *inode, struct file *filp, unsigned int cmd,
     struct hd_geometry *loc;
 
     if (!inode || !inode->i_rdev)
-	return -EINVAL;
+        return -EINVAL;
     type = MINOR(inode->i_rdev) >> MINOR_SHIFT;
     drive = DEVICE_NR(inode->i_rdev);
     if (type > 3)
-	fp = &minor_types[type >> 2];
+        fp = &minor_types[type >> 2];
     else if ((fp = current_type[drive]) == NULL)
-	return -ENODEV;
+        return -ENODEV;
 
     switch (cmd) {
-    case HDIO_GETGEO:	/* need this one for the sys/makeboot command */
+    case HDIO_GETGEO:   /* need this one for the sys/makeboot command */
     case FDGETPRM:
         loc = (struct hd_geometry *)param;
-	err = verify_area(VERIFY_WRITE, (void *)loc, sizeof(struct hd_geometry));
-	if (!err) {
-	    put_user_char(fp->head, &loc->heads);
-	    put_user_char(fp->sect, &loc->sectors);
-	    put_user(fp->track, &loc->cylinders);
-	    put_user_long(0L, &loc->start);
-	}
-	return err;
+        err = verify_area(VERIFY_WRITE, (void *)loc, sizeof(struct hd_geometry));
+        if (!err) {
+            put_user_char(fp->head, &loc->heads);
+            put_user_char(fp->sect, &loc->sectors);
+            put_user(fp->track, &loc->cylinders);
+            put_user_long(0L, &loc->start);
+        }
+        return err;
 #ifdef UNUSED
     case FDFMTEND:
-	if (!suser())
-	    return -EPERM;
-	clr_irq();
-	fake_change |= 1 << (drive & 3);
-	set_irq();
-	drive &= 3;
-	cmd = FDCLRPRM;
-	break;
+        if (!suser())
+            return -EPERM;
+        clr_irq();
+        fake_change |= 1 << (drive & 3);
+        set_irq();
+        drive &= 3;
+        cmd = FDCLRPRM;
+        break;
     case FDFMTTRK:
-	if (!suser())
-	    return -EPERM;
-	if (fd_ref[drive & 3] != 1)
-	    return -EBUSY;
-	clr_irq();
-	while (format_status != FORMAT_NONE)
-	    sleep_on(&format_done);
-	memcpy_fromfs((char *)(&format_req),
-		    (char *)param, sizeof(struct format_descr));
-	format_req.device = drive; 	/* Should this be a full device ID? */
-	format_status = FORMAT_WAIT;
-	format_errors = 0;
-	while (format_status != FORMAT_OKAY && format_status != FORMAT_ERROR) {
-	    if (fdc_busy)
-		sleep_on(&fdc_wait);
-	    else {
-		fdc_busy = 1;
-		redo_fd_request();
-	    }
-	}
-	while (format_status != FORMAT_OKAY && format_status != FORMAT_ERROR)
-	    sleep_on(&format_done);
-	set_irq();
-	err = format_status == FORMAT_OKAY;
-	format_status = FORMAT_NONE;
-	floppy_off(drive & 3);
-	wake_up(&format_done);
-	return err ? 0 : -EIO;
+        if (!suser())
+            return -EPERM;
+        if (fd_ref[drive & 3] != 1)
+            return -EBUSY;
+        clr_irq();
+        while (format_status != FORMAT_NONE)
+            sleep_on(&format_done);
+        memcpy_fromfs((char *)(&format_req),
+                    (char *)param, sizeof(struct format_descr));
+        format_req.device = drive;      /* Should this be a full device ID? */
+        format_status = FORMAT_WAIT;
+        format_errors = 0;
+        while (format_status != FORMAT_OKAY && format_status != FORMAT_ERROR) {
+            if (fdc_busy)
+                sleep_on(&fdc_wait);
+            else {
+                fdc_busy = 1;
+                redo_fd_request();
+            }
+        }
+        while (format_status != FORMAT_OKAY && format_status != FORMAT_ERROR)
+            sleep_on(&format_done);
+        set_irq();
+        err = format_status == FORMAT_OKAY;
+        format_status = FORMAT_NONE;
+        floppy_off(drive & 3);
+        wake_up(&format_done);
+        return err ? 0 : -EIO;
     case FDFLUSH:
-	if (!permission(inode, 2))
-	    return -EPERM;
-	clr_irq();
-	fake_change |= 1 << (drive & 3);
-	set_irq();
-	check_disk_change(inode->i_rdev);
-	return 0;
+        if (!permission(inode, 2))
+            return -EPERM;
+        clr_irq();
+        fake_change |= 1 << (drive & 3);
+        set_irq();
+        check_disk_change(inode->i_rdev);
+        return 0;
     }
     if (!suser())
-	return -EPERM;
+        return -EPERM;
     switch (cmd) {
     case FDCLRPRM:
-	current_type[drive] = NULL;
-	keep_data[drive] = 0;
-	break;
+        current_type[drive] = NULL;
+        keep_data[drive] = 0;
+        break;
     case FDSETPRM:
     case FDDEFPRM:
-	memcpy_fromfs(user_params + drive,
-		      (void *) param, sizeof(struct floppy_struct));
-	current_type[drive] = &user_params[drive];
-	if (cmd == FDDEFPRM)
-	    keep_data[drive] = -1;
-	else {
-	    clr_irq();
-	    while (fdc_busy)
-		sleep_on(&fdc_wait);
-	    fdc_busy = 1;
-	    set_irq();
-	    outb_p((current_DOR & 0xfc) | drive | (0x10 << drive), FD_DOR);
-	    delay_loop(1000);
-	    if (inb(FD_DIR) & 0x80)
-		keep_data[drive] = 1;
-	    else
-		keep_data[drive] = 0;
-	    outb_p(current_DOR, FD_DOR);
-	    fdc_busy = 0;
-	    wake_up(&fdc_wait);
-	}
-	break;
+        memcpy_fromfs(user_params + drive,
+                      (void *) param, sizeof(struct floppy_struct));
+        current_type[drive] = &user_params[drive];
+        if (cmd == FDDEFPRM)
+            keep_data[drive] = -1;
+        else {
+            clr_irq();
+            while (fdc_busy)
+                sleep_on(&fdc_wait);
+            fdc_busy = 1;
+            set_irq();
+            outb_p((current_DOR & 0xfc) | drive | (0x10 << drive), FD_DOR);
+            delay_loop(1000);
+            if (inb(FD_DIR) & 0x80)
+                keep_data[drive] = 1;
+            else
+                keep_data[drive] = 0;
+            outb_p(current_DOR, FD_DOR);
+            fdc_busy = 0;
+            wake_up(&fdc_wait);
+        }
+        break;
 #endif
     default:
-	return -EINVAL;
+        return -EINVAL;
     }
 }
 
@@ -1329,9 +1329,9 @@ static unsigned char * INITPROC find_base(int drive, int type)
     unsigned char *base;
 
     if (type > 0 && type <= CMOS_MAX) {
-	base = probe_list[type - 1];
-	printk("df%d is %s (%d)", drive, minor_types[*base].name, type);
-	return base;
+        base = probe_list[type - 1];
+        printk("df%d is %s (%d)", drive, minor_types[*base].name, type);
+        return base;
     }
     printk("df%d is unknown (%d)", drive, type);
     return NULL;
@@ -1343,8 +1343,8 @@ static void INITPROC config_types(void)
     base_type[0] = find_base(0, (CMOS_READ(0x10) >> 4) & 0xF);
     //base_type[0] = find_base(0, CMOS_360k);   /* force 360k FIXME add setup table */
     if (((CMOS_READ(0x14) >> 6) & 1) != 0) {
-	printk(", ");
-	base_type[1] = find_base(1, CMOS_READ(0x10) & 0xF);
+        printk(", ");
+        base_type[1] = find_base(1, CMOS_READ(0x10) & 0xF);
     }
     printk("\n");
 }
@@ -1358,20 +1358,20 @@ static int floppy_open(struct inode *inode, struct file *filp)
 
 #if CHECK_DISK_CHANGE
     if (filp && filp->f_mode)
-	check_disk_change(inode->i_rdev);
+        check_disk_change(inode->i_rdev);
 #endif
 
     probing = 0;
-    if (type > 3)		/* forced floppy type */
-	floppy = &minor_types[type >> 2];
-    else {			/* Auto-detection */
-	floppy = current_type[drive];
-	if (!floppy) {
+    if (type > 3)               /* forced floppy type */
+        floppy = &minor_types[type >> 2];
+    else {                      /* Auto-detection */
+        floppy = current_type[drive];
+        if (!floppy) {
             if (!base_type[drive])
                 return -ENXIO;
-	    probing = 1;
-	    floppy = &minor_types[base_type[drive][0]];
-	}
+            probing = 1;
+            floppy = &minor_types[base_type[drive][0]];
+        }
     }
 
     if (fd_ref[drive] == 0) {
@@ -1404,14 +1404,14 @@ static void floppy_release(struct inode *inode, struct file *filp)
 }
 
 static struct file_operations floppy_fops = {
-    NULL,			/* lseek - default */
-    block_read,			/* read - general block-dev read */
-    block_write,		/* write - general block-dev write */
-    NULL,			/* readdir - bad */
-    NULL,			/* select */
-    fd_ioctl,			/* ioctl */
-    floppy_open,		/* open */
-    floppy_release,		/* release */
+    NULL,                       /* lseek - default */
+    block_read,                 /* read - general block-dev read */
+    block_write,                /* write - general block-dev write */
+    NULL,                       /* readdir - bad */
+    NULL,                       /* select */
+    fd_ioctl,                   /* ioctl */
+    floppy_open,                /* open */
+    floppy_release,             /* release */
 };
 
 /*
@@ -1426,7 +1426,7 @@ static void ignore_interrupt(void)
 {
     printk("df: interrupt ignored (%d)\n", result());
     reset = 1;
-    do_floppy = NULL;		/* ignore only once */
+    do_floppy = NULL;           /* ignore only once */
 }
 
 static void floppy_interrupt(int irq, struct pt_regs *regs)
@@ -1435,7 +1435,7 @@ static void floppy_interrupt(int irq, struct pt_regs *regs)
 
     do_floppy = NULL;
     if (!handler)
-	handler = unexpected_floppy_interrupt;
+        handler = unexpected_floppy_interrupt;
     //printk("$");
     handler();
 }
@@ -1461,7 +1461,7 @@ static int DFPROC get_fdc_version(void)
     const char *name;
 
     do_floppy = ignore_interrupt;
-    output_byte(FD_VERSION);	/* get FDC version code */
+    output_byte(FD_VERSION);    /* get FDC version code */
     if (result() != 1) {
         printk("df: can't get FDC version\n");
         return 0;
@@ -1507,8 +1507,8 @@ static int DFPROC floppy_register(void)
     old_floppy_vec = *((__u32 __far *)FLOPPY_VEC);
     err = request_irq(FLOPPY_IRQ, floppy_interrupt, INT_GENERIC);
     if (err) {
-	printk("df: IRQ %d busy\n", FLOPPY_IRQ);
-	return err;
+        printk("df: IRQ %d busy\n", FLOPPY_IRQ);
+        return err;
     }
 
     fdc_version = get_fdc_version();
@@ -1519,8 +1519,8 @@ static int DFPROC floppy_register(void)
 void INITPROC floppy_init(void)
 {
     if (register_blkdev(MAJOR_NR, DEVICE_NAME, &floppy_fops)) {
-	printk("df: init error\n");
-	return;
+        printk("df: init error\n");
+        return;
     }
     blk_dev[MAJOR_NR].request_fn = DEVICE_REQUEST;
     config_types();


### PR DESCRIPTION
Adding `boot=df0` to /bootopts is no longer required for booting to the direct floppy driver. If both the BIOS and direct driver are linked in, ELKS will boot from direct floppy driver if the machine BIOS specified floppy boot, else the HD.

Also retabs directfd.c for maintainability, no functional changes.