### PR TITLE
[kernel] Fix sys_rename inode count bug on FAT filesystems

### DIFF
--- a/elks/fs/inode.c
+++ b/elks/fs/inode.c
@@ -203,7 +203,7 @@ void iput(register struct inode *inode)
 {
     register struct super_operations *sop;
 
-    debug("iput dev %p ino %lu count %d\n",
+    debug("iput dev %D ino %lu count %d\n",
         inode->i_dev, (unsigned long)inode->i_ino, inode->i_count);
     if (inode) {
         wait_on_inode(inode);

--- a/elks/fs/msdos/file.c
+++ b/elks/fs/msdos/file.c
@@ -151,7 +151,7 @@ void msdos_truncate(register struct inode *inode)
 {
 	cluster_t cluster;
 
-	debug_fat("truncate\n");
+	debug_fat("truncate inode %ld\n", inode->i_ino);
 	cluster = (cluster_t)SECTOR_SIZE(inode)*MSDOS_SB(inode->i_sb)->cluster_size;
 	(void)fat_free(inode,(inode->i_size + (cluster-1)) / cluster);
 	inode->u.msdos_i.i_attrs |= ATTR_ARCH;

--- a/elks/fs/msdos/namei.c
+++ b/elks/fs/msdos/namei.c
@@ -366,9 +366,9 @@ int msdos_unlink(register struct inode *dir,const char *name,int len)
 	mark_buffer_dirty(bh);
 unlink_done:
 	unmap_brelse(bh);
-	if (inode) debug_fat("unlink iput inode %u dirt %d count %d\n",
-		inode->i_ino, inode->i_dirt, inode->i_count);
-	if (dir) debug_fat("unlink iput dir %u dirt %d count %d\n", dir->i_ino, dir->i_dirt, dir->i_count);
+	if (inode) debug_fat("unlink iput inode %lu dirt %d count %d\n",
+		(unsigned long)inode->i_ino, inode->i_dirt, inode->i_count);
+	if (dir) debug_fat("unlink iput dir %lu dirt %d count %d\n", (unsigned long)dir->i_ino, dir->i_dirt, dir->i_count);
 	iput(inode);
 	iput(dir);
 	return res;

--- a/elks/fs/namei.c
+++ b/elks/fs/namei.c
@@ -550,8 +550,11 @@ int sys_link(char *oldname, char *pathname)
 
     debug_file("LINK '%t' '%t'\n", oldname, pathname);
     error = namei(oldname, &oldinode, 0, 0);
-    if (!error)
+    if (!error) {
         error = do_mknod(pathname, offsetof(struct inode_operations,link), (int)oldinode, 0);
+        if (error)
+            iput(oldinode);
+    }
     return error;
 #endif
 }


### PR DESCRIPTION
Fixes moving files using `mv` on FAT filesystems. Incorrect behavior found by @tyama501 and discussed in https://github.com/ghaerr/elks/discussions/1819#discussioncomment-8730798.

After some tracing, finally found that the `rename` system call on FAT didn't decrease the reference count on the source filename on failure. (`rename` attempts a `link` followed by `unlink` which will always fail on FAT filesystems). This ended up causing any subsequent `unlink` system calls to fail to clear the inode, causing lost FAT clusters.

I suspect this also fixes @tyama501's previously reported `vi` bug, which produced lost clusters. I would guess that `vi` also attempted a `rename` of the temp file which caused the same problem.

Note that it is still not possible to rename FAT directories using `mv` (discussed in #583).

Also fixes some debug statements that displayed incorrectly with 32-bit inodes.