### PR TITLE
[kernel,libc] Enhance debug output in kernel and printf %p

### DIFF
--- a/elks/arch/i86/tools/build.c
+++ b/elks/arch/i86/tools/build.c
@@ -33,7 +33,6 @@
 #include <stdlib.h>			/* contains exit */
 #include <unistd.h>			/* contains read/write */
 #include <fcntl.h>
-#include <stdint.h>
 
 #include <linuxmt/config.h>
 #include <linuxmt/errno.h>

--- a/elks/arch/i86/tools/build.c
+++ b/elks/arch/i86/tools/build.c
@@ -33,6 +33,7 @@
 #include <stdlib.h>			/* contains exit */
 #include <unistd.h>			/* contains read/write */
 #include <fcntl.h>
+#include <stdint.h>
 
 #include <linuxmt/config.h>
 #include <linuxmt/errno.h>

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -140,7 +140,7 @@ int sys_execve(const char *filename, char *sptr, size_t slen)
 #endif
 
     /* Open the image */
-    debug_file("EXEC: '%t' env %d\n", filename, slen);
+    debug_file("EXEC(%P): '%t' env %d\n", filename, slen);
 
     retval = open_namei(filename, 0, 0, &inode, NULL);
 
@@ -548,6 +548,6 @@ int sys_execve(const char *filename, char *sptr, size_t slen)
   error_exec2:
 	iput(inode);
   error_exec1:
-    debug("EXEC: Returning %d\n", retval);
+    debug("EXEC(%P): return %d\n", retval);
     return retval;
 }

--- a/elks/include/linuxmt/kernel.h
+++ b/elks/include/linuxmt/kernel.h
@@ -23,6 +23,7 @@
 #define structof(p,t,m) ((t *) ((char *) (p) - offsetof (t,m)))
 
 extern char running_qemu;
+extern dev_t dev_console;
 
 extern void do_exit(int) noreturn;
 

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -145,9 +145,12 @@ void INITPROC kernel_init(void)
     if (buffer_init())	/* also enables xms and unreal mode if configured and possible*/
         panic("No buf mem");
 
+#ifdef CONFIG_ARCH_IBMPC
     outw(0, 0x510);
     if (inb(0x511) == 'Q' && inb(0x511) == 'E')
         running_qemu = 1;
+#endif
+
     device_init();
 
 #ifdef CONFIG_SOCKET

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -80,6 +80,7 @@ pid_t do_fork(int virtual)
 
     if ((t = find_empty_process()) == NULL)
         return -EAGAIN;
+    debug_wait("FORK(%P): -> %d\n", t->pid);
 
     /* Fix up what's different */
 

--- a/libc/stdio/vfprintf.c
+++ b/libc/stdio/vfprintf.c
@@ -204,7 +204,7 @@ vfprintf(FILE *op, const char *fmt, va_list ap)
 	 case 'p':		/* Pointer */
 	    lval = (sizeof(char*) == sizeof(long));
 	    pad = '0';
-	    width = 6;
+	    width = 4;
 	    preci = 8;
 	    /* fall thru */
 


### PR DESCRIPTION
Display PID during exec/fork tracing.

`printf` using %p displays 4 hex digits by default (instead of 6).

Don't kernel check for QEMU running on non-IBM PC architectures.