### PR TITLE
[config] Allow configuration of default screen height

### DIFF
--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -772,7 +772,7 @@ arch_set_initseg:
 	movb	$1,15		// we've detected a VGA
 #else
         movb  $0,15		// no VGA in system
-        mov   $25,%al		// height of display in rows
+        mov   $CONFIG_DEF_SCREEN_HEIGHT,%al		// height of display in rows
 #endif /* CONFIG_HW_VGA*/
 
 novga:	mov	%al,14		// CGA 25 rows

--- a/elks/config.in
+++ b/elks/config.in
@@ -20,6 +20,11 @@ mainmenu_option next_comment
 		comment 'Devices'
 
 		bool 'VGA adapter'      CONFIG_HW_VGA       y
+
+		if [ "$CONFIG_HW_VGA" = "n" ]; then
+			int 'Default screen height' CONFIG_DEF_SCREEN_HEIGHT 25
+		fi
+
 		bool 'Serial port FIFO' CONFIG_HW_SERIAL_FIFO y
 
 		comment 'BIOS support'

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -148,6 +148,10 @@
 #define SETUP_DATA      REL_INITSEG
 #endif /* CONFIG_ARCH_PC98 && !CONFIG_ROMCODE */
 
+/* Assume the following screen height if VGA is not configured. */
+#if !defined(CONFIG_DEF_SCREEN_HEIGHT)
+#define CONFIG_DEF_SCREEN_HEIGHT 25
+#endif
 
 // DMASEG is a bouncing buffer of 1K (= BLOCKSIZE)
 // below the first 64K boundary (= 0x1000:0)


### PR DESCRIPTION
I'm using BIOS console in my system with a non-standard screen size (40x8).
However, screen height of 25 rows is hard-coded in setup.S, which messes up screen scrolling.

This PR adds a config parameter to specify a value different than 25 if VGA is disabled.