### PR TITLE
[tools] Fix mfs problem with max inodes on MINIX v2 filesystems

### DIFF
--- a/elks/tools/mfs/dir.c
+++ b/elks/tools/mfs/dir.c
@@ -209,7 +209,7 @@ int dostat_inode(struct minix_fs_dat *fs, int inode) {
     struct minix2_inode *ino = INODE2(fs,inode);
 	symlink = S_ISLNK(ino->i_mode);
     outmode(ino->i_mode);
-    printf(" %2d %3d ",ino->i_nlinks, inode);
+    printf(" %2d %5d ",ino->i_nlinks, inode);
     printf("%3d,%3d ",ino->i_uid,ino->i_gid);
     if (S_ISCHR(ino->i_mode) || S_ISBLK(ino->i_mode))
       printf("%2d, %3d ", (ino->i_zone[0]>>8) & 0xff, ino->i_zone[0] & 0xff);

--- a/elks/tools/mfs/mkfs.c
+++ b/elks/tools/mfs/mkfs.c
@@ -84,6 +84,8 @@ void parse_mkfs(int argc,char **argv,int *magic_p,int *nblks_p,int *inodes_p) {
   }
   if (*nblks_p == 0)
     fatalmsg("no filesystem size specified");
+  if (!*inodes_p)
+    *inodes_p = *nblks_p / 3;
 
   //printf("MKFS v%d namelen %d inodes %d size %d\n", version, namelen, *inodes_p, *nblks_p);
   if (version == 2)

--- a/elks/tools/mfs/super.c
+++ b/elks/tools/mfs/super.c
@@ -101,7 +101,7 @@ struct minix_fs_dat *new_fs(const char *fn,int magic,unsigned long fsize,int ino
   ZMAPS(fs)=UPPER(fsize-(1+IMAPS(fs)), BITS_PER_BLOCK);
   FIRSTZONE(fs) = NORM_FIRSTZONE(fs);
   debug("IMAPS %u, ZMAPS %u, FIRST %u\n", IMAPS(fs), ZMAPS(fs), FIRSTZONE(fs));
-  if (IMAPS(fs) > MINIX_I_MAP_SLOTS)
+  if (!VERSION_2(fs) && IMAPS(fs) > MINIX_I_MAP_SLOTS)
     fatalmsg("Too many inodes requested: max is 32736\n");
 
   fs->inode_bmap = domalloc(IMAPS(fs) * BLOCK_SIZE,0xff);


### PR DESCRIPTION
When creating MINIX v2 filesystem for use with FIWIX, max inodes was set at 32736 rather than 65535.
Also allows automatic calculation of inodes from max block number / 3 if not specified in command line.