### PR TITLE
[cmds] Meminfo and ps updates, small fixes

### DIFF
--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -1451,7 +1451,7 @@ static int DFPROC floppy_register(void)
     current_DOR = 0x0c;
     outb(0x0c, FD_DOR);         /* all motors off, enable IRQ and DMA */
 
-    floppy_buffer = heap_alloc(BLOCK_SIZE, HEAP_TAG_BUF);
+    floppy_buffer = heap_alloc(BLOCK_SIZE, HEAP_TAG_DRVR);
     if (!floppy_buffer)
         return -ENOMEM;
     old_floppy_vec = *((__u32 __far *)FLOPPY_VEC);

--- a/elks/include/linuxmt/heap.h
+++ b/elks/include/linuxmt/heap.h
@@ -16,7 +16,7 @@
 #define HEAP_TAG_CLEAR   0x40	/* return cleared memory*/
 #define HEAP_TAG_TYPE    0x0F
 #define HEAP_TAG_SEG     0x01   /* main memory segment */
-#define HEAP_TAG_BUF     0x02   /* DF floppy or driver buffers */
+#define HEAP_TAG_DRVR    0x02   /* DF floppy or driver buffers */
 #define HEAP_TAG_TTY     0x03   /* open tty in/out queues */
 #define HEAP_TAG_TASK    0x04   /* task array */
 #define HEAP_TAG_BUFHEAD 0x05   /* buffer heads */

--- a/elkscmd/debug/Makefile
+++ b/elkscmd/debug/Makefile
@@ -55,6 +55,9 @@ disasm.o: disasm.c
 dis.o: dis.c
 	$(CC) $(CFLAGS) $(NOINSTFLAGS) -c -o $*.o $<
 
+nm86.o: nm86.c
+	$(CC) $(CFLAGS) $(NOINSTFLAGS) -c -o $*.o $<
+
 nm86: nm86.c syms.c
 	$(HOSTCC) $(HOSTCFLAGS) -D__far= -o $@ $^
 

--- a/elkscmd/lib/tiny_vfprintf.c
+++ b/elkscmd/lib/tiny_vfprintf.c
@@ -171,6 +171,7 @@ int vfprintf(FILE *op, const char *fmt, va_list ap)
 
 	 case 'l':		/* long data */
 	    lval = 1;
+	 case 'h':      /* short data */
 	    goto fmtnxt;
 
 	 case 'd':		/* Signed decimal */

--- a/elkscmd/man/man1/meminfo.1
+++ b/elkscmd/man/man1/meminfo.1
@@ -18,10 +18,13 @@ Show application memory
 Show free memory
 .TP 5
 .B -t
-Show tty memory
+Show tty and driver memory
 .TP 5
 .B -b
-Show buffer memory
+Show system buffer and pipe memory
+.TP 5
+.B -s
+Show system task, inode and file memory.
 .SH DESCRIPTION
 .B meminfo
 traverses the kernel local heap and displays a line for each in-use or free entry. 
@@ -76,7 +79,7 @@ External (main) memory segment.
 TTY
 TTY input or output buffer.
 .TP 10
-BUF
+DRVR
 Direct Floppy or other driver buffers.
 .TP 10
 BUFH

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -19,6 +19,6 @@
 #root=hda1 ro		# root hd partition 1 readonly
 #kstack
 #strace
-root=df0
+#root=df0
 #debug net=ne0
 #console=ttyS0,19200 3

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -19,6 +19,6 @@
 #root=hda1 ro		# root hd partition 1 readonly
 #kstack
 #strace
-#root=df0
+root=df0
 #debug net=ne0
 #console=ttyS0,19200 3

--- a/elkscmd/sys_utils/ps.c
+++ b/elkscmd/sys_utils/ps.c
@@ -125,10 +125,14 @@ int main(int argc, char **argv)
 	word_t cseg, dseg;
 	struct passwd * pwent;
     int f_listall = 0;
-    char *progname = argv[0];
-    int f_uptime = !strcmp(basename(progname), "uptime");
+    char *progname;
+    int f_uptime;
     struct task_struct task_table;
 
+    if ((progname = strrchr(argv[0], '/')) != NULL)
+        progname++;
+    else progname = argv[0];
+    f_uptime = !strcmp(progname, "uptime");
     while ((c = getopt(argc, argv, "lu")) != -1) {
         switch (c) {
         case 'l':       /* list all - CSEG/DSEG */


### PR DESCRIPTION
Adds `meminfo -s` to display system memory (task, inode and files). Driver memory shown as "DRVR" with `-t`. Updated man page.

Replaced `basename` function call in `ps` with smaller code, as program was reaching 1K block boundary.