### PR TITLE
[cmds] Replace use of non-standard malloc.h header with stdlib.h

### DIFF
--- a/elks/tools/objdump86/objdump86.c
+++ b/elks/tools/objdump86/objdump86.c
@@ -13,11 +13,7 @@
  */
 
 #include <stdio.h>
-#ifdef __STDC__
 #include <stdlib.h>
-#else
-#include <malloc.h>
-#endif
 #include <string.h>
 
 /* config.h - configuration for linker */

--- a/elkscmd/busyelks/sash.h
+++ b/elkscmd/busyelks/sash.h
@@ -9,7 +9,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
 #include <ctype.h>
 
 #define	CMDLEN		512	

--- a/elkscmd/nano-X/engine/devrgn.c
+++ b/elkscmd/nano-X/engine/devrgn.c
@@ -83,7 +83,7 @@ SOFTWARE.
  * the y-x-banding that's so nice to have...
  */
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "device.h"
 
 typedef void (*voidProcp)();

--- a/elkscmd/nano-X/engine/list.c
+++ b/elkscmd/nano-X/engine/list.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "list.h"
 /*
  * linked list routines

--- a/elkscmd/sash/sash.h
+++ b/elkscmd/sash/sash.h
@@ -9,7 +9,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
 #include <ctype.h>
 #include <unistd.h>
 #include <fcntl.h>

--- a/elkscmd/sh_utils/shutils.h
+++ b/elkscmd/sh_utils/shutils.h
@@ -9,7 +9,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
 #include <ctype.h>
 
 #define	CMDLEN		512	

--- a/elkscmd/test/libc/malloc.c
+++ b/elkscmd/test/libc/malloc.c
@@ -1,7 +1,7 @@
 #include "testlib.h"
 
 #include <errno.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 
 TEST_CASE(malloc_malloc_free) {

--- a/libc/misc/putenv.c
+++ b/libc/misc/putenv.c
@@ -4,7 +4,7 @@
  */
 #include <string.h>
 #include <unistd.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <errno.h>
 
 /* macro for matching environment name in string*/

--- a/libc/regex/regex.c
+++ b/libc/regex/regex.c
@@ -24,7 +24,7 @@
  */
 #include <stdio.h>
 #include <regex.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 #include "regmagic.h"
 

--- a/libc/string/strdup.c
+++ b/libc/string/strdup.c
@@ -1,4 +1,4 @@
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 
 char *


### PR DESCRIPTION
Reduces application dependencies on unneeded header files.