### PR TITLE
[kernel] Automate detection of QEMU for ftp, ftpd and DF driver

### DIFF
--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -122,7 +122,7 @@
  *  82077AA      IBM PS/2 (gen 3)                   DOR,DIR,CCR  PERPENDICULAR,LOCK
  */
 
-#define USE_IMPLIED_SEEK    0   /* =1 for QEMU with 360k/AT stretch floppies (not real hw) */
+char USE_IMPLIED_SEEK = 0; /* =1 for QEMU with 360k/AT stretch floppies (not real hw) */
 #define CHECK_DIR_REG       1   /* =1 to read and clear DIR DSKCHG when media changed */
 #define CHECK_DISK_CHANGE   1   /* =1 to inform kernel of media changed */
 
@@ -1474,5 +1474,7 @@ void INITPROC floppy_init(void)
         return;
     }
     blk_dev[MAJOR_NR].request_fn = DEVICE_REQUEST;
+    if (!USE_IMPLIED_SEEK)
+        USE_IMPLIED_SEEK = running_qemu;
     config_types();
 }

--- a/elks/include/linuxmt/kernel.h
+++ b/elks/include/linuxmt/kernel.h
@@ -22,6 +22,8 @@
 
 #define structof(p,t,m) ((t *) ((char *) (p) - offsetof (t,m)))
 
+extern char running_qemu;
+
 extern void do_exit(int) noreturn;
 
 extern int kill_pg(pid_t,sig_t,int);

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -17,7 +17,6 @@
 #init=/bin/init 3 n	# muser serial no rc.sys
 #init=/bin/sh		# singleuser sh
 #root=hda1 ro		# root hd partition 1 readonly
-#QEMU=1			# ftp/ftpd
 #kstack
 #strace
 #root=df0


### PR DESCRIPTION
The ELKS kernel needs to know about whether its running on QEMU because of the following incompatibilities with real hardware:
- DF driver on 360k drives requires using the FDC implied seek command
- ftp and ftpd are special cased when running on QEMU

This PR sets a kernel variable `running_qemu` when QEMU is detected and also sets the global environment variable `QEMU=1` to /bin/sh and subsequent programs which allow ftp and ftpd to run properly without manually setting QEMU=1 in /bootopts.

