### PR TITLE
[libc] Reduce dependencies on certain standard header files

### DIFF
--- a/elks/include/linuxmt/kernel.h
+++ b/elks/include/linuxmt/kernel.h
@@ -15,19 +15,20 @@
 #define LONG_MAX	((long)(~0UL>>1))
 #define ULONG_MAX	(~0UL)
 
-#define wontreturn          __attribute__((__noreturn__))
+/* FIXME move compiler-specific attributes to new header file */
+#define noreturn            __attribute__((__noreturn__))
 //#define printfesque(n)    __attribute__((__format__(__gnu_printf__, n, n + 1)))
 #define printfesque(n)
 
 #define structof(p,t,m) ((t *) ((char *) (p) - offsetof (t,m)))
 
-extern void do_exit(int) wontreturn;
+extern void do_exit(int) noreturn;
 
 extern int kill_pg(pid_t,sig_t,int);
 extern int kill_sl(void);
 
-extern void halt(void) wontreturn;
-extern void panic(const char *, ...) wontreturn;
+extern void halt(void) noreturn;
+extern void panic(const char *, ...) noreturn;
 extern void printk(const char *, ...) printfesque(1);
 extern void early_putchar(int);
 

--- a/elkscmd/romprg/commands.c
+++ b/elkscmd/romprg/commands.c
@@ -6,8 +6,6 @@
 #include "common/replies.h"
 #include "version.h"
 #include "crc.h"
-#include <stdbool.h>
-
 
 void command_generate_error_reply(uint8_t err) {
   protocol_write_packet(1, &err);

--- a/libc/include/features.h
+++ b/libc/include/features.h
@@ -1,17 +1,11 @@
 #ifndef __FEATURES_H
 #define __FEATURES_H
 
-#define __P(x) x
-
 /* Pick an OS sysinclude directory */
 /* Use with #include __SYSINC__(errno.h) */
 
 #define __SYSINC__(_h_file_) <linuxmt/_h_file_>
 #define __SYSARCHINC__(_h_file_) <arch/_h_file_>
-
-/* No C++ */
-#define __BEGIN_DECLS
-#define __END_DECLS
 
 #include <sys/cdefs.h>
 

--- a/libc/include/setjmp.h
+++ b/libc/include/setjmp.h
@@ -2,7 +2,6 @@
 #define __SETJMP_H
 
 #include <features.h>
-#include <stdnoreturn.h>
 
 /* 
  * I know most systems use an array of ints here, but I prefer this   - RDB

--- a/libc/include/stdlib.h
+++ b/libc/include/stdlib.h
@@ -3,7 +3,6 @@
 
 /* stdlib.h  <ndf@linux.mit.edu> */
 #include <features.h>
-#include <stdnoreturn.h>
 #include <sys/types.h>
 #include <malloc.h>
 

--- a/libc/include/sys/cdefs.h
+++ b/libc/include/sys/cdefs.h
@@ -1,30 +1,28 @@
-
 #ifndef __SYS_CDEFS_H
 #define __SYS_CDEFS_H
-#include <features.h>
+/* compiler-specific definitions */
 
 #if __STDC__
 
 #define	__CONCAT(x,y)	x ## y
-#define	__STRING(x)	#x
-
-/* This is not a typedef so `const __ptr_t' does the right thing.  */
-#define __ptr_t void *
-#ifndef __HAS_NO_FLOATS__
-typedef long double __long_double_t;
-#endif
+#define	__STRING(x)     #x
+#define __ptr_t         void *
 
 #else
 
 #define	__CONCAT(x,y)	x/**/y
-#define	__STRING(x)	"x"
+#define	__STRING(x)     "x"
+#define __ptr_t         char *
 
-#define __ptr_t char *
-
-#ifndef __HAS_NO_FLOATS__
-typedef double __long_double_t;
 #endif
 
+#define __P(x) x        /* always ANSI C */
+
+/* don't require <stdnoreturn.h> */
+#if defined(__GNUC__)
+#define noreturn        __attribute__((__noreturn__))
+#else
+#define noreturn
 #endif
 
 /* No C++ */

--- a/libc/include/unistd.h
+++ b/libc/include/unistd.h
@@ -2,7 +2,6 @@
 #define __UNISTD_H
 
 #include <features.h>
-#include <stdnoreturn.h>
 #include <sys/types.h>
 #include <sys/select.h>
 


### PR DESCRIPTION
Removes use of `stdnoreturn.h` and `stdbool.h` in application and kernel builds, discussed in #1771.
Simplifies libc `features.h` and `sys/cdefs.h` and circular includes.