### PR TITLE
[kernel] Remove include config.h from types.h

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -32,7 +32,7 @@
  * Enhanced by Greg Haerr Oct 2020: add track cache, XT fixes, custom DDPT
  */
 
-#include <linuxmt/types.h>
+#include <linuxmt/config.h>
 #include <linuxmt/kernel.h>
 #include <linuxmt/sched.h>
 #include <linuxmt/errno.h>
@@ -43,7 +43,6 @@
 #include <linuxmt/string.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/memory.h>
-#include <linuxmt/config.h>
 #include <linuxmt/debug.h>
 #include <linuxmt/timer.h>
 

--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -96,6 +96,7 @@
 #include <arch/dma.h>
 #include <arch/system.h>
 #include <arch/io.h>
+#include <arch/irq.h>
 #include <arch/segment.h>
 #include <arch/ports.h>
 #include <arch/hdreg.h>         /* for ioctl GETGEO */

--- a/elks/arch/i86/drivers/block/directhd.c
+++ b/elks/arch/i86/drivers/block/directhd.c
@@ -6,6 +6,7 @@
  * 14.04.1998 Bugfixes by Alastair Bridgewater nyef@sudval.org
  */
 
+#include <linuxmt/config.h>
 #include <linuxmt/major.h>
 #include <linuxmt/genhd.h>
 #include <linuxmt/fs.h>

--- a/elks/arch/i86/drivers/block/init.c
+++ b/elks/arch/i86/drivers/block/init.c
@@ -27,6 +27,7 @@
 #include <linuxmt/memory.h>
 #include <linuxmt/devnum.h>
 
+#include <arch/irq.h>
 #include <arch/system.h>
 #include <arch/segment.h>
 

--- a/elks/arch/i86/drivers/block/init.c
+++ b/elks/arch/i86/drivers/block/init.c
@@ -16,8 +16,8 @@
  *  More flexible handling of extended partitions - aeb, 950831
  */
 
-#include <linuxmt/boot.h>
 #include <linuxmt/config.h>
+#include <linuxmt/boot.h>
 #include <linuxmt/fs.h>
 #include <linuxmt/genhd.h>
 #include <linuxmt/kernel.h>

--- a/elks/arch/i86/drivers/char/conio-8018x.c
+++ b/elks/arch/i86/drivers/char/conio-8018x.c
@@ -6,9 +6,9 @@
  * 16 May 21 Santiago Hormazabal
  */
 
-#include <linuxmt/types.h>
 #include <linuxmt/config.h>
 #include <arch/io.h>
+#include <arch/irq.h>
 #include "conio.h"
 
 

--- a/elks/arch/i86/drivers/char/console-bios.c
+++ b/elks/arch/i86/drivers/char/console-bios.c
@@ -10,7 +10,6 @@
  * added enough ansi escape sequences for visual editing
  */
 
-#include <linuxmt/types.h>
 #include <linuxmt/config.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/sched.h>

--- a/elks/arch/i86/drivers/char/console-direct-pc98.c
+++ b/elks/arch/i86/drivers/char/console-direct-pc98.c
@@ -14,7 +14,6 @@
  *
  */
 
-#include <linuxmt/types.h>
 #include <linuxmt/config.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/sched.h>

--- a/elks/arch/i86/drivers/char/console-direct.c
+++ b/elks/arch/i86/drivers/char/console-direct.c
@@ -10,7 +10,6 @@
  * added enough ansi escape sequences for visual editing
  */
 
-#include <linuxmt/types.h>
 #include <linuxmt/config.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/sched.h>

--- a/elks/arch/i86/drivers/char/console-headless.c
+++ b/elks/arch/i86/drivers/char/console-headless.c
@@ -5,7 +5,6 @@
  *
  * Oct 2020 Greg Haerr
  */
-#include <linuxmt/types.h>
 #include <linuxmt/config.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/kernel.h>

--- a/elks/arch/i86/drivers/char/console-serial-8018x.c
+++ b/elks/arch/i86/drivers/char/console-serial-8018x.c
@@ -8,14 +8,14 @@
  * 07 Nov 21 Santiago Hormazabal
  */
 
-#include <linuxmt/types.h>
-#include <arch/io.h>
-#include <arch/8018x.h>
+#include <linuxmt/config.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/kernel.h>
 #include <linuxmt/sched.h>
 #include <linuxmt/chqueue.h>
 #include <linuxmt/ntty.h>
+#include <arch/io.h>
+#include <arch/8018x.h>
 #include "console.h"
 
 struct serial_info {

--- a/elks/arch/i86/drivers/char/console-serial-8018x.c
+++ b/elks/arch/i86/drivers/char/console-serial-8018x.c
@@ -15,6 +15,7 @@
 #include <linuxmt/chqueue.h>
 #include <linuxmt/ntty.h>
 #include <arch/io.h>
+#include <arch/irq.h>
 #include <arch/8018x.h>
 #include "console.h"
 

--- a/elks/arch/i86/drivers/char/eth.c
+++ b/elks/arch/i86/drivers/char/eth.c
@@ -3,6 +3,7 @@
  * June 2022 Greg Haerr
  */
 
+#include <linuxmt/config.h>
 #include <linuxmt/init.h>
 #include <linuxmt/major.h>
 #include <linuxmt/errno.h>

--- a/elks/arch/i86/drivers/char/kbd-poll-pc98.c
+++ b/elks/arch/i86/drivers/char/kbd-poll-pc98.c
@@ -3,7 +3,6 @@
  *
  * Calls conio_poll to get kbd input
  */
-#include <linuxmt/types.h>
 #include <linuxmt/config.h>
 #include <linuxmt/timer.h>
 #include <linuxmt/sched.h>

--- a/elks/arch/i86/drivers/char/kbd-scancode.c
+++ b/elks/arch/i86/drivers/char/kbd-scancode.c
@@ -34,6 +34,7 @@
 #include <linuxmt/signal.h>
 #include <linuxmt/ntty.h>
 #include <arch/io.h>
+#include <arch/irq.h>
 #include <arch/ports.h>
 #include <arch/system.h>
 #include "console.h"

--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -12,7 +12,6 @@
  * VFS interface to the character drivers (what a mouthful! :)  
  */
 
-#include <linuxmt/types.h>
 #include <linuxmt/config.h>
 #include <linuxmt/sched.h>
 #include <linuxmt/fs.h>

--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -28,6 +28,7 @@
 #include <linuxmt/init.h>
 #include <linuxmt/debug.h>
 #include <linuxmt/heap.h>
+#include <arch/irq.h>
 
 /* default termios, set at init time, not reset at open*/
 struct termios def_vals = {

--- a/elks/arch/i86/drivers/char/pty.c
+++ b/elks/arch/i86/drivers/char/pty.c
@@ -3,7 +3,6 @@
  * (C) 1999 Alistair Riddoch
  */
 
-#include <linuxmt/types.h>
 #include <linuxmt/config.h>
 #include <linuxmt/sched.h>
 #include <linuxmt/fs.h>

--- a/elks/arch/i86/drivers/char/serial-8250.c
+++ b/elks/arch/i86/drivers/char/serial-8250.c
@@ -4,7 +4,7 @@
  * Probes for specific UART at boot.
  * Supports 8250, 16450, 16550, 16550A and 16750 variants.
  */
-#include <linuxmt/types.h>
+#include <linuxmt/config.h>
 #include <linuxmt/wait.h>
 #include <linuxmt/chqueue.h>
 #include <linuxmt/config.h>

--- a/elks/arch/i86/drivers/char/serial-8250.c
+++ b/elks/arch/i86/drivers/char/serial-8250.c
@@ -16,6 +16,7 @@
 #include <linuxmt/termios.h>
 #include <linuxmt/debug.h>
 #include <arch/io.h>
+#include <arch/irq.h>
 #include <arch/serial-8250.h>
 #include <arch/ports.h>
 

--- a/elks/arch/i86/drivers/char/serial-pc98.c
+++ b/elks/arch/i86/drivers/char/serial-pc98.c
@@ -18,6 +18,7 @@
 #include <linuxmt/termios.h>
 #include <linuxmt/debug.h>
 #include <arch/io.h>
+#include <arch/irq.h>
 #include <arch/serial-pc98.h>	/* UART-specific header*/
 #include <arch/ports.h>		/* definitions of COM1_PORT/COM1_IRQ*/
 

--- a/elks/arch/i86/drivers/char/serial-pc98.c
+++ b/elks/arch/i86/drivers/char/serial-pc98.c
@@ -6,7 +6,7 @@
  * 1 serial port.
  *
  */
-#include <linuxmt/types.h>
+#include <linuxmt/config.h>
 #include <linuxmt/wait.h>
 #include <linuxmt/chqueue.h>
 #include <linuxmt/config.h>

--- a/elks/arch/i86/drivers/char/serial-template.c
+++ b/elks/arch/i86/drivers/char/serial-template.c
@@ -6,7 +6,7 @@
  *
  * May 2021 Greg Haerr
  */
-#include <linuxmt/types.h>
+#include <linuxmt/config.h>
 #include <linuxmt/wait.h>
 #include <linuxmt/chqueue.h>
 #include <linuxmt/config.h>

--- a/elks/arch/i86/drivers/net/el3.c
+++ b/elks/arch/i86/drivers/net/el3.c
@@ -14,6 +14,7 @@
 #define ELKS
 
 #include <arch/io.h>
+#include <arch/irq.h>
 #include <arch/ports.h>
 #include <arch/segment.h>
 #include <linuxmt/errno.h>

--- a/elks/arch/i86/drivers/net/ne2k.c
+++ b/elks/arch/i86/drivers/net/ne2k.c
@@ -9,7 +9,6 @@
  *
  */
 
-#include <arch/io.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/major.h>
 #include <linuxmt/ioctl.h>
@@ -21,6 +20,8 @@
 #include <linuxmt/string.h>
 #include <linuxmt/debug.h>
 #include <linuxmt/netstat.h>
+#include <arch/io.h>
+#include <arch/irq.h>
 #include "eth-msgs.h"
 
 // Shared declarations between low and high parts

--- a/elks/arch/i86/drivers/net/wd.c
+++ b/elks/arch/i86/drivers/net/wd.c
@@ -9,6 +9,7 @@
  */
 
 #include <arch/io.h>
+#include <arch/irq.h>
 #include <arch/ports.h>
 #include <arch/segment.h>
 #include <linuxmt/memory.h>

--- a/elks/arch/i86/kernel/signal.c
+++ b/elks/arch/i86/kernel/signal.c
@@ -18,6 +18,7 @@
 #include <linuxmt/memory.h>
 
 #include <arch/segment.h>
+#include <arch/irq.h>
 
 int do_signal(void)
 {

--- a/elks/arch/i86/kernel/timer-8018x.c
+++ b/elks/arch/i86/kernel/timer-8018x.c
@@ -1,4 +1,6 @@
-/*
+
+#include <arch/types.h>
+*
  * 8018X's Integrated Timer/Counter Unit
  *
  * This file contains code used for the embedded 8018X family only.

--- a/elks/arch/i86/kernel/timer-8018x.c
+++ b/elks/arch/i86/kernel/timer-8018x.c
@@ -1,6 +1,4 @@
-
-#include <arch/types.h>
-*
+/*
  * 8018X's Integrated Timer/Counter Unit
  *
  * This file contains code used for the embedded 8018X family only.

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -2,7 +2,7 @@
  *	Memory management support.
  */
 
-#include <linuxmt/types.h>
+#include <linuxmt/config.h>
 #include <linuxmt/sched.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/errno.h>

--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -4,7 +4,7 @@
  * Nov 2021 Greg Haerr
  */
 
-#include <linuxmt/types.h>
+#include <linuxmt/config.h>
 #include <linuxmt/memory.h>
 #include <linuxmt/kernel.h>
 #include <linuxmt/init.h>

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -28,7 +28,7 @@
  *			for details.
  */
 
-#include <linuxmt/types.h>
+#include <linuxmt/config.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/fcntl.h>
 #include <linuxmt/stat.h>

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -4,6 +4,7 @@
  *  Written 1992 by Werner Almesberger
  */
 
+#include <linuxmt/config.h>
 #include <linuxmt/msdos_fs.h>
 #include <linuxmt/msdos_fs_i.h>
 #include <linuxmt/msdos_fs_sb.h>

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -6,6 +6,7 @@
  * Aug 2023 Greg Haerr - Don't use L1 cache/memset on new filesystem clusters.
  */
 
+#include <linuxmt/config.h>
 #include <linuxmt/msdos_fs.h>
 #include <linuxmt/sched.h>
 #include <linuxmt/kernel.h>

--- a/elks/fs/msdos/namei.c
+++ b/elks/fs/msdos/namei.c
@@ -4,6 +4,7 @@
  *  Written 1992 by Werner Almesberger
  */
 
+#include <linuxmt/config.h>
 #include <features.h>
 #include <arch/segment.h>
 

--- a/elks/include/arch/posix_types.h
+++ b/elks/include/arch/posix_types.h
@@ -2,7 +2,6 @@
 #define __ARCH_8086_POSIX_TYPES_H
 
 #ifdef __KERNEL__
-#include <arch/irq.h>
 #include <arch/bitops.h>
 #endif
 

--- a/elks/include/linuxmt/types.h
+++ b/elks/include/linuxmt/types.h
@@ -3,10 +3,6 @@
 
 #include <arch/types.h>
 
-#ifdef __KERNEL__
-#include <linuxmt/config.h>
-#endif
-
 typedef __s32                   loff_t;
 typedef __s32                   off_t;
 

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -16,6 +16,7 @@
 #include <arch/system.h>
 #include <arch/segment.h>
 #include <arch/ports.h>
+#include <arch/irq.h>
 
 /*
  *	System variable setups

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -28,7 +28,6 @@
  */
 
 #include <linuxmt/config.h>
-#include <arch/segment.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/kernel.h>
 #include <linuxmt/sched.h>
@@ -37,6 +36,8 @@
 #include <linuxmt/ntty.h>
 #include <linuxmt/debug.h>
 #include <linuxmt/signal.h>
+#include <arch/segment.h>
+#include <arch/irq.h>
 #include <stdarg.h>
 
 dev_t dev_console;

--- a/elks/kernel/sys.c
+++ b/elks/kernel/sys.c
@@ -4,6 +4,7 @@
  *  Copyright (C) 1991, 1992  Linus Torvalds
  */
 
+#include <linuxmt/config.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/sched.h>
 #include <linuxmt/kernel.h>

--- a/elks/kernel/time.c
+++ b/elks/kernel/time.c
@@ -24,14 +24,13 @@
  * todo: adjtime() and/or adjtimex()
  */
 
-#include <arch/types.h>
+#include <linuxmt/config.h>
 #include <linuxmt/time.h>
 #include <linuxmt/sched.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/string.h>
 
-#include <linuxmt/config.h>
 #include <arch/system.h>
 #include <arch/segment.h>
 

--- a/elks/lib/chqueue.c
+++ b/elks/lib/chqueue.c
@@ -26,6 +26,7 @@
 #include <linuxmt/types.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/debug.h>
+#include <arch/irq.h>
 
 void chq_init(register struct ch_queue *q, unsigned char *buf, int size)
 {

--- a/elks/net/protocols.c
+++ b/elks/net/protocols.c
@@ -3,7 +3,6 @@
  */
 
 #include <linuxmt/config.h>
-#include <linuxmt/types.h>
 #include <linuxmt/net.h>
 #include <linuxmt/fs.h>
 

--- a/elks/net/unix/af_unix.c
+++ b/elks/net/unix/af_unix.c
@@ -7,8 +7,8 @@
  * no more, no less.
  */
 
-#include <linuxmt/errno.h>
 #include <linuxmt/config.h>
+#include <linuxmt/errno.h>
 #include <linuxmt/socket.h>
 #include <linuxmt/fs.h>
 #include <linuxmt/sched.h>


### PR DESCRIPTION
This cleanup removes a large build dependency where libc including types.h ended up depending on config.h, thus requiring libc rebuild anytime config.h changed.

Removes `#include <arch/irq.h>` from `posix_types.h`.

Importantly, any kernel routine testing CONFIG_xxx build options must now `#include <linuxmt/config.h>` directly.