### PR TITLE
[build] Add NE2K, WD and 3COM NICs to default build

### DIFF
--- a/elks/arch/i86/defconfig
+++ b/elks/arch/i86/defconfig
@@ -150,6 +150,9 @@ CONFIG_PSEUDO_TTY=y
 # Network device drivers
 #
 CONFIG_ETH=y
+CONFIG_ETH_NE2K=y
+CONFIG_ETH_WD=y
+CONFIG_ETH_EL3=y
 
 #
 # Userland


### PR DESCRIPTION
Adds all network drivers to default build; discussed in https://github.com/ghaerr/elks/issues/1814#issuecomment-1962925654.