### PR TITLE
[cmds] Port ttytetris to ELKS

### DIFF
--- a/elks/kernel/sys2.c
+++ b/elks/kernel/sys2.c
@@ -18,7 +18,7 @@ static void alarm_callback(int data)
 {
 	struct task_struct *p = (struct task_struct *)data;
 
-	debug("kernel ALARM pid %P for %d\n", p->pid);
+	debug("(%P)ALARM for pid %d\n", p->pid);
 	send_sig(SIGALRM, p, 1);
 }
 
@@ -37,7 +37,7 @@ unsigned int sys_alarm(unsigned int secs)
 {
 	struct timer_list *ap;
 
-	debug("sys_alarm %d\n", secs);
+	debug("(%P)sys_alarm %d\n", secs);
 	ap = find_alarm(current);
 	if (secs == 0) {
 		if (ap) {

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -171,7 +171,7 @@ tui/cons                        :tui                            :1440k
 tui/ttyinfo                     :tui                            :1440k
 tui/sl                          :tui                    :1200k
 tui/ttyclock                    :tui                    :1200k
-tui/ttytetris                   :tui                    :1200k
+tui/ttytetris                   :tui            :360k
 busyelks/busyelks               :busyelks
 inet/httpd/sample_index.html ::var/www/index.html :net  :1200k
 ktcp/ktcp                       :net                    :1200k

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -171,6 +171,7 @@ tui/cons                        :tui                            :1440k
 tui/ttyinfo                     :tui                            :1440k
 tui/sl                          :tui                    :1200k
 tui/ttyclock                    :tui                    :1200k
+tui/ttytetris                   :tui                    :1200k
 busyelks/busyelks               :busyelks
 inet/httpd/sample_index.html ::var/www/index.html :net  :1200k
 ktcp/ktcp                       :net                    :1200k

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -21,4 +21,4 @@
 #strace
 #root=df0
 #debug net=ne0
-#console=ttyS0,19200 3
+console=ttyS0,19200 3

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -21,4 +21,4 @@
 #strace
 #root=df0
 #debug net=ne0
-console=ttyS0,19200 3
+#console=ttyS0,19200 3

--- a/elkscmd/tui/Makefile
+++ b/elkscmd/tui/Makefile
@@ -37,6 +37,9 @@ sl: sl.o curses.o tty.o unikey.o
 ttyclock: ttyclock.o curses.o curses2.o tty.o unikey.o
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
+ttytetris: ttytetris.o tetris-frame.o tetris-shapes.o tetris-util.o
+	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+
 install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 

--- a/elkscmd/tui/Makefile
+++ b/elkscmd/tui/Makefile
@@ -10,7 +10,7 @@ include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
-PRGS = fm matrix cons ttyinfo sl ttyclock
+PRGS = fm matrix cons ttyinfo sl ttyclock ttytetris
 
 #PRGS_HOST =
 

--- a/elkscmd/tui/tetris-frame.c
+++ b/elkscmd/tui/tetris-frame.c
@@ -1,0 +1,125 @@
+/*
+ *      frame.c
+ *      Copyright © 2008 Martin Duquesnoy <xorg62@gmail.com>
+ *      All rights reserved.
+ *
+ *      Redistribution and use in source and binary forms, with or without
+ *      modification, are permitted provided that the following conditions are
+ *      met:
+ *
+ *      * Redistributions of source code must retain the above copyright
+ *        notice, this list of conditions and the following disclaimer.
+ *      * Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following disclaimer
+ *        in the documentation and/or other materials provided with the
+ *        distribution.
+ *      * Neither the name of the  nor the names of its
+ *        contributors may be used to endorse or promote products derived from
+ *        this software without specific prior written permission.
+ *
+ *      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *      "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *      LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *      A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *      OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *      SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *      LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *      DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *      THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "tetris.h"
+
+
+/* Shape attribute for draw it in the next box (center etc..)
+ * [0]: +x
+ * [1]: +y
+ * [2]: What shape position choose for a perfect position in the box
+ */
+const int sattr[7][3] = {{0,2}, {-1,0}, {-1,1,1}, {-1,1}, {-1,1}, {0,1}, {0,1}};
+
+void
+frame_init(void)
+{
+     int i;
+
+     /* Frame border */
+     for(i = 0; i < FRAMEW + 1; ++i)
+     {
+          frame[0][i] = Border;
+          frame[FRAMEH][i] = Border;
+     }
+     for(i = 0; i < FRAMEH; ++i)
+     {
+          frame[i][0] = Border;
+          frame[i][1] = Border;
+          frame[i][FRAMEW] = Border;
+          frame[i][FRAMEW - 1] = Border;
+     }
+
+     frame_refresh();
+
+     return;
+}
+
+void
+frame_nextbox_init(void)
+{
+     int i;
+
+     for(i = 0; i < FRAMEH_NB; ++i)
+     {
+          frame_nextbox[i][0] = Border;
+          frame_nextbox[i][1] = Border;
+          frame_nextbox[i][FRAMEW_NB - 1] = Border;
+          frame_nextbox[i][FRAMEW_NB] = Border;
+
+     }
+     for(i = 0; i < FRAMEW_NB + 1; ++i)
+          frame_nextbox[0][i] = frame_nextbox[FRAMEH_NB][i] = Border;
+
+     frame_nextbox_refresh();
+
+     return;
+}
+
+void
+frame_refresh(void)
+{
+     int i, j;
+
+     for(i = 0; i < FRAMEH + 1; ++i)
+          for(j = 0; j < FRAMEW + 1; ++j)
+                    printxy(frame[i][j], i, j, " ");
+     return;
+}
+
+void
+frame_nextbox_refresh(void)
+{
+     int i, j;
+
+     /* Clean frame_nextbox[][] */
+     for(i = 1; i < FRAMEH_NB; ++i)
+          for(j = 2; j < FRAMEW_NB - 1; ++j)
+               frame_nextbox[i][j] = 0;
+
+     /* Set the shape in the frame */
+     for(i = 0; i < 4; ++i)
+          for(j = 0; j < EXP_FACT; ++j)
+               frame_nextbox
+                    [2 + shapes[current.next][sattr[current.next][2]][i][0] + sattr[current.next][0]]
+                    [4 + shapes[current.next][sattr[current.next][2]][i][1] * EXP_FACT + j + sattr[current.next][1]]
+                    = current.next + 1;
+
+     /* Draw the frame */
+     for(i = 0; i < FRAMEH_NB + 1; ++i)
+          for(j = 0; j < FRAMEW_NB + 1; ++j)
+               printxy(frame_nextbox[i][j], i, j + FRAMEW + 3, " ");
+
+     return;
+}
+
+

--- a/elkscmd/tui/tetris-frame.c
+++ b/elkscmd/tui/tetris-frame.c
@@ -30,7 +30,7 @@
  *      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "tetris.h"
+#include "ttytetris.h"
 
 
 /* Shape attribute for draw it in the next box (center etc..)

--- a/elkscmd/tui/tetris-shapes.c
+++ b/elkscmd/tui/tetris-shapes.c
@@ -1,0 +1,213 @@
+/*
+ *      shapes.c
+ *      Copyright © 2008 Martin Duquesnoy <xorg62@gmail.com>
+ *      All rights reserved.
+ *
+ *      Redistribution and use in source and binary forms, with or without
+ *      modification, are permitted provided that the following conditions are
+ *      met:
+ *
+ *      * Redistributions of source code must retain the above copyright
+ *        notice, this list of conditions and the following disclaimer.
+ *      * Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following disclaimer
+ *        in the documentation and/or other materials provided with the
+ *        distribution.
+ *      * Neither the name of the  nor the names of its
+ *        contributors may be used to endorse or promote products derived from
+ *        this software without specific prior written permission.
+ *
+ *      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *      "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *      LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *      A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *      OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *      SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *      LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *      DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *      THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "tetris.h"
+
+/* Shapes data */
+const int shapes[7][4][4][2] =
+{
+     /* O */
+     {
+          {{0,0},{1,0},{0,1},{1,1}},
+          {{0,0},{1,0},{0,1},{1,1}},
+          {{0,0},{1,0},{0,1},{1,1}},
+          {{0,0},{1,0},{0,1},{1,1}}
+     },
+     /* I */
+     {
+          {{1,0},{1,1},{1,2},{1,3}},
+          {{0,1},{1,1},{2,1},{3,1}},
+          {{1,0},{1,1},{1,2},{1,3}},
+          {{0,1},{1,1},{2,1},{3,1}}
+     },
+     /* L */
+     {
+          {{0,1},{1,1},{2,1},{2,2}},
+          {{1,0},{1,1},{1,2},{2,0}},
+          {{0,0},{0,1},{1,1},{2,1}},
+          {{1,0},{1,1},{1,2},{0,2}}
+     },
+     /* J */
+     {
+          {{1,0},{1,1},{1,2},{2,2}},
+          {{0,2},{1,2},{2,2},{2,1}},
+          {{0,0},{1,0},{1,1},{1,2}},
+          {{0,1},{0,2},{1,1},{2,1}}
+     },
+     /* S */
+     {
+          {{1,1},{1,2},{2,0},{2,1}},
+          {{0,1},{1,1},{1,2},{2,2}},
+          {{1,1},{1,2},{2,0},{2,1}},
+          {{0,1},{1,1},{1,2},{2,2}}
+     },
+     /* Z */
+     {
+          {{0,0},{0,1},{1,1},{1,2}},
+          {{0,2},{1,1},{2,1},{1,2}},
+          {{0,0},{0,1},{1,1},{1,2}},
+          {{0,2},{1,1},{2,1},{1,2}}
+     },
+     /* T */
+     {
+          {{0,1},{1,0},{1,1},{1,2}},
+          {{0,1},{1,1},{1,2},{2,1}},
+          {{1,0},{1,1},{1,2},{2,1}},
+          {{1,0},{0,1},{1,1},{2,1}}
+     }
+};
+
+void
+shape_set(void)
+{
+     int i, j;
+
+     for(i = 0; i < 4; ++i)
+          for(j = 0; j < EXP_FACT; ++j)
+               frame[current.x + shapes[current.num][current.pos][i][0]]
+                    [current.y + shapes[current.num][current.pos][i][1] * EXP_FACT + j]
+                    = current.num + 1;
+
+     if(current.x < 1)
+          for(i = 0; i < FRAMEW + 1; ++i)
+               frame[0][i] = Border;
+
+     return;
+}
+
+void
+shape_unset(void)
+{
+     int i, j;
+
+     for(i = 0; i < 4; ++i)
+          for(j = 0; j < EXP_FACT; ++j)
+               frame[current.x + shapes[current.num][current.pos][i][0]]
+                    [current.y + shapes[current.num][current.pos][i][1] * EXP_FACT + j] = 0;
+
+     if(current.x < 1)
+          for(i = 0; i < FRAMEW + 1; ++i)
+               frame[0][i] = Border;
+     return;
+}
+
+void
+shape_new(void)
+{
+     int i;
+
+     /* Draw the previous shape for it stay there */
+     shape_set();
+     check_plain_line();
+
+     /* Set the new shape property */
+     current.num = current.next;
+     current.x = 1;
+     current.y = (FRAMEW / 2) - 1;;
+     current.next = nrand(0, 6);
+
+     frame_nextbox_refresh();
+
+     if(current.x > 1)
+          for(i = 2; i < FRAMEW - 1; ++i)
+               frame[1][i] = 0;
+
+     return;
+}
+
+void
+shape_go_down(void)
+{
+
+     shape_unset();
+
+     /* Fall the shape else; collision with the ground or another shape
+      * then stop it and create another */
+     if(!check_possible_pos(current.x + 1, current.y))
+          ++current.x;
+     else
+          if(current.x > 2)
+               shape_new();
+          else
+          {
+               shape_new();
+               frame_refresh();
+               sleep(2);
+               running = False;
+          }
+
+
+
+
+     return;
+}
+
+void
+shape_set_position(int p)
+{
+     int old = current.pos;
+
+     shape_unset();
+
+     current.pos = p ;
+
+     if(check_possible_pos(current.x, current.y))
+          current.pos = old;
+
+     return;
+}
+
+
+void
+shape_move(int n)
+{
+
+     shape_unset();
+
+     if(!check_possible_pos(current.x, current.y + n))
+          current.y += n;
+
+     return;
+}
+
+void
+shape_drop(void)
+{
+     while(!check_possible_pos(current.x + 1, current.y))
+     {
+          shape_unset();
+          ++current.x;
+     }
+     score += FRAMEH - current.x;
+
+     return;
+}

--- a/elkscmd/tui/tetris-shapes.c
+++ b/elkscmd/tui/tetris-shapes.c
@@ -30,7 +30,7 @@
  *      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "tetris.h"
+#include "ttytetris.h"
 
 /* Shapes data */
 const int shapes[7][4][4][2] =

--- a/elkscmd/tui/tetris-util.c
+++ b/elkscmd/tui/tetris-util.c
@@ -31,9 +31,7 @@
  */
 
 #include <sys/time.h>
-
-#include "tetris.h"
-#include "config.h"
+#include "ttytetris.h"
 
 void
 clear_term(void)
@@ -103,8 +101,10 @@ sig_handler(int sig)
           running = False;
           break;
      case SIGALRM:
-          tv.it_value.tv_usec -= tv.it_value.tv_usec / 3000;
-          setitimer(0, &tv, NULL);
+          //tv.it_value.tv_usec -= tv.it_value.tv_usec / 3000;
+          //setitimer(0, &tv, NULL);
+          signal(SIGALRM, sig_handler); /* ELKS requires signal() every signal */
+          alarm(1);
           break;
      }
 

--- a/elkscmd/tui/tetris-util.c
+++ b/elkscmd/tui/tetris-util.c
@@ -1,0 +1,112 @@
+/*
+ *      util.c
+ *      Copyright © 2008 Martin Duquesnoy <xorg62@gmail.com>
+ *      All rights reserved.
+ *
+ *      Redistribution and use in source and binary forms, with or without
+ *      modification, are permitted provided that the following conditions are
+ *      met:
+ *
+ *      * Redistributions of source code must retain the above copyright
+ *        notice, this list of conditions and the following disclaimer.
+ *      * Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following disclaimer
+ *        in the documentation and/or other materials provided with the
+ *        distribution.
+ *      * Neither the name of the  nor the names of its
+ *        contributors may be used to endorse or promote products derived from
+ *        this software without specific prior written permission.
+ *
+ *      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *      "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *      LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *      A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *      OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *      SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *      LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *      DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *      THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/time.h>
+
+#include "tetris.h"
+#include "config.h"
+
+void
+clear_term(void)
+{
+     puts("\e[2J");
+
+     return;
+}
+
+void
+set_cursor(Bool b)
+{
+     printf("\e[?25%c", ((b) ? 'h' : 'l'));
+
+     return;
+}
+
+void
+set_color(int color)
+{
+     int bg = 0, fg = 0;
+
+     switch(color)
+     {
+     default:
+     case Black:   bg = 0;  break;
+     case Blue:    bg = 44; break;
+     case Red:     bg = 41; break;
+     case Magenta: bg = 45; break;
+     case White:   bg = 47; break;
+     case Green:   bg = 42; break;
+     case Cyan:    bg = 46; break;
+     case Yellow:  bg = 43; break;
+     case Border:  bg = 47; break;
+     case Score:   fg = 37; bg = 49; break;
+     }
+
+     printf("\e[%d;%dm", fg, bg);
+
+     return;
+}
+
+void
+printxy(int color, int x, int y, char *str)
+{
+     set_color(color);
+     printf("\e[%d;%dH%s", ++x, ++y, str);
+     set_color(0);
+
+     return;
+}
+
+int
+nrand(int min, int max)
+{
+     return (rand() % (max - min + 1)) + min;
+}
+
+void
+sig_handler(int sig)
+{
+     switch(sig)
+     {
+     case SIGTERM:
+     case SIGINT:
+     case SIGSEGV:
+          running = False;
+          break;
+     case SIGALRM:
+          tv.it_value.tv_usec -= tv.it_value.tv_usec / 3000;
+          setitimer(0, &tv, NULL);
+          break;
+     }
+
+     return;
+}

--- a/elkscmd/tui/ttytetris.c
+++ b/elkscmd/tui/ttytetris.c
@@ -1,0 +1,196 @@
+/*
+ *      tetris.c TTY-TETRIS Main file.
+ *      Copyright © 2008 Martin Duquesnoy <xorg62@gmail.com>
+ *      All rights reserved.
+ *
+ *      Redistribution and use in source and binary forms, with or without
+ *      modification, are permitted provided that the following conditions are
+ *      met:
+ *
+ *      * Redistributions of source code must retain the above copyright
+ *        notice, this list of conditions and the following disclaimer.
+ *      * Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following disclaimer
+ *        in the documentation and/or other materials provided with the
+ *        distribution.
+ *      * Neither the name of the  nor the names of its
+ *        contributors may be used to endorse or promote products derived from
+ *        this software without specific prior written permission.
+ *
+ *      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *      "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *      LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *      A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *      OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *      SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *      LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *      DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *      THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "tetris.h"
+#include "config.h"
+
+/* Functions */
+void
+init(void)
+{
+     struct sigaction siga;
+     struct termios term;
+
+     /* Clean term */
+     clear_term();
+     set_cursor(False);
+
+     /* Make rand() really random :) */
+     srand(getpid());
+
+     /* Init variables */
+     score = lines = 0;
+     running = True;
+     current.y = (FRAMEW / 2) - 1;
+     current.num = nrand(0, 6);
+     current.next = nrand(0, 6);
+
+     /* Score */
+     printxy(0, FRAMEH_NB + 2, FRAMEW + 3, "Score:");
+     printxy(0, FRAMEH_NB + 3, FRAMEW + 3, "Lines:");
+     DRAW_SCORE();
+
+     /* Init signal */
+     sigemptyset(&siga.sa_mask);
+     siga.sa_flags = 0;
+     siga.sa_handler = sig_handler;
+     sigaction(SIGALRM, &siga, NULL);
+     sigaction(SIGTERM, &siga, NULL);
+     sigaction(SIGINT,  &siga, NULL);
+     sigaction(SIGSEGV, &siga, NULL);
+
+     /* Init timer */
+     tv.it_value.tv_usec = TIMING;
+     sig_handler(SIGALRM);
+
+     /* Init terminal (for non blocking & noecho getchar(); */
+     tcgetattr(STDIN_FILENO, &term);
+     tcgetattr(STDIN_FILENO, &back_attr);
+     term.c_lflag &= ~(ICANON|ECHO);
+     tcsetattr(0, TCSANOW, &term);
+
+     return;
+}
+
+void
+get_key_event(void)
+{
+     int c = getchar();
+
+     if(c > 0)
+          --current.x;
+
+     switch(c)
+     {
+     case KEY_MOVE_LEFT:            shape_move(-EXP_FACT);              break;
+     case KEY_MOVE_RIGHT:           shape_move(EXP_FACT);               break;
+     case KEY_CHANGE_POSITION_NEXT: shape_set_position(N_POS);          break;
+     case KEY_CHANGE_POSITION_PREV: shape_set_position(P_POS);          break;
+     case KEY_DROP_SHAPE:           shape_drop();                       break;
+     case KEY_SPEED:                ++current.x; ++score; DRAW_SCORE(); break;
+     case KEY_PAUSE:                while(getchar() != KEY_PAUSE);      break;
+     case KEY_QUIT:                 running = False;                    break;
+     }
+
+     return;
+}
+
+void
+arrange_score(int l)
+{
+     /* Standard score count */
+     switch(l)
+     {
+     case 1: score += 40;   break; /* One line */
+     case 2: score += 100;  break; /* Two lines */
+     case 3: score += 300;  break; /* Three lines */
+     case 4: score += 1200; break; /* Four lines */
+     }
+
+     lines += l;
+
+     DRAW_SCORE();
+
+     return;
+}
+
+void
+check_plain_line(void)
+{
+     int i, j, k, f, c = 0, nl = 0;
+
+     for(i = 1; i < FRAMEH; ++i)
+     {
+          for(j = 1; j < FRAMEW; ++j)
+               if(frame[i][j] == 0)
+                    ++c;
+          if(!c)
+          {
+               ++nl;
+               for(k = i - 1; k > 1; --k)
+                    for(f = 1; f < FRAMEW; ++f)
+                         frame[k + 1][f] = frame[k][f];
+          }
+          c = 0;
+     }
+     arrange_score(nl);
+     frame_refresh();
+
+     return;
+}
+
+int
+check_possible_pos(int x, int y)
+{
+     int i, j, c = 0;
+
+     for(i = 0; i < 4; ++i)
+          for(j = 0; j < EXP_FACT; ++j)
+               if(frame[x + shapes[current.num][current.pos][i][0]]
+                  [y + shapes[current.num][current.pos][i][1] * EXP_FACT + j] != 0)
+                    ++c;
+
+     return c;
+}
+
+void
+quit(void)
+{
+     frame_refresh(); /* Redraw a last time the frame */
+     set_cursor(True);
+     tcsetattr(0, TCSANOW, &back_attr);
+     printf("\nBye! Your score: %d\n", score);
+
+     return;
+}
+
+int
+main(int argc, char **argv)
+{
+     init();
+     frame_init();
+     frame_nextbox_init();;
+
+     current.last_move = False;
+
+     while(running)
+     {
+          get_key_event();
+          shape_set();
+          frame_refresh();
+          shape_go_down();
+     }
+
+     quit();
+
+     return 0;
+}

--- a/elkscmd/tui/ttytetris.h
+++ b/elkscmd/tui/ttytetris.h
@@ -38,12 +38,40 @@
 #include <termios.h>
 #include <sys/time.h>
 
+/* Configuration of tty-tetris
+ * Need to re-compile to set the change.
+ */
+
+/* Move the shape */
+#define KEY_MOVE_LEFT  'h'
+#define KEY_MOVE_RIGHT 'l'
+
+/* Change the shape position */
+#define KEY_CHANGE_POSITION_NEXT 'k'
+#define KEY_CHANGE_POSITION_PREV 'j'
+
+/* ' ' for space key */
+#define KEY_DROP_SHAPE ' '
+
+/* Other key */
+#define KEY_PAUSE 'p'
+#define KEY_QUIT  'q'
+#define KEY_SPEED 's'
+
+/* Timing in milisecond */
+#define TIMING 300000
+
 /* Expension factor of shapes */
 #define EXP_FACT 2
 
 /* Frame dimension */
+#if __ia16__
+#define FRAMEW 23
+#define FRAMEH 20
+#else
 #define FRAMEW (int)(10*2.3)
 #define FRAMEH (int)(9*2.3)
+#endif
 #define FRAMEW_NB 15
 #define FRAMEH_NB 5
 
@@ -106,7 +134,7 @@ void get_key_event(void);
 /* Variables */
 
 const int shapes[7][4][4][2];
-struct itimerval tv;
+//struct itimerval tv;
 struct termios back_attr;
 shape_t current;
 int frame[FRAMEH + 1][FRAMEW + 1];

--- a/elkscmd/tui/ttytetris.h
+++ b/elkscmd/tui/ttytetris.h
@@ -1,0 +1,118 @@
+/*
+ *      tetris.h
+ *      Copyright © 2008 Martin Duquesnoy <xorg62@gmail.com>
+ *      All rights reserved.
+ *
+ *      Redistribution and use in source and binary forms, with or without
+ *      modification, are permitted provided that the following conditions are
+ *      met:
+ *
+ *      * Redistributions of source code must retain the above copyright
+ *        notice, this list of conditions and the following disclaimer.
+ *      * Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following disclaimer
+ *        in the documentation and/or other materials provided with the
+ *        distribution.
+ *      * Neither the name of the  nor the names of its
+ *        contributors may be used to endorse or promote products derived from
+ *        this software without specific prior written permission.
+ *
+ *      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *      "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *      LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *      A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *      OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *      SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *      LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *      DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *      THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* Libs */
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <signal.h>
+#include <termios.h>
+#include <sys/time.h>
+
+/* Expension factor of shapes */
+#define EXP_FACT 2
+
+/* Frame dimension */
+#define FRAMEW (int)(10*2.3)
+#define FRAMEH (int)(9*2.3)
+#define FRAMEW_NB 15
+#define FRAMEH_NB 5
+
+/* Shapes position */
+#define N_POS ((current.pos < 3) ? current.pos + 1 : 0)
+#define P_POS ((current.pos > 0) ? current.pos - 1 : 3)
+
+/* Draw the score.. */
+#define DRAW_SCORE() set_color(Score);                             \
+     printf("\033[%d;%dH %d", FRAMEH_NB + 3, FRAMEW + 10, score);   \
+     printf("\033[%d;%dH %d", FRAMEH_NB + 4, FRAMEW + 10, lines);   \
+     set_color(0);
+
+/* Bool type */
+typedef enum { False, True } Bool;
+
+/* Shape structure */
+typedef struct
+{
+     int num;
+     int next;
+     int pos;
+     int x, y;
+     Bool last_move;
+} shape_t;
+
+/* Color enum */
+enum { Black, Blue, Red, Magenta, White, Green, Cyan, Yellow, Border, Score, ColLast };
+
+/* Prototypes */
+
+/* util.c */
+void clear_term(void);
+void set_cursor(Bool);
+void printxy(int, int, int, char*);
+void set_color(int);
+int nrand(int, int);
+void sig_handler(int);
+
+/* frame.c */
+void frame_init(void);
+void frame_nextbox_init(void);
+void frame_refresh(void);
+void frame_nextbox_refresh(void);
+
+/* shapes.c */
+void shape_set(void);
+void shape_unset(void);
+void shape_new(void);
+void shape_go_down(void);
+void shape_set_position(int);
+void shape_move(int);
+void shape_drop(void);
+
+/* tetris.c */
+void arrange_score(int l);
+void check_plain_line(void);
+int check_possible_pos(int, int);
+void get_key_event(void);
+/* Variables */
+
+const int shapes[7][4][4][2];
+struct itimerval tv;
+struct termios back_attr;
+shape_t current;
+int frame[FRAMEH + 1][FRAMEW + 1];
+int frame_nextbox[FRAMEH_NB+1][FRAMEW_NB+1];
+int score;
+int lines;
+Bool running;
+
+


### PR DESCRIPTION
This game is lots smaller than the Nano-X `nxtetris`, at just 6K bytes. It also doesn't use curses.

Currently, ELKS doesn't implement `setitimer` so timeout delay is a bit long at 1 second intervals using `alarm(1)`.

To play, use `h` and `l` to shift left/right, `j` and `k` to spin block. `s` steps one down and space drops the block.
`q` quits.

Both `ttytetris` and `ttyclock` will run on the serial console too.

Distributed on 360k image, just for @toncho11! :) There's zero bytes free.
<img width="832" alt="tty-tetris" src="https://github.com/ghaerr/elks/assets/11985637/bd8899b6-6cdf-44d7-b4c8-d38c68f7f86c">
