### PR TITLE
[libc,cmds] Fix isprint and kilo for CP 437 display

### DIFF
--- a/elkscmd/misc_utils/kilo.c
+++ b/elkscmd/misc_utils/kilo.c
@@ -680,7 +680,7 @@ void editorQueryString(char* prompt, char *buffer){
 		} else if(c == ENTER) {
             editorSetStatusMessage("");
 			return;
-		} else if(isprint(c)) {
+		} else if(isprint(c & 255)) {
 			buffer[len++] = c;
 			buffer[len] = '\0';
 		}
@@ -870,7 +870,7 @@ int editorUpdateSyntax(erow *row) {
         }
 
         /* Handle non printable chars. */
-        if (!isprint(*p)) {
+        if (!isprint(*p & 255)) {
             row->hl[i] = HL_NONPRINT;
             p++; i++;
             prev_sep = 0;
@@ -987,7 +987,7 @@ int editorUpdateRow(erow *row) {
         if (row->chars[j] == TAB) {
             row->render[idx++] = ' ';
             while((idx+1) % TABSPACE != 0) row->render[idx++] = ' ';
-        } else if (!isprint(row->chars[j])) {
+        } else if (!isprint(row->chars[j] & 255)) {
             row->render[idx++] = '?';
         } else {
             row->render[idx++] = row->chars[j];
@@ -1715,7 +1715,7 @@ void editorFind(int fd, int mode) {
 			  find_next = 1;
             }
 
-        } else if (isprint(c)) {
+        } else if (isprint(c & 255)) {
             if (qlen < KILO_QUERY_LEN) {
                 query[qlen++] = c;
                 query[qlen] = '\0';

--- a/libc/ctype/isprint.c
+++ b/libc/ctype/isprint.c
@@ -1,6 +1,8 @@
 #include <ctype.h>
+#include <stdio.h>
 
 int isprint(int c)
 {
-	return (c & 0x7f) >= 32 && c < 127;
+    if (c == EOF) return 0;
+    return (c & 0xff) >= 32;    /* display ASCII and upper half of CP 437 */
 }


### PR DESCRIPTION
Fixes display problems in `kilo` identified by @Vutshi in https://github.com/ghaerr/elks/issues/1748#issuecomment-1752128760. This turned out to be a problem in `isprint` as well as sign extension on the character CP 437 character 0xff (non-blank space).

The C library `isprint` function is updated to designate the upper half of CP 437 as printable.