### PR TITLE
[kernel,libc] Rename u_ino_t to ino_t

### DIFF
--- a/elks/include/arch/stat.h
+++ b/elks/include/arch/stat.h
@@ -5,7 +5,7 @@
 
 struct stat {
     dev_t	st_dev;
-    u_ino_t	st_ino;
+    ino_t	st_ino;
     mode_t	st_mode;
     nlink_t	st_nlink;
     uid_t	st_uid;

--- a/elks/include/linuxmt/dirent.h
+++ b/elks/include/linuxmt/dirent.h
@@ -5,7 +5,7 @@
 #include <linuxmt/limits.h>
 
 struct dirent {
-    u_ino_t         d_ino;
+    ino_t           d_ino;
     off_t           d_offset;
     unsigned short  d_namlen;
     char            d_name[MAXNAMLEN+1];

--- a/elks/include/linuxmt/types.h
+++ b/elks/include/linuxmt/types.h
@@ -18,7 +18,6 @@ typedef __u16                   dev_t;
 typedef __u16                   flag_t;
 typedef __s32                   cluster_t;
 
-typedef __u32                   u_ino_t;
 typedef __u32                   ino_t;
 
 typedef __u16                   pid_t;

--- a/elkscmd/man/man5/dir.5
+++ b/elkscmd/man/man5/dir.5
@@ -13,7 +13,7 @@ following structure defined in <dirent.h>:
 .ta +5n +15n +15n
 #define MAXNAMLEN	26		   /* 14 for MINIX, 26 for FAT */
 struct dirent {
-	u_ino_t	d_ino;	        /* I-node number */
+	ino_t	d_ino;	        /* I-node number */
 	unsigned short d_namlen;
 	char	d_name[MAXNAMLEN+1];   /* File name */
 };

--- a/libc/misc/getcwd.c
+++ b/libc/misc/getcwd.c
@@ -13,12 +13,12 @@
 static char * path_buf;
 static size_t path_size;
 static dev_t root_dev;
-static u_ino_t root_ino;
+static ino_t root_ino;
 static struct stat st;
 
 /* routine to find the step back down */
 static char *
-search_dir(dev_t this_dev, u_ino_t this_ino)
+search_dir(dev_t this_dev, ino_t this_ino)
 {
    DIR * dp;
    struct dirent * d;
@@ -76,7 +76,7 @@ static char *
 recurser(void)
 {
    dev_t this_dev;
-   u_ino_t this_ino;
+   ino_t this_ino;
 
    if( stat(path_buf, &st) < 0 ) return NULL;
    this_dev = st.st_dev;


### PR DESCRIPTION
With internal inode numbers always occupying 32 bits, there is no need for a separate `u_ino_t` type. ABI unchanged.