### PR TITLE
[builds] Revise Applications list for PC-98 1232k image

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -23,8 +23,8 @@
 #   :192k       Additional apps to fit on 192k rom image
 #   :360k       Minimal set of apps to fit on 360k disks
 #   :360c       Extra apps to add to 360k disks if CONFIG_APPS_COMPRESS set
-#   :720k       Set of apps to fit on 720k disks (includes :net)
-#   :1200k      Set of apps to fit on 1200 disks (includes :net)
+#   :720k       Set of apps to fit on 720k disks
+#   :1200k      Set of apps to fit on 1200k disks
 #   :1200c      Extra apps to add to 1200k disks if CONFIG_APPS_COMPRESS set
 #   :1232k      Set of apps to fit on PC-98 1232k disks
 #   :1232c      Extra apps to add to 1232k disks if CONFIG_APPS_COMPRESS set
@@ -42,7 +42,7 @@
 #   :tui        Text user interface library programs        tui
 #   :mtools     MSDOS utilities                             mtools
 #   :elvis      Elvis vi editor                             elvis
-#   :net        Networking apps                             ktcp,inet
+#   :net        Networking apps (inc. on 720k,1200k/1440k)  ktcp,inet
 #   :nanox      Nano-X graphical apps                       nano-X
 #   :other      Other apps
 #   :busyelks   Busyelks                                    busyelks

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -24,7 +24,7 @@
 #   :360k       Minimal set of apps to fit on 360k disks
 #   :360c       Extra apps to add to 360k disks if CONFIG_APPS_COMPRESS set
 #   :720k       Set of apps to fit on 720k disks (includes :net)
-#   :1200k      Set of apps to fit on 1200 disks (almost all of 1440k)
+#   :1200k      Set of apps to fit on 1200 disks (includes :net)
 #   :1200c      Extra apps to add to 1200k disks if CONFIG_APPS_COMPRESS set
 #   :1232k      Set of apps to fit on PC-98 1232k disks
 #   :1232c      Extra apps to add to 1232k disks if CONFIG_APPS_COMPRESS set
@@ -98,7 +98,7 @@ sys_utils/sercat                :sysutil                :1200k
 sys_utils/console               :sysutil                :1200k
 #sys_utils/who                  :sysutil                :1200k
 sys_utils/unreal16              :sysutil                            :1440c
-sys_utils/beep                  :sysutil                        :1440k
+sys_utils/beep                  :sysutil                :1200k
 sys_utils/decomp                :sysutil         :360c          :1440k
 screen/screen                   :screen                 :1200k
 cron/cron                       :cron                   :1200k
@@ -180,21 +180,21 @@ tui/ttyclock                    :tui            :360c   :1200k
 tui/ttypong                     :tui            :360c           :1440k
 tui/ttytetris                   :tui            :360k
 busyelks/busyelks               :busyelks
-inet/httpd/sample_index.html ::var/www/index.html :net  :1200k
-ktcp/ktcp                       :net                    :1200k
-inet/nettools/netstat           :net                    :1200k
-inet/nettools/nslookup          :net                    :1200k
-inet/nettools/arp               :net                    :1200k
-inet/telnet/telnet              :net                    :1200k
-inet/telnetd/telnetd            :net                    :1200k
-inet/httpd/httpd                :net                    :1200k
-inet/ftp/ftp                    :net                    :1200k
-inet/ftp/ftpd                   :net                    :1200k
+inet/httpd/sample_index.html ::var/www/index.html :net
+ktcp/ktcp                       :net
+inet/nettools/netstat           :net
+inet/nettools/nslookup          :net
+inet/nettools/arp               :net
+inet/telnet/telnet              :net
+inet/telnetd/telnetd            :net
+inet/httpd/httpd                :net
+inet/ftp/ftp                    :net
+inet/ftp/ftpd                   :net
+inet/urlget/urlget              :net
+inet/urlget/urlget :::ftpget    :net
+inet/urlget/urlget :::ftpput    :net
+inet/urlget/urlget :::httpget   :net
 inet/tinyirc/tinyirc            :other                          :1440c
-inet/urlget/urlget              :net                    :1200k
-inet/urlget/urlget :::ftpget    :net                    :1200k
-inet/urlget/urlget :::ftpput    :net                    :1200k
-inet/urlget/urlget :::httpget   :net                    :1200k
 bc/bc                           :other                          :1440c
 test/libc/test_libc             :test                           :1440c
 test/other/test_fd              :test
@@ -212,12 +212,12 @@ test/other/test_float           :test
 #mtools/mwrite                  :other
 #m4/m4                          :other
 #prems/pres/pres                :other
-nano-X/bin/nxclock              :other                              :1440c
+nano-X/bin/nxclock              :other                   :1232k     :1440c
 nano-X/bin/nxdemo               :other
 nano-X/bin/nxtest               :other
 nano-X/bin/nxtetris             :nanox                  :1200k
-nano-X/bin/nxlandmine           :nanox                          :1440k
-nano-X/bin/nxterm               :nanox                          :1440k
+nano-X/bin/nxlandmine           :nanox                   :1232k :1440k
+nano-X/bin/nxterm               :nanox                   :1232k :1440k
 nano-X/bin/nxworld              :nanox                          :1440k
 nano-X/bin/nxworld.map ::lib/nxworld.map :nanox                 :1440k
 basic/basic                     :basic                  :1200k

--- a/elkscmd/Make.install
+++ b/elkscmd/Make.install
@@ -136,25 +136,25 @@ endif
 endif
 
 ifdef CONFIG_APPS_720K
-	TAGS = :boot|:360k|:net|:720k|
+	TAGS = :boot|:360k|:720k|:net|
 endif
 
 ifdef CONFIG_APPS_1200K
-	TAGS = :boot|:360k|:net|:720k|:1200k|
+	TAGS = :boot|:360k|:720k|:1200k|:net|
 ifdef CONFIG_APPS_COMPRESS
 	TAGS += :360c|:1200c|:1440k|
 endif
 endif
 
 ifdef CONFIG_APPS_1232K
-	TAGS = :boot|:360k|:net|:720k|:1200k|:1232k|
+	TAGS = :boot|:360k|:720k|:1200k|:1232k|
 ifdef CONFIG_APPS_COMPRESS
 	TAGS += :360c|:1232c|:1440k|
 endif
 endif
 
 ifdef CONFIG_APPS_1440K
-	TAGS = :boot|:360k|:net|:720k|:1200k|:1440k|
+	TAGS = :boot|:360k|:720k|:1200k|:1440k|:net|
 ifdef CONFIG_APPS_COMPRESS
 	TAGS += :360c|:1440c|
 endif


### PR DESCRIPTION
Hello @tyama501,

This PR revises elkscmd/Applications to provide both a compressed and non-compressed selection by image size for PC-98 1232k floppies with your requested applications included.

The `beep`, `nxclock`, `nxlandmine`, `nxterm`, and `nxworld` applications are included on the uncompressed 1232k image, and the compressed image includes the same plus all the applications marked `:1440k` in elkscmd/Applications.

To add files to the 1232k image(s), add either `:1232k` or `:1232c` to elkscmd/Applications for the applications you'd like to add to the automatically built installation, and update pc98-1232.config with one of the configurations below. There is still some space left so feel free to add what you think would be useful.

Here are the two configuration files used for the compressed and uncompressed (-nc) build. Please take a look and see what modifications you might like, and then you're welcome to post a PR with the `pc98-1232.config` changed to whichever one you prefer. This should solve the problem of Selecting Applications by Image Size being discussed in #1870.

[config-1232.zip](https://github.com/ghaerr/elks/files/14982020/config-1232.zip)


Thank you!