### PR TITLE
[cmds] Port ttypong to ELKS

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -171,6 +171,7 @@ tui/cons                        :tui                            :1440k
 tui/ttyinfo                     :tui                            :1440k
 tui/sl                          :tui                    :1200k
 tui/ttyclock                    :tui                    :1200k
+tui/ttypong                     :tui
 tui/ttytetris                   :tui            :360k
 busyelks/busyelks               :busyelks
 inet/httpd/sample_index.html ::var/www/index.html :net  :1200k

--- a/elkscmd/tui/.gitignore
+++ b/elkscmd/tui/.gitignore
@@ -5,3 +5,5 @@ cons
 ttyinfo
 sl
 ttyclock
+ttytetris
+ttypong

--- a/elkscmd/tui/Makefile
+++ b/elkscmd/tui/Makefile
@@ -10,7 +10,7 @@ include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
-PRGS = fm matrix cons ttyinfo sl ttyclock ttytetris
+PRGS = fm matrix cons ttyinfo sl ttyclock ttypong ttytetris
 
 #PRGS_HOST =
 
@@ -35,6 +35,9 @@ sl: sl.o curses.o tty.o unikey.o
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 ttyclock: ttyclock.o curses.o curses2.o tty.o unikey.o
+	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+
+ttypong: ttypong.o curses.o curses2.o tty.o unikey.o
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 ttytetris: ttytetris.o tetris-frame.o tetris-shapes.o tetris-util.o

--- a/elkscmd/tui/ttypong.c
+++ b/elkscmd/tui/ttypong.c
@@ -1,0 +1,222 @@
+#include "ttypong.h"
+
+void
+init_curses(void)
+{
+    int bg;
+
+    initscr();
+    noecho();
+    nodelay(stdscr, TRUE);
+    keypad(stdscr, TRUE);
+    curs_set(FALSE);
+
+    /* On check la taille du terminal */
+    if(COLS < FW || LINES < FH)
+    {
+        endwin();
+        fprintf(stderr, "Terminal too small (request %dx%d).\n", FH, FW);
+        free(pong);
+        exit(EXIT_FAILURE);
+    }
+
+    start_color();
+    bg = (use_default_colors() == OK) ? -1 : COLOR_BLACK;
+    init_pair(0, COLOR_GREEN, bg);
+    init_pair(BALL,   COLOR_WHITE, bg);
+    init_pair(WALL,   COLOR_WHITE, COLOR_WHITE);
+    init_pair(RACKET, bg, COLOR_GREEN);
+    init_pair(OUT,    bg, bg);
+
+    return;
+}
+
+/* Initialisation de la frame */
+void
+init_frame(void)
+{
+    int i, j;
+
+    for(i = 0; i <= FH; ++i)
+        for(j = 0; j <= FW; ++j)
+            pong->frame[i][j] = 0;
+
+    for(i = 0; i <= FW; ++i)
+        pong->frame[0][i] = pong->frame[FH][i] = WALL;
+
+    racket_move((FH / 2) - RACKETL / 2 - 1);
+
+    return;
+}
+
+void
+draw_frame(void)
+{
+    int i, j;
+
+    for(i = 0; i <= FH; ++i)
+        for(j = 0; j <= FW; ++j)
+        {
+            COL(pong->frame[i][j]);
+            mvaddch(i, j + GX, ((pong->frame[i][j] == BALL) ? 'O' : ' '));
+            UNCOL(pong->frame[i][j]);
+        }
+
+    return;
+}
+
+void
+key_event(void)
+{
+    int c;
+
+    switch((c = getch()))
+    {
+        case KEY_UP:
+            racket_move(pong->racket.y - 1);
+            break;
+
+        case KEY_DOWN:
+            racket_move(pong->racket.y + 1);
+            break;
+
+             /* Touche q ou Q pour quitter */
+        case 'q':
+        case 'Q':
+            pong->running = 0;
+            break;
+
+        /* Pause avec p ou P .. */
+        case 'p':
+        case 'P':
+            /* On attends tant que getch() soit pas egale à p ou P */
+            while(getch() != c);
+            break;
+    }
+
+    return;
+}
+
+/* C'est ici que l'on fait rebondir la balle */
+void
+manage_ball(void)
+{
+    if(pong->ball.x < 2
+      || pong->ball.x > FW - 2)
+        pong->ball.a = -pong->ball.a;
+    if(pong->ball.y < 2
+      || pong->ball.y > FH - 2)
+        pong->ball.b = -pong->ball.b;
+
+    /* On efface la balle à son ancienne position */
+    pong->frame[pong->ball.y][pong->ball.x] = 0;
+
+    pong->ball.x += pong->ball.a;
+    pong->ball.y += pong->ball.b;
+
+    pong->frame[pong->ball.y][pong->ball.x] = BALL;
+
+    refresh();
+
+    return;
+}
+
+/* Movement de la raquette */
+void
+racket_move(int y)
+{
+    int i, offset = y - pong->racket.y;
+
+    if(y <= 0 || y > FH - RACKETL)
+        return;
+
+    if(offset >= RACKETL
+      || offset <= -RACKETL)
+    {
+        for(i = pong->racket.y; i < pong->racket.y + RACKETL; ++i)
+            pong->frame[i][0] = 0;
+        for(i = y; i < y + RACKETL; ++i)
+            pong->frame[i][0] = RACKET;
+    }
+    else if(offset > 0)
+    {
+        for(i = pong->racket.y; i < y; ++i)
+            pong->frame[i][0] = 0;
+        for(i = pong->racket.y + RACKETL; i < y + RACKETL; ++i)
+            pong->frame[i][0] = RACKET;
+    }
+    else
+    {
+        for(i = y + RACKETL; i < pong->racket.y + RACKETL; ++i)
+            pong->frame[i][0] = 0;
+        for(i = y; i < pong->racket.y; ++i)
+            pong->frame[i][0] = RACKET;
+    }
+
+    pong->racket.y = y;
+
+    return;
+
+}
+
+/* Raquette de l'IA (enfin IA...) */
+void
+ia_racket(void)
+{
+    int i;
+
+    pong->racket.iay = pong->ball.y - (RACKETL / 2);
+
+    if(pong->ball.y < 4)
+        ++pong->racket.iay;
+    if(pong->ball.y > FH - 3)
+        --pong->racket.iay;
+
+    for(i = 1; i < FH; ++i)
+        pong->frame[i][FW] = 0;
+
+    for(i = 0; i < RACKETL; ++i)
+        pong->frame[i + pong->racket.iay][FW] = RACKET;
+
+    return;
+}
+
+int
+main(int argc, char **argv)
+{
+    int time;
+
+    pong = malloc(sizeof(Pong));
+
+    pong->running = 1;
+    pong->ball.a = 1;
+    pong->ball.b = -1;
+    pong->ball.x = 10;
+    pong->ball.y = 10;
+    pong->racket.y = 1;
+
+    init_curses();
+    init_frame();
+
+    /* Boucle principale */
+    for(time = 0; pong->running; ++time)
+    {
+        key_event();
+
+        if(time > TIMEDELAY)
+        {
+            ia_racket();
+            manage_ball();
+            time = 0;
+        }
+
+        draw_frame();
+        usleep(1000);
+    }
+
+    endwin();
+    free(pong);
+
+    return 1;
+}
+

--- a/elkscmd/tui/ttypong.c
+++ b/elkscmd/tui/ttypong.c
@@ -1,5 +1,7 @@
 #include "ttypong.h"
 
+unsigned long speed = 40000L;
+
 void
 init_curses(void)
 {
@@ -10,6 +12,7 @@ init_curses(void)
     nodelay(stdscr, TRUE);
     keypad(stdscr, TRUE);
     curs_set(FALSE);
+    clear();
 
     /* On check la taille du terminal */
     if(COLS < FW || LINES < FH)
@@ -53,15 +56,21 @@ void
 draw_frame(void)
 {
     int i, j;
+    int c, v, lastv = -1;
 
     for(i = 0; i <= FH; ++i)
         for(j = 0; j <= FW; ++j)
         {
-            COL(pong->frame[i][j]);
-            mvaddch(i, j + GX, ((pong->frame[i][j] == BALL) ? 'O' : ' '));
-            UNCOL(pong->frame[i][j]);
+            v = pong->frame[i][j];
+            if (v != lastv) {
+                COL(v);
+                lastv = v;
+            }
+            c = (v == BALL) ? 'O' : ' ';
+            if (j == 0)
+                mvaddch(i, j + GX, c);
+            else addch(c);
         }
-
     return;
 }
 
@@ -73,10 +82,12 @@ key_event(void)
     switch((c = getch()))
     {
         case KEY_UP:
+        case 'k':
             racket_move(pong->racket.y - 1);
             break;
 
         case KEY_DOWN:
+        case 'j':
             racket_move(pong->racket.y + 1);
             break;
 
@@ -186,6 +197,9 @@ main(int argc, char **argv)
 {
     int time;
 
+    if (argc > 1)
+        speed = atol(argv[1]);
+
     pong = malloc(sizeof(Pong));
 
     pong->running = 1;
@@ -203,17 +217,17 @@ main(int argc, char **argv)
     {
         key_event();
 
-        if(time > TIMEDELAY)
-        {
+        /*if(time > TIMEDELAY) {*/
             ia_racket();
             manage_ball();
             time = 0;
-        }
+        /*}*/
 
         draw_frame();
-        usleep(1000);
+        usleep(speed);
     }
 
+    move(LINES-2, 0);
     endwin();
     free(pong);
 

--- a/elkscmd/tui/ttypong.h
+++ b/elkscmd/tui/ttypong.h
@@ -1,0 +1,53 @@
+#include <stdlib.h>
+#include <unistd.h>
+#include <ncurses.h>
+
+/* Options */
+#define FH 20
+#define FW 60
+#define RACKETL 3
+#define TIMEDELAY 40
+
+/* Const */
+#define BALL   1
+#define WALL   2
+#define RACKET 3
+#define OUT    4
+
+/* Macros */
+#define GX ((COLS / 2) - (FW / 2))
+#define GY ((LINES / 2) - (FH / 2)) - 1
+#define COL(x)    attron(COLOR_PAIR(x))
+#define UNCOL(x)  attroff(COLOR_PAIR(x))
+
+/* Struct */
+typedef struct
+{
+     int running;
+     int frame[FH + 1][FW + 1];
+
+     struct
+     {
+          /* Ball position */
+          int x, y;
+
+          /* Incrementer (Oo ?) */
+          int a, b;
+     } ball;
+
+     struct
+     {
+          int y, iay;
+     } racket;
+
+} Pong;
+
+/* Prototypes */
+void init_curses(void);
+void init_frame(void);
+void key_event(void);
+void manage_ball(void);
+void racket_move(int y);
+void ia_racket(void);
+
+Pong *pong;

--- a/elkscmd/tui/ttypong.h
+++ b/elkscmd/tui/ttypong.h
@@ -1,6 +1,8 @@
+#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <ncurses.h>
+#include "unikey.h"
+#include "curses.h"
 
 /* Options */
 #define FH 20


### PR DESCRIPTION
As a final tty game before the v0.8.0 release, mostly to test the ELKS curses library (which worked for the most part for this port), `ttypong` is now running on ELKS.

The per-frame output routine had to be rewritten, much like `sl` running extremely slowly as discussed in https://github.com/ghaerr/elks/issues/1619#issuecomment-1703364279 until it was rewritten. ELKS just can't process the huge amount of ANSI escape sequences our mini version of curses spits out.

Tested only on QEMU. The default inter-frame delay is 40000 usecs, which can be changed to be half that using `ttypong 20000` for instance, to speed things up. It would be interesting to see how fast this runs on real hardware.

Unfortunately, at the moment `ttypong` is only available on the 2880k disk image, as the 1440k only has ~10k bytes left, and `ttypong` is 11k. Speaking of which, all these ncurses-based games are huge, compared to what ELKS is used to.

Here are the current sizes of the tty games and `fm`, which also uses curses:
```
-rwxr-xr-x  1 greg  staff  19904 Apr  8 17:45 ttyclock
-rwxr-xr-x  1 greg  staff  11360 Apr  8 18:08 ttypong
-rwxr-xr-x  1 greg  staff   6336 Apr  8 15:19 ttytetris
-rwxr-xr-x  1 greg  staff  21632 Apr  8 17:45 fm
```
<img width="832" alt="ttypong" src="https://github.com/ghaerr/elks/assets/11985637/685addd3-d9d0-45b4-ad03-4a851dde47c5">

Use the up/down arrow keys or `h` and `j` to move the racket, and `q` to quit.
