### PR TITLE
[config] Do not read MK_ARCH & MK_CPU if already defined

### DIFF
--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -113,14 +113,22 @@ CCDEFS = -D__KERNEL__
 #########################################################################
 # Set the target environment and the compiler to use.
 
+ifndef MK_ARCH
 ifeq ($(wildcard $(TOPDIR)/.config),)
     MK_ARCH	= ibmpc
-    MK_CPU	= 8086
 else
     MK_ARCH	= $(shell grep '^CONFIG_ARCH_' $(TOPDIR)/.config \
 			| cut -d = -f 1 | cut -d _ -f 3- | tr A-Z a-z)
+endif
+endif
+
+ifndef MK_CPU
+ifeq ($(wildcard $(TOPDIR)/.config),)
+    MK_CPU	= 8086
+else
     MK_CPU	= $(shell grep '^CONFIG_CPU_' $(TOPDIR)/.config \
 			| cut -d = -f 1 | cut -d _ -f 3- | tr A-Z a-z)
+endif
 endif
 
 # Use GCC-IA16 compiler


### PR DESCRIPTION
While investigating why my local bulds were taking so long, I noticed that `grep` is being called a *lot*. I figured that by running `make SHELL='sh -x'`.
This fix significantly improves rebuild times by not setting `MK_ARCH` & `MK_CPU` if they are already set somewhere up the Makefile chain.

On my machine, when running `make all` with some minor changes to the code (or no changes at all), this fix reduces build time from over 10 minutes to ~48s.

Similar change might be applied to some other places - I've seen some other heavy find/grep calls in the Makefile.