### PR TITLE
[kernel] Implement setitimer system call

### DIFF
--- a/elks/arch/i86/kernel/strace.h
+++ b/elks/arch/i86/kernel/strace.h
@@ -152,8 +152,8 @@ struct sc_info elks_table1[] = {
     ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),   // 67 dlload
     ENTRY("setsid",         packinfo(0, P_NONE,   P_NONE,    P_NONE   )),
     ENTRY("sbrk",           packinfo(1, P_SSHORT, P_NONE,    P_NONE   )),
-    ENTRY("ustatfs",        packinfo(2, P_USHORT, P_PDATA,   P_NONE   )),   // 70
-    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),
+    ENTRY("ustatfs",        packinfo(3, P_USHORT, P_PDATA,   P_SSHORT )),   // 70
+    ENTRY("setitimer",      packinfo(3, P_SSHORT, P_PDATA,   P_PDATA  )),
     ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),
     ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),
     ENTRY("uname",          packinfo(1, P_PDATA,  P_NONE,    P_NONE   )),   // 74

--- a/elks/arch/i86/kernel/syscall.dat
+++ b/elks/arch/i86/kernel/syscall.dat
@@ -91,6 +91,7 @@ dlload		67	2	- Removed support for dynamic libraries
 setsid		+68	0
 sbrk		+69	2	* Legacy number from Linux
 ustatfs		+70	3
+setitimer	+71	3
 uname		+74	1	. was knlvsn
 #
 # From /usr/include/asm-generic/unistd.h

--- a/elks/include/linuxmt/time.h
+++ b/elks/include/linuxmt/time.h
@@ -20,6 +20,13 @@ struct timeval {
     long tv_usec;		/* microseconds */
 };
 
+#define ITIMER_REAL     0
+
+struct  itimerval {
+    struct  timeval it_interval;/* timer interval */
+    struct  timeval it_value;   /* current value */
+};
+
 struct timezone {
     int tz_minuteswest;		/* minutes west of Greenwich */
     int tz_dsttime;		/* type of dst correction */

--- a/elks/kernel/sys2.c
+++ b/elks/kernel/sys2.c
@@ -3,6 +3,7 @@
 #include <linuxmt/kernel.h>
 #include <linuxmt/signal.h>
 #include <linuxmt/errno.h>
+#include <linuxmt/mm.h>
 #include <linuxmt/debug.h>
 #include <arch/segment.h>
 #include <arch/io.h>
@@ -33,13 +34,13 @@ static struct timer_list *find_alarm(struct task_struct *t)
 	return NULL;
 }
 
-unsigned int sys_alarm(unsigned int secs)
+static int setalarm(unsigned long jiffs)
 {
 	struct timer_list *ap;
 
 	debug("(%P)sys_alarm %d\n", secs);
 	ap = find_alarm(current);
-	if (secs == 0) {
+	if (jiffs == 0) {
 		if (ap) {
 			del_timer(ap);
 			ap->tl_data = 0;
@@ -51,10 +52,43 @@ unsigned int sys_alarm(unsigned int secs)
 			return 0;
 		}
 		del_timer(ap);
-		ap->tl_expires = jiffies + ((unsigned long)secs * HZ);
+		ap->tl_expires = jiffies + jiffs;
 		ap->tl_function = alarm_callback;
 		ap->tl_data = (int)current;	/* must delete timer on process exit*/
 		add_timer(ap);
 	}
 	return 0;
+}
+
+unsigned int sys_alarm(unsigned int secs)
+{
+    return setalarm((unsigned long)secs * HZ);
+}
+
+/* NOTE: itimer.it_interval not yet implemented */
+int sys_setitimer(int which, struct itimerval *value, struct itimerval *ovalue)
+{
+    unsigned long sec, usec, jiffs;
+    struct itimerval itv;
+
+    if (which != ITIMER_REAL)
+        return -EINVAL;
+    if (value) {
+        if (verified_memcpy_fromfs(&itv, value, sizeof(struct itimerval)))
+            return -EFAULT;
+    } else {
+        itv.it_value.tv_sec = 0;
+        itv.it_value.tv_usec = 0;
+    }
+
+    sec = itv.it_value.tv_sec;
+    usec = itv.it_value.tv_usec;
+    if (sec > (ULONG_MAX / HZ))
+        jiffs = ULONG_MAX;
+    else {
+        usec += 1000000 / HZ - 1;
+        usec /= 1000000 / HZ;
+        jiffs = HZ * sec + usec;
+    }
+    return setalarm(jiffs);
 }

--- a/elkscmd/tui/tetris-util.c
+++ b/elkscmd/tui/tetris-util.c
@@ -101,10 +101,9 @@ sig_handler(int sig)
           running = False;
           break;
      case SIGALRM:
-          //tv.it_value.tv_usec -= tv.it_value.tv_usec / 3000;
-          //setitimer(0, &tv, NULL);
           signal(SIGALRM, sig_handler); /* ELKS requires signal() every signal */
-          alarm(1);
+          tv.it_value.tv_usec -= tv.it_value.tv_usec / 3000;
+          setitimer(ITIMER_REAL, &tv, NULL);
           break;
      }
 

--- a/elkscmd/tui/ttytetris.c
+++ b/elkscmd/tui/ttytetris.c
@@ -68,7 +68,7 @@ init(void)
      sigaction(SIGSEGV, &siga, NULL);
 
      /* Init timer */
-     //tv.it_value.tv_usec = TIMING;
+     tv.it_value.tv_usec = TIMING;
      sig_handler(SIGALRM);
 
      /* Init terminal (for non blocking & noecho getchar(); */

--- a/elkscmd/tui/ttytetris.h
+++ b/elkscmd/tui/ttytetris.h
@@ -134,7 +134,7 @@ void get_key_event(void);
 /* Variables */
 
 const int shapes[7][4][4][2];
-//struct itimerval tv;
+struct itimerval tv;
 struct termios back_attr;
 shape_t current;
 int frame[FRAMEH + 1][FRAMEW + 1];

--- a/libc/include/sys/time.h
+++ b/libc/include/sys/time.h
@@ -3,7 +3,16 @@
 
 #include <time.h>
 
+#define ITIMER_REAL     0
+
+struct  itimerval {
+    struct  timeval it_interval;    /* timer interval */
+    struct  timeval it_value;       /* current value */
+};
+
 int gettimeofday (struct timeval * restrict tp, void * restrict tzp);
 int settimeofday (const struct timeval *tp, const struct timezone *tzp);
+
+int setitimer(int which, const struct itimerval *value, struct itimerval *ovalue);
 
 #endif

--- a/libc/include/unistd.h
+++ b/libc/include/unistd.h
@@ -12,10 +12,12 @@
 ssize_t read(int __fd, void * __buf, size_t __nbytes);
 ssize_t write(int __fd, const void * __buf, size_t __n);
 int     pipe(int __pipedes[2]);
-unsigned int alarm(unsigned int __seconds);
-unsigned int sleep(unsigned int __seconds);
 int     pause(void);
 char*   crypt(const char *__key, const char *__salt);
+
+unsigned int alarm(unsigned int seconds);
+unsigned int sleep(unsigned int seconds);
+int          usleep(unsigned long useconds);
 
 #ifndef SEEK_SET
 #define SEEK_SET 0
@@ -84,8 +86,6 @@ uid_t geteuid(void);
 
 char * getcwd (char * buf, size_t size);
 void sync(void);
-int usleep(unsigned long useconds);
-unsigned alarm(unsigned seconds);
 
 int getopt(int argc, char * const argv[], const char *opts);
 extern char *optarg;


### PR DESCRIPTION
Partially implements the `setitimer` system call which allows for sub-second (microsecond) interval timers. Previously only single-second resolution timers were available, through `alarm`.

This allows the recently ported #1858 `ttytetris` game to run with the timing it was designed for.