### PR TITLE
[libc] Cleanup C library header files

### DIFF
--- a/elks/fs/msdos/dir.c
+++ b/elks/fs/msdos/dir.c
@@ -8,9 +8,6 @@
 /* ported from linx-0.97 by zouys, Oct 21st, 2010 */
 /* neated from linx-2.0.34 fangzs, Nov 23rd, 2010 */
 
-#include <features.h>
-#include <arch/segment.h>
-
 #include <linuxmt/fs.h>
 #include <linuxmt/msdos_fs.h>
 #include <linuxmt/errno.h>
@@ -18,6 +15,8 @@
 #include <linuxmt/mm.h>
 #include <linuxmt/string.h>
 #include <linuxmt/debug.h>
+
+#include <arch/segment.h>
 
 static size_t msdos_dir_read(struct inode *dir, struct file *filp, char *buf, size_t count)
 {

--- a/elks/fs/msdos/namei.c
+++ b/elks/fs/msdos/namei.c
@@ -5,9 +5,6 @@
  */
 
 #include <linuxmt/config.h>
-#include <features.h>
-#include <arch/segment.h>
-
 #include <linuxmt/sched.h>
 #include <linuxmt/msdos_fs.h>
 #include <linuxmt/kernel.h>
@@ -16,6 +13,8 @@
 #include <linuxmt/stat.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/debug.h>
+
+#include <arch/segment.h>
 
 unsigned char FATPROC get_fs_byte(const void *dv)
 {

--- a/elkscmd/romprg/flash.c
+++ b/elkscmd/romprg/flash.c
@@ -1,5 +1,5 @@
 #include "flash.h"
-#include <memory.h>
+#include <string.h>
 
 #define _MK_FP(seg,off)	((void __far *)((((unsigned long)(seg)) << 16) | (off)))
 #define LINEAR(addr32)  _MK_FP(addr32 >> 4, addr32 & 0x0F)

--- a/elkscmd/romprg/main.c
+++ b/elkscmd/romprg/main.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <stdint.h>
-#include <memory.h>
+#include <string.h>
 
 #include "arch/io.h"
 #include "arch/8018x.h"

--- a/elkscmd/sys_utils/init.c
+++ b/elkscmd/sys_utils/init.c
@@ -31,7 +31,6 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <signal.h>
-#include <memory.h>
 #include <errno.h>
 #include <time.h>
 #include <paths.h>

--- a/libc/include/assert.h
+++ b/libc/include/assert.h
@@ -1,6 +1,5 @@
 #ifndef	__ASSERT_H
 #define	__ASSERT_H
-#include <features.h>
 
 /* If NDEBUG is defined, do nothing.
    If not, and EXPRESSION is zero, print an error message and abort.  */

--- a/libc/include/errno.h
+++ b/libc/include/errno.h
@@ -1,4 +1,6 @@
-/* libc errno.h*/
+#ifndef	__ERRNO_H
+#define	__ERRNO_H
+
 #include <features.h>
 #include __SYSINC__(errno.h)
 
@@ -47,3 +49,5 @@ extern int errno;
 #define ENOSYS  38  // Function not implemented
 
 #endif /* #if 0*/
+
+#endif

--- a/libc/include/getopt.h
+++ b/libc/include/getopt.h
@@ -1,12 +1,10 @@
+#ifndef __GETOPT_H
+#define __GETOPT_H
+
 /* Copyright (C) 1996 Robert de Bath <rdebath@cix.compulink.co.uk>
  * This file is part of the Linux-8086 C library and is distributed
  * under the GNU Library General Public License.
  */
-
-#ifndef __GETOPT_H
-#define __GETOPT_H
-
-#include <features.h>
 
 extern char *optarg;
 extern int opterr;

--- a/libc/include/grp.h
+++ b/libc/include/grp.h
@@ -2,8 +2,6 @@
 #define	__GRP_H
 
 #include <sys/types.h>
-#include <features.h>
-#include <stdio.h>
 
 /* The group structure */
 struct group

--- a/libc/include/inttypes.h
+++ b/libc/include/inttypes.h
@@ -1,3 +1,6 @@
+#ifndef _INTTYPES_H
+#define _INTTYPES_H
+
 /* Copyright (C) 1997-2014 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
@@ -22,10 +25,6 @@
  *	ISO C99: 7.8 Format conversion of integer types	<inttypes.h>
  */
 
-#ifndef _INTTYPES_H
-#define _INTTYPES_H	1
-
-#include <features.h>
 /* Get the type definitions.  */
 #include <stdint.h>
 
@@ -211,4 +210,4 @@
 # define SCNxPTR	"x"
 
 
-#endif /* inttypes.h */
+#endif

--- a/libc/include/malloc.h
+++ b/libc/include/malloc.h
@@ -1,6 +1,6 @@
 #ifndef __MALLOC_H
 #define __MALLOC_H
-#include <features.h>
+
 #include <sys/types.h>
 
 /*

--- a/libc/include/memory.h
+++ b/libc/include/memory.h
@@ -1,1 +1,0 @@
-#include <string.h>

--- a/libc/include/pwd.h
+++ b/libc/include/pwd.h
@@ -2,7 +2,6 @@
 #define	__PWD_H
 
 #include <sys/types.h>
-#include <features.h>
 #include <stdio.h>
 
 /* The passwd structure.  */

--- a/libc/include/regex.h
+++ b/libc/include/regex.h
@@ -1,3 +1,6 @@
+#ifndef	__REGEX_H
+#define	__REGEX_H
+
 /*
  * Definitions etc. for regexp(3) routines.
  *
@@ -21,3 +24,5 @@ void regerror();
 
 int expandwildcards(char *name, int maxargc, char **retargv);
 void freewildcards(void);
+
+#endif

--- a/libc/include/signal.h
+++ b/libc/include/signal.h
@@ -1,6 +1,7 @@
 #ifndef __SIGNAL_H
 #define __SIGNAL_H
 
+#include <features.h>
 #include <sys/types.h>
 
 #undef __KERNEL__

--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -1,8 +1,6 @@
-
 #ifndef __STDIO_H
 #define __STDIO_H
 
-#include <features.h>
 #include <sys/types.h>
 #include <stdarg.h>
 

--- a/libc/include/string.h
+++ b/libc/include/string.h
@@ -56,8 +56,9 @@ char *strfry(char *);
 
 void bzero(void * s, size_t n);
 
-// TODO: this is removed in POSIX-1.2008
-// TODO: replace by memcpy or memmove
+/* TODO: this is removed in POSIX-1.2008
+ * TODO: replace by memcpy or memmove
+ */
 #define bcopy(s, d, n) memcpy((d), (s), (n))
 
 #endif

--- a/libc/include/sys/dir.h
+++ b/libc/include/sys/dir.h
@@ -1,4 +1,4 @@
-/* backwards-comptabible pre-POSIX header - use <dirent.h> instead*/
+/* backwards-compatible pre-POSIX header - use <dirent.h> instead*/
 #include <dirent.h>
 
 #define direct dirent

--- a/libc/include/sys/ioctl.h
+++ b/libc/include/sys/ioctl.h
@@ -1,5 +1,6 @@
 #ifndef _SYS_IOCTL_H
 #define _SYS_IOCTL_H
+
 #include <features.h>
 #include __SYSINC__(ioctl.h)
 

--- a/libc/include/sys/mount.h
+++ b/libc/include/sys/mount.h
@@ -1,4 +1,5 @@
-/* sys/mount.h*/
+#ifndef __SYS_MOUNT_H
+#define __SYS_MOUNT_H
 
 #include <features.h>
 #include <sys/types.h>
@@ -24,3 +25,5 @@ int umount(const char *dir);
 int ustatfs(dev_t dev, struct statfs *statfs, int flags);
 
 int reboot(int magic1, int magic2, int magic3);
+
+#endif

--- a/libc/include/sys/socket.h
+++ b/libc/include/sys/socket.h
@@ -1,6 +1,6 @@
-
 #ifndef __SYS_SOCKET_H
 #define __SYS_SOCKET_H
+
 #include <features.h>
 #include __SYSINC__(socket.h)
 

--- a/libc/include/sys/time.h
+++ b/libc/include/sys/time.h
@@ -1,4 +1,9 @@
+#ifndef _SYS_TIME_H
+#define _SYS_TIME_H
+
 #include <time.h>
 
 int gettimeofday (struct timeval * restrict tp, void * restrict tzp);
 int settimeofday (const struct timeval *tp, const struct timezone *tzp);
+
+#endif

--- a/libc/include/sys/times.h
+++ b/libc/include/sys/times.h
@@ -1,8 +1,6 @@
 #ifndef _SYS_TIMES_H
 #define _SYS_TIMES_H
 
-#include <features.h>
-#include <sys/types.h>
 #include <time.h>
 
 struct tms {

--- a/libc/include/sys/types.h
+++ b/libc/include/sys/types.h
@@ -1,6 +1,11 @@
+#ifndef _SYS_TYPES_H
+#define _SYS_TYPES_H
+
 #include <features.h>
 #include <stddef.h>
 #include __SYSINC__(types.h)
 
 typedef int intptr_t;
 typedef intptr_t ssize_t;
+
+#endif

--- a/libc/include/sys/wait.h
+++ b/libc/include/sys/wait.h
@@ -1,8 +1,5 @@
-
 #ifndef	_SYS_WAIT_H
 #define	_SYS_WAIT_H
-
-#include <features.h>
 
 /* Bits in the third argument to `waitpid'.  */
 #define	WNOHANG		1	/* Don't block waiting.  */

--- a/libc/include/termcap.h
+++ b/libc/include/termcap.h
@@ -1,8 +1,7 @@
 #ifndef _TERMCAP_H
 #define _TERMCAP_H
 
-#include <features.h>
-#include <sys/types.h>
+#include <stdio.h>
 
 extern char PC;
 extern char *UP;

--- a/libc/include/time.h
+++ b/libc/include/time.h
@@ -1,7 +1,6 @@
 #ifndef __TIME_H
 #define __TIME_H
 
-#include <features.h>
 #include <sys/types.h>
 #include <stdint.h>
 #include <stddef.h>

--- a/libc/include/unistd.h
+++ b/libc/include/unistd.h
@@ -1,7 +1,6 @@
 #ifndef __UNISTD_H
 #define __UNISTD_H
 
-#include <features.h>
 #include <sys/types.h>
 #include <sys/select.h>
 

--- a/libc/include/unistd.h
+++ b/libc/include/unistd.h
@@ -1,6 +1,7 @@
 #ifndef __UNISTD_H
 #define __UNISTD_H
 
+#include <features.h>
 #include <sys/types.h>
 #include <sys/select.h>
 

--- a/libc/include/utime.h
+++ b/libc/include/utime.h
@@ -1,7 +1,6 @@
 #ifndef __UTIME_H
 #define __UTIME_H
 
-#include <features.h>
 #include <sys/types.h>
 
 struct utimbuf {

--- a/libc/include/utmp.h
+++ b/libc/include/utmp.h
@@ -1,9 +1,6 @@
-/* utmp.h */
-
 #ifndef __UTMP_H
 #define __UTMP_H
 
-#include <features.h>
 #include <sys/types.h>
 #include <paths.h>
 #include <time.h>


### PR DESCRIPTION
Removes features.h from libc headers not requiring it. This header is also confusing as can be internal to gcc.
Removes features.h from two kernel source files (which would use the gcc internal version, for no reason).
Removes non-standard memory.h header file, replace source with string.h.