### PR TITLE
[build] Don't automatically build host programs

### DIFF
--- a/elkscmd/advent/.gitignore
+++ b/elkscmd/advent/.gitignore
@@ -1,1 +1,3 @@
 advent
+hostadvent
+hostadvgen

--- a/elkscmd/advent/Makefile
+++ b/elkscmd/advent/Makefile
@@ -19,10 +19,12 @@ SRCS = advent.c adventdb.c database.c english.c itverb.c lib.c saveadv.c \
 
 OBJS = $(SRCS:.c=.o)
 
-#HOSTPRGS = hostadvent hostadvgen
-#DBFILE = advent.db
+HOSTPRGS = hostadvent hostadvgen
+#HOSTPRGS += advent.db
 
-all: $(PRGS) $(HOSTPRGS) $(DBFILE)
+all: $(PRGS)
+
+host: $(HOSTPRGS)
 
 advent: $(OBJS) advent.h
 	$(LD) $(LDFLAGS) -o $@ $(OBJS) $(LDLIBS)

--- a/elkscmd/basic/Makefile
+++ b/elkscmd/basic/Makefile
@@ -16,8 +16,6 @@ PRGS = basic
 OBJS = basic.o host.o
 #MAPFILE = -Wl,-Map=basic.map
 
-#HOSTPRGS = hostbasic
-
 # uncomment following four lines for --ftrace function tracing
 #CFLAGS += -finstrument-functions-simple
 #CFLAGS += -fno-optimize-sibling-calls -fno-omit-frame-pointer
@@ -36,7 +34,12 @@ ifeq ($(CONFIG_ARCH_PC98), y)
 OBJS += host-pc98.o intC5-pc98.o
 endif
 
-all: $(PRGS) $(HOSTPRGS)
+HOSTPRGS = hostbasic
+
+all: $(PRGS)
+
+.PHONY: host
+host: $(HOSTPRGS)
 
 basic: $(OBJS) basic.h host.h
 	$(LD) $(LDFLAGS) $(MAPFILE) -o basic $(OBJS) $(LDLIBS)
@@ -44,7 +47,8 @@ basic: $(OBJS) basic.h host.h
 HOSTSRC = basic.c host.c host-stubs.c
 HOSTSRC += ../../libc/misc/ecvt.c
 HOSTSRC += ../../libc/misc/dtostr.c
-hostbasic: $(HOSTSRC) host.h basic.h
+
+hostbasic: $(HOSTSRC)
 	$(HOSTCC) $(HOSTCFLAGS) $(HOSTSRC) -o $@
 
 install: $(PRGS)

--- a/elkscmd/debug/Makefile
+++ b/elkscmd/debug/Makefile
@@ -28,11 +28,13 @@ HOSTPRGS = nm86 hostdisasm
 HOSTCFLAGS += -I. -I$(TOPDIR)/elks/include
 SYMS_C = $(TOPDIR)/libc/debug/syms.c
 
-all: $(HOSTPRGS) $(PRGS) system.sym
+all: $(PRGS) system.sym
+
+host: $(HOSTPRGS)
 
 testsym: testsym.o
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
-	./nm86 $@ > $@.map
+#	./nm86 $@ > $@.map
 
 disasm: dis.o disasm.o
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)

--- a/elkscmd/misc_utils/.gitignore
+++ b/elkscmd/misc_utils/.gitignore
@@ -1,6 +1,6 @@
 miniterm
 compress
-compress.host
+hostcompress
 ed
 float
 tar

--- a/elkscmd/misc_utils/Makefile
+++ b/elkscmd/misc_utils/Makefile
@@ -13,9 +13,11 @@ include $(BASEDIR)/Make.rules
 #TODO: fix uncompress zcat lpfilter disabled
 PRGS = tar miniterm ed od hd time kilo mined sleep tty uuencode uudecode compress
 
-#HOSTPRGS = hostcompress
+HOSTPRGS = hostcompress
 
-all: $(PRGS) $(HOSTPRGS)
+all: $(PRGS)
+
+host: $(HOSTPRGS)
 
 ed: ed.o
 	$(LD) $(LDFLAGS) -o ed ed.o $(LDLIBS)

--- a/elkscmd/romprg/Makefile
+++ b/elkscmd/romprg/Makefile
@@ -16,15 +16,17 @@ PRGS = romprg
 OBJS = main.o flash.o commands.o crc.o protocol.o serial.o
 #MAPFILE = -Wl,-Map=romprWg.map
 
-#HOSTPRGS = hostromprg
+HOSTPRGS = hostromprg
+HOSTSRC = pc-main.c protocol.c pc-serial.c pc-commands.c crc.c
 
-all: $(PRGS) $(HOSTPRGS)
+all: $(PRGS)
+
+host: $(HOSTPRGS)
 
 romprg: $(OBJS) commands.h crc.h serial.h version.h
 	$(LD) $(LDFLAGS) $(MAPFILE) -o romprg $(OBJS) $(LDLIBS)
 
-HOSTSRC = pc-main.c protocol.c pc-serial.c pc-commands.c crc.c
-hostromprg: $(HOSTSRC) pc-serial.h pc-commands.h crc.h
+hostromprg: $(HOSTSRC)
 	$(HOSTCC) $(HOSTCFLAGS) $(HOSTSRC) -o $@
 
 install: $(PRGS)

--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -46,7 +46,9 @@ HOSTPRGS = hostdecomp
 HOSTCFLAGS += -I$(TOPDIR)/elks/include
 EXODECR_C = $(TOPDIR)/elks/fs/exodecr.c
 
-all: $(PRGS) $(HOSTPRGS)
+all: $(PRGS)
+
+host: $(HOSTPRGS)
 
 init: init.o
 	$(LD) $(LDFLAGS) -maout-heap=4096 -maout-stack=1024 -o init init.o $(LDLIBS)
@@ -139,4 +141,4 @@ install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 clean:
-	rm -f *.o core $(PRGS)
+	rm -f *.o core $(PRGS) $(HOSTPRGS)


### PR DESCRIPTION
Should fix #1868. To build host programs if desired, use `make host` within appropriate elkscmd/ subdirectories.