### PR TITLE
Tweaks to allow building on other BSDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all: .config include/autoconf.h
 	$(MAKE) -C bootblocks all
 	$(MAKE) -C elkscmd all
 	$(MAKE) -C image all
-ifneq ($(shell uname), Darwin)
+ifeq ($(shell uname), Linux)
 	$(MAKE) -C elksemu PREFIX='$(TOPDIR)/cross' elksemu
 endif
 
@@ -28,7 +28,7 @@ clean:
 	$(MAKE) -C bootblocks clean
 	$(MAKE) -C elkscmd clean
 	$(MAKE) -C image clean
-ifneq ($(shell uname), Darwin)
+ifeq ($(shell uname), Linux)
 	$(MAKE) -C elksemu clean
 endif
 	@echo

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This build script is called in main.yml by GitHub Continuous Integration
 # Full build (including the cross tool chain)

--- a/clean.sh
+++ b/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Full clean (except the cross build chain)
 

--- a/config/lxdialog/Makefile
+++ b/config/lxdialog/Makefile
@@ -1,22 +1,25 @@
 #########################################################################
 # Where are the curses libraries?
 
-ifeq (/usr/include/ncurses/ncurses.h, $(wildcard /usr/include/ncurses/ncurses.h))
+ifeq ($(shell pkg-config --exists ncurses ; echo $$?), 0)
+	CURSES_INC := $(shell pkg-config --cflags-only-I ncurses)
+	CURSES_LOC := "<ncurses.h>"
+	CURSES_LIBS := $(shell pkg-config --libs ncurses)
+else ifeq (/usr/include/ncurses/ncurses.h, $(wildcard /usr/include/ncurses/ncurses.h))
 	CURSES_INC = -I/usr/include/ncurses
 	CURSES_LOC = "<ncurses.h>"
-else
-ifeq (/usr/include/ncurses/curses.h, $(wildcard /usr/include/ncurses/curses.h))
+else ifeq (/usr/include/ncurses/curses.h, $(wildcard /usr/include/ncurses/curses.h))
 	CURSES_INC = -I/usr/include/ncurses
 	CURSES_LOC = "<ncurses/curses.h>"
-else
-ifeq (/usr/include/ncurses.h, $(wildcard /usr/include/ncurses.h))
+else ifeq (/usr/include/ncurses.h, $(wildcard /usr/include/ncurses.h))
 	CURSES_INC =
 	CURSES_LOC = "<ncurses.h>"
 else
 	CURSES_INC =
 	CURSES_LOC = "<curses.h>"
 endif
-endif
+ifeq ($(CURSES_LIBS), )
+	CURSES_LIBS = -lncurses
 endif
 
 #########################################################################
@@ -26,11 +29,7 @@ CC = gcc
 CFLAGS = -std=c99 -O2 -Wall -pedantic -DLOCALE $(CURSES_INC)
 
 LDFLAGS = -s
-LDLIBS = $(shell pkg-config ncurses --libs)
-ifeq ($(LDLIBS), )
-	LDLIBS = -lncurses
-endif
-#LDLIBS = /usr/local/opt/ncurses/lib/libncurses.a
+LDLIBS = $(CURSES_LIBS)
 
 #########################################################################
 # What do we compile?
@@ -61,8 +60,8 @@ $(PGM): $(OBJS)
 # Write a custom header for curses.
 
 local-curses.h:
-	@x=`find /lib/ /lib64/ /usr/lib/ /usr/lib64/ /usr/local/lib/ /usr/local/lib64/ /usr/pkg/lib /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/lib/ -maxdepth 2 -name 'libncurses.*'` ;\
-	if [ ! "$$x" ]; then \
+	@if ! pkg-config --exists ncurses && \
+		! find /lib/ /lib64/ /usr/lib/ /usr/lib64/ /usr/local/lib/ /usr/local/lib64/ /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/lib/ -maxdepth 2 -name 'libncurses.*' | grep . ; then \
 		echo -e "\007" ;\
 		echo ">> Unable to find the Ncurses libraries." ;\
 		echo ">>" ;\

--- a/config/lxdialog/Makefile
+++ b/config/lxdialog/Makefile
@@ -61,7 +61,7 @@ $(PGM): $(OBJS)
 # Write a custom header for curses.
 
 local-curses.h:
-	@x=`find /lib/ /lib64/ /usr/lib/ /usr/lib64/ /usr/local/lib/ /usr/local/lib64/ /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/lib/ -maxdepth 2 -name 'libncurses.*'` ;\
+	@x=`find /lib/ /lib64/ /usr/lib/ /usr/lib64/ /usr/local/lib/ /usr/local/lib64/ /usr/pkg/lib /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/lib/ -maxdepth 2 -name 'libncurses.*'` ;\
 	if [ ! "$$x" ]; then \
 		echo -e "\007" ;\
 		echo ">> Unable to find the Ncurses libraries." ;\

--- a/config/lxdialog/checklist.c
+++ b/config/lxdialog/checklist.c
@@ -54,12 +54,12 @@ static void print_item(WINDOW * win, const char *item, int status,
 /*
  * Print the scroll indicators.
  */
-static void print_arrows(WINDOW * win, int choice, int item_no, int scroll,
+static void print_arrows(WINDOW * win, int choice, int item_no, int nscroll,
 			 int y, int x, int height)
 {
     wmove(win, y, x);
 
-    if (scroll > 0) {
+    if (nscroll > 0) {
 	wattrset(win, uarrow_attr);
 	waddch(win, ACS_UARROW);
 	waddstr(win, "(-)");
@@ -74,7 +74,7 @@ static void print_arrows(WINDOW * win, int choice, int item_no, int scroll,
     y = y + height + 1;
     wmove(win, y, x);
 
-    if ((height < item_no) && (scroll + choice < item_no - 1)) {
+    if ((height < item_no) && (nscroll + choice < item_no - 1)) {
 	wattrset(win, darrow_attr);
 	waddch(win, ACS_DARROW);
 	waddstr(win, "(+)");
@@ -110,7 +110,7 @@ int dialog_checklist(const char *title, const char *prompt, int height,
 		     const char *const *items, int flag)
 {
     WINDOW *dialog, *list;
-    int *status, key = 0, button = 0, choice = 0, scroll = 0, max_choice;
+    int *status, key = 0, button = 0, choice = 0, nscroll = 0, max_choice;
     int i, x, y, box_x, box_y;
 
     checkflag = flag;
@@ -181,19 +181,19 @@ int dialog_checklist(const char *title, const char *prompt, int height,
     item_x = check_x + 4;
 
     if (choice >= list_height) {
-	scroll = choice - list_height + 1;
-	choice -= scroll;
+	nscroll = choice - list_height + 1;
+	choice -= nscroll;
     }
 
     /* Print the list */
     for (i = 0; i < max_choice; i++) {
-	print_item(list, items[(scroll + i) * 3 + 1],
-		   status[i + scroll], i, i == choice);
+	print_item(list, items[(nscroll + i) * 3 + 1],
+		   status[i + nscroll], i, i == choice);
     }
 
     wnoutrefresh(list);
 
-    print_arrows(dialog, choice, item_no, scroll,
+    print_arrows(dialog, choice, item_no, nscroll,
 		 box_y, box_x + check_x + 5, list_height);
 
     print_buttons(dialog, height, width, 0);
@@ -202,7 +202,7 @@ int dialog_checklist(const char *title, const char *prompt, int height,
 	key = wgetch(dialog);
 
 	for (i = 0; i < max_choice; i++)
-	    if (toupper(key) == toupper(items[(scroll + i) * 3 + 1][0]))
+	    if (toupper(key) == toupper(items[(nscroll + i) * 3 + 1][0]))
 		break;
 
 
@@ -210,23 +210,23 @@ int dialog_checklist(const char *title, const char *prompt, int height,
 	    key == '+' || key == '-') {
 	    if (key == KEY_UP || key == '-') {
 		if (!choice) {
-		    if (!scroll)
+		    if (!nscroll)
 			continue;
 		    /* Scroll list down */
 		    if (list_height > 1) {
 			/* De-highlight current first item */
-			print_item(list, items[scroll * 3 + 1],
-				   status[scroll], 0, FALSE);
+			print_item(list, items[nscroll * 3 + 1],
+				   status[nscroll], 0, FALSE);
 			scrollok(list, TRUE);
 			wscrl(list, -1);
 			scrollok(list, FALSE);
 		    }
-		    scroll--;
-		    print_item(list, items[scroll * 3 + 1],
-			       status[scroll], 0, TRUE);
+		    nscroll--;
+		    print_item(list, items[nscroll * 3 + 1],
+			       status[nscroll], 0, TRUE);
 		    wnoutrefresh(list);
 
-		    print_arrows(dialog, choice, item_no, scroll,
+		    print_arrows(dialog, choice, item_no, nscroll,
 				 box_y, box_x + check_x + 5, list_height);
 
 		    wrefresh(dialog);
@@ -236,26 +236,26 @@ int dialog_checklist(const char *title, const char *prompt, int height,
 		    i = choice - 1;
 	    } else if (key == KEY_DOWN || key == '+') {
 		if (choice == max_choice - 1) {
-		    if (scroll + choice >= item_no - 1)
+		    if (nscroll + choice >= item_no - 1)
 			continue;
 		    /* Scroll list up */
 		    if (list_height > 1) {
 			/* De-highlight current last item before scrolling up */
 			print_item(list,
-				   items[(scroll + max_choice - 1) * 3 + 1],
-				   status[scroll + max_choice - 1],
+				   items[(nscroll + max_choice - 1) * 3 + 1],
+				   status[nscroll + max_choice - 1],
 				   max_choice - 1, FALSE);
 			scrollok(list, TRUE);
 			scroll(list);
 			scrollok(list, FALSE);
 		    }
-		    scroll++;
-		    print_item(list, items[(scroll + max_choice - 1) * 3 + 1],
-			       status[scroll + max_choice - 1],
+		    nscroll++;
+		    print_item(list, items[(nscroll + max_choice - 1) * 3 + 1],
+			       status[nscroll + max_choice - 1],
 			       max_choice - 1, TRUE);
 		    wnoutrefresh(list);
 
-		    print_arrows(dialog, choice, item_no, scroll,
+		    print_arrows(dialog, choice, item_no, nscroll,
 				 box_y, box_x + check_x + 5, list_height);
 
 		    wrefresh(dialog);
@@ -266,12 +266,12 @@ int dialog_checklist(const char *title, const char *prompt, int height,
 	    }
 	    if (i != choice) {
 		/* De-highlight current item */
-		print_item(list, items[(scroll + choice) * 3 + 1],
-			   status[scroll + choice], choice, FALSE);
+		print_item(list, items[(nscroll + choice) * 3 + 1],
+			   status[nscroll + choice], choice, FALSE);
 		/* Highlight new item */
 		choice = i;
-		print_item(list, items[(scroll + choice) * 3 + 1],
-			   status[scroll + choice], choice, TRUE);
+		print_item(list, items[(nscroll + choice) * 3 + 1],
+			   status[nscroll + choice], choice, TRUE);
 		wnoutrefresh(list);
 		wrefresh(dialog);
 	    }
@@ -299,18 +299,18 @@ int dialog_checklist(const char *title, const char *prompt, int height,
 	case '\n':
 	    if (!button) {
 		if (flag == FLAG_CHECK) {
-		    status[scroll + choice] = !status[scroll + choice];
+		    status[nscroll + choice] = !status[nscroll + choice];
 		    wmove(list, choice, check_x);
 		    wattrset(list, check_selected_attr);
-		    wprintw(list, "[%c]", status[scroll + choice] ? 'X' : ' ');
+		    wprintw(list, "[%c]", status[nscroll + choice] ? 'X' : ' ');
 		} else {
-		    if (!status[scroll + choice]) {
+		    if (!status[nscroll + choice]) {
 			for (i = 0; i < item_no; i++)
 			    status[i] = 0;
-			status[scroll + choice] = 1;
+			status[nscroll + choice] = 1;
 			for (i = 0; i < max_choice; i++)
-			    print_item(list, items[(scroll + i) * 3 + 1],
-				       status[scroll + i], i, i == choice);
+			    print_item(list, items[(nscroll + i) * 3 + 1],
+				       status[nscroll + i], i, i == choice);
 		    }
 		}
 		wnoutrefresh(list);

--- a/config/lxdialog/inputbox.c
+++ b/config/lxdialog/inputbox.c
@@ -46,7 +46,7 @@ int dialog_inputbox(const char *title, const char *prompt, int height,
     WINDOW *dialog;
     char *instr = dialog_input_result;
     int i, x, y, box_y, box_x, box_width;
-    int input_x = 0, scroll = 0, key = 0, button = -1;
+    int input_x = 0, nscroll = 0, key = 0, button = -1;
 
     /* center dialog box on screen */
     x = (COLS - width) / 2;
@@ -97,10 +97,10 @@ int dialog_inputbox(const char *title, const char *prompt, int height,
     input_x = strlen(instr);
 
     if (input_x >= box_width) {
-	scroll = input_x - box_width + 1;
+	nscroll = input_x - box_width + 1;
 	input_x = box_width - 1;
 	for (i = 0; i < box_width - 1; i++)
-	    waddch(dialog, instr[scroll + i]);
+	    waddch(dialog, instr[nscroll + i]);
     } else
 	waddstr(dialog, instr);
 
@@ -123,19 +123,19 @@ int dialog_inputbox(const char *title, const char *prompt, int height,
 		continue;
 	    case KEY_BACKSPACE:
 	    case 127:
-		if (input_x || scroll) {
+		if (input_x || nscroll) {
 		    wattrset(dialog, inputbox_attr);
 		    if (!input_x) {
-			scroll = scroll < box_width - 1 ?
-			    0 : scroll - (box_width - 1);
+			nscroll = nscroll < box_width - 1 ?
+			    0 : nscroll - (box_width - 1);
 			wmove(dialog, box_y, box_x);
 			for (i = 0; i < box_width; i++)
-			    waddch(dialog, instr[scroll + input_x + i] ?
-				   instr[scroll + input_x + i] : ' ');
-			input_x = strlen(instr) - scroll;
+			    waddch(dialog, instr[nscroll + input_x + i] ?
+				   instr[nscroll + input_x + i] : ' ');
+			input_x = strlen(instr) - nscroll;
 		    } else
 			input_x--;
-		    instr[scroll + input_x] = '\0';
+		    instr[nscroll + input_x] = '\0';
 		    mvwaddch(dialog, box_y, input_x + box_x, ' ');
 		    wmove(dialog, box_y, input_x + box_x);
 		    wrefresh(dialog);
@@ -143,15 +143,15 @@ int dialog_inputbox(const char *title, const char *prompt, int height,
 		continue;
 	    default:
 		if (key < 0x100 && isprint(key)) {
-		    if (scroll + input_x < MAX_LEN) {
+		    if (nscroll + input_x < MAX_LEN) {
 			wattrset(dialog, inputbox_attr);
-			instr[scroll + input_x] = key;
-			instr[scroll + input_x + 1] = '\0';
+			instr[nscroll + input_x] = key;
+			instr[nscroll + input_x + 1] = '\0';
 			if (input_x == box_width - 1) {
-			    scroll++;
+			    nscroll++;
 			    wmove(dialog, box_y, box_x);
 			    for (i = 0; i < box_width - 1; i++)
-				waddch(dialog, instr[scroll + i]);
+				waddch(dialog, instr[nscroll + i]);
 			} else {
 			    wmove(dialog, box_y, input_x++ + box_x);
 			    waddch(dialog, key);

--- a/elks/arch/i86/tools/build.c
+++ b/elks/arch/i86/tools/build.c
@@ -23,8 +23,8 @@
 
 #include <stdio.h>			/* fprintf */
 
-#if !defined(__APPLE__)
-#include <sys/sysmacros.h>		/* We NEED these macros */
+#ifdef __linux__
+#include <sys/sysmacros.h>		/* for major/minor macros */
 #endif
 #include <sys/stat.h>
 #include <sys/types.h>			/* unistd.h needs this */

--- a/elks/tools/mfs/genfs.c
+++ b/elks/tools/mfs/genfs.c
@@ -19,6 +19,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
+#if __linux__
+#include <sys/sysmacros.h>
+#endif
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>
@@ -30,12 +33,6 @@
 #include <fcntl.h>
 #include "minix_fs.h"
 #include "protos.h"
-
-#if __APPLE__
-#define MAJOR_SHIFT		24	/* OSX: right shift dev_t to get major device # */
-#else
-#define MAJOR_SHIFT		8
-#endif
 
 typedef unsigned short u16_t;
 typedef unsigned long u32_t;
@@ -407,22 +404,22 @@ compile_fs(struct minix_fs_dat *fs)
 				cmd_cp(fs, 3, av);
 			} else if (flags == S_IFCHR) {
 				if (opt_verbose) printf("mknod %s c %d %d\n", prefix+inode_build->path,
-					inode_build->dev >> MAJOR_SHIFT, inode_build->dev & 0xff);
+					major(inode_build->dev), minor(inode_build->dev));
 				av[0] = "mknod";
 				av[1] = prefix+inode_build->path;
 				av[2] = "c";
-				av[3] = major; sprintf(major, "%d", inode_build->dev >> MAJOR_SHIFT);
-				av[4] = minor; sprintf(minor, "%d", inode_build->dev & 0xff);
+				av[3] = major; sprintf(major, "%d", major(inode_build->dev));
+				av[4] = minor; sprintf(minor, "%d", minor(inode_build->dev));
 				av[5] = 0;
 				cmd_mknode(fs, 5, av);
 			} else if (flags == S_IFBLK) {
 				if (opt_verbose) printf("mknod %s b %d %d\n", prefix+inode_build->path,
-					inode_build->dev >> MAJOR_SHIFT, inode_build->dev & 0xff);
+					major(inode_build->dev), minor(inode_build->dev));
 				av[0] = "mknod";
 				av[1] = prefix+inode_build->path;
 				av[2] = "b";
-				av[3] = major; sprintf(major, "%d", inode_build->dev >> MAJOR_SHIFT);
-				av[4] = minor; sprintf(minor, "%d", inode_build->dev & 0xff);
+				av[3] = major; sprintf(major, "%d", major(inode_build->dev));
+				av[4] = minor; sprintf(minor, "%d", minor(inode_build->dev));
 				av[5] = 0;
 				cmd_mknode(fs, 5, av);
 			} else if (flags == S_IFLNK) {

--- a/elkscmd/build_hd_image.sh
+++ b/elkscmd/build_hd_image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # BROKEN SCRIPT
 # DEV86 is no more linked to this project

--- a/emu86.sh
+++ b/emu86.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Run ELKS in EMU86 (basic IA16 emulator)
 # EMU86 is part of the cross tools

--- a/env.sh
+++ b/env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Set up the build environment
 

--- a/image/ver.pl
+++ b/image/ver.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #Get the version from the kernel makefile
 
 while (<>) {

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Build the cross tools for the IA16 target
 

--- a/tools/prune.sh
+++ b/tools/prune.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Prune the cross tools to save disk space
 


### PR DESCRIPTION
My machine that can write a floppy is now old enough that Linux doesn't really support it, so I switched it to NetBSD.  Here are the minimal changes that I needed to get a build.

lxconfig still doesn't build because it has a `scroll` variable that collides with the ncurses function.  I don't know how this normally manages to build.  But that can be bypassed by dropping a .config in place.

This expects all the GNU stuff to be installed, and I had to trick the Makefiles to use GNU make instead of BSD's make, by first running `alias make=gmake`.  But all things considered, it was surprisingly easy.