### PR TITLE
[kernel] Disallow reschedule during kernel startup

### DIFF
--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -114,6 +114,7 @@ extern __task task[MAX_TASKS];
 
 extern volatile jiff_t jiffies; /* ticks updated by the timer interrupt*/
 extern __ptask current;
+extern pid_t last_pid;
 
 extern struct timeval xtime;
 extern jiff_t xtime_jiffies;

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -10,11 +10,11 @@
 
 int task_slots_unused = MAX_TASKS;
 struct task_struct *next_task_slot = task;
+pid_t last_pid = -1;
 
 static pid_t get_pid(void)
 {
     register struct task_struct *p;
-    static pid_t last_pid = -1;
 
     goto startgp;
     do {

--- a/elks/kernel/sched.c
+++ b/elks/kernel/sched.c
@@ -75,7 +75,7 @@ void schedule(void)
     }
 #endif
 
-    /* Don't reschedule waiting for async I/O complete during kernel startup */
+    /* Disallow rescheduling during startup when idle task is the only task */
     if ((int)last_pid <= 0)
         return;
 


### PR DESCRIPTION
This problem was identified by @Mellvik in https://github.com/Mellvik/TLVC/pull/51.

If a kernel waits for I/O complete during `bread` at startup, which will currently only happen when an interrupt-driven hard disk driver reads a hard disk partition table, `wait_for_buffer` may try to sleep/reschedule the current task, which will always be the idle task.

This alternative fix to https://github.com/Mellvik/TLVC/pull/51 disallows a task switch during kernel startup (when last allocated process ID will be <= 0), while still checking and printing a warning message should a device driver attempt to sleep from an interrupt handler.