### PR TITLE
[console] Use bg color and invert for PC-98 when bg is not zero

### DIFF
--- a/elks/arch/i86/drivers/char/console-direct-pc98.c
+++ b/elks/arch/i86/drivers/char/console-direct-pc98.c
@@ -117,7 +117,7 @@ static word_t conv_pcattr(word_t attr)
 
     if (fg_grb == bg_grb)
 	attr98 = fg_grb;        /* No display */
-    else if (fg_grb == 0)
+    else if (bg_grb != 0)
 	attr98 = 0x05 | bg_grb; /* Use bg color and invert */
     else
 	attr98 = 0x01 | fg_grb; /* Use fg color */


### PR DESCRIPTION
I may debug for white, but PR for the clock.
https://github.com/ghaerr/elks/discussions/1817#discussioncomment-9157071

Thank you.

