### PR TITLE
[cmds] Get ttyclock working with keyboard commands

### DIFF
--- a/elkscmd/tui/curses.c
+++ b/elkscmd/tui/curses.c
@@ -74,6 +74,10 @@ void leaveok(void *win, int flag)
 
 void nodelay(void *win, int flag)
 {
+    if (flag) {
+        _tty_flags |= NoWait;
+        tty_enable_unikey();
+    }
 }
 
 void scrollok(void *win, int flag)

--- a/elkscmd/tui/curses.h
+++ b/elkscmd/tui/curses.h
@@ -87,3 +87,24 @@ typedef struct window {
 } WINDOW;
 
 typedef int chtype;
+
+/* partially implemented functions for ttyclock */
+SCREEN *newterm();
+WINDOW *newwin();
+void clear();
+void werase();
+void mvwaddch(WINDOW *w, int y, int x, int ch);
+void mvwaddstr(WINDOW *w, int y, int x, char *str);
+void mvwprintw(WINDOW *w, int y, int x, char *fmt, ...);
+void mvwin(WINDOW *w, int y, int x);
+void delscreen();
+void set_term();
+void clearok();
+void wrefresh();
+void box();
+void wborder();
+void wresize();
+void wattron(WINDOW *w, int a);
+void wattroff(WINDOW *w, int a);
+int wgetch();
+void wbkgdset();

--- a/elkscmd/tui/curses2.c
+++ b/elkscmd/tui/curses2.c
@@ -133,10 +133,9 @@ void wattroff(WINDOW *w, int a)
     attroff(a);
 }
 
-int wgetch(void)
+int wgetch()
 {
-    fflush(stdout);
-    return 0;       // FIXME
+    return getch();
 }
 
 void wbkgdset()         {}

--- a/elkscmd/tui/tty.c
+++ b/elkscmd/tui/tty.c
@@ -10,7 +10,7 @@
 
 static struct termios oldterm;
 static struct termios t;
-static int flags;
+int _tty_flags;
 int iselksconsole;
 
 #define WRITE(FD, SLIT)             write(FD, SLIT, strlen(SLIT))
@@ -31,29 +31,34 @@ void tty_restore(void)
 {
     WRITE(1, DISABLE_MOUSE_TRACKING);
     WRITE(1, RESET_VIDEO);
-    if (flags & ExitLastLine)
+    if (_tty_flags & ExitLastLine)
         WRITE(1, GOTO_LASTLINE);
     tcsetattr(1, TCSADRAIN, &oldterm);
 }
 
 void tty_enable_unikey(void)
 {
-    t.c_cc[VMIN] = 1;         /* requires ESC ESC ESC for ESC */
-    t.c_cc[VTIME] = 1;
+    if (_tty_flags & NoWait) {
+        t.c_cc[VMIN] = 0;
+        t.c_cc[VTIME] = 0;
+    } else {
+        t.c_cc[VMIN] = 1;         /* requires ESC ESC ESC for ESC */
+        t.c_cc[VTIME] = 1;
+    }
     t.c_iflag &= ~(INPCK | ISTRIP | PARMRK | INLCR | IGNCR | ICRNL | IXON |
                    IGNBRK | BRKINT);
-    if (flags & Utf8)
+    if (_tty_flags & Utf8)
         t.c_iflag |= IUTF8;         /* correct kernel backspace behaviour */
     t.c_lflag &= ~(IEXTEN | ICANON | ECHO | ECHONL | ISIG);
-    if (flags & CatchISig)
+    if (_tty_flags & CatchISig)
         t.c_lflag |= ISIG;
     t.c_cflag &= ~(CSIZE | PARENB);
     t.c_cflag |= CS8;
     tcsetattr(1, TCSADRAIN, &t);
     WRITE(1, ENABLE_SAFE_PASTE);
-    if (flags & FullMouseTracking) {
+    if (_tty_flags & FullMouseTracking) {
         WRITE(1, ENABLE_ALL_MOUSE_TRACKING);
-    } else if (flags & MouseTracking) {
+    } else if (_tty_flags & MouseTracking) {
         WRITE(1, ENABLE_MOUSE_TRACKING);
     }
 }
@@ -96,7 +101,7 @@ int tty_init(enum ttyflags f)
 {
     static int once;
 
-    flags = f;
+    _tty_flags = f;
     if (!once) {
         if (tcgetattr(1, &oldterm) != -1) {
             atexit(tty_restore);
@@ -110,7 +115,7 @@ int tty_init(enum ttyflags f)
         iselksconsole = tty_iselksconsole(1);
     }
     tty_enable_unikey();
-    if (flags & FullBuffer)
+    if (_tty_flags & FullBuffer)
         tty_fullbuffer();
     return 0;
 }

--- a/elkscmd/tui/ttyclock.c
+++ b/elkscmd/tui/ttyclock.c
@@ -279,9 +279,10 @@ draw_clock(void)
 
      if (ttyclock.option.date)
      {
+          int x = ttyclock.option.second? DATEWINX: DATEWINX - 10;
           wbkgdset(ttyclock.datewin, (COLOR_PAIR(2)));
           //mvwprintw(ttyclock.datewin, (DATEWINH / 2), 1, "%s", ttyclock.date.datestr);
-          mvwprintw(ttyclock.datewin, DATEWINY, DATEWINX, "%s", ttyclock.date.datestr);
+          mvwprintw(ttyclock.datewin, DATEWINY, x, "%s", ttyclock.date.datestr);
           wrefresh(ttyclock.datewin);
      }
 
@@ -581,7 +582,7 @@ main(int argc, char **argv)
           {
           case 'h':
           default:
-               printf("usage : tty-clock [-iuvsScbtrahDBxn] [-C [0-7]] [-f format] [-d delay] [-a nsdelay] [-T tty] \n"
+               printf("usage: ttyclock [-iuvsScbtrahDBxn] [-C [0-7]] [-f format] [-d delay] [-a nsdelay] [-T tty] \n"
                       "    -s            Show seconds                                   \n"
                       "    -S            Screensaver mode                               \n"
                       "    -x            Show box                                       \n"

--- a/elkscmd/tui/unikey.h
+++ b/elkscmd/tui/unikey.h
@@ -11,6 +11,7 @@ enum ttyflags {
     CatchISig = 4,                  /* catch SIGINT and exit by default */
     Utf8 = 8,                       /* set termios IUTF8 */
     ExitLastLine = 16,              /* on exit, cursor position to bottom */
+    NoWait = 32,                    /* don't hang in getch */
     FullBuffer                      /* fully buffered output */
 };
 
@@ -22,6 +23,7 @@ void tty_fullbuffer(void);
 void tty_linebuffer(void);
 int tty_getsize(int *cols, int *rows);
 extern int iselksconsole;
+extern int _tty_flags;
 
 /* tty-cp437.c - display cp437 characters */
 char *tty_allocate_screen(int cols, int lines);


### PR DESCRIPTION
's' and 't' now do something useful.

Cleanup compilation warnings.

TUI library now accepts NoWait flag in `tty_init` and curses `nodelay`.