### PR TITLE
[driver] Minor floppy driver cleanups

### DIFF
--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -316,28 +316,6 @@ static void INITPROC check_partition(register struct gendisk *hd, kdev_t dev)
 }
 #endif
 
-/* This function is used to re-read partition tables for removable disks.
-   Much of the cleanup from the old partition tables should have already been
-   done */
-
-#if UNUSED
-/* This function will re-read the partition tables for a given device, and set
- * things back up again. There are some important caveats, however. You must
- * ensure that no one is using the device, and no one can start using the
- * device while this function is being executed.
- */
-void resetup_one_dev(struct gendisk *dev, int drive)
-{
-    int i;
-    int first_minor = drive << dev->minor_shift;
-    int end_minor = first_minor + dev->max_p;
-
-    blk_size[dev->major] = NULL;
-    current_minor = 1 + first_minor;
-    check_partition(dev, MKDEV(dev->major, first_minor));
-}
-#endif
-
 void INITPROC setup_dev(register struct gendisk *dev)
 {
     //memset((void *)dev->part, 0, sizeof(struct hd_struct)*dev->max_nr*dev->max_p);

--- a/elks/include/linuxmt/limits.h
+++ b/elks/include/linuxmt/limits.h
@@ -26,7 +26,7 @@
 #define NR_MAPBUFS      8       /* Number of internal L1 buffers */
 
 #ifdef CONFIG_ASYNCIO
-#define NR_REQUEST      12      /* Number of async I/O request headers */
+#define NR_REQUEST      15      /* Number of async I/O request headers */
 #else
 #define NR_REQUEST      1       /* only 1 is required for non-async I/O */
 #endif


### PR DESCRIPTION
Removes `fdc_busy` wait/wakeup synchronization from DF driver. Closer inspection reveals the only reason for these is that the floppy driver needed reentry protection from the floppy format routines which were implemented using `ioctl`, and required exclusive use of the driver during formatting.

Removed unused and non-working CDROM media revalidation and partition re-checking code from BIOS disk driver. The ancient BIOS driver also seemed to once use busy-waiting to protect partition revalidation from CDROM media change events. Currently, general purpose media change and device revalidation are not supported, although the DF driver has specific support for both built-in to it only.

Cleans up and bounds-checks DF driver minor number, used for pre-defined (non-autoprobed) floppy formats.

Removes unused MINOR_SHIFT in DF driver. The final portions of the unused floppy formatting code are also removed.

Changed NR_REQUESTS from 12 to 15. After testing, with multiple processes reading/writing between floppies with the DF driver, it was found a max of 8 I/O were queued. This was 7 beforehand, so increased to 15 for headroom. (The upper 1/3 of requests are reserved for write requests, thus allowing max 10 outstanding I/O requests before process sleeping at this point).



