### PR TITLE
[docs] Add fmemalloc man pages for section 2 and 3

### DIFF
--- a/Documentation/text/parameter-passing.txt
+++ b/Documentation/text/parameter-passing.txt
@@ -1,5 +1,6 @@
 ELKS system calls requires registers set in order of parameters:
     BX, CX, DX, DI, SI
+AX is set to the systen call number defined in elks/arch/i86/kernel/syscall.dat
 
 
 Cdecl calling convention, stack has parms, passed in this order in registers:

--- a/elkscmd/Make.install
+++ b/elkscmd/Make.install
@@ -235,6 +235,9 @@ ifdef CONFIG_APP_MAN_PAGES
 	mkdir -p $(DESTDIR)/lib/man2
 	cp -rp man/man2 $(DESTDIR)/lib
 	-compress -b 12 $(DESTDIR)/lib/man2/*
+	mkdir -p $(DESTDIR)/lib/man3
+	cp -rp man/man3 $(DESTDIR)/lib
+	-compress -b 12 $(DESTDIR)/lib/man3/*
 	mkdir -p $(DESTDIR)/lib/man4
 	cp -rp man/man4 $(DESTDIR)/lib
 	-compress -b 12 $(DESTDIR)/lib/man4/*

--- a/elkscmd/man/man2/fmemalloc.2
+++ b/elkscmd/man/man2/fmemalloc.2
@@ -1,0 +1,33 @@
+.TH FMEMALLOC 2
+.SH NAME
+_fmemalloc \- allocate far memory outside process
+.SH SYNOPSIS
+.nf
+.ft B
+_fmemalloc(int \fIparas\fP, unsigned short \fIpseg\fP)
+.ft R
+.fi
+.SH DESCRIPTION
+.PP
+.B _fmemalloc 
+allocates 
+.IR paras
+paragraphs of main memory
+from outside the process for use using a __far pointer within the application.
+The segment address of the memory is stored in the pointer
+.IR pseg .
+.SH "RETURN VALUE
+The value 0 is returned if no error occurs.  Otherwise,
+the call returns a negative error number.
+.SH ERRORS
+.I _fmemalloc
+will fail if one of the following occur:
+.TP 15
+[EFFAULT]
+.I pseg
+points outside the process's allocated address space.
+.TP 15
+[NOMEM]
+The requested amount of memory is not available.
+.SH "SEE ALSO"
+.BR fmemalloc (3).

--- a/elkscmd/man/man3/fmemalloc.3
+++ b/elkscmd/man/man3/fmemalloc.3
@@ -1,0 +1,28 @@
+.TH FMEMALLOC 3
+.SH NAME
+fmemalloc \- allocate far memory outside process
+.SH SYNOPSIS
+.nf
+.ft B
+#include <stdlib.h>
+
+void __far *fmemalloc(unsigned long \fIsize\fP)
+.ft R
+.fi
+.SH DESCRIPTION
+.PP
+.B fmemalloc
+allocates 
+.IR size
+bytes of main memory from outside the process for use using a __far pointer
+within the application.
+The
+.IR size
+parameter will be rounded up to the next paragraph boundary.
+
+Any allocated memory will be automatically freed on exit from the application.
+.SH "RETURN VALUE
+The value 0 is returned if no error occurs.  Otherwise,
+the call returns a __far pointer to the memory allocated.
+.SH "SEE ALSO"
+.BR fmemalloc (2).


### PR DESCRIPTION
Some documentation of the items discussed in https://github.com/ghaerr/elks/issues/871#issuecomment-2123293775.

@Vutshi: The ELKS man pages for system calls can be viewed outside of ELKS by running `eman`. So `eman fmemalloc` and `eman 3 fmemalloc` will allow you to see the documentation for the actual system _fmemalloc system call as well as the C wrapper.

The parameter-passing documentation for system calls is also updated.

<img width="752" alt="fmemalloc 2" src="https://github.com/ghaerr/elks/assets/11985637/f6e3f893-cb17-4c3e-943b-e312a547dd2e">
<img width="752" alt="fmemalloc 3" src="https://github.com/ghaerr/elks/assets/11985637/e250adab-2ab2-47eb-a2c3-bdd776b42f83">

