### PR TITLE
[kernel,cmds] Add sysctl system call and option get/set command

### DIFF
--- a/elks/arch/i86/kernel/strace.h
+++ b/elks/arch/i86/kernel/strace.h
@@ -154,7 +154,7 @@ struct sc_info elks_table1[] = {
     ENTRY("sbrk",           packinfo(1, P_SSHORT, P_NONE,    P_NONE   )),
     ENTRY("ustatfs",        packinfo(3, P_USHORT, P_PDATA,   P_SSHORT )),   // 70
     ENTRY("setitimer",      packinfo(3, P_SSHORT, P_PDATA,   P_PDATA  )),
-    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),
+    ENTRY("sysctl",         packinfo(3, P_PSTR,   P_SSHORT,  P_SSHORT )),
     ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),
     ENTRY("uname",          packinfo(1, P_PDATA,  P_NONE,    P_NONE   )),   // 74
 };

--- a/elks/arch/i86/kernel/strace.h
+++ b/elks/arch/i86/kernel/strace.h
@@ -154,7 +154,7 @@ struct sc_info elks_table1[] = {
     ENTRY("sbrk",           packinfo(1, P_SSHORT, P_NONE,    P_NONE   )),
     ENTRY("ustatfs",        packinfo(3, P_USHORT, P_PDATA,   P_SSHORT )),   // 70
     ENTRY("setitimer",      packinfo(3, P_SSHORT, P_PDATA,   P_PDATA  )),
-    ENTRY("sysctl",         packinfo(3, P_PSTR,   P_SSHORT,  P_SSHORT )),
+    ENTRY("sysctl",         packinfo(3, P_SSHORT, P_STR,     P_SSHORT )),
     ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),
     ENTRY("uname",          packinfo(1, P_PDATA,  P_NONE,    P_NONE   )),   // 74
 };

--- a/elks/arch/i86/kernel/syscall.dat
+++ b/elks/arch/i86/kernel/syscall.dat
@@ -92,6 +92,7 @@ setsid		+68	0
 sbrk		+69	2	* Legacy number from Linux
 ustatfs		+70	3
 setitimer	+71	3
+sysctl		+72	3	. ELKS
 uname		+74	1	. was knlvsn
 #
 # From /usr/include/asm-generic/unistd.h

--- a/elks/include/linuxmt/kernel.h
+++ b/elks/include/linuxmt/kernel.h
@@ -24,6 +24,7 @@
 
 extern char running_qemu;
 extern dev_t dev_console;
+extern int dprintk_on;
 
 extern void do_exit(int) noreturn;
 

--- a/elks/include/linuxmt/sysctl.h
+++ b/elks/include/linuxmt/sysctl.h
@@ -1,0 +1,12 @@
+#ifndef __LINUXMT_SYSCTL_H
+#define __LINUXMT_SYSCTL_H
+
+/* sysctl(2) parameters */
+
+#define CTL_MAXNAMESZ   32      /* max size of option name */
+
+#define CTL_LIST        0       /* get option list from index */
+#define CTL_GET         (-1)    /* get option value by name */
+#define CTL_SET         (-2)    /* set option value by name */
+
+#endif

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -73,7 +73,6 @@ static char *envp_init[MAX_INIT_ENVS+1];
 static unsigned char options[OPTSEGSZ];
 
 extern int boot_rootdev;
-extern int dprintk_on;
 static char * INITPROC root_dev_name(int dev);
 static int INITPROC parse_options(void);
 static void INITPROC finalize_options(void);

--- a/elks/kernel/Makefile
+++ b/elks/kernel/Makefile
@@ -37,7 +37,7 @@ include $(BASEDIR)/Makefile-rules
 
 # unused: wait.o lock.o
 OBJS  = sched.o printk.o sleepwake.o version.o sys.o sys2.o fork.o \
-	exit.o time.o signal.o
+	exit.o time.o signal.o sysctl.o
 
 #########################################################################
 # Commands:

--- a/elks/kernel/sysctl.c
+++ b/elks/kernel/sysctl.c
@@ -3,20 +3,26 @@
 #include <linuxmt/string.h>
 #include <linuxmt/sysctl.h>
 
-static char ctlname[CTL_MAXNAMESZ];
+#include <linuxmt/trace.h>
+#include <linuxmt/kernel.h>
 
 struct sysctl {
     const char *name;
     int *value;
 };
 
-int debug_malloc = 1;
-int debug_tcp = 200;
+static int malloc_debug;
+static int net_debug;
 
 struct sysctl sysctl[] = {
-    { "debug.malloc",       &debug_malloc,  },
-    { "debug.tcp",          &debug_tcp,     },
+    { "kern.debug",         &dprintk_on         },  /* debug (^P) on/off */
+    { "kern.strace",        &tracing            },  /* strace=1, kstack=2 */
+    { "kern.console",       (int *)&dev_console },  /* console */
+    { "malloc.debug",       &malloc_debug       },
+    { "net.debug",          &net_debug          },
 };
+
+static char ctlname[CTL_MAXNAMESZ];
 
 #define ARRAYLEN(a)     (sizeof(a)/sizeof(a[0]))
 

--- a/elks/kernel/sysctl.c
+++ b/elks/kernel/sysctl.c
@@ -1,0 +1,50 @@
+#include <linuxmt/mm.h>
+#include <linuxmt/errno.h>
+#include <linuxmt/string.h>
+
+#define MAXCTLNAME      32
+static char ctlname[MAXCTLNAME];
+
+struct sysctl {
+    const char *name;
+    int *value;
+};
+
+int debug_malloc = 1;
+int debug_tcp = 200;
+
+struct sysctl sysctl[] = {
+    { "debug.malloc",       &debug_malloc,  },
+    { "debug.tcp",          &debug_tcp,     },
+};
+
+#define ARRAYLEN(a)     (sizeof(a)/sizeof(a[0]))
+
+int sys_sysctl(int *name, int *oldval, int *newval)
+{
+    int error, n;
+    struct sysctl *sc;
+
+    n = strlen_fromfs(name, MAXCTLNAME) + 1;
+    if (n >= MAXCTLNAME) return -EFAULT;
+    error = verified_memcpy_fromfs(ctlname, name, n);
+    if (error) return error;
+
+    for (sc = sysctl;; sc++) {
+        if (sc >= &sysctl[ARRAYLEN(sysctl)]) return -ENOTDIR;
+        if (!strcmp(sc->name, ctlname))
+            break;
+    }
+
+    if (oldval) {
+            error = verify_area(VERIFY_WRITE, oldval, sizeof(int));
+            if (error) return error;
+            put_user(*sc->value, oldval);
+    }
+    if (newval) {
+            error = verify_area(VERIFY_READ, newval, sizeof(int));
+            if (error) return error;
+            *sc->value = get_user(newval);
+    }
+    return 0;
+}

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -100,6 +100,7 @@ sys_utils/console               :sysutil                :1200k
 sys_utils/unreal16              :sysutil                            :1440c
 sys_utils/beep                  :sysutil                :1200k
 sys_utils/decomp                :sysutil         :360c          :1440k
+sys_utils/sysctl                :sysutil                :1200k
 screen/screen                   :screen                 :1200k
 cron/cron                       :cron                   :1200k
 cron/crontab                    :cron                   :1200k

--- a/elkscmd/sys_utils/.gitignore
+++ b/elkscmd/sys_utils/.gitignore
@@ -22,6 +22,7 @@ ps
 reboot
 sercat
 shutdown
+sysctl
 umount
 unreal16
 who

--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -40,6 +40,7 @@ PRGS = \
 	console \
 	makeboot \
 	decomp \
+	sysctl \
 	# EOL
 
 HOSTPRGS = hostdecomp
@@ -124,6 +125,9 @@ unreal.o: $(ELKS_LIB)/unreal.S
 
 beep: beep.o
 	$(LD) $(LDFLAGS) -o beep beep.o $(LDLIBS)
+
+sysctl: sysctl.o
+	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 unreal16: unreal16.o unreal.o
 	$(LD) -melks-libc -mcmodel=small -c unreal16.S -o unreal16.o

--- a/elkscmd/sys_utils/sysctl.c
+++ b/elkscmd/sys_utils/sysctl.c
@@ -90,7 +90,7 @@ int main(int ac, char **av)
             val = strtoi(p+1);
             ret = sysctl(CTL_SET, av[i], &val);
             if (ret) {
-                msg(STDOUT_FILENO, "Failed to set option: ", av[i], "\n", 0);
+                msg(STDOUT_FILENO, "Unknown option: ", av[i], "\n", 0);
                 continue;
             }
         }

--- a/elkscmd/sys_utils/sysctl.c
+++ b/elkscmd/sys_utils/sysctl.c
@@ -1,0 +1,56 @@
+/*
+ * sysctl - system control utility for ELKS
+ *
+ * 8 May 2024 Greg Haerr
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdarg.h>
+#include <sys/sysctl.h>
+
+#define errmsg(str) write(STDERR_FILENO, str, sizeof(str) - 1)
+
+void msg(int fd, const char *s, ...)
+{
+    va_list va;
+
+    va_start(va, s);
+    do {
+        write(fd, s, strlen(s));
+        s = va_arg(va, const char *);
+    } while (s);
+    va_end(va);
+}
+
+int main(int ac, char **av)
+{
+    int i, ret, old, new;
+
+    if (ac < 2) {
+        errmsg("usage: sysctl name[=value]\n");
+        exit(-1);
+    }
+
+    for (i = 1; i < ac; i++) {
+        char *p = strchr(av[i], '=');
+        if (p) {
+            *p = '\0';
+            new = atoi(p+1);
+            ret = sysctl(av[i], 0, &new);
+            if (ret) {
+                msg(STDOUT_FILENO, "Failed to set option: ", av[i], "\n", 0);
+                continue;
+            }
+        }
+        ret = sysctl(av[i], &old, 0);
+        if (ret)
+            msg(STDERR_FILENO, "Invalid option: ", av[i], "\n", 0);
+        else {
+            msg(STDOUT_FILENO, av[i], "=", itoa(old), "\n", 0);
+        }
+    }
+    return ret;
+}

--- a/libc/include/sys/sysctl.h
+++ b/libc/include/sys/sysctl.h
@@ -1,6 +1,9 @@
 #ifndef __SYS_SYSCTL_H
 #define __SYS_SYSCTL_H
 
-int sysctl(const char *name, int *oldval, int *newval);
+#include <features.h>
+#include __SYSINC__(sysctl.h)
+
+int sysctl(int op, char *name, int *value);
 
 #endif

--- a/libc/include/sys/sysctl.h
+++ b/libc/include/sys/sysctl.h
@@ -1,0 +1,6 @@
+#ifndef __SYS_SYSCTL_H
+#define __SYS_SYSCTL_H
+
+int sysctl(const char *name, int *oldval, int *newval);
+
+#endif


### PR DESCRIPTION
Adds new lightweight `sysctl(int op, char *name, int *value)` system call and 
`sysctl [-a] [option_name[=value]]` utility. `syscall -a` lists all available options and their values.

These enhancements are for some upcoming functionality that allows for turning on and off various options at runtime, such as malloc debugging information, TCP/IP options, etc. The combination allows for both querying a human-readable option "name" value and and its associated (currently numeric only) value. The `sysctl` command is also scriptable, for easy test integration. The combination allows for application programs to query and set information, which previously required special techniques. 

The planned usage might be something like `sysctl malloc.debug=1` to turn on level 1 `malloc` debug output, for instance, or communicating with a running `ktcp` by using `sysctl net.debug=3`, etc. The option names are just string values defined in the kernel and associated with an `int` variable.

The current list of options are:
```
# sysctl -a
kern.debug=1       # ^P kernel debug messages on/off
kern.strace=0      # kernel strace=1, kstack=2 with CONFIG_TRACE=y
kern.console=1024  # console device (e.g. 0x440 for /dev/ttyS0)
malloc.debug=0     # not yet implemented
net.debug=0        # not yet implemented
```

Ideas for future options are welcomed.