### PR TITLE
[kernel] Remove CONFIG_APM

### DIFF
--- a/blink16.config
+++ b/blink16.config
@@ -17,7 +17,6 @@ CONFIG_ARCH_IBMPC=y
 # CONFIG_ARCH_PC98 is not set
 CONFIG_HW_VGA=y
 # CONFIG_HW_SERIAL_FIFO is not set
-CONFIG_APM=y
 
 #
 # Kernel settings

--- a/elks/arch/i86/defconfig
+++ b/elks/arch/i86/defconfig
@@ -32,11 +32,6 @@ CONFIG_HW_VGA=y
 CONFIG_HW_SERIAL_FIFO=y
 
 #
-# BIOS support
-#
-CONFIG_APM=y
-
-#
 # Kernel settings
 #
 # CONFIG_TRACE is not set

--- a/elks/arch/i86/kernel/system.c
+++ b/elks/arch/i86/kernel/system.c
@@ -11,7 +11,6 @@
 #include <arch/segment.h>
 #include <arch/io.h>
 
-
 byte_t sys_caps;		/* system capabilities bits */
 unsigned int heapsize;	/* max size of kernel near heap */
 
@@ -99,7 +98,7 @@ void hard_reset_now(void)
  */
 void apm_shutdown_now(void)
 {
-#if defined(CONFIG_APM) && defined(CONFIG_ARCH_IBMPC)
+#ifdef CONFIG_ARCH_IBMPC
     asm("movw $0x5301,%ax\n\t"
 	"xorw %bx,%bx\n\t"
 	"int $0x15\n\t"

--- a/elks/config.in
+++ b/elks/config.in
@@ -22,10 +22,6 @@ mainmenu_option next_comment
 		bool 'VGA adapter'      CONFIG_HW_VGA       y
 		bool 'Serial port FIFO' CONFIG_HW_SERIAL_FIFO y
 
-		comment 'BIOS support'
-
-		bool 'Advanced Power Management support'         CONFIG_APM y
-
 	elif [ "$CONFIG_ARCH_8018X" = "y" ]; then
 
 		comment 'Devices'
@@ -44,8 +40,6 @@ mainmenu_option next_comment
 	elif [ "$CONFIG_ARCH_PC98" = "y" ]; then
 
 		comment 'Devices'
-
-		define_bool CONFIG_APM n
 
 	fi
 

--- a/emu86-disk.config
+++ b/emu86-disk.config
@@ -15,7 +15,6 @@
 CONFIG_ARCH_IBMPC=y
 CONFIG_HW_VGA=y
 # CONFIG_HW_SERIAL_FIFO is not set
-CONFIG_APM=y
 
 #
 # Kernel settings

--- a/emu86-rom-full.config
+++ b/emu86-rom-full.config
@@ -15,7 +15,6 @@
 CONFIG_ARCH_IBMPC=y
 # CONFIG_HW_VGA is not set
 # CONFIG_HW_SERIAL_FIFO is not set
-# CONFIG_APM is not set
 
 #
 # Kernel settings

--- a/emu86-rom.config
+++ b/emu86-rom.config
@@ -14,7 +14,6 @@
 
 CONFIG_ARCH_IBMPC=y
 # CONFIG_HW_SERIAL_FIFO is not set
-# CONFIG_APM is not set
 
 #
 # Kernel settings

--- a/ibmpc-1440.config
+++ b/ibmpc-1440.config
@@ -19,7 +19,6 @@ CONFIG_ARCH_IBMPC=y
 # CONFIG_HW_MK88 is not set
 CONFIG_HW_VGA=y
 # CONFIG_HW_SERIAL_FIFO is not set
-CONFIG_APM=y
 
 #
 # Kernel settings

--- a/pc98-1232.config
+++ b/pc98-1232.config
@@ -15,7 +15,6 @@
 # CONFIG_ARCH_IBMPC is not set
 # CONFIG_ARCH_8018X is not set
 CONFIG_ARCH_PC98=y
-# CONFIG_APM is not set
 
 #
 # Kernel settings

--- a/pc98-1440.config
+++ b/pc98-1440.config
@@ -15,7 +15,6 @@
 # CONFIG_ARCH_IBMPC is not set
 # CONFIG_ARCH_8018X is not set
 CONFIG_ARCH_PC98=y
-# CONFIG_APM is not set
 
 #
 # Kernel settings


### PR DESCRIPTION
Removes CONFIG_APM, `poweroff` defaults to using BIOS INT 15 APM routines for CONFIG_ARCH_IBMPC (along with other BIOS-dependencies like `reboot`).