### PR TITLE
[libc] Cleanup rindex issues

### DIFF
--- a/libc/misc/aliases.c
+++ b/libc/misc/aliases.c
@@ -77,6 +77,7 @@ int chr;
 }
 #endif
 
+#ifdef L_rindex
 #undef rindex
 char *
 rindex(src, chr)
@@ -85,6 +86,7 @@ int chr;
 {
    return strrchr(src, chr);
 }
+#endif
 
 #ifdef L_remove
 #include <errno.h>
@@ -112,4 +114,3 @@ mode_t mode;
 {
    return open(file, O_TRUNC|O_CREAT|O_WRONLY, mode);
 }
-

--- a/libc/misc/basename.c
+++ b/libc/misc/basename.c
@@ -5,7 +5,7 @@
 /* POSIX implementation of basename(3) */
 
 char *
-basename (char *path)
+basename(char *path)
 {
   static char *def = ".";
   char *base;
@@ -22,7 +22,7 @@ basename (char *path)
   if (last == 0 && path[0] == '/')
     return path;
 
-  base = rindex (path, '/');
+  base = strrchr (path, '/');
 
   if (base != NULL)
       return base + 1;

--- a/libc/misc/dirname.c
+++ b/libc/misc/dirname.c
@@ -5,7 +5,7 @@
 /* POSIX implementation of dirname(3) */
 
 char *
-dirname (char *path)
+dirname(char *path)
 {
   char *dir;
   int last;
@@ -18,7 +18,7 @@ dirname (char *path)
   while (last > 0 && path[last] == '/')
     path[last--] = '\0';
 
-  dir = rindex (path, '/');
+  dir = strrchr (path, '/');
 
   if (dir == NULL)
   {


### PR DESCRIPTION
Use `strrchr` weak alias for `rindex` rather than wrapper function.
Use `strrchr` rather than `rindex` within C library.