### PR TITLE
[cmds] Remove fsck-dos FAT32 support allowing it to work on floppies

### DIFF
--- a/elkscmd/fsck_dos/Makefile
+++ b/elkscmd/fsck_dos/Makefile
@@ -11,6 +11,8 @@ include $(BASEDIR)/Make.rules
 ###############################################################################
 
 LOCALCFLAGS = -Dlint -DELKS=1
+# remove next line when FAT32 supported
+LOCALCFLAGS += -Wno-shift-count-overflow
 
 PRGS = fsck-dos
 

--- a/elkscmd/fsck_dos/boot.c
+++ b/elkscmd/fsck_dos/boot.c
@@ -232,7 +232,7 @@ readboot(dosfs, boot)
 		boot->ClustMask = CLUST16_MASK;
 	else {
 		pfatal("Filesystem too big (%lu clusters) for non-FAT32 partition",
-		       boot->NumClusters);
+		       (U32)boot->NumClusters);
 		return FSFATAL;
 	}
 
@@ -250,7 +250,7 @@ readboot(dosfs, boot)
 
 	if (boot->NumFatEntries < boot->NumClusters) {
 		pfatal("FAT size too small, %lu entries won't fit into %lu sectors\n",
-		       boot->NumClusters, boot->FATsecs);
+		       (U32)boot->NumClusters, (U32)boot->FATsecs);
 		return FSFATAL;
 	}
 	boot->ClusterSize = boot->BytesPerSec * boot->SecPerClust;

--- a/elkscmd/fsck_dos/boot.c
+++ b/elkscmd/fsck_dos/boot.c
@@ -94,6 +94,10 @@ readboot(dosfs, boot)
 	if (!boot->RootDirEnts)
 		boot->flags |= FAT32;
 	if (boot->flags & FAT32) {
+#ifdef ELKS
+		printf("Sorry, FAT32 checking not supported on ELKS\n");
+		exit(2);
+#else
 		boot->FATsecs = block[36] + ((U32)block[37] << 8)
 				+ ((U32)block[38] << 16) + ((U32)block[39] << 24);
 		if (block[40] & 0x80)
@@ -196,6 +200,7 @@ readboot(dosfs, boot)
                         pwarn("%s\n", tmp);
 		}
 		/* Check backup FSInfo?					XXX */
+#endif /* !ELKS */
 	}
 
 	boot->ClusterOffset = (boot->RootDirEnts * 32 + boot->BytesPerSec - 1)

--- a/elkscmd/fsck_dos/boot.c
+++ b/elkscmd/fsck_dos/boot.c
@@ -53,8 +53,6 @@ readboot(dosfs, boot)
 	struct bootblock *boot;
 {
 	u_char block[DOSBOOTBLOCKSIZE];
-	u_char fsinfo[2 * DOSBOOTBLOCKSIZE];
-	u_char backup[DOSBOOTBLOCKSIZE];
 	int ret = FSOK;
 	
 	if (read(dosfs, block, sizeof block) < sizeof block) {
@@ -98,6 +96,9 @@ readboot(dosfs, boot)
 		printf("Sorry, FAT32 checking not supported on ELKS\n");
 		exit(2);
 #else
+		u_char fsinfo[2 * DOSBOOTBLOCKSIZE];
+		u_char backup[DOSBOOTBLOCKSIZE];
+
 		boot->FATsecs = block[36] + ((U32)block[37] << 8)
 				+ ((U32)block[38] << 16) + ((U32)block[39] << 24);
 		if (block[40] & 0x80)

--- a/elkscmd/fsck_dos/dir.c
+++ b/elkscmd/fsck_dos/dir.c
@@ -400,7 +400,7 @@ checksize(struct bootblock *boot, struct fatEntry *fat, u_char *p,
 	else {
 		if (dir->head < CLUST_FIRST || dir->head >= boot->NumClusters)
 			return FSERROR;
-		physicalSize = fat[dir->head].length * boot->ClusterSize;
+		physicalSize = (U32)fat[dir->head].length * boot->ClusterSize;
 	}
 	if (physicalSize < dir->size) {
 		pwarn("size of %s is %lu, should at most be %lu\n",
@@ -1068,7 +1068,7 @@ reconnect(int dosfs, struct bootblock *boot, struct fatEntry *fat, cl_t head)
 	snprintf(d.name, sizeof(d.name), "%lu", (U32)head);
 	d.flags = 0;
 	d.head = head;
-	d.size = fat[head].length * boot->ClusterSize;
+	d.size = (U32)fat[head].length * boot->ClusterSize;
 
 	memset(p, 0, 32);
 	memset(p, ' ', 11);

--- a/elkscmd/fsck_dos/dir.c
+++ b/elkscmd/fsck_dos/dir.c
@@ -240,7 +240,7 @@ resetDosDirSection(struct bootblock *boot, struct fatEntry *fat)
 	if (boot->flags & FAT32) {
 		if (boot->RootCl < CLUST_FIRST || boot->RootCl >= boot->NumClusters) {
 			pfatal("Root directory starts with cluster out of range(%lu)",
-			       boot->RootCl);
+			       (U32)boot->RootCl);
 			return FSFATAL;
 		}
 		cl = fat[boot->RootCl].next;
@@ -794,7 +794,7 @@ readDosDirSection(int f, struct bootblock *boot, struct fatEntry *fat,
 					 || dirent.head >= boot->NumClusters)
 					pwarn("%s starts with cluster out of range(%lu)\n",
 					      fullpath(&dirent),
-					      dirent.head);
+					      (U32)dirent.head);
 				else if (fat[dirent.head].next == CLUST_FREE)
 					pwarn("%s starts with free cluster\n",
 					      fullpath(&dirent));
@@ -1065,7 +1065,7 @@ reconnect(int dosfs, struct bootblock *boot, struct fatEntry *fat, cl_t head)
 	boot->NumFiles++;
 	/* Ensure uniqueness of entry here!				XXX */
 	memset(&d, 0, sizeof d);
-	(void)snprintf(d.name, sizeof(d.name), "%lu", head);
+	snprintf(d.name, sizeof(d.name), "%lu", (U32)head);
 	d.flags = 0;
 	d.head = head;
 	d.size = fat[head].length * boot->ClusterSize;

--- a/elkscmd/fsck_dos/dosfs.h
+++ b/elkscmd/fsck_dos/dosfs.h
@@ -39,7 +39,11 @@
 
 #define DOSBOOTBLOCKSIZE 512
 
+#ifdef ELKS
+typedef	unsigned short	cl_t;	/* type holding a cluster number */
+#else
 typedef	u_int32_t	cl_t;	/* type holding a cluster number */
+#endif
 
 /*
  * architecture independent description of all the info stored in a
@@ -95,17 +99,25 @@ struct fatEntry {
 
 #define	CLUST_FREE	0		/* 0 means cluster is free */
 #define	CLUST_FIRST	2		/* 2 is the minimum valid cluster number */
+#ifdef ELKS
+#define	CLUST_RSRVD	0xfff6UL	/* start of reserved clusters */
+#define	CLUST_BAD	0xfff7UL	/* a cluster with a defect */
+#define	CLUST_EOFS	0xfff8UL	/* start of EOF indicators */
+#define	CLUST_EOF	0xffffUL	/* standard value for last cluster */
+#define	CLUST32_MASK	0x0000UL        /* BAD VALUE, not supported on ELKS */
+#else
 #define	CLUST_RSRVD	0xfffffff6UL	/* start of reserved clusters */
 #define	CLUST_BAD	0xfffffff7UL	/* a cluster with a defect */
 #define	CLUST_EOFS	0xfffffff8UL	/* start of EOF indicators */
 #define	CLUST_EOF	0xffffffffUL	/* standard value for last cluster */
+#define	CLUST32_MASK	0x0fffffffUL
+#endif
 
 /*
  * Masks for cluster values
  */
 #define	CLUST12_MASK	0xfff
 #define	CLUST16_MASK	0xffff
-#define	CLUST32_MASK	0xfffffffUL
 
 #define	FAT_USED	1		/* This fat chain is used in a file */
 

--- a/elkscmd/fsck_dos/dosfs.h
+++ b/elkscmd/fsck_dos/dosfs.h
@@ -93,7 +93,7 @@ struct bootblock {
 struct fatEntry {
 	cl_t	next;			/* pointer to next cluster */
 	cl_t	head;			/* pointer to start of chain */
-	u_int32_t length;		/* number of clusters on chain */
+	cl_t	length;			/* number of clusters on chain */
 	int	flags;			/* see below */
 };
 

--- a/elkscmd/fsck_dos/fat.c
+++ b/elkscmd/fsck_dos/fat.c
@@ -450,7 +450,7 @@ int
 checkfat(struct bootblock *boot, struct fatEntry *fat)
 {
 	cl_t head, p, h, n, wdk;
-	u_int len;
+	cl_t len;
 	int ret = 0;
 	int conf;
 
@@ -675,7 +675,7 @@ checklost(int dosfs, struct bootblock *boot, struct fatEntry *fat)
 			continue;
 
 		pwarn("Lost cluster chain at cluster %lu\n%ld Cluster(s) lost\n",
-		      (U32)head, fat[head].length);
+		      (U32)head, (U32)fat[head].length);
 		mod |= ret = reconnect(dosfs, boot, fat, head);
 		if (mod & FSFATAL) {
 			/* If the reconnect failed, then just clear the chain */


### PR DESCRIPTION
Since FAT12 and FAT16 cluster sizes are 16-bits, removing support (at least for now) from `fsck-dos` allows for reducing the memory size of `struct fatEntry` by about half. This in turn seems to allow `fsck-dos` to run on 1440k floppies and repair them without running out of memory.

Tested on @tyama501's floppy image posted in https://github.com/ghaerr/elks/discussions/1819#discussioncomment-8696583.

Here's a screenshot of @tyama501's vi-damaged floppy image being repaired which matches the screenshot of the repair working succcesfully with the original fsck_msdos on his host PC (except FAT compare is being skipped):
<img width="832" alt="fsck-dos ok" src="https://github.com/ghaerr/elks/assets/11985637/5bddcab2-d4f5-4f7e-b713-a24ae370aeae">

Obviously we need more testing, but things are looking better now. I would be interested in test cases for more badly damaged FAT filesystems in FAT16 or FAT12 format.