### PR TITLE
[direct floppy] Small updates to DF driver

### DIFF
--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -73,7 +73,7 @@ static void floppy_off(int nr);
 
 #define DEVICE_NAME "df"
 #define DEVICE_REQUEST do_fd_request
-#define DEVICE_NR(device) ((device) & 3)
+#define DEVICE_NR(device) ((device) & 1)
 #define DEVICE_OFF(device) floppy_off(DEVICE_NR(device))
 
 #elif (MAJOR_NR == ATHD_MAJOR)

--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -189,7 +189,7 @@ static unsigned char reply_buffer[MAX_REPLIES];
 
 /*
  * Minor number based formats. Each drive type is specified starting
- * from minor number 4 plus the table index, and no auto-probing is used.
+ * from minor number 2 plus the table index, and no auto-probing is used.
  *
  * Stretch tells if the tracks need to be doubled for some
  * types (ie 360kB diskette in 1.2MB drive etc).
@@ -242,10 +242,10 @@ static unsigned char p2880k[] = { FT_2880k,   FT_1440k,    0 };
 static unsigned char *probe_list[CMOS_MAX] = { p360k, p1200k, p720k, p1440k, p2880k };
 
 /* Auto-detection: disk type determined from CMOS and probing */
-static struct floppy_struct *current_type[4];
+static struct floppy_struct *current_type[2];
 
 /* initial probe per drive */
-static unsigned char * base_type[4];
+static unsigned char *base_type[2];
 
 /*
  * The driver is trying to determine the correct media format
@@ -255,7 +255,7 @@ static unsigned char * base_type[4];
 static int probing;
 
 /* device reference counters */
-static int fd_ref[4];
+static int fd_ref[2];
 static int access_count;
 
 /* Synchronization of FDC access. */
@@ -367,17 +367,13 @@ static void motor_on_callback(int nr)
     floppy_select(nr);
 }
 
-static struct timer_list motor_on_timer[4] = {
+static struct timer_list motor_on_timer[2] = {
     {NULL, 0, 0, motor_on_callback},
-    {NULL, 0, 1, motor_on_callback},
-    {NULL, 0, 2, motor_on_callback},
-    {NULL, 0, 3, motor_on_callback}
+    {NULL, 0, 1, motor_on_callback}
 };
-static struct timer_list motor_off_timer[4] = {
+static struct timer_list motor_off_timer[2] = {
     {NULL, 0, 0, motor_off_callback},
-    {NULL, 0, 1, motor_off_callback},
-    {NULL, 0, 2, motor_off_callback},
-    {NULL, 0, 3, motor_off_callback}
+    {NULL, 0, 1, motor_off_callback}
 };
 static struct timer_list fd_timeout = {NULL, 0, 0, floppy_shutdown};
 
@@ -1156,8 +1152,8 @@ static void DFPROC redo_fd_request(void)
     }
 #endif
 
-    if (type > 3)
-        floppy = &minor_types[type >> 2];
+    if (type > 1)
+        floppy = &minor_types[type >> 1];
     else {                      /* Auto-detection */
         floppy = current_type[drive];
         if (!floppy) {
@@ -1247,8 +1243,8 @@ static int fd_ioctl(struct inode *inode, struct file *filp, unsigned int cmd,
         return -EINVAL;
     type = MINOR(inode->i_rdev) >> MINOR_SHIFT;
     drive = DEVICE_NR(inode->i_rdev);
-    if (type > 3)
-        fp = &minor_types[type >> 2];
+    if (type > 1)
+        fp = &minor_types[type >> 1];
     else if ((fp = current_type[drive]) == NULL)
         return -ENODEV;
 
@@ -1375,8 +1371,8 @@ static int floppy_open(struct inode *inode, struct file *filp)
 #endif
 
     probing = 0;
-    if (type > 3)               /* forced floppy type */
-        floppy = &minor_types[type >> 2];
+    if (type > 1)               /* forced floppy type */
+        floppy = &minor_types[type >> 1];
     else {                      /* Auto-detection */
         floppy = current_type[drive];
         if (!floppy) {

--- a/elks/arch/i86/drivers/block/ll_rw_blk.c
+++ b/elks/arch/i86/drivers/block/ll_rw_blk.c
@@ -221,12 +221,6 @@ static void make_request(unsigned short major, int rw, struct buffer_head *bh)
     req->rq_buffer = buffer_data(bh);
     req->rq_bh = bh;
     req->rq_errors = 0;
-
-#ifdef BLOAT_FS
-    req->rq_nr_sectors = count;
-    req->rq_current_nr_sectors = count;
-#endif
-
     req->rq_next = NULL;
     add_request(&blk_dev[major], req);
 }
@@ -291,7 +285,7 @@ void ll_rw_block(int rw, int nr, register struct buffer_head **bh)
 {
     struct blk_dev_struct *dev;
     struct request plug;
-    unsigned short int major;
+    unsigned int major;
     int i;
 
     /* Make sure the first block contains something reasonable */
@@ -324,8 +318,8 @@ void ll_rw_block(int rw, int nr, register struct buffer_head **bh)
   sorry:
     for (i = 0; i < nr; i++)
         if (bh[i]) {
-                mark_buffer_clean(bh[i]);
-                mark_buffer_uptodate(bh[i], 0);
+            mark_buffer_clean(bh[i]);
+            mark_buffer_uptodate(bh[i], 0);
         }
 }
 #endif /* MULTI_BH */

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -267,12 +267,10 @@ updct:
 //
 	cmp	$16,%ax
 	jge	was_trap	// Traps need no reset
-#ifdef CONFIG_ARCH_PC98
-	jmp	do_eoi
-#else
+
+#if defined(CONFIG_BLK_DEV_BFD) && !defined(CONFIG_ARCH_PC98)
 	or	%ax,%ax		// Is int #0?
 	jnz	do_eoi
-#endif
 
 //
 //	IRQ 0 (timer) has to go on to the bios for some systems
@@ -283,6 +281,7 @@ updct:
 	pushf
 	lcall	*org_irq0
 	jmp	was_trap	// EOI already sent by bios int
+#endif
 
 //
 //	Send EOI to interrupt controller


### PR DESCRIPTION
Don't call original BIOS hardware IRQ 0 timer routine unless configured for BIOS floppy driver (CONFIG_DEV_BLK_BFD). I'm pretty sure this is only useful for BIOS floppy motor timeout, but this hasn't been tested on real hardware. Also assumes that BIOS HD support does not require the timer.

Add adjustable timeout values for motor on, off and command timeout.

Support two floppy drives; this halves the number of /dev entries required for preset floppy format types, should anyone actually ever use that feature.