### PR TITLE
[libc] More cleanup C library header files

### DIFF
--- a/elks/include/linuxmt/errno.h
+++ b/elks/include/linuxmt/errno.h
@@ -145,6 +145,9 @@
 #define EQUERYREFUSED	128	/* Query refused */
 #define ESERVERERR	129	/* Server error */
 
+/* added here for userland ktcp compile */
+#define ERESTARTSYS	512	/* Restart system call*/
+
 /*****************************************************************************/
 
 /* These are comedy ones inserted for fun, and are never used.
@@ -162,7 +165,6 @@
 
 /* Should never be seen by user programs */
 
-#define ERESTARTSYS	512	/* Restart system call*/
 #define ERESTARTNOINTR	513	/* Restart without interrupts */
 #define ENOIOCTLCMD	515	/* No ioctl command */
 

--- a/elkscmd/ktcp/tcpdev.c
+++ b/elkscmd/ktcp/tcpdev.c
@@ -17,7 +17,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <arpa/inet.h>
-#define __KERNEL__
 #include <errno.h>
 #include "ip.h"
 #include "tcp.h"

--- a/elkscmd/sys_utils/ps.c
+++ b/elkscmd/sys_utils/ps.c
@@ -10,7 +10,7 @@
  * Enhanced by Greg Haerr 17 Apr 2020
  */
 #define __KERNEL__
-#include <linuxmt/ntty.h>
+#include <linuxmt/ntty.h>       /* for struct tty */
 #undef __KERNEL__
 
 #include <autoconf.h>           /* for CONFIG_ options */

--- a/libc/include/signal.h
+++ b/libc/include/signal.h
@@ -4,14 +4,7 @@
 #include <features.h>
 #include <sys/types.h>
 
-#undef __KERNEL__
 #include __SYSINC__(signal.h)
-
-/* BSDisms */
-#ifdef BSD
-extern const char * const sys_siglist[];
-#define sig_t sighandler_t
-#endif
 
 sighandler_t signal(int number, sighandler_t pointer);
 int kill (pid_t pid, int sig);

--- a/libc/misc/getopt.c
+++ b/libc/misc/getopt.c
@@ -21,35 +21,19 @@
  * The current SVR2 man page reflects the actual behavor of this getopt.
  * However, I am not about to post a copy of anything licensed by AT&T.
  */
-
-/*#include "global.h"*/
-#define index strchr
-#ifdef BSD
-#include <strings.h>
-#else
 #include <string.h>
-#endif
+#include <unistd.h>
 
-#ifdef	__TURBOC__
-#include <io.h>			/* added by KA9Q for Turbo-C */
-#endif
-#ifdef	AMIGA
-#include <fcntl.h>
-#endif
-
- /*LINTLIBRARY*/
 #ifndef NULL
 #define NULL	0
 #endif
 #define EOF	(-1)
 #define ERR(s, c)	if (opterr){\
-	extern int write();\
 	char errbuf[2];\
 	errbuf[0] = c; errbuf[1] = '\n';\
 	(void) write(2, argv[0], (unsigned)strlen(argv[0]));\
 	(void) write(2, s, (unsigned)strlen(s));\
 	(void) write(2, errbuf, 2);}
-extern char *index();
 
 int opterr = 1;
 int optind = 1;
@@ -71,7 +55,7 @@ int getopt(int argc, char * const argv[], const char *opts)
 	}
     }
     optopt = c = argv[optind][sp];
-    if (c == ':' || (cp = index(opts, c)) == NULL) {
+    if (c == ':' || (cp = strchr(opts, c)) == NULL) {
 	ERR(": illegal option -- ", c);
 	if (argv[optind][++sp] == '\0') {
 	    optind++;


### PR DESCRIPTION
Removes `#ifdef BSD` code.
Removes need for `#define __KERNEL__` in some user programs.
Use proper header files for external functions in getopt.h.