### PR TITLE
[watcom] Add heap and stack size processing to ewlink and os2toelks

### DIFF
--- a/elks/tools/objtools/ewlink
+++ b/elks/tools/objtools/ewlink
@@ -75,6 +75,7 @@ LDFLAGS="\
     -Wl,option -Wl,start=_start_    \
     -Wl,option -Wl,dosseg           \
     -Wl,option -Wl,stack=0x1000     \
+    -Wl,option -Wl,heapsize=0x1000  \
     "
 
 PROG=$1

--- a/elkscmd/minix3/Makefile
+++ b/elkscmd/minix3/Makefile
@@ -22,7 +22,7 @@ cal: cal.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -o cal cal.o $(TINYPRINTF) $(LDLIBS)
 
 diff: diff.o
-	$(LD) $(LDFLAGS) -o diff diff.o $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-heap=0xffff -o diff diff.o $(LDLIBS)
 
 file: file.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -o file file.o $(TINYPRINTF) $(LDLIBS)

--- a/libc/stdio/__fopen.c
+++ b/libc/stdio/__fopen.c
@@ -1,6 +1,7 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <errno.h>
 
 #include "_stdio.h"
 
@@ -74,6 +75,11 @@ __fopen(const char * fname, int fd, FILE * fp, const char * mode)
       break;
    }
 
+   if (!fname) {
+        errno = EINVAL;
+        return 0;
+   }
+
    /* Allocate the (FILE) before we do anything irreversable */
    if (fp == 0)
    {
@@ -83,8 +89,7 @@ __fopen(const char * fname, int fd, FILE * fp, const char * mode)
    }
 
    /* Open the file itself */
-   if (fname)
-      fd = open(fname, open_mode, 0666);
+   fd = open(fname, open_mode, 0666);
    if (fd < 0)			/* Grrrr */
    {
       if (nfp)

--- a/libc/watcom/syscall/crt0.c
+++ b/libc/watcom/syscall/crt0.c
@@ -9,6 +9,8 @@
 #include <unistd.h>
 #include <errno.h>
 
+/* Watcom extern code refs are sym_, extern data refs are _sym */
+
 /* external references created by Watcom C compilation - unused */
 int _argc;              /* with declaration of main() */
 int _8087;              /* when floating point seen */


### PR DESCRIPTION
A non-default stack or heap size can now be specified by editing `ewlink`. Command line options may be added in the future. `os2toelks` updated to accept non-default stack/heap sizes.

Fixes `diff` running out of memory.

Return -EINVAL when `fopen` called with NULL filename.