### PR TITLE
[kernel,cmds] Small fixes to ps, mkfs and ramdisk driver

### DIFF
--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -170,7 +170,7 @@ LHFLAGS 	= $(LCFLAGS) -exportfcn -declundef -fcnuse -fielduse \
 ifneq ($(USEBCC), N)
 
 ################################
-# Definitions using ia16-unknown-elks-gcc compiler
+# Definitions using ia16-elf-gcc compiler
 
 AS      = ia16-elf-as
 ASFLAGS = $(CPU_AS) $(ARCH_AS) --32-segelf

--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -200,6 +200,7 @@ static void INITPROC extended_partition(register struct gendisk *hd, kdev_t dev)
     unmap_brelse(bh);
 }
 
+#ifdef CONFIG_MSDOS_PARTITION
 static int INITPROC msdos_partition(struct gendisk *hd,
                            kdev_t dev, sector_t first_sector)
 {
@@ -287,6 +288,7 @@ out:
     unmap_brelse(bh);
     return 1;
 }
+#endif
 
 static void INITPROC check_partition(register struct gendisk *hd, kdev_t dev)
 {

--- a/elks/arch/i86/drivers/block/rd.c
+++ b/elks/arch/i86/drivers/block/rd.c
@@ -74,7 +74,11 @@ static int rd_open(struct inode *inode, struct file *filp)
     int target = DEVICE_NR(inode->i_rdev);
 
     debug("RD: open /dev/rd%d\n", target);
-    if (!rd_initialised || target >= MAX_DRIVES || !drive_info[target].valid)
+    if (!rd_initialised || target >= MAX_DRIVES
+#if CONFIG_RAMDISK_SEGMENT
+        || !drive_info[target].valid
+#endif
+                                                )
         return -ENXIO;
 
     ++access_count[target];
@@ -286,6 +290,7 @@ void INITPROC rd_init(void)
     if (register_blkdev(MAJOR_NR, DEVICE_NAME, &rd_fops) == 0) {
 	blk_dev[MAJOR_NR].request_fn = DEVICE_REQUEST;
 	rd_initialised = 1;
+
 #if CONFIG_RAMDISK_SEGMENT
 	printk("rd: %dK ramdisk at %x:0000\n",
 	    drive_info[0].size >> 1, rd_segment[0].seg);

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -8,6 +8,8 @@
  * Compile-time configuration
  */
 
+#define CONFIG_MSDOS_PARTITION  1               /* support DOS HD partitions */
+
 #ifdef CONFIG_ARCH_IBMPC
 #define MAX_SERIAL              4               /* max number of serial tty devices*/
 

--- a/elks/include/linuxmt/genhd.h
+++ b/elks/include/linuxmt/genhd.h
@@ -11,8 +11,6 @@
  *              <drew@colorado.edu>
  */
 
-#define CONFIG_MSDOS_PARTITION 1
-
 /* These two have identical behaviour; use the second one if DOS fdisk gets
    confused about extended/logical partitions starting past cylinder 1023. */
 

--- a/elkscmd/disk_utils/mkfs.c
+++ b/elkscmd/disk_utils/mkfs.c
@@ -49,7 +49,6 @@
 #include <string.h>
 #include <signal.h>
 #include <fcntl.h>
-/*#include <ctype.h>*/
 #include <stdlib.h>
 #include <termios.h>
 #include <sys/stat.h>
@@ -301,9 +300,13 @@ int main(int argc, char ** argv)
 		die("unable to open device");
 	if (fstat(DEV,&statbuf)<0)
 		die("unable to stat %s");
-	//else if (statbuf.st_rdev == 0x0300 || statbuf.st_rdev == 0x0340)
-		//die("Will not try to make filesystem on '%s'");
-
+	/***if (statbuf.st_rdev == DEV_FD0 || statbuf.st_rdev == DEV_HDA)
+		die("Will not try to make filesystem on '%s'");***/
+	if ((BLOCKS << 10) > statbuf.st_size) {
+		printf("Requested block count %luK exceeds device size %luK\n",
+			BLOCKS, statbuf.st_size >> 10);
+		exit(8);
+	}
 	setup_tables();
 	make_root_inode();
 	write_tables();

--- a/elkscmd/sys_utils/ps.c
+++ b/elkscmd/sys_utils/ps.c
@@ -31,6 +31,7 @@
 #include <pwd.h>
 #include <getopt.h>
 #include <paths.h>
+#include <libgen.h>
 
 #define LINEARADDRESS(off, seg)		((off_t) (((off_t)seg << 4) + off))
 
@@ -125,7 +126,7 @@ int main(int argc, char **argv)
 	struct passwd * pwent;
     int f_listall = 0;
     char *progname = argv[0];
-    int f_uptime = !strcmp(progname, "uptime");
+    int f_uptime = !strcmp(basename(progname), "uptime");
     struct task_struct task_table;
 
     while ((c = getopt(argc, argv, "lu")) != -1) {

--- a/image/Make.devices
+++ b/image/Make.devices
@@ -1,4 +1,4 @@
-# Make.devices - make character and block special devies on MINIX image
+# Make.devices - make character and block special devices on MINIX image
 #
 # Devices MAJOR are defined in /include/linuxmt/major.h
 
@@ -61,8 +61,16 @@ devices:
 
 ##############################################################################
 # Direct floppy devices.
-	$(MKDEV) /dev/df0  b 4 0
-	$(MKDEV) /dev/df1  b 4 1
+	$(MKDEV) /dev/df0        b 4 0
+	$(MKDEV) /dev/df1        b 4 1
+#	$(MKDEV) /dev/df0-360    b 4 2
+#	$(MKDEV) /dev/df0-1200   b 4 4
+#	$(MKDEV) /dev/df0-360at3 b 4 6
+#	$(MKDEV) /dev/df0-720    b 4 8
+#	$(MKDEV) /dev/df0-360at5 b 4 10
+#	$(MKDEV) /dev/df0-720at5 b 4 12
+#	$(MKDEV) /dev/df0-1440   b 4 14
+#	$(MKDEV) /dev/df0-2880   b 4 16
 
 ##############################################################################
 # Pseudo-TTY master devices. 


### PR DESCRIPTION
Fixes ramdisk driver when dynamically allocated using `ramdisk`. (Use `ramdisk /dev/rd0 make 96` to create dynamic ramdisk).

Fixes `ps` when aliased as `uptime` (thanks @Mellvik).
Adds error checking of destination block device max size to `mkfs` (thanks @Mellvik).