### PR TITLE
PC-98 beep support

### DIFF
--- a/elks/include/arch/ports.h
+++ b/elks/include/arch/ports.h
@@ -56,6 +56,10 @@
 #define TIMER_DATA_PORT 0x71		/* data port    */
 #define TIMER_IRQ	0		/* can't change*/
 
+/* bell*/
+#define TIMER1_PORT 0x3FDB		/* timer 1 data port for speaker frequency*/
+#define PORTC_CONTROL 0x37		/* 8255A Port C control*/
+
 /* serial, serial-pc98.c*/
 #define TIMER2_PORT	0x75		/* timer 2 data port for serial port*/
 


### PR DESCRIPTION
Hello @ghaerr and @floriangit ,

I haven't added option to change the frequency and time,
but I have added the code for PC-98 according to 
https://github.com/ghaerr/elks/pull/1796

I could hear beep from PC-98 NekoProject/W emulator as below.
I also replaced IBM port numbers to defines of ports.h,
but I couldn't check it since my qemu on windows cannot enable speaker.
Could you double check it?

https://github.com/ghaerr/elks/assets/61556504/5932d298-2095-49d0-9d5b-d07a9188a1d8

Thank you!

