### PR TITLE
[build] Fix ROM build when using emu86-rom.config

### DIFF
--- a/emu86-rom.config
+++ b/emu86-rom.config
@@ -83,6 +83,8 @@ CONFIG_PIPE=y
 # Block device drivers
 #
 
+# CONFIG_BLK_DEV_BFD is not set
+# CONFIG_BLK_DEV_BHD is not set
 # CONFIG_BLK_DEV_FD is not set
 # CONFIG_BLK_DEV_HD is not set
 # CONFIG_BLK_DEV_RAM is not set


### PR DESCRIPTION
As reported in #1795, building using `emu86-rom.config` failed. This was due to CONFIG_BLK_DEV_BFD/BHD being turned on by default in `elks/arch/i86/defconfig`.

Emulated ROM boot tested using `emu86.sh`.