### PR TITLE
[cmds] Finish fsck-dos port to ELKS, add to distribution

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -164,7 +164,7 @@ disk_utils/mkfat                :diskutil       :360k
 disk_utils/partype              :diskutil               :1200k
 disk_utils/ramdisk              :diskutil               :1200k
 disk_utils/fdisk                :be-diskutil    :360k
-#fsck_dos/fsck-dos              :diskutil                       :1440k
+fsck_dos/fsck-dos               :diskutil                       :1440k
 tui/fm                          :tui                            :1440k
 tui/matrix                      :tui                            :1440k
 tui/cons                        :tui                            :1440k

--- a/elkscmd/fsck_dos/boot.c
+++ b/elkscmd/fsck_dos/boot.c
@@ -71,18 +71,18 @@ readboot(dosfs, boot)
 	boot->ValidFat = -1;
 
 	/* decode bios parameter block */
-	boot->BytesPerSec = block[11] + (block[12] << 8);
+	boot->BytesPerSec = block[11] + ((U32)block[12] << 8);
 	boot->SecPerClust = block[13];
-	boot->ResSectors = block[14] + (block[15] << 8);
+	boot->ResSectors = block[14] + ((U32)block[15] << 8);
 	boot->FATs = block[16];
-	boot->RootDirEnts = block[17] + (block[18] << 8);
-	boot->Sectors = block[19] + (block[20] << 8);
+	boot->RootDirEnts = block[17] + ((U32)block[18] << 8);
+	boot->Sectors = block[19] + ((U32)block[20] << 8);
 	boot->Media = block[21];
-	boot->FATsmall = block[22] + (block[23] << 8);
-	boot->SecPerTrack = block[24] + (block[25] << 8);
-	boot->Heads = block[26] + (block[27] << 8);
-	boot->HiddenSecs = block[28] + (block[29] << 8) + ((U32)block[30] << 16) + ((U32)block[31] << 24);
-	boot->HugeSectors = block[32] + (block[33] << 8) + ((U32)block[34] << 16) + ((U32)block[35] << 24);
+	boot->FATsmall = block[22] + ((U32)block[23] << 8);
+	boot->SecPerTrack = block[24] + ((U32)block[25] << 8);
+	boot->Heads = block[26] + ((U32)block[27] << 8);
+	boot->HiddenSecs = block[28] + ((U32)block[29] << 8) + ((U32)block[30] << 16) + ((U32)block[31] << 24);
+	boot->HugeSectors = block[32] + ((U32)block[33] << 8) + ((U32)block[34] << 16) + ((U32)block[35] << 24);
 
 	boot->FATsecs = boot->FATsmall;
 
@@ -94,7 +94,7 @@ readboot(dosfs, boot)
 	if (!boot->RootDirEnts)
 		boot->flags |= FAT32;
 	if (boot->flags & FAT32) {
-		boot->FATsecs = block[36] + (block[37] << 8)
+		boot->FATsecs = block[36] + ((U32)block[37] << 8)
 				+ ((U32)block[38] << 16) + ((U32)block[39] << 24);
 		if (block[40] & 0x80)
 			boot->ValidFat = block[40] & 0x0f;
@@ -106,10 +106,10 @@ readboot(dosfs, boot)
 			       block[43], block[42]);
                         exit(2);
 		}
-		boot->RootCl = block[44] + (block[45] << 8)
+		boot->RootCl = block[44] + ((U32)block[45] << 8)
 			       + ((U32)block[46] << 16) + ((U32)block[47] << 24);
-		boot->FSInfo = block[48] + (block[49] << 8);
-		boot->Backup = block[50] + (block[51] << 8);
+		boot->FSInfo = block[48] + ((U32)block[49] << 8);
+		boot->Backup = block[50] + ((U32)block[51] << 8);
 
 		if (lseek(dosfs, boot->FSInfo * boot->BytesPerSec, SEEK_SET)
 		    != boot->FSInfo * boot->BytesPerSec
@@ -150,10 +150,10 @@ readboot(dosfs, boot)
 				boot->FSInfo = 0;
 		}
 		if (boot->FSInfo) {
-			boot->FSFree = fsinfo[0x1e8] + (fsinfo[0x1e9] << 8)
+			boot->FSFree = fsinfo[0x1e8] + ((U32)fsinfo[0x1e9] << 8)
 				       + ((U32)fsinfo[0x1ea] << 16)
 				       + ((U32)fsinfo[0x1eb] << 24);
-			boot->FSNext = fsinfo[0x1ec] + (fsinfo[0x1ed] << 8)
+			boot->FSNext = fsinfo[0x1ec] + ((U32)fsinfo[0x1ed] << 8)
 				       + ((U32)fsinfo[0x1ee] << 16)
 				       + ((U32)fsinfo[0x1ef] << 24);
 		}
@@ -205,7 +205,7 @@ readboot(dosfs, boot)
 	    - CLUST_FIRST * boot->SecPerClust;
 
 	if (boot->BytesPerSec % DOSBOOTBLOCKSIZE != 0) {
-		pfatal("Invalid sector size: %u", boot->BytesPerSec);
+		pfatal("Invalid sector size: %u, check if DOS disk?", boot->BytesPerSec);
 		return FSFATAL;
 	}
 	if (boot->SecPerClust == 0) {

--- a/elkscmd/fsck_dos/dir.c
+++ b/elkscmd/fsck_dos/dir.c
@@ -730,10 +730,10 @@ readDosDirSection(int f, struct bootblock *boot, struct fatEntry *fat,
 				}
 				vallfn = NULL;
 			}
-			dirent.head = p[26] | (p[27] << 8);
+			dirent.head = p[26] | ((U32)p[27] << 8);
 			if (boot->ClustMask == CLUST32_MASK)
 				dirent.head |= ((U32)p[20] << 16) | ((U32)p[21] << 24);
-			dirent.size = p[28] | (p[29] << 8) | ((U32)p[30] << 16) | ((U32)p[31] << 24);
+			dirent.size = p[28] | ((U32)p[29] << 8) | ((U32)p[30] << 16) | ((U32)p[31] << 24);
 			if (vallfn) {
 				strcpy(dirent.lname, longName);
 				longName[0] = '\0';

--- a/elkscmd/fsck_dos/dosfs.h
+++ b/elkscmd/fsck_dos/dosfs.h
@@ -95,21 +95,25 @@ struct fatEntry {
 
 #define	CLUST_FREE	0		/* 0 means cluster is free */
 #define	CLUST_FIRST	2		/* 2 is the minimum valid cluster number */
-#define	CLUST_RSRVD	0xfffffff6	/* start of reserved clusters */
-#define	CLUST_BAD	0xfffffff7	/* a cluster with a defect */
-#define	CLUST_EOFS	0xfffffff8	/* start of EOF indicators */
-#define	CLUST_EOF	0xffffffff	/* standard value for last cluster */
+#define	CLUST_RSRVD	0xfffffff6UL	/* start of reserved clusters */
+#define	CLUST_BAD	0xfffffff7UL	/* a cluster with a defect */
+#define	CLUST_EOFS	0xfffffff8UL	/* start of EOF indicators */
+#define	CLUST_EOF	0xffffffffUL	/* standard value for last cluster */
 
 /*
  * Masks for cluster values
  */
 #define	CLUST12_MASK	0xfff
 #define	CLUST16_MASK	0xffff
-#define	CLUST32_MASK	0xfffffff
+#define	CLUST32_MASK	0xfffffffUL
 
 #define	FAT_USED	1		/* This fat chain is used in a file */
 
+#ifdef ELKS
+#define	DOSLONGNAMELEN	26		/* long name maximal length */
+#else
 #define	DOSLONGNAMELEN	256		/* long name maximal length */
+#endif
 #define LRFIRST		0x40		/* first long name record */
 #define	LRNOMASK	0x1f		/* mask to extract long record
 					 * sequence number */

--- a/elkscmd/fsck_dos/fat.c
+++ b/elkscmd/fsck_dos/fat.c
@@ -286,7 +286,7 @@ readfat(int fs, struct bootblock *boot, int no, struct fatEntry **fp)
 	for (cl = CLUST_FIRST; cl < boot->NumClusters;) {
 		switch (boot->ClustMask) {
 		case CLUST32_MASK:
-			fat[cl].next = p[0] + (p[1] << 8)
+			fat[cl].next = p[0] + ((U32)p[1] << 8)
 				       + ((U32)p[2] << 16) + ((U32)p[3] << 24);
 			fat[cl].next &= boot->ClustMask;
 			ret |= checkclnum(boot, no, cl, &fat[cl].next);
@@ -294,13 +294,13 @@ readfat(int fs, struct bootblock *boot, int no, struct fatEntry **fp)
 			p += 4;
 			break;
 		case CLUST16_MASK:
-			fat[cl].next = p[0] + (p[1] << 8);
+			fat[cl].next = p[0] + ((U32)p[1] << 8);
 			ret |= checkclnum(boot, no, cl, &fat[cl].next);
 			cl++;
 			p += 2;
 			break;
 		default:
-			fat[cl].next = (p[0] + (p[1] << 8)) & 0x0fff;
+			fat[cl].next = (p[0] + ((U32)p[1] << 8)) & 0x0fff;
 			ret |= checkclnum(boot, no, cl, &fat[cl].next);
 			cl++;
 			if (cl >= boot->NumClusters)


### PR DESCRIPTION
As discussed in https://github.com/ghaerr/elks/discussions/1819#discussioncomment-8672281, the excessive memory usage in `fsck-dos` was identified, where each directory entry found was allocating 256 bytes for a filename. Since ELKS only handles 26 characters max for FAT, this was shortened, and `fsck-dos` is no longer running out of memory on 1440k floppy disks.

This PR adds `fsck-dos` to the 1440k distribution, for testing:
```
$ fsck-dos -pf /dev/fd1    # run in "preen" mode to quickly force fix small errors
$ fsck-dos -yf /dev/fd1    # force check and answer yes to all errors
$ fsck-dos -nf /dev/fd1    # force check and answer no to all errors
```

I'll look for a man page for ELKS, but [this one from OpenBSD](https://man.openbsd.org/fsck_msdos.8) seems to describe its use fairly accurately.

CURRENTLY USE AT YOUR OWN RISK - NOT TESTED THOROUGHLY!