### PR TITLE
[libc] Change default Watcom compilations to large model

### DIFF
--- a/elks/tools/objtools/ewcc
+++ b/elks/tools/objtools/ewcc
@@ -51,10 +51,11 @@ WATCINCLUDE=$WATDIR/bld/hdr/dos/h
 
 CCFLAGS="\
     -bos2                           \
-    -mcmodel=c                      \
+    -mcmodel=l                      \
     -march=i86                      \
     -std=c99                        \
     -fno-stack-check                \
+    -Wc,-wcd=303                    \
     -Wc,-fpi87                      \
     -Wc,-zev                        \
     -fnostdlib                      \
@@ -65,7 +66,6 @@ CCFLAGS="\
 
 LDFLAGS="\
     -bos2 -s                        \
-    -Wl,disable -Wl,1014            \
     -Wl,option -Wl,start=_start_    \
     -Wl,option -Wl,dosseg           \
     -Wl,option -Wl,stack=0x400      \

--- a/elks/tools/objtools/ewlink
+++ b/elks/tools/objtools/ewlink
@@ -51,10 +51,11 @@ WATCINCLUDE=$WATDIR/bld/hdr/dos/h
 
 CCFLAGS="\
     -bos2                           \
-    -mcmodel=c                      \
+    -mcmodel=l                      \
     -march=i86                      \
     -std=c99                        \
     -fno-stack-check                \
+    -Wc,-wcd=303                    \
     -Wc,-fpi87                      \
     -Wc,-zev                        \
     -fnostdlib                      \
@@ -65,7 +66,6 @@ CCFLAGS="\
 
 LDFLAGS="\
     -bos2 -s                        \
-    -Wl,disable -Wl,1014            \
     -Wl,option -Wl,start=_start_    \
     -Wl,option -Wl,dosseg           \
     -Wl,option -Wl,stack=0x1000     \

--- a/elkscmd/minix1/grep.c
+++ b/elkscmd/minix1/grep.c
@@ -61,12 +61,10 @@ extern int optind;
 extern char *optarg;
 
 /* Internal interfaces */
-int main();
 static int match();
 static char *get_line();
 static char *map_nocase();
 static void error_exit();
-void regerror();
 
 
 int main(argc, argv)

--- a/libc/include/regex.h
+++ b/libc/include/regex.h
@@ -20,7 +20,7 @@ typedef struct regexp {
 
 regexp *regcomp(char *exp);
 int regexec(regexp *prog, char *string);
-void regerror();
+void regerror(const char *);
 
 int expandwildcards(char *name, int maxargc, char **retargv);
 void freewildcards(void);

--- a/libc/include/regex.h
+++ b/libc/include/regex.h
@@ -20,7 +20,7 @@ typedef struct regexp {
 
 regexp *regcomp(char *exp);
 int regexec(regexp *prog, char *string);
-void regerror(const char *);
+void regerror(char *);
 
 int expandwildcards(char *name, int maxargc, char **retargv);
 void freewildcards(void);

--- a/libc/malloc/free.c
+++ b/libc/malloc/free.c
@@ -46,7 +46,7 @@ free(void * ptr)
 			m_next(prev) = chk;
 		}
 #else
-		m_next(chk) = __freed_list;
+		m_next(chk) = (union mem_cell __wcnear *)__freed_list;
 		__freed_list = chk;
 #endif
 		__noise("ADD LIST", chk);

--- a/libc/malloc/malloc.c
+++ b/libc/malloc/malloc.c
@@ -34,7 +34,8 @@ __insert_chunk(mem *mem_chunk)
    register mem *p1, *p2;
    if (chunk_list == 0)		/* Simple case first */
    {
-      m_next(mem_chunk) = chunk_list = mem_chunk;
+      chunk_list = mem_chunk;
+      m_next(mem_chunk) = (union mem_cell __wcnear *)mem_chunk;
       __noise("FIRST CHUNK", mem_chunk);
       return;
    }
@@ -58,7 +59,7 @@ __insert_chunk(mem *mem_chunk)
 	    else
 	    {
 	       m_next(p1) = m_next(p2);
-	       m_next(p2) = p1;
+	       m_next(p2) = (union mem_cell __wcnear *)p1;
 	       __noise("INSERT CHUNK", mem_chunk);
 	       __noise("FROM", p2);
 	    }
@@ -69,7 +70,7 @@ __insert_chunk(mem *mem_chunk)
 	    /* In chain, p1 between p2 and next */
 
 	    m_next(p1) = m_next(p2);
-	    m_next(p2) = p1;
+	    m_next(p2) = (union mem_cell __wcnear *)p1;
 	    __noise("INSERT CHUNK", mem_chunk);
 	    __noise("FROM", p2);
 
@@ -98,7 +99,7 @@ __insert_chunk(mem *mem_chunk)
 	    /* At top of chain, next is bottom of chain, p1 is below next */
 
 	    m_next(p1) = m_next(p2);
-	    m_next(p2) = p1;
+	    m_next(p2) = (union mem_cell __wcnear *)p1;
 	    __noise("INSERT CHUNK", mem_chunk);
 	    __noise("FROM", p2);
 	    chunk_list = p2;
@@ -165,7 +166,7 @@ __search_chunk(unsigned int mem_size)
 
    __noise("SPLIT", p1);
    /* Otherwise split it */
-   m_next(p2) = p1 + mem_size;
+   m_next(p2) = (union mem_cell __wcnear *)(p1 + mem_size);
    chunk_list = p2;
 
    p2 = m_next(p2);

--- a/libc/stdio/Makefile
+++ b/libc/stdio/Makefile
@@ -42,7 +42,6 @@ OBJS = \
 	stderr.o \
 	stdin.o \
 	stdout.o \
-	putchar.o \
 	ungetc.o \
 	vfprintf.o \
 	vfscanf.o \

--- a/libc/stdio/_stdio.h
+++ b/libc/stdio/_stdio.h
@@ -1,16 +1,8 @@
-#if !defined(_STDIO_H)
+#ifndef _STDIO_H
 #define	_STDIO_H
 
 #include <stdio.h>
 #include <sys/linksym.h>
-
-#if defined(__STDC__) && !defined(__FIRST_ARG_IN_AX__)
-#	include <stdarg.h>
-#	define va_strt      va_start
-#else
-#	include <varargs.h>
-#	define va_strt(p,i) va_start(p)
-#endif
 
 extern FILE *__IO_list;		/* For fflush at exit */
 

--- a/libc/stdio/fscanf.c
+++ b/libc/stdio/fscanf.c
@@ -6,7 +6,7 @@ fscanf(FILE * fp, const char * fmt, ...)
   va_list ptr;
   int rv;
 
-  va_strt(ptr, fmt);
+  va_start(ptr, fmt);
   rv = vfscanf(fp, (char *)fmt, ptr);
   va_end(ptr);
 

--- a/libc/stdio/scanf.c
+++ b/libc/stdio/scanf.c
@@ -6,7 +6,7 @@ scanf(const char * fmt, ...)
   va_list ptr;
   int rv;
 
-  va_strt(ptr, fmt);
+  va_start(ptr, fmt);
   rv = vfscanf(stdin, (char *)fmt, ptr);
   va_end(ptr);
 

--- a/libc/stdio/sscanf.c
+++ b/libc/stdio/sscanf.c
@@ -19,7 +19,7 @@ sscanf(const char *str, const char *format, ...)
 	va_list ptr;
 	int rv;
 
-	va_strt(ptr, format);
+	va_start(ptr, format);
 	string->bufpos = (unsigned char *)str;
 	rv = vfscanf(string, (char *)format, ptr);
 	va_end(ptr);

--- a/libc/watcom.inc
+++ b/libc/watcom.inc
@@ -11,10 +11,11 @@ LIBOBJS=$(OBJS:.o=.obj)
 
 CARCH =\
     -bos2                           \
-    -mcmodel=c                      \
+    -mcmodel=l                      \
     -march=i86                      \
     -std=c99                        \
     -fno-stack-check                \
+    -Wc,-wcd=303                    \
     -Wc,-fpi87                      \
     -Wc,-zev                        \
     -fnostdlib                      \

--- a/libc/watcom/syscall/crt0.c
+++ b/libc/watcom/syscall/crt0.c
@@ -37,8 +37,8 @@ noreturn void exit(int status)
 #pragma aux main "*" modify [ bx cx dx si di ]
 int main(int argc, char __wcnear * __wcfar *argv);
 
-#if defined(__SMALL__) || defined(__MEDIUM__)
 noreturn static void _crt0(void);
+#if defined(__SMALL__) || defined(__MEDIUM__)
 #pragma aux _crt0 =         \
     "pop ax"                \
     "mov dx, sp"            \

--- a/libc/wcenv.sh
+++ b/libc/wcenv.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Set up Watcom build environment
+#
+# Usage: . ./wcenv.sh
+
+# change to OpenWatcom source tree top
+export WATDIR=/Users/greg/net/open-watcom-v2
+
+#export WATCOM=$WATDIR/rel/binl     # for Linux-32
+#export WATCOM=$WATDIR/rel/binl64   # for Linux-64
+export WATCOM=$WATDIR/rel/bino64    # for macOS
+
+add_path () {
+	if [[ ":$PATH:" != *":$1:"* ]]; then
+		export PATH="$1:$PATH"
+	fi
+}
+
+add_path "$WATCOM"
+
+echo PATH set to $PATH


### PR DESCRIPTION
`ewcc`, `ewlink` and libc/watcom.mk now default to large model. This is better because it will (eventually) allow for multiple code and data segments, while currently supporting far text and far data in a single segment each.

Adds libc/wcenv.sh sample shell script to setup required OpenWatcom WATCOM= and WATDIR= environment variables. This script must be edited to set the root directory of the OpenWatcom source tree on your system.

Cleans up some other C library warnings.