### PR TITLE
[build] Remove xxd tool from build requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update -qq \
  && apt-get install -y --no-install-recommends \
   flex bison texinfo libncurses5-dev \
   bash make g++ git libelf-dev patch \
-  xxd ca-certificates wget mtools \
+  ca-certificates wget mtools \
  && rm -r /var/lib/apt/lists /var/cache/apt/archives \
  && addgroup \
     --gid $GID \

--- a/bootblocks/Makefile
+++ b/bootblocks/Makefile
@@ -51,7 +51,6 @@ mbr.bin: mbr.S
 	$(CC) $(INCLUDES) -E -o mbr.tmp mbr.S
 	$(AS) $(ASFLAGS) -o mbr.o mbr.tmp
 	$(LD) $(LDFLAGS) -M -o mbr.bin mbr.o > mbr.map
-	xxd -i mbr.bin > mbr_autogen.c
 	rm -f mbr.tmp
 
 boot_sect_fat.o: boot_sect.S boot_sect_fat.h $(TOPDIR)/include/autoconf.h
@@ -60,7 +59,7 @@ boot_sect_fat.o: boot_sect.S boot_sect_fat.h $(TOPDIR)/include/autoconf.h
 	rm -f boot_sect_fat.tmp
 
 clean:
-	rm -f *.o *.bin *.map mbr_autogen.c
+	rm -f *.o *.bin *.map
 
 # Boot blocks are not part of the target filesystem
 # but embedded in the target disk image


### PR DESCRIPTION
Removes need for external `xxd` tool from build. Discussed in #1894.