### PR TITLE
[libc] First pass at compiling most all of C library with OpenWatcom

### DIFF
--- a/elks/include/arch/cdefs.h
+++ b/elks/include/arch/cdefs.h
@@ -26,6 +26,7 @@
 #define restrict        __restrict
 #define printfesque(n)
 #define noinstrument
+#define __attribute__(n)
 /* force __cdecl calling convention and no register saves in main() arc/argv */
 #pragma aux main "*" modify [ bx cx dx si di ]
 #endif

--- a/libc/.gitignore
+++ b/libc/.gitignore
@@ -1,3 +1,5 @@
 crt0.o
 libc.a
 build-ml/
+*.obj
+*.lib

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -239,4 +239,4 @@ endif
 clean:
 	for DIR in $(SUBDIRS); do $(MAKE) -C $$DIR clean || exit 1; done
 	rm -rf build-ml *.o libc.a
-	$(MAKE) -f Watcom clean
+	$(MAKE) -f watcom.mk clean

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,4 +1,4 @@
-# Makefile of ELKS C Library
+# ia16-elf-gcc Makefile for ELKS C Library
 
 ifndef TOPDIR
 $(error TOPDIR is not defined)
@@ -6,7 +6,7 @@ endif
 
 include $(TOPDIR)/Make.defs
 
-include Makefile.inc
+include ia16.inc
 
 # Defines
 
@@ -239,3 +239,4 @@ endif
 clean:
 	for DIR in $(SUBDIRS); do $(MAKE) -C $$DIR clean || exit 1; done
 	rm -rf build-ml *.o libc.a
+	$(MAKE) -f Watcom clean

--- a/libc/Watcom
+++ b/libc/Watcom
@@ -1,0 +1,36 @@
+# OpenWatcom Makefile for ELKS C Library 
+
+include watcom.inc
+
+# \
+	asm	    \
+	gcc	    \
+	math	\
+	crt0.S	\
+
+SUBDIRS =	\
+	ctype	\
+	error	\
+	getent	\
+	malloc	\
+	misc	\
+	net	    \
+	regex	\
+	stdio	\
+	string	\
+	termcap	\
+	termios	\
+	time	\
+	# end of list
+
+.PHONY: all
+all:
+	$(MAKE) -C system -f out.mk COMPILER=watcom LIB=out.lib
+	for DIR in $(SUBDIRS); do $(MAKE) -C $$DIR COMPILER=watcom LIB=out.lib || exit 1; done
+	wlib -n -b -fo libc.lib */*.lib
+
+.PHONY: clean
+clean:
+	rm -f system/*.obj system/*.lib
+	for DIR in $(SUBDIRS); do rm -f $$DIR/*.obj $$DIR/*.lib || exit 1; done
+	rm -f libc.lib

--- a/libc/asm/Makefile
+++ b/libc/asm/Makefile
@@ -1,6 +1,9 @@
 # Makefile of /libc/asm module
 
-include $(TOPDIR)/libc/Makefile.inc
+COMPILER ?= ia16
+LIB ?= out.a
+
+include $(TOPDIR)/libc/$(COMPILER).inc
 
 SRCS = \
     memcpy-s.S \
@@ -16,11 +19,11 @@ LEFTOUT = \
 
 OBJS = $(SRCS:.S=.o)
 
-all: out.a
+all: $(LIB)
 
-out.a: $(OBJS)
+$(LIB): $(LIBOBJS)
 	$(RM) $@
-	$(AR) $(ARFLAGS_SUB) $@ $^
+	$(AR) $(ARFLAGS_SUB) $@ $(LIBOBJS)
 
 clean:
 	$(RM) *.[aod]

--- a/libc/ctype/Makefile
+++ b/libc/ctype/Makefile
@@ -1,8 +1,9 @@
 # Makefile of /libc/ctype module
 
-include $(TOPDIR)/libc/Makefile.inc
+COMPILER ?= ia16
+LIB ?= out.a
 
-LIB = out.a
+include $(TOPDIR)/libc/$(COMPILER).inc
 
 OBJS = \
 	ctype.o \
@@ -23,9 +24,9 @@ OBJS = \
 
 all: $(LIB)
 
-$(LIB): $(OBJS)
+$(LIB): $(LIBOBJS)
 	$(RM) $@
-	$(AR) $(ARFLAGS_SUB) $@ $^
+	$(AR) $(ARFLAGS_SUB) $@ $(LIBOBJS)
 
 clean:
 	$(RM) *.[aod]

--- a/libc/debug/Makefile
+++ b/libc/debug/Makefile
@@ -1,8 +1,9 @@
 # Makefile of /libc/debug module
 
-include $(TOPDIR)/libc/Makefile.inc
+COMPILER ?= ia16
+LIB ?= out.a
 
-LIB = out.a
+include $(TOPDIR)/libc/$(COMPILER).inc
 
 OBJS = \
 	instrument.o \
@@ -16,9 +17,9 @@ OBJS = \
 
 all: $(LIB)
 
-$(LIB): $(OBJS)
+$(LIB): $(LIBOBJS)
 	$(RM) $@
-	$(AR) $(ARFLAGS_SUB) $@ $^
+	$(AR) $(ARFLAGS_SUB) $@ $(LIBOBJS)
 
 clean:
 	$(RM) *.[aod]

--- a/libc/error/Makefile
+++ b/libc/error/Makefile
@@ -1,8 +1,11 @@
 # Makefile of /libc/error module
 
-include $(TOPDIR)/libc/Makefile.inc
+COMPILER ?= watcom
+LIB ?= out.lib
+#COMPILER ?= ia16
+#LIB ?= out.a
 
-LIB = out.a
+include $(TOPDIR)/libc/$(COMPILER).inc
 
 OBJS= \
     __assert.o \
@@ -12,9 +15,9 @@ OBJS= \
 
 all: $(LIB)
 
-$(LIB): $(OBJS)
+$(LIB): $(LIBOBJS)
 	$(RM) $@
-	$(AR) $(ARFLAGS_SUB) $@ $^
+	$(AR) $(ARFLAGS_SUB) $@ $(LIBOBJS)
 
 clean:
 	$(RM) *.[aod]

--- a/libc/error/Makefile
+++ b/libc/error/Makefile
@@ -1,9 +1,7 @@
 # Makefile of /libc/error module
 
-COMPILER ?= watcom
-LIB ?= out.lib
-#COMPILER ?= ia16
-#LIB ?= out.a
+COMPILER ?= ia16
+LIB ?= out.a
 
 include $(TOPDIR)/libc/$(COMPILER).inc
 

--- a/libc/error/Makefile
+++ b/libc/error/Makefile
@@ -5,7 +5,7 @@ LIB ?= out.a
 
 include $(TOPDIR)/libc/$(COMPILER).inc
 
-OBJS= \
+OBJS = \
     __assert.o \
     error.o \
     perror.o \

--- a/libc/gcc/Makefile
+++ b/libc/gcc/Makefile
@@ -32,17 +32,20 @@
 # to link programs with the real libgcc, so these routines are no longer
 # needed.)	-- tkchia 20221204
 
-include $(TOPDIR)/libc/Makefile.inc
+COMPILER ?= ia16
+LIB ?= out.a
+
+include $(TOPDIR)/libc/$(COMPILER).inc
 
 # SRCS = divmodsi3.s ldivmod.s ashlsi3.s
 SRCS = do-global-ctors.S do-global-dtors.S
 OBJS = $(SRCS:.S=.o)
 
-all: out.a
+all: $(LIB)
 
-out.a: $(OBJS)
+$(LIB): $(OBJS)
 	$(RM) $@
-	$(AR) $(ARFLAGS_SUB) $@ $^
+	$(AR) $(ARFLAGS_SUB) $@ $(OBJS)
 
 clean:
 	$(RM) *.[aod]

--- a/libc/getent/Makefile
+++ b/libc/getent/Makefile
@@ -1,8 +1,11 @@
 # Makefile of /libc/getent module
 
-include $(TOPDIR)/libc/Makefile.inc
+COMPILER ?= ia16
+LIB ?= out.a
 
-LIB = out.a
+include $(TOPDIR)/libc/$(COMPILER).inc
+
+# \
 
 OBJS = \
     utent.o \
@@ -19,9 +22,9 @@ OBJS = \
 
 all: $(LIB)
 
-$(LIB): $(OBJS)
+$(LIB): $(LIBOBJS)
 	$(RM) $@
-	$(AR) $(ARFLAGS_SUB) $@ $^
+	$(AR) $(ARFLAGS_SUB) $@ $(LIBOBJS)
 
 clean:
 	$(RM) *.[aod]

--- a/libc/getent/Makefile
+++ b/libc/getent/Makefile
@@ -5,8 +5,6 @@ LIB ?= out.a
 
 include $(TOPDIR)/libc/$(COMPILER).inc
 
-# \
-
 OBJS = \
     utent.o \
     pwent.o \

--- a/libc/ia16.inc
+++ b/libc/ia16.inc
@@ -1,6 +1,8 @@
+# Makefile include for ia16-elf-gcc build
 
 INCLUDES=-I$(TOPDIR)/include -I$(TOPDIR)/libc/include -I$(TOPDIR)/elks/include
 DEFINES=-D__LIBC__
+LIBOBJS=$(OBJS)
 
 INCS=$(INCLUDES)
 SDEFS=$(DEFINES)
@@ -19,8 +21,7 @@ LD=ia16-elf-ld
 CFLAGS=$(ARCH) $(INCLUDES) $(CDEFS) -Wall -Os $(MULTILIB)
 ASFLAGS=--32-segelf -mtune=i8086
 LDFLAGS=-mtune=i8086
-# This is used in subdirectories to quickly create a library archive without
-# a symbol index
+# Used in subdirs to quickly create a library archive without a symbol index
 ARFLAGS_SUB=cqS
 
 ifdef MULTISUBDIR

--- a/libc/include/asm/config.h
+++ b/libc/include/asm/config.h
@@ -3,7 +3,9 @@
 
 #pragma once
 
+#ifndef __WATCOMC__
 #define LIBC_ASM_MEMCPY
 #define LIBC_ASM_MEMSET
 #define LIBC_ASM_STRCPY
 #define LIBC_ASM_STRLEN
+#endif

--- a/libc/include/asm/config.h
+++ b/libc/include/asm/config.h
@@ -1,9 +1,8 @@
-// LIBC assembly configuration
-// List of functions implemented in assembly
+/* List of libc functions implemented in assembly */
 
 #pragma once
 
-#ifndef __WATCOMC__
+#ifdef __ia16__
 #define LIBC_ASM_MEMCPY
 #define LIBC_ASM_MEMSET
 #define LIBC_ASM_STRCPY

--- a/libc/include/unistd.h
+++ b/libc/include/unistd.h
@@ -49,8 +49,8 @@ int execv(const char *fname, char **argv);
 int execve(const char *fname, char **argv, char **envp);
 int execvp(const char *fname, char **argv);
 int execvpe(const char *fname, char **argv, char **envp);
-int _execve(const char *fname, char *stk_ptr, int stack_bytes);
-noreturn void _exit(int status);
+int _execve(const char *fname, char *stk_ptr, int stack_bytes); /* syscall */
+noreturn void _exit(int status); /* syscall */
 int isatty (int fd);
 char *ttyname(int fd);
 off_t lseek (int fildes, off_t offset, int whence);

--- a/libc/malloc/Makefile
+++ b/libc/malloc/Makefile
@@ -1,7 +1,9 @@
 # Makefile of /libc/malloc module
 
-include $(TOPDIR)/libc/Makefile.inc
+COMPILER ?= ia16
+LIB ?= out.a
 
+include $(TOPDIR)/libc/$(COMPILER).inc
 #CFLAGS	+= -DL_alloca
 #CFLAGS	+= -DLAZY_FREE
 # MCHUNK is word not byte min allocation size
@@ -28,11 +30,11 @@ OBJS = \
 
 .PHONY: all
 
-all: out.a
+all: $(LIB)
 
-out.a: $(OBJS)
+$(LIB): $(LIBOBJS)
 	$(RM) $@
-	$(AR) $(ARFLAGS_SUB) $@ $^
+	$(AR) $(ARFLAGS_SUB) $@ $(LIBOBJS)
 
 clean:
 	$(RM) *.[aod]

--- a/libc/math/Makefile
+++ b/libc/math/Makefile
@@ -1,10 +1,11 @@
 # Makefile of /libc/math module
 
-include $(TOPDIR)/libc/Makefile.inc
+COMPILER ?= ia16
+LIB ?= out.a
+
+include $(TOPDIR)/libc/$(COMPILER).inc
 
 CFLAGS += -I$(TOPDIR)/libc/math -D__BSD_VISIBLE
-
-LIB = out.a
 
 DOUBLE = \
 	s_floor.o \
@@ -57,9 +58,9 @@ OBJS = $(DOUBLE) $(FLOAT)
 
 all: $(LIB)
 
-$(LIB): $(OBJS)
+$(LIB): $(LIBOBJS)
 	$(RM) $@
-	$(AR) $(ARFLAGS_SUB) $@ $^
+	$(AR) $(ARFLAGS_SUB) $@ $(LIBOBJS)
 
 clean:
 	$(RM) *.[aod]

--- a/libc/misc/Makefile
+++ b/libc/misc/Makefile
@@ -1,8 +1,9 @@
 # Makefile of /libc/misc module
 
-include $(TOPDIR)/libc/Makefile.inc
+COMPILER ?= ia16
+LIB ?= out.a
 
-LIB = out.a
+include $(TOPDIR)/libc/$(COMPILER).inc
 
 OBJS = \
 	aliases.o \
@@ -43,9 +44,9 @@ OBJS = \
 
 all: $(LIB)
 
-$(LIB): $(OBJS)
+$(LIB): $(LIBOBJS)
 	$(RM) $@
-	$(AR) $(ARFLAGS_SUB) $@ $^
+	$(AR) $(ARFLAGS_SUB) $@ $(LIBOBJS)
 
 clean:
 	$(RM) *.[aod]

--- a/libc/misc/basename.c
+++ b/libc/misc/basename.c
@@ -7,14 +7,13 @@
 char *
 basename(char *path)
 {
-  static char *def = ".";
   char *base;
   int last;
 
   last = strlen (path) - 1;
 
   if (last == -1)
-    return def;
+    return ".";
 
   while (last > 0 && path[last] == '/')
     path[last--] = '\0';

--- a/libc/net/Makefile
+++ b/libc/net/Makefile
@@ -1,17 +1,17 @@
 # Makefile of /libc/net module
 
-include $(TOPDIR)/libc/Makefile.inc
+COMPILER ?= ia16
+LIB ?= out.a
 
-SRCS= in_aton.c in_ntoa.c in_gethostbyname.c getsocknam.c in_connect.c in_resolv.c
-OBJS= $(SRCS:.c=.o)
+include $(TOPDIR)/libc/$(COMPILER).inc
 
-$(OBJS): $(SRCS)
+OBJS= in_aton.o in_ntoa.o in_gethostbyname.o getsocknam.o in_connect.o in_resolv.o
 
-all: out.a
+all: $(LIB)
 
-out.a: $(OBJS)
+$(LIB): $(LIBOBJS)
 	$(RM) $@
-	$(AR) $(ARFLAGS_SUB) $@ $^
+	$(AR) $(ARFLAGS_SUB) $@ $(LIBOBJS)
 
 clean:
 	$(RM) *.[aod]

--- a/libc/net/Makefile
+++ b/libc/net/Makefile
@@ -5,7 +5,7 @@ LIB ?= out.a
 
 include $(TOPDIR)/libc/$(COMPILER).inc
 
-OBJS= in_aton.o in_ntoa.o in_gethostbyname.o getsocknam.o in_connect.o in_resolv.o
+OBJS = in_aton.o in_ntoa.o in_gethostbyname.o getsocknam.o in_connect.o in_resolv.o
 
 all: $(LIB)
 

--- a/libc/regex/Makefile
+++ b/libc/regex/Makefile
@@ -4,6 +4,7 @@ COMPILER ?= ia16
 LIB ?= out.a
 
 include $(TOPDIR)/libc/$(COMPILER).inc
+
 OBJS = regex.o
 
 all: $(LIB)

--- a/libc/regex/Makefile
+++ b/libc/regex/Makefile
@@ -1,17 +1,16 @@
 # Makefile of /libc/regex module
 
-include $(TOPDIR)/libc/Makefile.inc
+COMPILER ?= ia16
+LIB ?= out.a
 
-SRCS= regex.c
-OBJS= $(SRCS:.c=.o)
+include $(TOPDIR)/libc/$(COMPILER).inc
+OBJS = regex.o
 
-$(OBJS): $(SRCS)
+all: $(LIB)
 
-all: out.a
-
-out.a: $(OBJS)
+$(LIB): $(LIBOBJS)
 	$(RM) $@
-	$(AR) $(ARFLAGS_SUB) $@ $^
+	$(AR) $(ARFLAGS_SUB) $@ $(LIBOBJS)
 
 clean:
 	$(RM) *.[aod]

--- a/libc/stdio/Makefile
+++ b/libc/stdio/Makefile
@@ -1,6 +1,9 @@
 # Makefile of /libc/stdio module
 
-include $(TOPDIR)/libc/Makefile.inc
+COMPILER ?= ia16
+LIB ?= out.a
+
+include $(TOPDIR)/libc/$(COMPILER).inc
 
 CFLAGS	+= -DL_ftell
 
@@ -50,11 +53,11 @@ OBJS = \
 	vsnprintf.o \
 	# end of list
 
-all: out.a
+all: $(LIB)
 
-out.a: $(OBJS)
+$(LIB): $(LIBOBJS)
 	$(RM) $@
-	$(AR) $(ARFLAGS_SUB) $@ $^
+	$(AR) $(ARFLAGS_SUB) $@ $(LIBOBJS)
 
 clean:
 	$(RM) *.[aod]

--- a/libc/string/Makefile
+++ b/libc/string/Makefile
@@ -1,6 +1,9 @@
 # Makefile of /libc/string module
 
-include $(TOPDIR)/libc/Makefile.inc
+COMPILER ?= ia16
+LIB ?= out.a
+
+include $(TOPDIR)/libc/$(COMPILER).inc
 
 OBJS = \
 	bzero.o \
@@ -33,11 +36,11 @@ OBJS = \
 
 .PHONY: all
 
-all: out.a
+all: $(LIB)
 
-out.a: $(OBJS)
+$(LIB): $(LIBOBJS)
 	$(RM) $@
-	$(AR) $(ARFLAGS_SUB) $@ $^
+	$(AR) $(ARFLAGS_SUB) $@ $(LIBOBJS)
 
 clean:
 	$(RM) *.[aod]

--- a/libc/system/Makefile
+++ b/libc/system/Makefile
@@ -1,3 +1,5 @@
+# Makefile for ia16-elf-gcc build of ELKS system calls
+
 SYSCALLDAT=${TOPDIR}/elks/arch/i86/kernel/syscall.dat
 
 ifeq "$(VPATH)" ""

--- a/libc/system/out.mk
+++ b/libc/system/out.mk
@@ -20,6 +20,10 @@ OBJS = \
 	dup.o \
 	dup2.o \
 	errno.o \
+	execv.o \
+	execve.o \
+	execvp.o \
+	execvpe.o \
 	getegid.o \
 	geteuid.o \
 	getgid.o \
@@ -45,6 +49,7 @@ OBJS = \
 	wait3.o \
 	waitpid.o \
 
+# these files written in assembly language
 IA16OBJS = \
 	argcargv.o \
 	environ.o \
@@ -52,10 +57,6 @@ IA16OBJS = \
 	execle.o \
 	execlp.o \
 	execlpe.o \
-	execv.o \
-	execve.o \
-	execvp.o \
-	execvpe.o \
 	program_filename.o \
 	setjmp.o \
 	signal.o \

--- a/libc/system/out.mk
+++ b/libc/system/out.mk
@@ -1,4 +1,9 @@
-include $(TOPDIR)/libc/Makefile.inc
+# Sub-Makefile of /libc/system module
+
+COMPILER ?= ia16
+LIB ?= out.a
+
+include $(TOPDIR)/libc/$(COMPILER).inc
 
 DEFINES	+= -DL_execl -DL_execle -DL_execlp -DL_execlpe \
 	   -DL_sleep -DL_usleep
@@ -11,20 +16,10 @@ endif
 
 OBJS = \
 	abort.o \
-	argcargv.o \
 	closedir.o \
 	dup.o \
 	dup2.o \
-	environ.o \
 	errno.o \
-	execl.o \
-	execle.o \
-	execlp.o \
-	execlpe.o \
-	execv.o \
-	execve.o \
-	execvp.o \
-	execvpe.o \
 	getegid.o \
 	geteuid.o \
 	getgid.o \
@@ -36,20 +31,12 @@ OBJS = \
 	lseek.o \
 	mkfifo.o \
 	opendir.o \
-	program_filename.o \
 	readdir.o \
 	rewinddir.o \
 	seekdir.o \
-	setjmp.o \
 	setpgrp.o \
-	signal.o \
 	sigaction.o \
 	sleep.o \
-	syscall01.o \
-	syscall23.o \
-	syscall4.o \
-	syscall5.o \
-	signalcb.o \
 	telldir.o \
 	time.o \
 	times.o \
@@ -58,14 +45,37 @@ OBJS = \
 	wait3.o \
 	waitpid.o \
 
-include syscall.mk
+IA16OBJS = \
+	argcargv.o \
+	environ.o \
+	execl.o \
+	execle.o \
+	execlp.o \
+	execlpe.o \
+	execv.o \
+	execve.o \
+	execvp.o \
+	execvpe.o \
+	program_filename.o \
+	setjmp.o \
+	signal.o \
+	syscall01.o \
+	syscall23.o \
+	syscall4.o \
+	syscall5.o \
+	signalcb.o \
 
-all: out.a
+ifeq "$(COMPILER)" "ia16"
+OBJS += $(IA16OBJS)
+include syscall.mk
+endif
+
+all: $(LIB)
 .PHONY: all
 
-out.a: $(OBJS)
+$(LIB): $(LIBOBJS)
 	$(RM) $@
-	$(AR) $(ARFLAGS_SUB) $@ $^
+	$(AR) $(ARFLAGS_SUB) $@ $(LIBOBJS)
 
 clean:
 	$(RM) *.[aod]

--- a/libc/termcap/Makefile
+++ b/libc/termcap/Makefile
@@ -1,8 +1,9 @@
 # Makefile of /libc/termcap module
 
-include $(TOPDIR)/libc/Makefile.inc
+COMPILER ?= ia16
+LIB ?= out.a
 
-LIB	= out.a
+include $(TOPDIR)/libc/$(COMPILER).inc
 
 OBJS = \
 	entry.o \
@@ -27,9 +28,9 @@ OBJS = \
 
 all: $(LIB)
 
-$(LIB): $(OBJS)
+$(LIB): $(LIBOBJS)
 	$(RM) $@
-	$(AR) $(ARFLAGS_SUB) $@ $^
+	$(AR) $(ARFLAGS_SUB) $@ $(LIBOBJS)
 
 TC_OBJS = termcap.o
 

--- a/libc/termios/Makefile
+++ b/libc/termios/Makefile
@@ -1,7 +1,10 @@
 # Makefile of /libc/termios module
 
-include $(TOPDIR)/libc/Makefile.inc
 
+COMPILER ?= ia16
+LIB ?= out.a
+
+include $(TOPDIR)/libc/$(COMPILER).inc
 OBJS = \
 	cfgetispeed.o \
 	cfgetospeed.o \
@@ -19,11 +22,11 @@ OBJS = \
 	tcsetpgrp.o \
 	ttyname.o \
 
-all: out.a
+all: $(LIB)
 
-out.a: $(OBJS)
+$(LIB): $(LIBOBJS)
 	$(RM) $@
-	$(AR) $(ARFLAGS_SUB) $@ $^
+	$(AR) $(ARFLAGS_SUB) $@ $(LIBOBJS)
 
 clean::
 	$(RM) *.[aod]

--- a/libc/time/Makefile
+++ b/libc/time/Makefile
@@ -5,7 +5,7 @@ LIB ?= out.a
 
 include $(TOPDIR)/libc/$(COMPILER).inc
 
-OBJS= \
+OBJS = \
     gmtime.o \
     localtime.o \
     ctime.o \

--- a/libc/time/Makefile
+++ b/libc/time/Makefile
@@ -1,15 +1,26 @@
 # Makefile of /libc/time module
 
-include $(TOPDIR)/libc/Makefile.inc
+COMPILER ?= ia16
+LIB ?= out.a
 
-OBJS= gmtime.o localtime.o ctime.o tm_conv.o asctime.o asc_conv.o tzset.o mktime.o \
-    strftime.o
+include $(TOPDIR)/libc/$(COMPILER).inc
 
-all: out.a
+OBJS= \
+    gmtime.o \
+    localtime.o \
+    ctime.o \
+    tm_conv.o \
+    asctime.o \
+    asc_conv.o \
+    tzset.o \
+    mktime.o \
+    strftime.o \
 
-out.a: $(OBJS)
+all: $(LIB)
+
+$(LIB): $(LIBOBJS)
 	$(RM) $@
-	$(AR) $(ARFLAGS_SUB) $@ $^
+	$(AR) $(ARFLAGS_SUB) $@ $(LIBOBJS)
 
 clean:
 	$(RM) *.[aod]

--- a/libc/time/strftime.c
+++ b/libc/time/strftime.c
@@ -245,7 +245,7 @@ _fmt(const char *format, const struct tm *t)
 					return(0);
 				continue;
 			case 'Z':
-#if __ia16__
+#if defined(__ia16__) || defined(__WATCOMC__)
 				if (!getenv("TZ") || _add(getenv("TZ")))
 					return(0);
 #else

--- a/libc/watcom.inc
+++ b/libc/watcom.inc
@@ -1,0 +1,31 @@
+# Makefile include for OpenWatcom build
+
+ifeq "$(WATDIR)" ""
+$(error Must set WATDIR environment variable to top of OpenWatcom C directory)
+endif
+
+INCLUDES = -I$(TOPDIR)/libc/include -I$(TOPDIR)/elks/include
+INCLUDES += -I$(WATDIR)/bld/hdr/dos/h
+DEFINES = -D__LIBC__ -D__HAS_NO_FLOATS__
+LIBOBJS=$(OBJS:.o=.obj)
+
+ARCH =\
+    -bos2                           \
+    -mcmodel=c                      \
+    -mabi=cdecl                     \
+    -march=i86                      \
+    -std=c99                        \
+    -fno-stack-check                \
+    -Wc,-fpi87                      \
+    -Wc,-zev                        \
+    -fnostdlib                      \
+    -v                              \
+
+CC=owcc
+AR=wlib
+ARFLAGS_SUB=-n -b -fo
+
+CFLAGS=$(ARCH) $(INCLUDES) $(DEFINES) -Wall -Os
+
+%.obj: %.c
+	$(CC) $(CFLAGS) -c -o $*.obj $<

--- a/libc/watcom.mk
+++ b/libc/watcom.mk
@@ -2,8 +2,9 @@
 
 include watcom.inc
 
-# \
+#NOTBUILT = \
 	asm	    \
+	debug	\
 	gcc	    \
 	math	\
 	crt0.S	\


### PR DESCRIPTION
Compiles almost all the ELKS C library using the OpenWatcom C compiler for compact model. Large, medium and small mode are easily built by editing libc/watcom.inc.

This first version is mostly for OpenWatcom compatibility testing, getting the Makefiles adjusted, and further application linking testing. Discussed a bit in #1443 and #1786.

To use, the [OpenWatcom C Toolchain](https://github.com/open-watcom/open-watcom-v2) needs to be cloned and built, and then the `WATCOM` and `WATDIR` environment variables need to be setup by sourcing a script like the following with the full path to the OpenWatcom binary directory (WATCOM) and top-level directory (WATDIR):
```
#!/usr/bin/env bash

# Set up Watcom build environment

export WATCOM=/Users/greg/net/open-watcom-v2/rel/bino64 # for macOS
export WATCOM=/Users/greg/net/open-watcom-v2/rel/binl   # for Linux
export WATDIR=/Users/greg/net/open-watcom-v2

add_path () {
    if [[ ":$PATH:" != *":$1:"* ]]; then
        export PATH="$1:$PATH"
    fi
}

add_path "$WATCOM"

echo PATH set to $PATH
```
After that, to build the C library `libc.lib`:
```
cd $TOPDIR            # ELKS top-level directory
cd libc
make -f watcom.mk     # creates libc.lib
```

