### PR TITLE
[serial] Use Transmitter Hold Register Empty for buggy 8251 UARTs

### DIFF
--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -467,8 +467,7 @@ static void DFPROC setup_DMA(void)
     use_xms = req->rq_seg >> 16; /* will be nonzero only if XMS configured & XMS buffer */
     physaddr = (req->rq_seg << 4) + (unsigned int)req->rq_buffer;
 
-    /* FIXME req->rq_nr_sectors will be 0 for TLVC only */
-    count = req->rq_nr_sectors? (unsigned)req->rq_nr_sectors << 9: BLOCK_SIZE;
+    count = (unsigned)req->rq_nr_sectors << 9;
     if (use_xms || (physaddr + count) < physaddr)
         dma_addr = LAST_DMA_ADDR + 1;   /* force use of bounce buffer */
     else

--- a/elks/arch/i86/drivers/char/serial-8250.c
+++ b/elks/arch/i86/drivers/char/serial-8250.c
@@ -475,7 +475,7 @@ void rs_conout(dev_t dev, int Ch)
 {
     register struct serial_info *sp = &ports[MINOR(dev) - RS_MINOR_OFFSET];
 
-    while (!(INB(sp->io + UART_LSR) & UART_LSR_TEMT))
+    while (!(INB(sp->io + UART_LSR) & UART_LSR_THRE))
         continue;
     outb(Ch, sp->io + UART_TX);
 }

--- a/elks/arch/i86/drivers/char/serial-template.c
+++ b/elks/arch/i86/drivers/char/serial-template.c
@@ -188,7 +188,7 @@ void rs_conout(dev_t dev, int c)
 {
     struct serial_info *sp = &ports[MINOR(dev) - RS_MINOR_OFFSET];
 
-    while (!(inb(sp->io + UART_LSR) & UART_LSR_TEMT))
+    while (!(inb(sp->io + UART_LSR) & UART_LSR_THRE))
 	continue;
     outb(c, sp->io + UART_TX);
 }


### PR DESCRIPTION
Updates serial driver for old 8251 UARTs discussed in https://github.com/Mellvik/TLVC/issues/42#issuecomment-1906532375.

Removes unused TLVC workaround in direct FD driver.