### PR TITLE
[beep] make it round

### DIFF
--- a/elkscmd/sys_utils/beep.c
+++ b/elkscmd/sys_utils/beep.c
@@ -1,7 +1,14 @@
 /* beep - This file is part of the ELKS project
- * authors: Florian Zimmermann et al.
+ * authors: Florian Zimmermann, Takahiro Yamada et al.
  * Free software "as-is"
- * Takes one optional parameter: the beep duration
+ *
+ * By default (no parameters) one beep is output, 
+ * this can be adjusted by using parameters that can be consecutives of each:
+ * -f frequency as digit
+ * -l length as digit in milliseconds
+ * -n (to indicate the next beep)
+ *
+ * Happy Birthday example: beep -f1059 -l300 -n -f1059 -l200 -n -f1188 -l500 -n -f1059 -l500 -n -f1413 -l500 -n -f1334 -l950 -n -f1059 -l300 -n -f1059 -l200 -n -f1188 -l500 -n -f1059 -l500 -n -f1587 -l500 -n -f1413 -l950 -n -f1059 -l300 -n -f1059 -l200 -n -f2118 -l500 -n -f1781 -l500 -n -f1413 -l500 -n -f1334 -l500 -n -f1188 -l500 -n -f1887 -l300 -n -f1887 -l200 -n -f1781 -l500 -n -f1413 -l500 -n -f1587 -l500 -n -f1413 -l900
  */
 #include <autoconf.h>           /* for CONFIG_ options */
 #include "stdio.h"
@@ -58,7 +65,6 @@ static void silent()
 void beep_signal(int sig)
 {
     switch(sig) {
-	case SIGKILL: /* I'm falling */
 	case SIGTERM: /* I'm falling */
         case SIGINT:
             silent();
@@ -93,7 +99,6 @@ int main(int ac, char **av)
             ac--;
         }
 
-        signal(SIGKILL, beep_signal);
         signal(SIGINT,  beep_signal);
         signal(SIGTERM, beep_signal);
 


### PR DESCRIPTION
1) adding author and adding documentation
2) remove the SIGKILL handling, since this will never get caught in userland

We are now exactly with 1024bytes of the executable on x86_16: 0x3c0 for `.text`, 0x10 for `.data` and 0x30 for `.bss`
Main sizes analysed by map-files in `.text` are in almost same sizes:

1. signal handling (also the signal callback is inserted)
2. `atol`
3. `usleep`
4. divisions (`ldiv` from ia16-ldivmodu.o and `udiv`/`umod` from libgcc.a)

IMO removing the switch/case from `beep_signal` would deterior code readability, since now it's easy to catch what is handled and what not. Your mileage may vary, it would save only 16 bytes, though.

Happy beeping!