### PR TITLE
[directfd] Dynamically allocate floppy bounce buffer

### DIFF
--- a/elks/include/linuxmt/heap.h
+++ b/elks/include/linuxmt/heap.h
@@ -16,7 +16,7 @@
 #define HEAP_TAG_CLEAR   0x40	/* return cleared memory*/
 #define HEAP_TAG_TYPE    0x0F
 #define HEAP_TAG_SEG     0x01
-#define HEAP_TAG_STRING  0x02	/* unused*/
+#define HEAP_TAG_BUF     0x02
 #define HEAP_TAG_TTY     0x03
 #define HEAP_TAG_INTHAND 0x04
 #define HEAP_TAG_BUFHEAD 0x05

--- a/elkscmd/sys_utils/meminfo.c
+++ b/elkscmd/sys_utils/meminfo.c
@@ -85,7 +85,7 @@ void dump_heap(int fd)
 	word_t total_size = 0;
 	word_t total_free = 0;
 	long total_segsize = 0;
-	static char *heaptype[] = { "free", "SEG ", "STR ", "TTY ", "INT ", "BUFH", "PIPE" };
+	static char *heaptype[] = { "free", "SEG ", "BUF ", "TTY ", "INT ", "BUFH", "PIPE" };
 	static char *segtype[] = { "free", "CSEG", "DSEG", "BUF ", "RDSK", "PROG" };
 
 	printf("  HEAP   TYPE  SIZE    SEG   TYPE    SIZE  CNT  NAME\n");


### PR DESCRIPTION
Saves 1024 bytes in kernel heap when DF driver linked but not active.