### PR TITLE
[debug] Enhance stack backtrace and instrumention library

### DIFF
--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -193,6 +193,8 @@ static void vprintk(const char *fmt, va_list p)
                 break;
             case 'P':
                 v = current->pid;
+                c = 'd';
+                n = 10;
                 goto out;
             case 'D':
                 c += 'X' - 'D';

--- a/elkscmd/debug/Makefile
+++ b/elkscmd/debug/Makefile
@@ -22,8 +22,8 @@ CFLAGS += -fno-optimize-sibling-calls
 CFLAGS += -fno-omit-frame-pointer
 # optional instrumentation for function tracing
 CFLAGS += -finstrument-functions-simple
-# include symbol table in executable and heap to read it
-LDFLAGS += -maout-symtab -maout-heap=12000
+# include symbol table in executable
+LDFLAGS += -maout-symtab
 
 # added after CFLAGS for non-instrumented .c files in this directory
 NOINSTFLAGS = -fno-instrument-functions -fno-instrument-functions-simple
@@ -37,7 +37,7 @@ testsym: $(TESTOBJS)
 	./nm86 $@ > $@.map
 
 disasm: $(DISASMOBJS)
-	$(LD) $(LDFLAGS) -maout-heap=0xffff -o $@ $^ $(LDLIBS)
+	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 system.sym:
 	cp -p $(TOPDIR)/elks/arch/i86/boot/system.sym $(TOPDIR)/elkscmd/debug
@@ -53,7 +53,7 @@ dis.o: dis.c
 	$(CC) $(CFLAGS) $(NOINSTFLAGS) -c -o $*.o $<
 
 nm86: nm86.c syms.c
-	$(HOSTCC) $(HOSTCFLAGS) -o $@ $^
+	$(HOSTCC) $(HOSTCFLAGS) -D__far= -o $@ $^
 
 hostdisasm: dis.c disasm.c syms.c
 	$(HOSTCC) $(HOSTCFLAGS) -D__far= -Wno-int-to-void-pointer-cast -Wno-format -o $@ $^

--- a/elkscmd/debug/stacktrace.c
+++ b/elkscmd/debug/stacktrace.c
@@ -4,6 +4,7 @@
  * June 2022 Greg Haerr
  */
 #include <stdio.h>
+#include <unistd.h>
 #include "instrument.h"
 #include "syms.h"
 
@@ -54,6 +55,7 @@ void noinstrument _print_stack(int arg1)
     int *fn = (int *)_print_stack;
     int i = 0;
 
+    sym_read_exe_symbols(__program_filename);
     printf("Level Addr    BP   DI   SI   Ret  Arg  Arg2 Arg3 Arg4\n"
            "~~~~~ ~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n");
     do {

--- a/elkscmd/debug/syms.c
+++ b/elkscmd/debug/syms.c
@@ -14,42 +14,71 @@
 #include <stdint.h>
 #include "syms.h"
 
-static unsigned char *syms;
+static unsigned char __far *syms;
 struct minix_exec_hdr sym_hdr;
-
-#if __ia16__
-#define ALLOC(s,n)    ((int)(s = sbrk(n)) != -1)
-#else
-#define ALLOC(s,n)    ((s = malloc(n)) !=  NULL)
-char * __program_filename;
-#endif
 
 #define MAGIC       0x0301  /* magic number for executable progs */
 
+static void noinstrument fmemcpy(unsigned char __far *dst, unsigned char *src, int n)
+{
+    do {
+        *dst++ = *src++;
+    } while (--n);
+}
+
+/* allocate space and read symbol table */
+static unsigned char __far * noinstrument alloc_read(int fd, size_t size)
+{
+    if (size == 0 || size > 32767)
+        return NULL;
+#if __ia16__
+    unsigned char __far *s;
+    size_t n, t = 0;
+    unsigned char buf[512];
+    if (!(s = fmemalloc(size)))
+        return NULL;
+    do {
+        n = size > sizeof(buf)? sizeof(buf): size;
+        if (read(fd, buf, n) != n)
+            return NULL;            // FIXME no fmemfree
+        fmemcpy(s+t, buf, n);
+        t += n;
+        size -= n;
+    } while (size);
+    return s;
+#else
+    unsigned char *s;
+    if (!(s = malloc(size)))
+        return NULL;
+    if (read(fd, s, size) != size)
+        return NULL;
+    return (unsigned char __far *)s;
+#endif
+}
+
 /* read symbol table from executable into memory */
-unsigned char * noinstrument sym_read_exe_symbols(char *path)
+unsigned char __far * noinstrument sym_read_exe_symbols(char *path)
 {
     int fd;
-    unsigned char *s;
+    unsigned char __far *s;
     char fullpath[PATH_MAX];
 
     if (syms) return syms;
     if ((fd = open(path, O_RDONLY)) < 0) {
-        sprintf(fullpath, "/bin/%s", path);     // FIXME use PATH
+        strcpy(fullpath, "/bin/");          // FIXME use path
+        strcpy(fullpath+5, path);
         if ((fd = open(fullpath, O_RDONLY)) < 0)
                 return NULL;
     }
     errno = 0;
     if (read(fd, &sym_hdr, sizeof(sym_hdr)) != sizeof(sym_hdr)
         || ((sym_hdr.type & 0xFFFF) != MAGIC)
-        || (sym_hdr.syms == 0 || sym_hdr.syms > 32767)
-        || (!ALLOC(s, (int)sym_hdr.syms))
         || (lseek(fd, -(int)sym_hdr.syms, SEEK_END) < 0)
-        || (read(fd, s, (int)sym_hdr.syms) != (int)sym_hdr.syms)) {
-                int e = errno;
-                close(fd);
-                errno = e;
-                return NULL;
+        || !(s = alloc_read(fd, (size_t)sym_hdr.syms))) {
+            int e = errno;
+            close(fd);
+            errno = e;
+            return NULL;
     }
     close(fd);
     syms = s;
@@ -57,10 +86,10 @@ unsigned char * noinstrument sym_read_exe_symbols(char *path)
 }
 
 /* read symbol table file into memory */
-unsigned char * noinstrument sym_read_symbols(char *path)
+unsigned char __far * noinstrument sym_read_symbols(char *path)
 {
     int fd;
-    unsigned char *s;
+    unsigned char __far *s;
     struct stat sbuf;
 
     if (syms) return syms;
@@ -68,70 +97,91 @@ unsigned char * noinstrument sym_read_symbols(char *path)
         return NULL;
     errno = 0;
     if (fstat(fd, &sbuf) < 0
-        || (sbuf.st_size == 0 || sbuf.st_size > 32767)
-        || (!ALLOC(s, (int)sbuf.st_size))
-        || (read(fd, s, (int)sbuf.st_size) != (int)sbuf.st_size)) {
-                int e = errno;
-                close(fd);
-                errno = e;
-                return NULL;
+        || !(s = alloc_read(fd, (size_t)sbuf.st_size))) {
+            int e = errno;
+            close(fd);
+            errno = e;
+            return NULL;
     }
     close(fd);
     syms = s;
     return syms;
 }
 
-static int noinstrument type_text(unsigned char *p)
+static int noinstrument type_text(unsigned char __far *p)
 {
     return (p[TYPE] == 'T' || p[TYPE] == 't' || p[TYPE] == 'W');
 }
 
-static int noinstrument type_ftext(unsigned char *p)
+static int noinstrument type_ftext(unsigned char __far *p)
 {
     return (p[TYPE] == 'F' || p[TYPE] == 'f');
 }
 
-static int noinstrument type_data(unsigned char *p)
+static int noinstrument type_data(unsigned char __far *p)
 {
     return (p[TYPE] == 'D' || p[TYPE] == 'd' ||
             p[TYPE] == 'B' || p[TYPE] == 'b' ||
             p[TYPE] == 'V');
 }
 
-#if UNUSED
-/* map .text address to function start address */
-void * noinstrument sym_fn_start_address(void *addr) 
+static char * noinstrument hexout(char *buf, unsigned int v, int zstart)
 {
-    unsigned char *p, *lastp;
+    int sh = 12;
 
-    if (!syms && !sym_read_exe_symbols(__program_filename))
-        return 0;
-
-    lastp = syms;
-    for (p = next(lastp); ; lastp = p, p = next(p)) {
-        if (!type_text(p) || ((unsigned short)addr < *(unsigned short *)(&p[ADDR])))
-            break;
-    }
-    return (void *) (intptr_t) *(unsigned short *)(&lastp[ADDR]);
+    do {
+        int c = (v >> sh) & 15;
+        if (!c && sh > zstart)
+            continue;
+        if (c > 9)
+            *buf++ = 'a' - 10 + c;
+        else
+            *buf++ = '0' + c;
+    } while ((sh -= 4) >= 0);
+    *buf = '\0';
+    return buf;
 }
-#endif
+
+static char * noinstrument hex(char *buf, unsigned int v)
+{
+    return hexout(buf, v, 0);   /* %x */
+}
+
+static char * noinstrument hex4(char *buf, unsigned int v)
+{
+    return hexout(buf, v, 12);  /* %04x */
+}
+
+static char * noinstrument fstrncpy(char *dst, unsigned char __far *src, int n)
+{
+    do {
+        *dst++ = *src++;
+    } while (--n);
+    *dst = '\0';
+    return dst;
+}
 
 /*
  * Convert address to symbol string+offset,
  * offset = 0 don't show offset, offset = -1 no offset specified.
  */
 static char * noinstrument sym_string(void *addr, int offset,
-    int (*istype)(unsigned char *p))
+    int (*istype)(unsigned char __far *p))
 {
-    unsigned char *p, *lastp;
+    unsigned char __far *p;
+    unsigned char __far *lastp;
+    char *cp;
     static char buf[64];
 
-    if (!syms && !sym_read_exe_symbols(__program_filename)) {
+    if (!syms) {
 hex:
-        if (!offset || offset == -1)
-            sprintf(buf, "%04x", (unsigned int)addr);
-        else
-            sprintf(buf, "%04x+%x", (unsigned int)addr-offset, offset);
+        if (!offset || offset == -1) {
+            hex4(buf, (size_t)addr);
+        } else {
+            cp = hex4(buf, (size_t)addr-offset);
+            *cp++ = '+';
+            hex(cp, offset);
+        }
         return buf;
     }
 
@@ -142,14 +192,17 @@ hex:
             goto hex;
     }
     for (p = next(lastp); ; lastp = p, p = next(p)) {
-        if (!istype(p) || ((unsigned short)addr < *(unsigned short *)(&p[ADDR])))
+        if (!istype(p) || ((unsigned short)addr < *(unsigned short __far *)(&p[ADDR])))
             break;
     }
-    int lastaddr = *(unsigned short *)(&lastp[ADDR]);
+    int lastaddr = *(unsigned short __far *)(&lastp[ADDR]);
     if (offset && addr - lastaddr) {
-        sprintf(buf, "%.*s+%x", lastp[SYMLEN], lastp+SYMBOL,
-                                (unsigned int)addr - lastaddr);
-    } else sprintf(buf, "%.*s", lastp[SYMLEN], lastp+SYMBOL);
+        cp = fstrncpy(buf, lastp+SYMBOL, lastp[SYMLEN]);
+        *cp++ = '+';
+        hex(cp, (size_t)addr - lastaddr);
+    } else {
+        fstrncpy(buf, lastp+SYMBOL, lastp[SYMLEN]);
+    }
     return buf;
 }
 
@@ -172,6 +225,21 @@ char * noinstrument sym_data_symbol(void *addr, int offset)
 }
 
 #if UNUSED
+/* map .text address to function start address */
+void * noinstrument sym_fn_start_address(void *addr)
+{
+    unsigned char __far *p;
+    unsigned char __far *lastp;
+
+    if (!syms) return NULL;
+    lastp = syms;
+    for (p = next(lastp); ; lastp = p, p = next(p)) {
+        if (!type_text(p) || ((unsigned short)addr < *(unsigned short __far *)(&p[ADDR])))
+            break;
+    }
+    return (void *) (intptr_t) *(unsigned short __far *)(&lastp[ADDR]);
+}
+
 static int noinstrument type_any(unsigned char *p)
 {
     return p[TYPE] != '\0';

--- a/elkscmd/debug/syms.h
+++ b/elkscmd/debug/syms.h
@@ -11,7 +11,7 @@
  */
 
 #define next(sym)   \
-    ((sym) + 1 + sizeof(unsigned short) + ((unsigned char *)sym)[SYMLEN] + 1)
+    ((sym) + 1 + sizeof(unsigned short) + ((unsigned char __far *)sym)[SYMLEN] + 1)
 #define TYPE        0
 #define ADDR        1
 #define SYMLEN      3
@@ -19,8 +19,8 @@
 
 #define noinstrument    __attribute__((no_instrument_function))
 
-unsigned char * noinstrument sym_read_exe_symbols(char *path);
-unsigned char * noinstrument sym_read_symbols(char *path);
+unsigned char __far * noinstrument sym_read_exe_symbols(char *path);
+unsigned char __far * noinstrument sym_read_symbols(char *path);
 char * noinstrument sym_text_symbol(void *addr, int offset);
 char * noinstrument sym_ftext_symbol(void *addr, int offset);
 char * noinstrument sym_data_symbol(void *addr, int offset);

--- a/libc/misc/instrument.c
+++ b/libc/misc/instrument.c
@@ -5,10 +5,10 @@
 #include <string.h>
 #define noinstrument    __attribute__((no_instrument_function))
 
-static char ftrace;
-static int count;
+static size_t ftrace;
 static size_t start_sp;
 static size_t max_stack;
+static int count;
 
 /* runs before main and rewrites argc/argv on stack if --ftrace found */
 __attribute__((no_instrument_function,constructor(120)))
@@ -16,13 +16,14 @@ static void ftrace_checkargs(void)
 {
     char **avp = __argv + 1;
 
-    if ((*avp && !strcmp(*avp, "--ftrace")) || getenv("FTRACE")) {
+    ftrace = (size_t)getenv("FTRACE");
+    if ((*avp && !strcmp(*avp, "--ftrace"))) {
         while (*avp) {
             *avp = *(avp + 1);
             avp++;
         }
-        ftrace = 1;
         __argc--;
+        ftrace = 1;
     }
 }
 
@@ -41,7 +42,7 @@ void noinstrument __cyg_profile_func_enter_simple(void)
 
     for (i=0; i<count; i++)
         putchar('|');
-    printf("@%04x stack %u/%u\n", (int)calling_fn, stack_used, max_stack);
+    printf("@%04x stack %u/%u\n", (size_t)calling_fn, stack_used, max_stack);
     ++count;
 }
 


### PR DESCRIPTION
Loads symbol table into far memory which reduces requirement for additional heap to be specified in application builds desiring debugging. Next step will be optional automatic building of all ELKS applications with debug information so function tracing can be enabled using `program --ftrace <args>...`. Calling `_print_stack` will produce symbolic stack backtrace with or without symbols.

Removes requirement for `sprintf`, `ltostr`, `ultostr` functions being linked in. Uses `__far` pointers and small internal hex to string and far/near copy routines instead.

Fixes function tracing using FTRACE=1 environment variable.

Also fixes %P (display PID) in kernel `printk`.