### PR TITLE
[build] Add :1232k, :1232c, :1200k and :1200c for app selection

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -25,7 +25,10 @@
 #   :360c       Extra apps to add to 360k disks if CONFIG_APPS_COMPRESS set
 #   :720k       Set of apps to fit on 720k disks (includes :net)
 #   :1200k      Set of apps to fit on 1200 disks (almost all of 1440k)
-#   :1440k      Set of apps to fit on 1440k disks
+#   :1200c      Extra apps to add to 1200k disks if CONFIG_APPS_COMPRESS set
+#   :1232k      Set of apps to fit on PC-98 1232k disks
+#   :1232c      Extra apps to add to 1232k disks if CONFIG_APPS_COMPRESS set
+#   :1440k      Set of apps to fit on 1440k disks (and 1200k if compressed)
 #   :1440c      Extra apps to add to 1440k disks if CONFIG_APPS_COMPRESS set
 #   :ash        Ash (bash) shell                            ash
 #   :sash       Sash (standalone very small) shell          sash
@@ -174,7 +177,7 @@ tui/cons                        :tui                            :1440k
 tui/ttyinfo                     :tui                            :1440k
 tui/sl                          :tui                    :1200k
 tui/ttyclock                    :tui            :360c   :1200k
-tui/ttypong                     :tui            :360c
+tui/ttypong                     :tui            :360c           :1440k
 tui/ttytetris                   :tui            :360k
 busyelks/busyelks               :busyelks
 inet/httpd/sample_index.html ::var/www/index.html :net  :1200k

--- a/elkscmd/Make.install
+++ b/elkscmd/Make.install
@@ -141,10 +141,16 @@ endif
 
 ifdef CONFIG_APPS_1200K
 	TAGS = :boot|:360k|:net|:720k|:1200k|
+ifdef CONFIG_APPS_COMPRESS
+	TAGS += :360c|:1200c|:1440k|
+endif
 endif
 
 ifdef CONFIG_APPS_1232K
-	TAGS = :boot|:360k|:net|:720k|:1200k|
+	TAGS = :boot|:360k|:net|:720k|:1200k|:1232k|
+ifdef CONFIG_APPS_COMPRESS
+	TAGS += :360c|:1232c|:1440k|
+endif
 endif
 
 ifdef CONFIG_APPS_1440K

--- a/elkscmd/config.in
+++ b/elkscmd/config.in
@@ -77,6 +77,7 @@ mainmenu_option next_comment
 		choice 'Apps and Image Size' \
 		"All-2880k/HD	CONFIG_APPS_2880K	\
 		 Large-1440k	CONFIG_APPS_1440K	\
+		 PC98-1232k`    CONFIG_APPS_1232K	\
 		 Medium-1200k	CONFIG_APPS_1200K	\
 		 Medium-720k	CONFIG_APPS_720K	\
 		 Small-360k		CONFIG_APPS_360K" Large-1440k


### PR DESCRIPTION
As discussed in #1870, this adds application selection tags that allow compressed 1200k and PC-98 1232k disks to be built.

For 1200k and 1232k compressed images, all :1440k applications can successfully be added to the 1200/1232k image, with 61 blocks to spare. The extra :1200c tag is available to add specific applications to 1200k, and the :1232k and :1232c tags are available to add specific applications to the 1232k disk in non-compressed and compressed modes, respectively.

Also, CONFIG_APPS_1232k has been added to `make menuconfig` to allow Select Image by Application Size for PC-98.

Currently, `ttypong` and `ttytetris` remain on the 360k distribution image, but may be removed as suggested by @toncho11.