### PR TITLE
[debug] Add CONFIG_APPS_FTRACE to build all apps with function tracing

### DIFF
--- a/elkscmd/Make.defs
+++ b/elkscmd/Make.defs
@@ -70,8 +70,11 @@ HOSTCFLAGS = -O3
 
 CC=ia16-elf-gcc
 CFLBASE=-fno-inline -melks-libc -mcmodel=small -mno-segment-relocation-stuff -mtune=i8086 -Wall -Os
+ifeq ($(CONFIG_APPS_FTRACE), y)
+  CFLBASE += -fno-optimize-sibling-calls -fno-omit-frame-pointer
+  CFLBASE += -finstrument-functions-simple -maout-symtab
+endif
 #CFLBASE += -mregparmcall
-#CFLBASE += -finstrument-functions-simple
 LD=ia16-elf-gcc
 LDFLAGS=$(CFLBASE)
 CHECK=gcc -c -o .null.o -Wall -pedantic

--- a/elkscmd/debug/Makefile
+++ b/elkscmd/debug/Makefile
@@ -22,7 +22,7 @@ CFLAGS += -finstrument-functions-simple
 LDFLAGS += -maout-symtab
 
 # added after CFLAGS for non-instrumented .c files in this directory
-NOINSTFLAGS = -fno-instrument-functions -fno-instrument-functions-simple
+#NOINSTFLAGS = -fno-instrument-functions -fno-instrument-functions-simple
 
 HOSTPRGS = nm86 hostdisasm
 HOSTCFLAGS += -I.

--- a/elkscmd/file_utils/Makefile
+++ b/elkscmd/file_utils/Makefile
@@ -69,7 +69,7 @@ mv: mv.o
 	$(LD) $(LDFLAGS) -o mv mv.o $(LDLIBS)
 
 rm: rm.o $(TINYPRINTF)
-	$(LD) $(LDFLAGS) -maout-stack=12228 -o rm rm.o $(TINYPRINTF) $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-stack=12288 -o rm rm.o $(TINYPRINTF) $(LDLIBS)
 
 rmdir: rmdir.o
 	$(LD) $(LDFLAGS) -o rmdir rmdir.o $(LDLIBS)

--- a/elkscmd/lib/Makefile
+++ b/elkscmd/lib/Makefile
@@ -14,6 +14,8 @@ OBJS = \
 	tiny_vfprintf.o \
 	# END
 
+CFLAGS += -fno-instrument-functions -fno-instrument-functions-simple
+
 all: $(OBJS)
 
 clean:

--- a/elkscmd/sh_utils/Makefile
+++ b/elkscmd/sh_utils/Makefile
@@ -14,9 +14,9 @@ include $(BASEDIR)/Make.rules
 PRGS=basename clear date dirname echo false printenv pwd true which whoami \
 	yes logname tr xargs mesg stty test uname
 
-write: write.o ../sys_utils/utent.o
-
 all: $(PRGS)
+
+write: write.o ../sys_utils/utent.o
 
 basename: basename.o
 	$(LD) $(LDFLAGS) -o basename basename.o $(LDLIBS)


### PR DESCRIPTION
Setting CONFIG_APPS_FTRACE=y builds all applications with the new function profiling and symbol table support.
`nm` can be used to list any program's symbol table.

Once built, a user or programmer can easily see exactly what functions are being called with the trace output, allowing much easier understanding of program execution. 

In addition, a program's stack and max stack usage are shown, allowing for proper optional setting of the `-maout-stack=` linker option.

For instance, here `sh --ftrace` is started, showing all functions called up until the first shell prompt displayed:
<img width="752" alt="sh --ftrace" src="https://github.com/ghaerr/elks/assets/11985637/93b6014e-29b3-4f6e-b3b2-af18f042fb1b">

Currently, the option expands the program size such that only the 2880k floppy can be used to fit them all. More enhancements to selecting programs based on disk image size are coming.