### PR TITLE
[tui] Optimize curses library for smaller executables

### DIFF
--- a/elkscmd/tui/Makefile
+++ b/elkscmd/tui/Makefile
@@ -34,7 +34,7 @@ ttyinfo: ttyinfo.o $(TUILIB)
 sl: sl.o curses.o tty.o unikey.o
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
-ttyclock: ttyclock.o curses.o curses2.o tty.o unikey.o
+ttyclock: ttyclock.o curses.o curses2.o curses3.o tty.o unikey.o
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 ttypong: ttypong.o curses.o curses2.o tty.o unikey.o

--- a/elkscmd/tui/curses.c
+++ b/elkscmd/tui/curses.c
@@ -40,48 +40,12 @@ int has_colors()
     return 1;
 }
 
-void cbreak()
-{
-}
-
-void noecho()
-{
-}
-
-void nonl()
-{
-}
-
-void intrflush(void *win, int bf)
-{
-}
-
-void keypad(void *win, int bf)
-{
-}
-
-void echo()
-{
-}
-
-void timeout(int t)
-{
-}
-
-void leaveok(void *win, int flag)
-{
-}
-
 void nodelay(void *win, int flag)
 {
     if (flag) {
         _tty_flags |= NoWait;
         tty_enable_unikey();
     }
-}
-
-void scrollok(void *win, int flag)
-{
 }
 
 void refresh()
@@ -148,59 +112,3 @@ void printw(char *fmt, ...)
     vfprintf(stdout,fmt,ptr);
     va_end(ptr);
 }
-
-/*** for ttyclock *****************************/
-
-SCREEN *newterm()
-{
-    return NULL;
-}
-
-WINDOW *newwin()
-{
-    return NULL;
-}
-
-void clear()
-{
-    erase();
-}
-
-void werase()
-{
-    erase();
-}
-
-void mvwaddch(WINDOW *w, int y, int x, int ch)
-{
-    mvaddch(y, x, ch);
-}
-
-void mvwaddstr(WINDOW *w, int y, int x, char *str)
-{
-    move(y, x);
-    printw(str);
-}
-
-void mvwprintw(WINDOW *w, int y, int x, char *fmt, ...)
-{
-    va_list ptr;
-
-    move(y, x);
-    va_start(ptr, fmt);
-    vfprintf(stdout,fmt,ptr);
-    va_end(ptr);
-}
-
-void mvwin(WINDOW *w, int y, int x)
-{
-    //yoff = y;
-    //xoff = x;
-}
-
-void delscreen()    {}
-void set_term()     {}
-void clearok()      {}
-void box()          {}
-void wborder()      {}
-void wresize()      {}

--- a/elkscmd/tui/curses.h
+++ b/elkscmd/tui/curses.h
@@ -51,16 +51,22 @@ void init_pair(int ndx, int fg, int bg);
 void *initscr();
 void endwin();
 int has_colors();
-void cbreak();
-void noecho();
-void nonl();
-void intrflush(void *, int);
-void keypad(void *, int);
-void echo();
 void erase();
+void nodelay();
+#define cbreak()
+#define noecho()
+#define echo()
+#define nonl()
+#define intrflush(w,flag)
+#define keypad(scr,flag)
+#define timeout(t)
+#define leaveok(w,f)
+#define scrollok(w,f)
+#define clear()             erase()
+#define werase(w)           erase()
+#define wgetch(w)           getch()
 
 void curs_set(int cursoron);
-void timeout(int t);
 void move(int y, int x);
 void clrnl(void);
 void clrtoeos(void);
@@ -72,9 +78,6 @@ void wgetnstr(void *, char *, int);
 void attron(int a);
 void attroff(int a);
 
-void scrollok(void *,int);
-void leaveok(void *,int);
-void nodelay(void *,int);
 void refresh();
 void mvcur(int,int,int,int);
 int mvaddch(int,int,int);
@@ -89,22 +92,19 @@ typedef struct window {
 typedef int chtype;
 
 /* partially implemented functions for ttyclock */
-SCREEN *newterm();
-WINDOW *newwin();
-void clear();
-void werase();
 void mvwaddch(WINDOW *w, int y, int x, int ch);
 void mvwaddstr(WINDOW *w, int y, int x, char *str);
 void mvwprintw(WINDOW *w, int y, int x, char *fmt, ...);
 void mvwin(WINDOW *w, int y, int x);
 void wrefresh(WINDOW *w);
-void delscreen();
-void set_term();
-void clearok();
-void box();
-void wborder();
-void wresize();
+#define newterm(type,ofd,ifd)   NULL
+#define newwin(l,c,y,x)         NULL
+#define delscreen(s)
+#define set_term(s)
+#define clearok(w,flag)
+#define box(w,y,x)
+#define wborder(w,a,b,c,d,e,f,g,h)
+#define wresize(win,h,w)
 void wattron(WINDOW *w, int a);
 void wattroff(WINDOW *w, int a);
-int wgetch();
 void wbkgdset(WINDOW *w, int a);

--- a/elkscmd/tui/curses2.c
+++ b/elkscmd/tui/curses2.c
@@ -118,33 +118,3 @@ void attroff(int a)
 {
     printf("\e[1;0;0m");
 }
-
-/*** for ttyclock *****************************/
-
-void wattron(WINDOW *w, int a)
-{
-    if (a & (A_BLINK|A_BOLD)) attroff(-1);
-    attron(a);
-}
-
-void wattroff(WINDOW *w, int a)
-{
-    if (a & (A_BLINK|A_BOLD)) attroff(-1);
-    attroff(a);
-}
-
-int wgetch()
-{
-    return getch();
-}
-
-void wbkgdset(WINDOW *w, int a)
-{
-    printf("\e[7m");
-    attron(a);
-}
-
-void wrefresh(WINDOW *w)
-{
-    printf("\e[m");
-}

--- a/elkscmd/tui/curses3.c
+++ b/elkscmd/tui/curses3.c
@@ -1,0 +1,58 @@
+/*
+ * curses library workaround - Part III
+ *
+ * routines mostly used for ttyclock port
+ */
+
+#include "curses.h"
+#include <stdio.h>
+
+void mvwaddch(WINDOW *w, int y, int x, int ch)
+{
+    mvaddch(y, x, ch);
+}
+
+void mvwaddstr(WINDOW *w, int y, int x, char *str)
+{
+    move(y, x);
+    printw(str);
+}
+
+void mvwprintw(WINDOW *w, int y, int x, char *fmt, ...)
+{
+    va_list ptr;
+
+    move(y, x);
+    va_start(ptr, fmt);
+    vfprintf(stdout,fmt,ptr);
+    va_end(ptr);
+}
+
+void mvwin(WINDOW *w, int y, int x)
+{
+    //yoff = y;
+    //xoff = x;
+}
+
+void wattron(WINDOW *w, int a)
+{
+    if (a & (A_BLINK|A_BOLD)) attroff(-1);
+    attron(a);
+}
+
+void wattroff(WINDOW *w, int a)
+{
+    if (a & (A_BLINK|A_BOLD)) attroff(-1);
+    attroff(a);
+}
+
+void wbkgdset(WINDOW *w, int a)
+{
+    printf("\e[7m");
+    attron(a);
+}
+
+void wrefresh(WINDOW *w)
+{
+    printf("\e[m");
+}

--- a/elkscmd/tui/fm.c
+++ b/elkscmd/tui/fm.c
@@ -577,8 +577,11 @@ printent(struct entry *ent, int active)
 
 	attron(attr);
 	name[NAME_COLS] = '\0';
-	printw("%s%*s %9lu  %s", active ? CURSR : EMPTY, -NAME_COLS, name, ent->size,
-        timestring(ent->t));
+	printw("%s%*s ", active ? CURSR : EMPTY, -NAME_COLS, name);
+	if (S_ISBLK(ent->mode) || S_ISCHR(ent->mode))
+		printw("%3u, %3u", ent->size >> 8, ent->size & 0xff);
+	else printw("%9lu", ent->size);
+	printw(" %s", timestring(ent->t));
 	attroff(attr);
 	clrnl();
 }
@@ -611,9 +614,10 @@ dentfill(char *path, struct entry **dents,
 		r = lstat(newpath, &sb);
 		if (r == -1)
 			fatal("lstat");
-		(*dents)[n].mode = sb.st_mode;
 		(*dents)[n].t = sb.st_mtime;
-		(*dents)[n].size = sb.st_size;
+		(*dents)[n].mode = sb.st_mode;
+		r = S_ISBLK(sb.st_mode) || S_ISCHR(sb.st_mode);
+		(*dents)[n].size = r? sb.st_rdev: sb.st_size;
 		n++;
 	}
 

--- a/elkscmd/tui/ttyclock.c
+++ b/elkscmd/tui/ttyclock.c
@@ -55,7 +55,7 @@ init(void)
 
      cbreak();
      noecho();
-     keypad(stdscr, true);
+     keypad(stdscr, TRUE);
      start_color();
      curs_set(false);
      clear();
@@ -601,7 +601,7 @@ main(int argc, char **argv)
                       "    -D            Hide date                                      \n"
                       "    -B            Enable blinking colon                          \n"
                       "    -d delay      Set the delay between two redraws of the clock. Default 1s. \n"
-                      "    -a nsdelay    Additional delay between two redraws in nanoseconds. Default 0ns.\n");
+                      "    -a nsdelay    Delay between two redraws in nanoseconds.\n");
                exit(EXIT_SUCCESS);
                break;
           case 'i':
@@ -651,8 +651,7 @@ main(int argc, char **argv)
                ttyclock.option.blink = true;
                break;
           case 'a':
-               if(atol(optarg) >= 0 && atol(optarg) < 1000000000L)
-                    ttyclock.option.nsdelay = atol(optarg);
+               ttyclock.option.nsdelay = atol(optarg);
                break;
           case 'x':
                ttyclock.option.box = true;

--- a/elkscmd/tui/ttyclock.c
+++ b/elkscmd/tui/ttyclock.c
@@ -55,7 +55,7 @@ init(void)
 
      cbreak();
      noecho();
-     keypad(stdscr, TRUE);
+     keypad(stdscr, true);
      start_color();
      curs_set(false);
      clear();


### PR DESCRIPTION
Decreases size of all curses-based TUI apps by moving ttyclock-only new routines to curses3.c. Most were just over a 1024-byte block boundary so this should help on smaller images.

Enhances `fm` to properly display device files.