### PR TITLE
[libc] Clean up termcap lib and some header files

### DIFF
--- a/libc/include/sys/cdefs.h
+++ b/libc/include/sys/cdefs.h
@@ -19,7 +19,7 @@
 #define __P(x) x        /* always ANSI C */
 
 /* don't require <stdnoreturn.h> */
-#if defined(__GNUC__)
+#ifdef __GNUC__
 #define noreturn        __attribute__((__noreturn__))
 #else
 #define noreturn

--- a/libc/malloc/_malloc.h
+++ b/libc/malloc/_malloc.h
@@ -1,4 +1,4 @@
-#if !defined(_MALLOC_H)
+#ifndef _MALLOC_H
 #define	_MALLOC_H
 
 typedef union mem_cell
@@ -9,24 +9,15 @@ typedef union mem_cell
 }
 mem;
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
-
-#if defined(VERBOSE)
+#ifdef VERBOSE
 void __noise(char *y, mem *x);
 #else
-#	define __noise(y,x)
-#endif
-
-#if defined(__cplusplus)
-}
+#define __noise(y,x)
 #endif
 
 #define m_deep(p)  ((p) [0].depth)	/* For alloca */
 #define m_next(p)  ((p) [1].next)	/* For malloc and alloca */
 #define m_size(p)  ((p) [0].size)	/* For malloc */
-
 
 extern mem *__freed_list;
 

--- a/libc/termcap/Makefile
+++ b/libc/termcap/Makefile
@@ -1,7 +1,6 @@
 # Makefile of /libc/termcap module
-include $(TOPDIR)/libc/Makefile.inc
 
-#EMACS	= yes
+include $(TOPDIR)/libc/Makefile.inc
 
 LIB	= out.a
 
@@ -15,16 +14,11 @@ OBJS = \
 	tgetst1.o \
 	tgetstr.o \
 	tgoto.o \
-	tp-main.o \
 	tparam.o \
 	tparam1.o \
 	tputs.o \
 	xmalloc.o \
 	xrealloc.o \
-
-ifeq "$(EMACS)" "yes"
-	CFLAGS += -Demcas
-endif
 
 #CFLAGS	+= -DDEBUG
 #CFLAGS	+= -DTIOCGWINSZ

--- a/libc/termcap/t.h
+++ b/libc/termcap/t.h
@@ -1,4 +1,4 @@
-#if !defined(_T_H)
+#ifndef _T_H
 #define	_T_H
 
 struct termcap_buffer
@@ -10,20 +10,13 @@ struct termcap_buffer
 	int	full;
 };
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
-
-const char *	termcap_find_capability (register const char *bp, register const char *cap);
+const char *termcap_find_capability (const char *bp, const char *cap);
 void termcap_memory_out(void);
 char * termcap_tgetst1(const char *ptr, char **area);
 char * termcap_xmalloc(unsigned size);
 char * termcap_xrealloc(char * ptr, unsigned size);
-char * termcap_tparam1(const char *string, char *outstring, int len, char *up, char *left, register int *argp);
-
-#if defined(__cplusplus)
-}
-#endif
+char * termcap_tparam1(const char *string, char *outstring, int len, char *up,
+    char *left, int *argp);
 
 extern	char *termcap_term_entry;
 


### PR DESCRIPTION
libc/termcap included some sample program code that included the `main` symbol entry point.

Removes some C++ header cruft and changed a few `#if defined` to `#ifdef` to match rest of libc source.