### PR TITLE
[build] Misc fixes

### DIFF
--- a/elks/arch/i86/drivers/block/config.in
+++ b/elks/arch/i86/drivers/block/config.in
@@ -10,6 +10,9 @@ mainmenu_option next_comment
 	bool '  BIOS preset floppy types'	CONFIG_BLK_DEV_BFD_HARD n
 	bool '  BIOS hard drive support'	CONFIG_BLK_DEV_BHD	y
 	bool '  IDE hard drive CHS probe'	CONFIG_IDE_PROBE	y
+	if [ "$CONFIG_BLK_DEV_FD" == "y" ]; then
+		define_bool CONFIG_ASYNCIO y
+	fi
 
 	comment 'Additional block devices'
 

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -93,7 +93,7 @@ sys_utils/sercat                :sysutil                :1200k
 sys_utils/console               :sysutil                :1200k
 #sys_utils/who                  :sysutil                :1200k
 sys_utils/unreal16              :sysutil
-sys_utils/beep                  :sysutil
+sys_utils/beep                  :sysutil                        :1440k
 screen/screen                   :screen                 :1200k
 cron/cron                       :cron                   :1200k
 cron/crontab                    :cron                   :1200k
@@ -204,8 +204,8 @@ test/other/test_float           :test
 nano-X/bin/nxclock              :other
 nano-X/bin/nxdemo               :other
 nano-X/bin/nxtest               :other
-nano-X/bin/nxtetris             :nanox
-nano-X/bin/nxlandmine           :nanox              :1200k
+nano-X/bin/nxtetris             :nanox              :1200k
+nano-X/bin/nxlandmine           :nanox
 nano-X/bin/nxterm               :nanox
 nano-X/bin/nxworld              :nanox
 nano-X/bin/nxworld.map ::lib/nxworld.map :nanox


### PR DESCRIPTION
Swaps `txtetris` for `nxlandmine` on 1440k floppy #1805.
Adds `beep` to 144k floppy https://github.com/ghaerr/elks/pull/1796#issuecomment-1937039976.
Enables CONFIG_ASYNCIO when direct floppy driver selected https://github.com/ghaerr/elks/pull/1803#issuecomment-1937103152.

