### PR TITLE
arch: add homebrew API

### DIFF
--- a/Documentation/text/porting-guide.txt
+++ b/Documentation/text/porting-guide.txt
@@ -25,6 +25,12 @@ IBM PC/XT/AT Personal Computer (CONFIG_ARCH_IBMPC)
 		NE2K
 		WD8003
 
+    Homebrew modifications of IBM PC:
+        Homebrew extensions can be enabled with CONFIG_HW_HOMEBREW.
+        This replaces some hard-coded values with INT 0x88 calls:
+        - AH=0 - get display columns
+        - AH=1 - get display rows
+
 8018X Architecture (CONFIG_ARCH_8018X)
 Advantech SNMP-1000B (advtech)
 	System

--- a/elks/arch/i86/drivers/char/console-bios.c
+++ b/elks/arch/i86/drivers/char/console-bios.c
@@ -19,6 +19,7 @@
 #include <linuxmt/chqueue.h>
 #include <linuxmt/ntty.h>
 #include <linuxmt/kd.h>
+#include <linuxmt/homebrew.h>
 #include "console.h"
 #include "console-bios.h"
 

--- a/elks/arch/i86/lib/Makefile
+++ b/elks/arch/i86/lib/Makefile
@@ -35,6 +35,7 @@ include $(BASEDIR)/Makefile-rules
 SRCS1 = \
 	fmemory.S \
 	peekpoke.S \
+	homebrew.S \
 	string.S \
 	printreg.S \
 	# end of list

--- a/elks/arch/i86/lib/homebrew.S
+++ b/elks/arch/i86/lib/homebrew.S
@@ -1,0 +1,17 @@
+// functions for communicating with homebrew computers (INT 0x88 API)
+
+#define ARG0	2
+
+	.code16
+	.text
+
+	.global	int88
+
+int88:
+	mov	%ds,%dx
+	mov	%sp,%bx
+	mov	ARG0(%bx),%ax
+	xchg	%al,%ah		// function number into AH
+	int	$0x88
+	mov	%dx,%ds
+	ret

--- a/elks/config.in
+++ b/elks/config.in
@@ -16,6 +16,7 @@ mainmenu_option next_comment
 
 		bool 'Compaq DeskPro Hardware (fast mode)' CONFIG_HW_COMPAQFAST n
 		bool 'MK-88 Hardware (IRQ 3 keyboard)' CONFIG_HW_MK88 n
+		bool 'Homebrew extensions (INT 0x88)' CONFIG_HW_HOMEBREW n
 
 		comment 'Devices'
 

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -16,8 +16,13 @@
  * be overridden for embedded systems with less overhead.
  * See setup.S for more details.
  */
+#if defined(CONFIG_HW_HOMEBREW)
+#define SETUP_VID_COLS          int88(0)        /* BIOS video # columns */
+#define SETUP_VID_LINES         int88(1)        /* BIOS video # lines */
+#else
 #define SETUP_VID_COLS          setupb(7)       /* BIOS video # columns */
 #define SETUP_VID_LINES         setupb(14)      /* BIOS video # lines */
+#endif /* CONFIG_HW_HOMEBREW */
 #define SETUP_CPU_TYPE          setupb(0x20)    /* processor type */
 #define SETUP_MEM_KBYTES        setupw(0x2a)    /* base memory in 1K bytes */
 #define SETUP_ROOT_DEV          setupw(0x1fc)   /* root device, kdev_t or BIOS dev */

--- a/elks/include/linuxmt/homebrew.h
+++ b/elks/include/linuxmt/homebrew.h
@@ -1,0 +1,11 @@
+#ifndef __LINUXMT_HOMEBREW_H
+#define __LINUXMT_HOMEBREW_H
+
+/* APIs for homebrew computers */
+
+#include <linuxmt/types.h>
+#include <stddef.h>
+
+byte_t int88 (byte_t fn);
+
+#endif


### PR DESCRIPTION
This PR supersedes #1761 and adds a new hardware sub-platform - `CONFIG_HW_HOMEBREW`, which is a subset of IBM PC. When enabled, certain config parameters will be queried using INT 0x88, thus allowing custom BIOSes and bootloaders to modify ELKS kernel setup process during runtime by implementing their own INT 0x88 handler.

Currently there are only two functions that are used by BIOS console:

- INT 0x88, AH=0: Get display columns
- INT 0x88, AH=1: Get display rows

This allows us to keep the machine-specific parameters out of kernel code.

Why INT 0x88?
- i80**88**
- **88** miles per hour!
- Not a 0x80, since that one is reserved
- Eights are nice!

Let me know what you think about this approach. It's similar to what's been suggested  by @ghaerr in the original PR.