### PR TITLE
[boot] Add media descriptor 0xfe and boot signature in image FD1232 for PC-98

### DIFF
--- a/bootblocks/boot_sect.S
+++ b/bootblocks/boot_sect.S
@@ -591,6 +591,11 @@ tvram_x:
 end_of_code:
 //------------------------------------------------------------------------------
 
+#if defined(CONFIG_IMG_FD1232)
+	.org SECTOR_SIZE/2-2
+	.word 0xAA55 // boot signature need to be at 0x1FE and 0x1FF
+#endif
+
 // ELKS disk parameter structure
 // For future expansion, fields should be added at the _front_ of structure
 

--- a/image/Make.defs
+++ b/image/Make.defs
@@ -43,8 +43,9 @@ MINIX_MKFSOPTS=
 # -k		only update offsets 11 through 61 in boot block, all else unchanged
 # -N 0		serial number 0
 # -v label	volume label (don't use with first format as uses two directory entries)
+# -m 0xfe   media descriptor
 ifdef CONFIG_IMG_FD1232
-FAT_MKFSOPTS = -s 8 -h 2 -t 77 -M 1024 -d 2 -L 2 -r 6 -k -N 0 -c 1
+FAT_MKFSOPTS = -s 8 -h 2 -t 77 -M 1024 -d 2 -L 2 -r 6 -k -N 0 -c 1 -m 0xfe
 else
 FAT_MKFSOPTS = -f $(TARGET_BLKS) -M 512 -d 2 -L 9 -r 14 -k -N 0 -c 1
 endif


### PR DESCRIPTION
Hello @ghaerr ,

This is the PR for adding the media descriptor 0xfe and the boot signature in image FD1232 for PC-98 as we talked in 
https://github.com/ghaerr/elks/discussions/1819

I could make MS-DOS for PC-98 readable image by adding -m option to mformat as you mentioned.

Also, I have added the boot signature to boot_sect.S.
I was misunderstanding and there were 13 Bytes left in the first 512 Bytes so I could add it without shrink.
Now the current fsck-dos works to the disk without modification.

Thank you!

