### PR TITLE
[libc] exit,abort,longjmp are noreturn

### DIFF
--- a/libc/include/setjmp.h
+++ b/libc/include/setjmp.h
@@ -2,6 +2,7 @@
 #define __SETJMP_H
 
 #include <features.h>
+#include <stdnoreturn.h>
 
 /* 
  * I know most systems use an array of ints here, but I prefer this   - RDB
@@ -21,7 +22,7 @@ typedef struct
 } jmp_buf[1];
 
 int _setjmp(jmp_buf env);
-void _longjmp(jmp_buf env, int rv);
+noreturn void _longjmp(jmp_buf env, int rv);
 
 /* LATER: Seems GNU beat me to it, must be OK then :-)
  *        Humm, what's this about setjmp being a macro !?

--- a/libc/include/stdlib.h
+++ b/libc/include/stdlib.h
@@ -3,6 +3,7 @@
 
 /* stdlib.h  <ndf@linux.mit.edu> */
 #include <features.h>
+#include <stdnoreturn.h>
 #include <sys/types.h>
 #include <malloc.h>
 
@@ -52,9 +53,9 @@ char *getenv(const char *name);
 int putenv(char *string);
 char *mktemp(char *template);
 
-void abort (void);
+noreturn void abort (void);
 int atexit (void (* function) ());
-void exit (int status);
+noreturn void exit (int status);
 int system(const char *command);
 void qsort(void *base, size_t nel, size_t width,
 	int (*compar)(/*const void *, const void * */));

--- a/libc/include/unistd.h
+++ b/libc/include/unistd.h
@@ -2,6 +2,7 @@
 #define __UNISTD_H
 
 #include <features.h>
+#include <stdnoreturn.h>
 #include <sys/types.h>
 #include <sys/select.h>
 
@@ -49,7 +50,7 @@ int execve(char *fname, char **argv, char **envp);
 int execvp(char *fname, char **argv);
 int execvpe(char *fname, char **argv, char **envp);
 int _execve(char *fname, char *stk_ptr, int stack_bytes);
-void _exit(int status);
+noreturn void _exit(int status);
 int isatty (int fd);
 char *ttyname(int fd);
 off_t lseek (int fildes, off_t offset, int whence);


### PR DESCRIPTION
If the compiler supports `noreturn` annotations, it can occasionally allow the optimizer to be more effective.

I checked a full build with and without this change, and didn't see any new warnings.  It does save one block when building everything on the 2.88M floppy.

    < blocks inuse 2229, free 624, overhead 27, total 2880
    ---
    > blocks inuse 2228, free 625, overhead 27, total 2880
