### PR TITLE
[libc,cmds] Fix perror and rm -f, improve rmdir

### DIFF
--- a/elkscmd/file_utils/rmdir.c
+++ b/elkscmd/file_utils/rmdir.c
@@ -7,24 +7,23 @@
 
 static int remove_dir(char *name, int f)
 {
-	int ret, once = 1;
-	char *line;
-	
-	while (((ret = rmdir(name)) == 0) && ((line = strrchr(name,'/')) != NULL) && f) {
-		while ((line > name) && (*line == '/'))
-			--line;
-		line[1] = 0;
-		once = 0;
-	}
-	return (ret && once);
+    int ret, once = 1;
+    char *line;
+
+    while (((ret = rmdir(name)) == 0) && ((line = strrchr(name,'/')) != NULL) && f) {
+        while ((line > name) && (*line == '/'))
+            --line;
+        line[1] = 0;
+        once = 0;
+    }
+    return (ret && once);
 }
-	
 
 int main(int argc, char **argv)
 {
-	int i, parent = 0, force = 0, er = 0;
-	
-	if (argc < 2) goto usage;
+    int i, parent = 0, force = 0, ret = 0;
+
+    if (argc < 2) goto usage;
 
     while (argv[1][0] == '-') {
         switch (argv[1][1]) {
@@ -36,17 +35,19 @@ int main(int argc, char **argv)
         argc--;
     }
 
-	for (i = 1; i < argc; i++) {
-			while (argv[i][strlen(argv[i])-1] == '/')
-				argv[i][strlen(argv[i])-1] = '\0';
-			if (remove_dir(argv[i],parent)) {
-				perror(argv[i]);
-				er = 1;
-			}
-	}
-	return force? 0: er;
+    for (i = 1; i < argc; i++) {
+            while (argv[i][strlen(argv[i])-1] == '/')
+                argv[i][strlen(argv[i])-1] = '\0';
+            if (remove_dir(argv[i],parent)) {
+                errstr(argv[i]);
+                errmsg(": cannot remove directory\n");
+                if (!force)
+                    ret = 1;
+            }
+    }
+    return ret;
 
 usage:
-	errmsg("usage: rmdir [-pf] directory [...]\n");
-	return 1;
+    errmsg("usage: rmdir [-pf] directory [...]\n");
+    return 1;
 }

--- a/libc/error/perror.c
+++ b/libc/error/perror.c
@@ -7,7 +7,7 @@ perror(const char *str)
 {
     char *ptr;
 
-    if (!str) {
+    if (str) {
         write(2, str, strlen(str));
         write(2, ": ", 2);
     }


### PR DESCRIPTION
Fixes `perror` bug introduced in previous enhancement.

Fixes `rm -f` to always return 0 exit status along with other minor fixes.

Decreases size of `rmdir` to less than 1 block (was 1070 bytes), source retabbed.

