### PR TITLE
[debug] Add nm (symbol table name lister) to distribution

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -215,5 +215,6 @@ basic/basic                     :basic              :1200k
 advent/advent                   :other
 advent/advent.db ::lib/advent.db :other
 debug/disasm                    :other
+debug/nm                        :other
 debug/system.sym ::lib/system.sym :other
 debug/testsym                   :other

--- a/elkscmd/debug/.gitignore
+++ b/elkscmd/debug/.gitignore
@@ -1,5 +1,6 @@
 *.o
 nm86
+nm
 testsym
 disasm
 hostdisasm

--- a/elkscmd/debug/Makefile
+++ b/elkscmd/debug/Makefile
@@ -10,7 +10,7 @@ include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
-PRGS = testsym disasm opcodes
+PRGS = testsym disasm nm opcodes
 INSTRUMENTOBJS = instrument.o readprologue.o syms.o
 #INSTRUMENTOBJS += rdtsc.o
 DISASMOBJS = dis.o disasm.o syms.o
@@ -37,6 +37,9 @@ testsym: $(TESTOBJS)
 	./nm86 $@ > $@.map
 
 disasm: $(DISASMOBJS)
+	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+
+nm: nm86.o syms.o
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 system.sym:

--- a/elkscmd/debug/nm86.c
+++ b/elkscmd/debug/nm86.c
@@ -4,11 +4,22 @@
 #include <errno.h>
 #include "syms.h"
 
+static char * fstrncpy(char *dst, unsigned char __far *src, int n)
+{
+    do {
+        *dst++ = *src++;
+    } while (--n);
+    *dst = '\0';
+    return dst;
+}
+
 void nm(char *path)
 {
-    unsigned char *syms = sym_read_exe_symbols(path);
-    unsigned char *p;
+    unsigned char __far *syms;
+    unsigned char __far *p;
+    static char name[64];
 
+    syms = sym_read_exe_symbols(path);
     if (!syms) {
         if (errno)
             perror(path);
@@ -16,14 +27,14 @@ void nm(char *path)
         return;
     }
     for (p = syms; p[TYPE] != '\0'; p = next(p)) {
-        printf("0x%.4x %c %.*s\n", *(unsigned short *)(p + ADDR), p[TYPE],
-            p[SYMLEN], p+SYMBOL);
+        fstrncpy(name, p+SYMBOL, p[SYMLEN]);
+        printf("0x%04x %c %s\n", *(unsigned short __far *)(p + ADDR), p[TYPE], name);
     }
 }
 
 int main(int ac, char **av)
 {
     if (ac != 2)
-        fprintf(stderr, "Usage: nm86 <a.out executable>\n");
+        fprintf(stderr, "Usage: %s <a.out executable>\n", av[0]);
     else nm(av[1]);
 }


### PR DESCRIPTION
Lists symbol table of programs. Currently, `nm`, `disasm` and `testsym` are built with symbol tables.