### PR TITLE
[libc] Cleanup sleep.c source

### DIFF
--- a/libc/include/unistd.h
+++ b/libc/include/unistd.h
@@ -14,7 +14,6 @@ ssize_t write(int __fd, const void * __buf, size_t __n);
 int     pipe(int __pipedes[2]);
 unsigned int alarm(unsigned int __seconds);
 unsigned int sleep(unsigned int __seconds);
-int     pause(void);
 char*   crypt(const char *__key, const char *__salt);
 
 #ifndef SEEK_SET

--- a/libc/system/sleep.c
+++ b/libc/system/sleep.c
@@ -1,53 +1,20 @@
 #ifdef L_sleep
-#include <signal.h>
-#include <unistd.h>
-#include <sys/time.h>
-#include <sys/types.h>
-
-#if 0
-/* This uses SIGALRM, it does keep the previous alarm call but will lose
- * any alarms that go off during the sleep
- */
-
-static void
-alrm(void)
-{
-}
+#include <time.h>
+#include <sys/select.h>
 
 unsigned int
 sleep(unsigned int seconds)
 {
- void (*last_alarm)();
-  unsigned int prev_sec;
-
-  prev_sec = alarm(0);
-  if(prev_sec <= seconds)
-   prev_sec = 1;
-  else
-   prev_sec -= seconds;
-
-  last_alarm = signal(SIGALRM, alrm);
-  alarm(seconds);
-  pause();
-  seconds = alarm(prev_sec);
-  signal(SIGALRM, last_alarm);
-  return seconds;
-}
-
-#else
-        /* Is this a better way ? If we have select of course :-) */
-unsigned int
-sleep(unsigned int seconds)
-{
+    time_t start, stop, elapsed;
     struct timeval timeout;
+
     timeout.tv_sec = seconds;
     timeout.tv_usec = 0;
-    time_t start = time((void*)0);
+    start = time(NULL);
     select(1, NULL, NULL, NULL, &timeout);
-    time_t stop = time((void*)0);
-    time_t elapsed = stop <= start ? 0 : stop - start;
+    stop = time(NULL);
+    elapsed = stop <= start ? 0 : stop - start;
     return elapsed > seconds ? 0 : seconds - elapsed;
 }
-#endif
 
 #endif


### PR DESCRIPTION
Also removes non-existent `pause` system call declaration.