### PR TITLE
[kernel] Don't allocate IRQ trampolines from heap

### DIFF
--- a/elks/include/linuxmt/heap.h
+++ b/elks/include/linuxmt/heap.h
@@ -18,7 +18,7 @@
 #define HEAP_TAG_SEG     0x01
 #define HEAP_TAG_BUF     0x02
 #define HEAP_TAG_TTY     0x03
-#define HEAP_TAG_INTHAND 0x04
+#define HEAP_TAG_INTHAND 0x04   /* unused */
 #define HEAP_TAG_BUFHEAD 0x05
 #define HEAP_TAG_PIPE    0x06
 


### PR DESCRIPTION
Replaces kernel heap allocation with allocation from static table. This relieves the fragmentation to the kernel heap when drivers (serial, network, floppy, etc) are frequently opened and closed.

Uses idea from @Mellvik's https://github.com/Mellvik/TLVC/pull/33.
