### PR TITLE
[kernel] First pass at adding media change support to kernel

### DIFF
--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -114,6 +114,7 @@ static void end_request(int uptodate)
     req = CURRENT;
 
     if (!uptodate) {
+        /*if (req->rq_errors >= 0)*/
         printk(DEVICE_NAME ": I/O %s error dev %D lba sector %lu\n",
             (req->rq_cmd == WRITE)? "write": "read",
             req->rq_dev, req->rq_sector);

--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -82,7 +82,6 @@ int tty_intcheck(register struct tty *ttyp, unsigned char key)
             kill_pg(ttyp->pgrp, sig, 1);
         }
     }
-    (void) check_disk_change(0);    /* check any floppy media changed */
     return sig;
 }
 

--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -82,6 +82,7 @@ int tty_intcheck(register struct tty *ttyp, unsigned char key)
             kill_pg(ttyp->pgrp, sig, 1);
         }
     }
+    (void) check_disk_change(0);    /* check any floppy media changed */
     return sig;
 }
 

--- a/elks/fs/block_dev.c
+++ b/elks/fs/block_dev.c
@@ -23,6 +23,9 @@ size_t block_read(struct inode *inode, struct file *filp, char *buf, size_t coun
     if (pos <= 0)
 	return 0;       /* EOF */
 
+    if (check_disk_change(inode->i_rdev))
+        return -ENXIO;
+
     if ((loff_t)count > pos) count = (size_t)pos;
 
     while (count > 0) {
@@ -69,6 +72,9 @@ size_t block_write(struct inode *inode, struct file *filp, char *buf, size_t cou
 #if defined(CONFIG_MINIX_FS) || defined(CONFIG_BLK_DEV_CHAR)
     size_t chars, offset;
     size_t written = 0;
+
+    if (check_disk_change(inode->i_rdev))
+        return -ENXIO;
 
     if (filp->f_flags & O_APPEND) filp->f_pos = (loff_t)inode->i_size;
 

--- a/elks/fs/devices.c
+++ b/elks/fs/devices.c
@@ -50,38 +50,6 @@ int register_blkdev(unsigned int major, const char *name, struct file_operations
     return 0;
 }
 
-#ifdef BLOAT_FS
-/*
- * This routine checks whether a removable media has been changed,
- * and invalidates all buffer-cache-entries in that case. This
- * is a relatively slow routine, so we have to try to minimize using
- * it. Thus it is called only upon a 'mount' or 'open'. This
- * is the best way of combining speed and utility, I think.
- * People changing diskettes in the middle of an operation deserve
- * to lose :-)
- */
-int check_disk_change(kdev_t dev)
-{
-    register struct file_operations *fops;
-    int i;
-
-    i = MAJOR(dev);
-    if (i >= MAX_BLKDEV || (fops = blkdevs[i].ds_fops) == NULL) return 0;
-    if (fops->check_media_change == NULL) return 0;
-    if (!fops->check_media_change(dev)) return 0;
-
-    printk("VFS: Disk change detected on device %s\n", kdevname(dev));
-    for (i = 0; i < NR_SUPER; i++)
-	if (super_blocks[i].s_dev == dev) put_super(super_blocks[i].s_dev);
-    invalidate_inodes(dev);
-    invalidate_buffers(dev);
-
-    if (fops->revalidate)
-	fops->revalidate(dev);
-    return 1;
-}
-#endif
-
 /*
  * Called every time a block special file is opened
  */

--- a/elks/fs/minix/bitmap.c
+++ b/elks/fs/minix/bitmap.c
@@ -32,7 +32,7 @@ struct buffer_head *get_map_block(kdev_t dev, block_t block)
     else
         bh = bread(dev, block);
     if (!EBH(bh)->b_uptodate) {
-        printk("get_map_block: can't read block %D/%u\n", dev, block);
+        debug_blk("get_map_block: can't read block %D/%u\n", dev, block);
         brelse(bh);
         return NULL;
     }

--- a/elks/fs/super.c
+++ b/elks/fs/super.c
@@ -170,9 +170,7 @@ static struct super_block *read_super(kdev_t dev, int t, int flags,
     register struct file_system_type *type;
 
     if (!dev) return NULL;
-#ifdef BLOAT_FS
     check_disk_change(dev);
-#endif
     s = get_super(dev);
     if (s) return s;
 

--- a/elks/fs/super.c
+++ b/elks/fs/super.c
@@ -104,7 +104,7 @@ void sync_supers(kdev_t dev)
     } while (++sb < super_blocks + NR_SUPER);
 }
 
-static struct super_block *get_super(kdev_t dev)
+struct super_block *get_super(kdev_t dev)
 {
     register struct super_block *s;
 
@@ -170,7 +170,7 @@ static struct super_block *read_super(kdev_t dev, int t, int flags,
     register struct file_system_type *type;
 
     if (!dev) return NULL;
-    check_disk_change(dev);
+    (void) check_disk_change(dev);
     s = get_super(dev);
     if (s) return s;
 
@@ -208,7 +208,7 @@ static struct super_block *read_super(kdev_t dev, int t, int flags,
     return s;
 }
 
-static int do_umount(kdev_t dev)
+int do_umount(kdev_t dev)
 {
     register struct super_block *sb;
     register struct super_operations *sop;
@@ -489,10 +489,8 @@ void mount_root(void)
         }
     } while (*(++fs_type) && !retval);
 
-#ifdef CONFIG_BLK_DEV_BIOS
-    if (ROOT_DEV == DEV_FD0) {
-        if (!filp->f_op->release)
-            printk("Release not defined\n");
+#if defined(CONFIG_BLK_DEV_BFD) || defined(CONFIG_BLK_DEV_FD)
+    if (ROOT_DEV == DEV_FD0 || ROOT_DEV == DEV_DF0) {
         close_filp(d_inode, filp);
         printk("VFS: Insert root floppy and press ENTER\n");
         wait_for_keypress();

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -481,10 +481,15 @@ extern size_t block_write(struct inode *,struct file *,char *,size_t);
 extern size_t decompress(char *buf, seg_t seg, size_t orig_size, size_t compr_size, int safety);
 #endif
 
+#ifdef CONFIG_BLK_DEV_FD
+extern int check_disk_change(kdev_t);
+#else
+#define check_disk_change(dev)      0
+#endif
+
 #ifdef BLOAT_FS
 extern int get_write_access(struct inode *);
 extern void put_write_access(struct inode *);
-extern int check_disk_change(kdev_t);
 #else
 #define get_write_access(_a)
 #define put_write_access(_a)

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -447,7 +447,9 @@ extern struct buffer_head *readbuf(struct buffer_head *);
 extern void ll_rw_blk(int,struct buffer_head *);
 extern int get_sector_size(kdev_t dev);
 
+extern struct super_block *get_super(kdev_t);
 extern void put_super(kdev_t);
+extern int do_umount(kdev_t);
 extern kdev_t ROOT_DEV;
 
 extern void mount_root(void);


### PR DESCRIPTION
This PR adds initial support for media change to the kernel, posted early for discussion. The support requires the use of the direct floppy driver, which uses the hardware DIR register to know whether floppy media has changed during operation.

While this first version is operational, it has quickly run into problems, detailed below. The support adds/renames two configuration settings in directfd.c: `CHECK_DIR_REG` and `CHECK_DISK_CHANGE`. The former turns on support to check the hardware DIR register for media change, along with the FDC extra code to move the head etc to turn the DISKCHG bit in the DIR register off. The latter option `CHECK_DISK_CHANGE` adds support for the kernel to call `check_disk_change(dev)` at various times to do something after the media has been noticed changed.

Because the direct floppy driver is interrupt-driven, and the various routines called to invalidate buffers, etc may sleep, the driver itself is limited in what it can do at interrupt time - thus the "upper level" requirement that the kernel call `check_disk_change` at various points in filesystem activity. This first pass has the kernel call before mount and block device open, but testing shows the need for calls before file read, write and probably directory operations as well (namei?).

Because all of the initial development is being done on QEMU for speed, a CTRL-P debug callback has been added to simulate the DIR register media change, since QEMU cannot be told of a media switch. The testing setup is booting to 1.2M direct floppy in drive A, and then mounting a floppy in drive B, then running various commands, issuing CTRL-P to fake a media change, then seeing the results.

After taking a hard look at the minimal BLOAT_FS support for media change in ELKS, along with support for media change in Linux 2.0, I'm finding a number of problems, which need to be discussed a bit in order to understand what kind of support can actually be made to work, given the complications.

Here's the initial list of issues:
- The kernel can't support media change for the root device - instead, it will have to `panic`. This means the entire effort is only for the second floppy if booted off floppy.
- Both Linux 2.0 and ELKS currently call `invalidate_inodes` and `invalidate_buffers` on disk change, which can become very problematic: if an inode is "in use", it can't be cleared, which means it may become intertwined with the new media inodes if they have the same number. And `invalidate_buffers` waits on any in-progress I/O to complete, which is no good, since the media has been removed.
- Both the invalidate_ routines could be rewritten, but if I/O is in progress on a buffer, the direct floppy drive may go ahead and process an I/O request at the next interrupt to the new media anyway, causing data loss. Inodes could be force-cleared, but this could cause system instability if quite a few internal variables (like current directory and running processes with open inodes) aren't somehow handled.
- Removed media that have mounted filesystems on top of them will cause big issues not easily solved. (Basic mounted media should be able to be handled by force-unmounting without too many ill effects).

If we take the approach of only handling basic cases, like trying to only handle media changes when I/O is not in progress, things become simpler, but I'm not sure they can be guaranteed to work well. Thus, the entire idea of kernel media change handling working reliably is probably not possible.

Here's what might possible to be made to work (most of the time). On media change:
- Force unmount any filesystem on the block device. All buffers would be invalidated without waiting for I/O, and I/O cancelled if not started. All filesystem inodes could be force-cleared, but current directories or open inodes held by running processes may not be guaranteed to return an error on read/write, and instead the system could hang, depending on the exact state of the running or sleeping processes and the kernel's handling of invalid or duplicate inode pointers/numbers.
- Somehow cancel all outstanding I/O on just the changed device. This would likely result in a bunch of kernel I/O error messages scrolling quickly on the console.
- The block device would stay open; the current media type could either be reused, or probably better a new probe sequence started for the new media on the next I/O request.
- Lots more code is added to the kernel: DIR register handling, reset/recalibrate head movement to reset it, disk change handling, rewriting both invalidate buffer and inode routines specially, etc.

@Mellvik, I know this sort of thing is probably interesting to you. What do you think about the kind of support that should be included for media change? Can you think of anything I haven't mentioned? Thank you!

NOTE: Much of the original kernel (not driver) code for media change is being deleted in this PR, since it can't be used: the old code tries to write out the prior super block (bad idea), then tries to read the superblock (what for, the filesystem can't be auto-mounted as the in-core superblock info won't match), as well as attempts a probe by reading the superblock (not needed, as the new direct floppy driver auto-probes on any sector read/write request).

This PR also contains a fix for the direct floppy driver access counting: previously, a separate access counter was used for each floppy drive. This caused problems with unregistering the IRQ etc when a sub-floppy drive was opened/closed, so an additional global access_count was added which tracks the total access count for the whole driver.
