### PR TITLE
[net] Temp fix ftpd startup with QEMU=1 set

### DIFF
--- a/elkscmd/inet/ftp/ftpd.c
+++ b/elkscmd/inet/ftp/ftpd.c
@@ -617,12 +617,13 @@ int main(int argc, char **argv) {
 		} else 
 			myport = atoi(argv[0]);
 	}
+#if 0 /* FIXME temporarily remove as ftpd hangs on start with QEMU=1 */
 	if ((cp = getenv("QEMU")) != NULL) {
 		qemu = atoi(cp);
 		//printf("QEMU set to %d\n", qemu);
 		if (qemu) debug++;	//FIXME: Temporary - for debugging
 	}
-		
+#endif
 	if ((listenfd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
 		perror("socket error");
 		exit(1);


### PR DESCRIPTION
Fixes `ftpd` hang on `net start` on QEMU when QEMU=1 exported variable set. Use `ftpd -q` in etc/net.cfg to force passive mode and other hacks contained in ftpd for QEMU. This will probably be re-looked at after the v0.8 release.