### PR TITLE
[build] Free up more space on PC-98 1232k compressed image

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -80,7 +80,7 @@ file_utils/ln                   :fileutil           :720k
 file_utils/ls                   :fileutil       :360k           :128k       :nocomp
 file_utils/rm                   :fileutil       :360k
 file_utils/rmdir                :fileutil       :360k
-file_utils/split                :fileutil                :1200k
+file_utils/split                :fileutil                 :1200c    :1440k
 file_utils/sync                 :fileutil       :360k
 file_utils/touch                :fileutil           :720k
 sys_utils/chmem                 :sysutil            :720k
@@ -91,10 +91,10 @@ sys_utils/reboot                :sysutil        :360k           :128k
 sys_utils/makeboot              :sysutil        :360k
 sys_utils/man                   :sysutil                :1200k
 sys_utils/meminfo       :sash   :sysutil        :360k           :128k
-sys_utils/mouse                 :sysutil                :1200k
+sys_utils/mouse                 :sysutil                 :1200c     :1440k
 sys_utils/passwd                :sysutil                :1200k
 sys_utils/poweroff              :sysutil            :720k
-sys_utils/sercat                :sysutil                :1200k
+sys_utils/sercat                :sysutil                            :1400c
 sys_utils/console               :sysutil                :1200k
 #sys_utils/who                  :sysutil                :1200k
 sys_utils/unreal16              :sysutil                            :1440c
@@ -115,11 +115,11 @@ sh_utils/echo                   :be-shutil              :1200k
 sh_utils/stty                   :shutil                 :1200k  :192k
 sh_utils/printenv               :shutil         :360k           :128k
 sh_utils/pwd                    :shutil         :360k           :128k
-sh_utils/tr                     :shutil             :720k
+sh_utils/tr                     :shutil                  :1200c     :1440k
 #sh_utils/which                 :shutil                 :1200k
 #sh_utils/whoami                :shutil                 :1200k
-sh_utils/xargs                  :shutil                 :1200k
-sh_utils/yes                    :shutil             :720k
+sh_utils/xargs                  :shutil                  :1200c     :1440k
+sh_utils/yes                    :shutil                  :1200c     :1440k
 misc_utils/compress             :miscutil               :1200k
 misc_utils/miniterm             :miscutil           :720k
 misc_utils/tar                  :miscutil               :1200k
@@ -130,19 +130,19 @@ misc_utils/kilo                 :miscutil               :1200k
 misc_utils/mined ::bin/edit     :miscutil       :360k
 misc_utils/sleep                :miscutil               :1200k
 misc_utils/tty                  :miscutil               :1200k
-misc_utils/uuencode             :miscutil               :1200k
-misc_utils/uudecode             :miscutil               :1200k
+misc_utils/uuencode             :miscutil                :1200c     :1440k
+misc_utils/uudecode             :miscutil                :1200c     :1440k
 #misc_utils/ed                  :be-miscutil        :720k
 elvis/elvis ::bin/vi            :elvis              :720k
 minix1/banner                   :minix1                 :1200k
 #minix1/decomp16                :minix1                         :1440k
 #minix1/fgrep                   :minix1                 :1200k
 minix1/grep                     :minix1         :360k
-minix1/sum                      :minix1                 :1200k
+minix1/sum                      :minix1                  :1200c     :1440k
 minix1/uniq                     :minix1             :720k
 minix1/wc                       :minix1                 :1200k
 #minix1/proto                   :minix1                 :1200k
-minix1/cut                      :be-minix1          :720k
+minix1/cut                      :be-minix1               :1200c     :1440k
 #minix1/cksum                   :be-minix1              :1200k
 minix1/du                       :be-minix1              :1200k
 #minix2/env                     :minix2                 :1200k
@@ -155,11 +155,11 @@ minix2/synctree                 :other
 #minix2/man                     :minix2                 :1200k
 minix3/sed                      :minix3             :720k
 minix3/file                     :minix3             :720k
-minix3/head                     :minix3             :720k
+minix3/head                     :minix3                  :1200c     :1440k
 minix3/sort                     :minix3             :720k
 minix3/tail                     :minix3             :720k
-minix3/tee                      :minix3                 :1200k
-minix3/cal                      :be-minix3              :1200k
+minix3/tee                      :minix3                  :1200c     :1440k
+minix3/cal                      :be-minix3               :1200c     :1440k
 minix3/diff                     :be-minix3          :720k
 minix3/find                     :be-minix3          :720k
 minix3/mail                     :minix3                         :other  :1440c
@@ -200,14 +200,14 @@ test/libc/test_libc             :test                           :1440c
 test/other/test_fd              :test
 test/other/test_float           :test
 #nano/nano-2.0.6/src/nano       :other
-nano-X/bin/nxclock              :other                   :1232k     :1440c
+nano-X/bin/nxclock              :other                              :1440c
 nano-X/bin/nxdemo               :other
 nano-X/bin/nxtest               :other
 nano-X/bin/nxtetris             :nanox                  :1200k
 nano-X/bin/nxlandmine           :nanox                   :1232k :1440k
 nano-X/bin/nxterm               :nanox                   :1232k     :1440c
-nano-X/bin/nxworld              :nanox                          :1440k
-nano-X/bin/nxworld.map ::lib/nxworld.map :nanox                 :1440k
+nano-X/bin/nxworld              :nanox                   :1232c :1440k
+nano-X/bin/nxworld.map ::lib/nxworld.map :nanox          :1232c :1440k
 basic/basic                     :basic                  :1200k
 advent/advent                     :other                            :1440c
 advent/advent.db ::lib/advent.db  :other                            :1440c

--- a/elkscmd/Make.install
+++ b/elkscmd/Make.install
@@ -149,19 +149,21 @@ endif
 ifdef CONFIG_APPS_1232K
 	TAGS = :boot|:360k|:720k|:1200k|:1232k|
 ifdef CONFIG_APPS_COMPRESS
-	TAGS += :360c|:1232c|:1440k|
+	# does not include :1200c
+	TAGS += :360c|:1232c|
 endif
 endif
 
 ifdef CONFIG_APPS_1440K
 	TAGS = :boot|:360k|:720k|:1200k|:1440k|:net|
 ifdef CONFIG_APPS_COMPRESS
-	TAGS += :360c|:1440c|
+	# does not include :1232c
+	TAGS += :360c|:1200c|:1440c|
 endif
 endif
 
 ifdef CONFIG_APPS_2880K
-    # below TAGS relies on :ash rule following :defsash rule in Applications
+	# below TAGS relies on :ash rule following :defsash rule in Applications
 	TAGS = :*|
 	CONFIG_APP_MAN_PAGES=y
 endif


### PR DESCRIPTION
Hello @tyama501,

This PR frees up more space on the compressed 1232k image by moving tee, cal, head, tr, xargs, cut, split, sum, yes, mouse, uuencode and uudecode to the `:1200c` image, which is only created for IBM PC 1200k. The nxclock and sercat programs are moved to the `:1440c` image.

This creates a PC-98 1232k compressed image with 275k free. The above method works because now, the 1232k compressed image does not include programs specified for 1200k compressed, only 1232k compressed. It also removes the `:1440k` programs from the 1232k compressed image.

Hopefully this all makes sense, it seems complicated but basically only the `:1200c` and `:1232c` tags are handled mutually exclusively, rather than cumulatively like the others which include all smaller image tags in increasing image sizes.

If this works out, then we should probably update the `pc98-1232k.config` to specify a compressed image by default. Let me know and I will do that. After that, you can add back programs from `:1200c` if you want them.

Thank you!