### PR TITLE
[libc] Revert large mode change, default Openwatcom build is compact

### DIFF
--- a/elks/tools/objtools/ewcc
+++ b/elks/tools/objtools/ewcc
@@ -38,7 +38,6 @@ ELKSLIBCINCLUDE=$TOPDIR/libc/include
 ELKSINCLUDE=$TOPDIR/elks/include
 WATCINCLUDE=$WATDIR/bld/hdr/dos/h
 
-# -mregparm=0
 # -fpmath
 # -mabi=cdecl               # push all args
 # -msoft-float              # -Wc,-fpc
@@ -51,7 +50,7 @@ WATCINCLUDE=$WATDIR/bld/hdr/dos/h
 
 CCFLAGS="\
     -bos2                           \
-    -mcmodel=l                      \
+    -mcmodel=c                      \
     -march=i86                      \
     -std=c99                        \
     -fno-stack-check                \
@@ -62,13 +61,6 @@ CCFLAGS="\
     -I$ELKSLIBCINCLUDE              \
     -I$ELKSINCLUDE                  \
     -I$WATCINCLUDE                  \
-    "
-
-LDFLAGS="\
-    -bos2 -s                        \
-    -Wl,option -Wl,start=_start_    \
-    -Wl,option -Wl,dosseg           \
-    -Wl,option -Wl,stack=0x400      \
     "
 
 owcc -v -c -Wall -Wextra -Os $CCFLAGS -o ${PROG%.c}.obj $PROG

--- a/elks/tools/objtools/ewlink
+++ b/elks/tools/objtools/ewlink
@@ -38,7 +38,6 @@ ELKSLIBCINCLUDE=$TOPDIR/libc/include
 ELKSINCLUDE=$TOPDIR/elks/include
 WATCINCLUDE=$WATDIR/bld/hdr/dos/h
 
-# -mregparm=0
 # -fpmath
 # -mabi=cdecl               # push all args
 # -msoft-float              # -Wc,-fpc
@@ -51,7 +50,7 @@ WATCINCLUDE=$WATDIR/bld/hdr/dos/h
 
 CCFLAGS="\
     -bos2                           \
-    -mcmodel=l                      \
+    -mcmodel=c                      \
     -march=i86                      \
     -std=c99                        \
     -fno-stack-check                \
@@ -64,8 +63,11 @@ CCFLAGS="\
     -I$WATCINCLUDE                  \
     "
 
+# Warning 1014: stack segment not found
+
 LDFLAGS="\
     -bos2 -s                        \
+    -Wl,disable -Wl,1014            \
     -Wl,option -Wl,start=_start_    \
     -Wl,option -Wl,dosseg           \
     -Wl,option -Wl,stack=0x1000     \

--- a/elkscmd/basic/host.c
+++ b/elkscmd/basic/host.c
@@ -246,7 +246,6 @@ float host_floor(float x)
 
 void host_sleep(long ms) {
     usleep(ms * 1000);
-    printf("BACK!\n");
 }
 
 #if DISK_FUNCTIONS

--- a/elkscmd/basic/host.c
+++ b/elkscmd/basic/host.c
@@ -245,9 +245,8 @@ float host_floor(float x)
 }
 
 void host_sleep(long ms) {
-#ifndef __WATCOMC__
     usleep(ms * 1000);
-#endif
+    printf("BACK!\n");
 }
 
 #if DISK_FUNCTIONS

--- a/libc/include/watcom/syselks.h
+++ b/libc/include/watcom/syselks.h
@@ -187,16 +187,16 @@ syscall_res sys_call3( unsigned func, unsigned r_bx, unsigned r_cx, unsigned r_d
     __parm [__ax] [__bx] [__cx] [__dx]  \
     __value [__ax]
 
-syscall_res sys_call4( unsigned func, unsigned r_bx, unsigned r_cx, unsigned r_dx, unsigned r_si );
+syscall_res sys_call4( unsigned func, unsigned r_bx, unsigned r_cx, unsigned r_dx, unsigned r_di );
 #pragma aux sys_call4 =                         \
     "int    0x80"                               \
-    __parm [__ax] [__bx] [__cx] [__dx] [__si]   \
+    __parm [__ax] [__bx] [__cx] [__dx] [__di]   \
     __value [__ax]
 
-syscall_res sys_call5( unsigned func, unsigned r_bx, unsigned r_cx, unsigned r_dx, unsigned r_si, unsigned r_di );
+syscall_res sys_call5( unsigned func, unsigned r_bx, unsigned r_cx, unsigned r_dx, unsigned r_di, unsigned r_si );
 #pragma aux sys_call5 =                              \
     "int    0x80"                                    \
-    __parm [__ax] [__bx] [__cx] [__dx] [__si] [__di] \
+    __parm [__ax] [__bx] [__cx] [__dx] [__di] [__si] \
     __value [__ax]
 
 /* Set the DS register from passed far address before system call */

--- a/libc/watcom.inc
+++ b/libc/watcom.inc
@@ -11,7 +11,7 @@ LIBOBJS=$(OBJS:.o=.obj)
 
 CARCH =\
     -bos2                           \
-    -mcmodel=l                      \
+    -mcmodel=c                      \
     -march=i86                      \
     -std=c99                        \
     -fno-stack-check                \

--- a/libc/watcom/syscall/fcntl.c
+++ b/libc/watcom/syscall/fcntl.c
@@ -1,0 +1,50 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS fcntl() implementation.
+*
+****************************************************************************/
+
+
+#include <stdarg.h>
+#include <fcntl.h>
+#include "watcom/syselks.h"
+
+
+int fcntl( int __fildes, int __cmd, ... )
+{
+    char *      argp;
+    va_list     args;
+    syscall_res res;
+
+    va_start( args, __cmd );
+    argp = va_arg( args, char * ); /* get largest of (int) and (char *) data types */
+    va_end( args );
+    sys_setseg(argp); /* (sets DS to garbage when int passed in large/compact model) */
+    res = sys_call3( SYS_fcntl, __fildes, __cmd, (unsigned)argp );
+    __syscall_return( int, res );
+}

--- a/libc/watcom/syscall/select.c
+++ b/libc/watcom/syscall/select.c
@@ -1,0 +1,44 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS select() implementation.
+*
+****************************************************************************/
+
+
+#include <sys/select.h>
+#include "watcom/syselks.h"
+
+
+int select( int __width, fd_set * __readfds, fd_set * __writefds, fd_set * __exceptfds, struct timeval * __timeout )
+{
+    if (__readfds) sys_setseg(__readfds);
+    else if (__writefds) sys_setseg(__writefds);
+    else if (__timeout) sys_setseg(__timeout);
+    syscall_res res = sys_call5( SYS_select, __width, (unsigned)__readfds, (unsigned)__writefds, (unsigned)__exceptfds, (unsigned)__timeout );
+    __syscall_return( int, res );
+}


### PR DESCRIPTION
Reverts change from compact to small model in #1913. More testing has revealed large code model isn't working fully in `basic`. Will change when fixed.

More fixes to OWC libc.

This PR also adds `select` and `fcntl` system calls to OWC libc.