### PR TITLE
[watcom] Rewrite argv/environ array in large model to far pointers

### DIFF
--- a/elks/include/arch/cdefs.h
+++ b/elks/include/arch/cdefs.h
@@ -31,7 +31,6 @@
 #define __attribute__(n)
 /* force __cdecl calling convention and no register saves in main() arc/argv */
 #pragma aux main "*" modify [ bx cx dx si di ]
-extern int main(int, char **);
 #define __wcfar         __far
 #define __wcnear        __near
 #endif

--- a/elks/include/arch/cdefs.h
+++ b/elks/include/arch/cdefs.h
@@ -31,6 +31,7 @@
 #define __attribute__(n)
 /* force __cdecl calling convention and no register saves in main() arc/argv */
 #pragma aux main "*" modify [ bx cx dx si di ]
+extern int main(int, char **);
 #define __wcfar         __far
 #define __wcnear        __near
 #endif

--- a/elkscmd/basic/host.c
+++ b/elkscmd/basic/host.c
@@ -389,7 +389,7 @@ void host_pokeb(int offset, int segment, int value) {
 #endif
 }
 
-int main(int ac, char __wcnear * __wcfar *av) {
+int main(int ac, char **av) {
 	outfile = stdout;
 
 	tcgetattr(0, &def_termios);

--- a/libc/include/sys/cdefs.h
+++ b/libc/include/sys/cdefs.h
@@ -14,6 +14,7 @@
  * Force no register saves in main(), saves space.
  */
 #pragma aux main "*" modify [ bx cx dx si di ]
+extern int main(int, char **);
 #endif
 
 #endif

--- a/libc/include/sys/cdefs.h
+++ b/libc/include/sys/cdefs.h
@@ -12,10 +12,8 @@
 #ifdef __WATCOMC__
 /*
  * Force no register saves in main(), saves space.
- * For now, argv array is left unmodified requiring special main declaration.
  */
 #pragma aux main "*" modify [ bx cx dx si di ]
-int main(int argc, char __wcnear * __wcfar *argv);
 #endif
 
 #endif

--- a/libc/include/unistd.h
+++ b/libc/include/unistd.h
@@ -48,9 +48,9 @@ int execle(const char *fname, const char *arg0, ...);
 int execlp(const char *fname, const char *arg0, ...);
 int execlpe(const char *fname, const char *arg0, ...);
 int execv(const char *fname, char **argv);
-int execve(const char *fname, char **argv, char __wcnear * __wcfar *envp);
+int execve(const char *fname, char **argv, char **envp);
 int execvp(const char *fname, char **argv);
-int execvpe(const char *fname, char **argv, char __wcnear * __wcfar *envp);
+int execvpe(const char *fname, char **argv, char **envp);
 int _execve(const char *fname, char *stk_ptr, int stack_bytes); /* syscall */
 int isatty (int fd);
 char *ttyname(int fd);
@@ -94,11 +94,9 @@ extern int optind;
 extern int optopt;
 extern int opterr;
 
-#ifndef __WATCOMC__
 extern int     __argc;
 extern char ** __argv;
 extern char *  __program_filename;          /* process argv[0] */
-#endif
-extern char __wcnear * __wcfar * environ;   /* process global environment */
+extern char ** environ;                     /* process global environment */
 
 #endif

--- a/libc/misc/getenv.c
+++ b/libc/misc/getenv.c
@@ -10,7 +10,7 @@ char *
 getenv(const char *name)
 {
     size_t l = strlen(name);
-    char __wcnear * __wcfar *ep = environ;
+    char **ep = environ;
 
     if (ep == 0 || l == 0)
         return 0;

--- a/libc/system/execve.c
+++ b/libc/system/execve.c
@@ -3,10 +3,10 @@
 #include <unistd.h>
 
 int
-execve(const char *fname, char **argv, char __wcnear * __wcfar *envp)
+execve(const char *fname, char **argv, char **envp)
 {
-    char **p;
-	char __wcnear * __wcfar *q;
+	char **p;
+	char **q;
 	int argv_len=0, argv_count=0;
 	int envp_len=0, envp_count=0;
 	int stack_bytes;

--- a/libc/system/execvpe.c
+++ b/libc/system/execvpe.c
@@ -6,7 +6,7 @@
 #include <paths.h>
 
 static void
-tryrun(const char *pname, char **argv, char __wcnear * __wcfar *envp)
+tryrun(const char *pname, char **argv, char **envp)
 {
    struct stat st;
 
@@ -17,7 +17,7 @@ tryrun(const char *pname, char **argv, char __wcnear * __wcfar *envp)
 }
 
 int
-execvpe(const char *fname, char **argv, char __wcnear * __wcfar *envp)
+execvpe(const char *fname, char **argv, char **envp)
 {
    char *path;
    char *pname = (char *)fname;

--- a/libc/system/signal.c
+++ b/libc/system/signal.c
@@ -52,7 +52,7 @@ sighandler_t signal(int number, sighandler_t pointer)
     if (number < 1 || number > _NSIG) { errno = EINVAL; return SIG_ERR; }
 
     if (pointer == SIG_DFL || pointer == SIG_IGN)
-        rv = _signal(number, (__kern_sighandler_t) (unsigned long) (unsigned)pointer);
+        rv = _signal(number, (__kern_sighandler_t) (unsigned long)pointer);
     else
         rv = _signal(number, (__kern_sighandler_t) _signal_cbhandler);
     if (rv < 0) return SIG_ERR;

--- a/libc/watcom/syscall/crt0.c
+++ b/libc/watcom/syscall/crt0.c
@@ -53,12 +53,12 @@ noreturn void cstart_(void)
 /* rewrite argv and environ arrays in compact and large models */
 noreturn void cstart_(char __near *newsp, char __near *oldsp, int bx, int n)
 {
-    char __far * __far *nap = newsp;
-    char __near * __near *oap = oldsp;
+    char __far  * __far  *nap = (char __far  * __far  *)newsp;
+    char __near * __near *oap = (char __near * __near *)oldsp;
     unsigned int v;
-    __argv = newsp;
+    __argv = (char **)newsp;
     do {
-        if (v = *oap) {
+        if (v = (unsigned)*oap) {
             *nap = *oap;
         } else {
             *nap = 0;

--- a/libc/watcom/syscall/crt0.c
+++ b/libc/watcom/syscall/crt0.c
@@ -13,9 +13,6 @@ int cstart_;            /* with declaration of main() */
 int _argc;              /* with declaration of main() */
 int _8087;              /* when floating point seen */
 
-/* FIXME near/far declaration of environ works only in compact/large models */
-char __wcnear * __wcfar *environ;
-
 noreturn void _exit(int status);
 #pragma aux _exit =         \
     "xchg ax, bx"           \
@@ -31,40 +28,93 @@ noreturn void exit(int status)
 
 /*
  * Force no register saves in main(), saves space.
- * For now, argv array is left unmodified requiring special main declaration.
  * This code is repeated in libc/include/sys/cdefs.h
+ *
+ * main(ac, av) called by AX, DX (small/medium) or AX, CX:BX (compact/large) model
  */
 #pragma aux main "*" modify [ bx cx dx si di ]
-int main(int argc, char __wcnear * __wcfar *argv);
+extern int main(int argc, char **argv);
+
+int __argc;
+char **__argv;
+char *__program_filename;
+char **environ;
+
+#pragma aux _crtargs "*" modify [ bx cx dx si di ]
+#if defined(__SMALL__) || defined(__MEDIUM__)
+noreturn static void _crtargs(void)
+{
+    exit(main(__argc, __argv));
+}
+#else
+noreturn static void _crtargs(char __near *newsp, char __near *oldsp, int bx, int n)
+{
+    char __far * __far *nap = newsp;
+    char __near * __near *oap = oldsp;
+    unsigned int v;
+    __argv = newsp;
+    do {
+       //printf("%d %04x '%s'\n", n/2, (unsigned)*oap, *oap);
+        if (v = *oap) {
+            *nap = *oap;
+        } else {
+            *nap = 0;
+        }
+        ++nap;
+        ++oap;
+        n -= 2;
+        if (n && !v)
+            environ = nap;
+    } while (n > 0);
+    exit(main(__argc, __argv));
+}
+#endif
 
 noreturn static void _crt0(void);
 #if defined(__SMALL__) || defined(__MEDIUM__)
 #pragma aux _crt0 =         \
     "pop ax"                \
-    "mov dx, sp"            \
+    "mov word ptr __argc, ax"       \
     "mov bx, sp"            \
+    "mov word ptr __argv, bx"       \
     "next_env: cmp word ptr [bx], 1" \
     "inc bx"                \
     "inc bx"                \
     "jnc next_env"          \
     "mov word ptr environ, bx" \
-    "call main"             \
-    "call exit";
+    "mov bx, sp"            \
+    "mov bx,word ptr [bx]"  \
+    "mov word ptr __program_filename, bx"       \
+    "call _crtargs";
 #else
 #pragma aux _crt0 =         \
     "pop ax"                \
+    "mov word ptr __argc, ax"       \
     "mov bx, sp"            \
-    "mov dx, bx"            \
     "mov cx, ds"            \
+    "mov word ptr __argv, bx"       \
+    "mov word ptr __argv+2,cx"      \
+    "mov word ptr __program_filename+2, cx"     \
+    "mov word ptr environ+2, cx" \
     "next_env: cmp word ptr [bx], 1" \
     "inc bx"                \
     "inc bx"                \
     "jnc next_env"          \
     "mov word ptr environ, bx" \
-    "mov word ptr environ+2, cx" \
-    "mov bx, dx"            \
-    "call main"             \
-    "call exit";
+    "next_env2: cmp word ptr [bx], 1" \
+    "inc bx"                \
+    "inc bx"                \
+    "jnc next_env2"         \
+    "sub bx, sp"            \
+    "mov cx, bx"            \
+    "mov dx, sp"            \
+    "mov bx, sp"            \
+    "mov bx,word ptr [bx]"  \
+    "mov word ptr __program_filename, bx"       \
+    "mov bx, cx"            \
+    "sub sp, bx"            \
+    "mov ax, sp"            \
+    "call _crtargs";
 #endif
 
 /* actual program entry point */


### PR DESCRIPTION
The Watcom C startup now rewrites the argv and environ near pointer array supplied by the kernel to a far pointer array for the case of compact and large models. 

This removes the need for special handling of main using the `char __wcnear * __wcfar *argv` pointer declaration.
