### PR TITLE
[kernel] Source code readability and optimization improvements

### DIFF
--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -144,8 +144,7 @@ void tty_freeq(struct tty *tty)
 
 int tty_open(struct inode *inode, struct file *file)
 {
-    register struct tty *otty;
-    register __ptask currentp = current;
+    struct tty *otty;
     int err;
 
     if (!(otty = determine_tty(inode->i_rdev)))
@@ -165,11 +164,11 @@ int tty_open(struct inode *inode, struct file *file)
 
     err = otty->ops->open(otty);
     if (!err) {
-        if (!(file->f_flags & O_NOCTTY) && currentp->session == currentp->pid
-                && currentp->tty == NULL && otty->pgrp == 0) {
-            debug_tty("TTY setting pgrp %d pid %P\n", currentp->pgrp);
-            otty->pgrp = currentp->pgrp;
-            currentp->tty = otty;
+        if (!(file->f_flags & O_NOCTTY) && current->session == current->pid
+                && current->tty == NULL && otty->pgrp == 0) {
+            debug_tty("TTY setting pgrp %d pid %P\n", current->pgrp);
+            otty->pgrp = current->pgrp;
+            current->tty = otty;
         }
         otty->flags |= TTY_OPEN;
     }

--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -48,29 +48,28 @@ int run_init_process_sptr(const char *cmd, char *sptr, int slen)
  */
 void stack_check(void)
 {
-    register __ptask currentp = current;
-    segoff_t end = currentp->t_endbrk;
+    segoff_t end = current->t_endbrk;
 
 #ifdef CONFIG_EXEC_LOW_STACK
-    if (currentp->t_begstack <= currentp->t_enddata) {  /* stack below heap?*/
-        if (currentp->t_regs.sp < end)
+    if (current->t_begstack <= current->t_enddata) {  /* stack below heap?*/
+        if (current->t_regs.sp < end)
             return;
         end = 0;
     } else
 #endif
     {
         /* optional: check stack over min stack*/
-        if (currentp->t_regs.sp < currentp->t_begstack - currentp->t_minstack) {
-          if (currentp->t_minstack)     /* display if protected stack*/
+        if (current->t_regs.sp < current->t_begstack - current->t_minstack) {
+          if (current->t_minstack)     /* display if protected stack*/
             printk("(%P)STACK OVER MINSTACK by %u BYTES\n",
-                currentp->t_begstack - currentp->t_minstack - currentp->t_regs.sp);
+                current->t_begstack - current->t_minstack - current->t_regs.sp);
         }
 
         /* check stack overflow heap*/
-        if (currentp->t_regs.sp > end)
+        if (current->t_regs.sp > end)
             return;
     }
-    printk("(%P)STACK OVERFLOW BY %u BYTES\n", end - currentp->t_regs.sp);
+    printk("(%P)STACK OVERFLOW BY %u BYTES\n", end - current->t_regs.sp);
     do_exit(SIGSEGV);
 }
 

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -234,30 +234,28 @@ void mm_get_usage (unsigned int * pfree, unsigned int * pused)
 
 int sys_brk(segoff_t newbrk)
 {
-    register __ptask currentp = current;
-
 	/***unsigned int memfree, memused;
 	mm_get_usage(&memfree, &memused);
 	printk("brk(%P): new %x, edat %x, ebrk %x, free %x sp %x, eseg %x, %d/%dK\n",
-		newbrk, currentp->t_enddata, currentp->t_endbrk,
-		currentp->t_regs.sp - currentp->t_endbrk,
-		currentp->t_regs.sp, currentp->t_endseg, memfree, memused);***/
+		newbrk, current->t_enddata, current->t_endbrk,
+		current->t_regs.sp - current->t_endbrk,
+		current->t_regs.sp, current->t_endseg, memfree, memused);***/
 
-    if (newbrk < currentp->t_enddata)
+    if (newbrk < current->t_enddata)
         return -ENOMEM;
 
-    if (currentp->t_begstack > currentp->t_endbrk) {				/* stack above heap?*/
-        if (newbrk > currentp->t_begstack - currentp->t_minstack) {
+    if (current->t_begstack > current->t_endbrk) {				/* stack above heap?*/
+        if (newbrk > current->t_begstack - current->t_minstack) {
 			printk("sys_brk(%d) fail: brk %x over by %u bytes\n",
-				currentp->pid, newbrk, newbrk - (currentp->t_begstack - currentp->t_minstack));
+				current->pid, newbrk, newbrk - (current->t_begstack - current->t_minstack));
             return -ENOMEM;
 		}
     }
 #ifdef CONFIG_EXEC_LOW_STACK
-    if (newbrk > currentp->t_endseg)
+    if (newbrk > current->t_endseg)
         return -ENOMEM;
 #endif
-    currentp->t_endbrk = newbrk;
+    current->t_endbrk = newbrk;
 
     return 0;
 }

--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -188,7 +188,7 @@ static int relocate(seg_t place_base, unsigned long rsize, segment_s *seg_code,
 
 static int execve_aout(struct inode *inode, struct file *filp, char *sptr, size_t slen)
 {
-    register __ptask currentp;
+    register struct task_struct *currentp;
     int retval;
     seg_t ds = current->t_regs.ds;
     seg_t base_data = 0;
@@ -524,7 +524,7 @@ static int execve_aout(struct inode *inode, struct file *filp, char *sptr, size_
 static void finalize_exec(struct inode *inode, segment_s *seg_code, segment_s *seg_data,
     word_t entry, int multisegment)
 {
-    __ptask currentp = current;
+    struct task_struct *currentp = current;
     int i, n, v;
 
     /* From this point, the old code and data segments are not needed anymore */

--- a/elks/fs/file_table.c
+++ b/elks/fs/file_table.c
@@ -26,7 +26,7 @@ struct file *file_array;    /* dynamically allocated */
  * we run out of memory.
  */
 
-int open_filp(unsigned short flags, struct inode *inode, struct file **fp)
+int open_filp(mode_t flags, struct inode *inode, struct file **fp)
 {
     int result = 0;
     register struct file *f = file_array;
@@ -40,7 +40,7 @@ int open_filp(unsigned short flags, struct inode *inode, struct file **fp)
     }
     memset(f, 0, sizeof(struct file));
     f->f_flags = flags;
-    f->f_mode = (mode_t) ((flags + 1) & O_ACCMODE);
+    f->f_mode = (flags + 1) & O_ACCMODE;
     f->f_count = 1;
 /*  f->f_pos = 0;*/	/* FIXME - should call lseek */
     f->f_inode = inode;

--- a/elks/fs/minix/namei.c
+++ b/elks/fs/minix/namei.c
@@ -132,7 +132,7 @@ int minix_lookup(register struct inode *dir, const char *name, size_t len,
  *
  */
 
-static int minix_add_entry(register struct inode *dir, char *name,
+static int minix_add_entry(register struct inode *dir, const char *name,
 			   size_t namelen, ino_t ino)
 {
     unsigned short offset;
@@ -176,7 +176,7 @@ static int minix_add_entry(register struct inode *dir, char *name,
     }
     dir->i_mtime = dir->i_ctime = current_time();
     dir->i_dirt = 1;
-    memcpy_fromfs(de->name, name, namelen);
+    memcpy_fromfs(de->name, (char *)name, namelen);
     if (info->s_namelen > namelen)
 	memset(de->name + namelen, 0, info->s_namelen - namelen);
 
@@ -186,8 +186,8 @@ static int minix_add_entry(register struct inode *dir, char *name,
     return 0;
 }
 
-int minix_create(register struct inode *dir, char *name, size_t len,
-		 int mode, struct inode **result)
+int minix_create(register struct inode *dir, const char *name, size_t len,
+		 mode_t mode, struct inode **result)
 {
     register struct inode *inode = NULL;
     int error;
@@ -211,8 +211,8 @@ int minix_create(register struct inode *dir, char *name, size_t len,
     return error;
 }
 
-int minix_mknod(register struct inode *dir, char *name, size_t len,
-		int mode, int rdev)
+int minix_mknod(register struct inode *dir, const char *name, size_t len,
+		mode_t mode, int rdev)
 {
     int error;
     register struct inode *inode;
@@ -246,7 +246,7 @@ int minix_mknod(register struct inode *dir, char *name, size_t len,
     return error;
 }
 
-int minix_mkdir(register struct inode *dir, char *name, size_t len, int mode)
+int minix_mkdir(register struct inode *dir, const char *name, size_t len, mode_t mode)
 {
     int error;
     register struct inode *inode;

--- a/elks/fs/minix/symlink.c
+++ b/elks/fs/minix/symlink.c
@@ -19,7 +19,7 @@
 
 static int minix_follow_link(struct inode *dir,
 			     register struct inode *inode,
-			     int flag, int mode, struct inode **res_inode)
+			     int flag, mode_t mode, struct inode **res_inode)
 {
     /*
      *      FIXME: #1 Stack use is too high

--- a/elks/fs/msdos/namei.c
+++ b/elks/fs/msdos/namei.c
@@ -200,7 +200,7 @@ static int FATPROC msdos_create_entry(struct inode *dir,const char *name,int is_
 }
 
 
-int msdos_create(register struct inode *dir,const char *name,int len,int mode,
+int msdos_create(register struct inode *dir,const char *name,size_t len,mode_t mode,
 	struct inode **result)
 {
 	struct buffer_head *bh;
@@ -228,7 +228,7 @@ int msdos_create(register struct inode *dir,const char *name,int len,int mode,
 }
 
 
-int msdos_mkdir(struct inode *dir,const char *name,int len,int mode)
+int msdos_mkdir(struct inode *dir,const const char *name,size_t len,mode_t mode)
 {
 	struct buffer_head *bh;
 	struct msdos_dir_entry *de;

--- a/elks/fs/namei.c
+++ b/elks/fs/namei.c
@@ -36,9 +36,10 @@ int permission(register struct inode *inode, int mask)
 {
     mode_t mode = inode->i_mode;
     int error = -EACCES;
+    struct task_struct *p;
 
     if (mask & MAY_WRITE) {     /* disallow writing over running programs */
-        __ptask p = &task[0];
+        p = &task[0];
         do {
             if (p->state <= TASK_STOPPED && (p->t_inode == inode))
                 return -EBUSY;

--- a/elks/fs/namei.c
+++ b/elks/fs/namei.c
@@ -116,7 +116,7 @@ static int lookup(register struct inode *dir, const char *name, size_t len,
 }
 
 static int follow_link(struct inode *dir, register struct inode *inode,
-                int flag, int mode, struct inode **res_inode)
+                int flag, mode_t mode, struct inode **res_inode)
 {
     struct inode_operations *iop;
     int error = 0;
@@ -286,7 +286,7 @@ int namei(const char *pathname, register struct inode **res_inode, int dir, int 
  * for symlinks (where the permissions are checked later).
  */
 
-int open_namei(const char *pathname, int flag, int mode,
+int open_namei(const char *pathname, int flag, mode_t mode,
                struct inode **res_inode, struct inode *base)
 {
     register struct inode *dirp;
@@ -382,7 +382,7 @@ int open_namei(const char *pathname, int flag, int mode,
     return error;
 }
 
-int do_mknod(char *pathname, int offst, int mode, dev_t dev)
+int do_mknod(char *pathname, int offst, mode_t mode, dev_t dev)
 {
     register struct inode *dirp;
     register struct inode_operations *iop;
@@ -424,7 +424,7 @@ int do_mknod(char *pathname, int offst, int mode, dev_t dev)
     return error;
 }
 
-int sys_mknod(char *pathname, int mode, dev_t dev)
+int sys_mknod(char *pathname, mode_t mode, dev_t dev)
 {
     if (S_ISDIR(mode) || (!S_ISFIFO(mode) && !suser())) return -EPERM;
 
@@ -444,7 +444,7 @@ int sys_mknod(char *pathname, int mode, dev_t dev)
     return do_mknod(pathname, offsetof(struct inode_operations,mknod), mode, dev);
 }
 
-int sys_mkdir(char *pathname, int mode)
+int sys_mkdir(char *pathname, mode_t mode)
 {
     return do_mknod(pathname, offsetof(struct inode_operations,mkdir), (mode & 0777)|S_IFDIR, 0);
 }

--- a/elks/fs/open.c
+++ b/elks/fs/open.c
@@ -43,7 +43,7 @@ int sys_utime(char *filename, register struct utimbuf *times)
  * We do this by temporarily setting fsuid/fsgid to the wanted values
  */
 
-int sys_access(char *filename, int mode)
+int sys_access(char *filename, mode_t mode)
 {
     struct inode *inode;
     uid_t old_euid;
@@ -107,7 +107,7 @@ int sys_chmod(char *filename, mode_t mode)
         iput(inodep);
         return -EROFS;
     }
-    if (mode == (mode_t) - 1)
+    if (mode == (mode_t) -1)
         mode = inodep->i_mode;
     nap->ia_mode = (mode & S_IALLUGO) | (inodep->i_mode & ~S_IALLUGO);
     nap->ia_valid = ATTR_MODE | ATTR_CTIME;
@@ -231,13 +231,13 @@ int sys_fchown(unsigned int fd, uid_t user, gid_t group)
  * used by symlinks.
  */
 
-int sys_open(const char *filename, int flags, int mode)
+int sys_open(const char *filename, int flags, mode_t mode)
 {
     struct inode *inode;
     int error, flag;
 
     flag = flags;
-    if ((mode_t)((flags + 1) & O_ACCMODE)) flag++;
+    if ((flags + 1) & O_ACCMODE) flag++;
     if (flag & (O_TRUNC | O_CREAT)) flag |= FMODE_WRITE;
 
     debug_file("OPEN '%t' flags %#x", filename, flags);

--- a/elks/fs/open.c
+++ b/elks/fs/open.c
@@ -46,7 +46,6 @@ int sys_utime(char *filename, register struct utimbuf *times)
 int sys_access(char *filename, int mode)
 {
     struct inode *inode;
-    register __ptask currentp = current;
     uid_t old_euid;
     gid_t old_egid;
     int error;
@@ -54,42 +53,40 @@ int sys_access(char *filename, int mode)
     if (mode != (mode & S_IRWXO))       /* where's F_OK, X_OK, W_OK, R_OK? */
         error = -EINVAL;
     else {
-        old_euid = currentp->euid;
-        old_egid = currentp->egid;
-        currentp->euid = currentp->uid;
-        currentp->egid = currentp->gid;
+        old_euid = current->euid;
+        old_egid = current->egid;
+        current->euid = current->uid;
+        current->egid = current->gid;
         error = namei(filename, &inode, 0, mode);
         if (!error) iput(inode);
-        currentp->euid = old_euid;
-        currentp->egid = old_egid;
+        current->euid = old_euid;
+        current->egid = old_egid;
     }
     return error;
 }
 
 int sys_chdir(char *filename)
 {
-    register __ptask currentp = current;
     struct inode *inode;
     int error;
 
     error = namei(filename, &inode, IS_DIR, MAY_EXEC);
     if (!error) {
-        iput(currentp->fs.pwd);
-        currentp->fs.pwd = inode;
+        iput(current->fs.pwd);
+        current->fs.pwd = inode;
     }
     return error;
 }
 
 int sys_chroot(char *filename)
 {
-    register __ptask currentp = current;
     struct inode *inode;
     int error;
 
     error = (suser() ? namei(filename, &inode, IS_DIR, 0) : -EPERM);
     if (!error) {
-        iput(currentp->fs.root);
-        currentp->fs.root = inode;
+        iput(current->fs.root);
+        current->fs.root = inode;
     }
     return error;
 }

--- a/elks/fs/romfs/romfs.c
+++ b/elks/fs/romfs/romfs.c
@@ -158,7 +158,7 @@ static int romfs_readlink (struct inode * inode, char * buf, size_t len)
 
 
 static int romfs_followlink (struct inode * dir, register struct inode * inode,
-	int flag, int mode, struct inode ** res_inode)
+	int flag, mode_t mode, struct inode ** res_inode)
 {
 	int err;
 

--- a/elks/fs/super.c
+++ b/elks/fs/super.c
@@ -410,7 +410,7 @@ int sys_mount(char *dev_name, char *dir_name, int type, int flags)
     else if (MAJOR(inodep->i_rdev) >= MAX_BLKDEV)
         retval = -ENXIO;
     else
-        retval = open_filp((mode_t)((flags & MS_RDONLY) ? 1 : 3), inodep, &filp);
+        retval = open_filp((flags & MS_RDONLY) ? 1 : 3, inodep, &filp);
     if (retval) {
         iput(inodep);
         return retval;

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -278,16 +278,16 @@ struct file_operations {
 
 struct inode_operations {
     struct file_operations      *default_file_ops;
-    int                         (*create) ();
+    int                         (*create) (struct inode *, const char *, size_t, mode_t, struct inode **);
     int                         (*lookup) (struct inode * dir, const char * name, size_t len, struct inode ** res);
     int                         (*link) ();
     int                         (*unlink) ();
     int                         (*symlink) ();
-    int                         (*mkdir) ();
+    int                         (*mkdir) (struct inode *, const char *, size_t, mode_t);
     int                         (*rmdir) ();
-    int                         (*mknod) ();
+    int                         (*mknod) (struct inode *, const char *, size_t, mode_t, int);
     int                         (*readlink) (struct inode * i, char * buf, size_t len);
-    int                         (*follow_link) ();
+    int                         (*follow_link) (struct inode *, struct inode *, int, mode_t, struct inode **);
     struct buffer_head *        (*getblk) (struct inode *, block_t, int);
     void                        (*truncate) ();
 };
@@ -359,7 +359,7 @@ struct iattr {
 extern int notify_change(struct inode *,struct iattr *);
 #endif
 
-extern int sys_open(const char *,int,int);
+extern int sys_open(const char *,int,mode_t);
 extern int sys_close(unsigned int);     /* yes, it's really unsigned */
 
 extern void _close_allfiles(void);
@@ -412,11 +412,11 @@ extern int namei(const char *,struct inode **,int,int);
 
 extern int permission(struct inode *,int);
 
-extern int open_namei(const char *,int,int,struct inode **,struct inode *);
-extern int do_mknod(char *,int,int,dev_t);
+extern int open_namei(const char *,int,mode_t,struct inode **,struct inode *);
+extern int do_mknod(char *,int,mode_t,dev_t);
 extern void iput(struct inode *);
 
-extern struct inode *new_inode(struct inode *dir, __u16 mode);
+extern struct inode *new_inode(struct inode *dir, mode_t mode);
 extern void clear_inode(struct inode *);
 extern int open_filp(unsigned short, struct inode *, struct file **);
 extern void close_filp(struct inode *, struct file *);

--- a/elks/include/linuxmt/minix_fs.h
+++ b/elks/include/linuxmt/minix_fs.h
@@ -79,7 +79,7 @@ extern struct buffer_head *minix_bread(struct inode *,block_t,int);
 extern struct buffer_head *get_map_block(kdev_t dev, block_t block);
 extern unsigned short minix_count_free_blocks(register struct super_block *);
 extern unsigned short minix_count_free_inodes(register struct super_block *);
-extern int minix_create(register struct inode *,char *,size_t,int,
+extern int minix_create(register struct inode *,const char *,size_t,mode_t,
 			struct inode **);
 extern void minix_free_block(register struct super_block *,block_t);
 extern void minix_free_inode(register struct inode *);
@@ -88,10 +88,10 @@ extern int minix_link(register struct inode *,char *,size_t,
 			register struct inode *);
 extern int minix_lookup(register struct inode *,const char *,size_t,
 			register struct inode **);
-extern int minix_mkdir(register struct inode *,char *,size_t,int);
-extern int minix_mknod(register struct inode *,char *,size_t,int,int);
+extern int minix_mkdir(register struct inode *,const char *,size_t,mode_t);
+extern int minix_mknod(register struct inode *,const char *,size_t,mode_t,int);
 extern block_t minix_new_block(register struct super_block *);
-extern struct inode *minix_new_inode(struct inode *,__u16);
+extern struct inode *minix_new_inode(struct inode *,mode_t);
 /*extern void minix_put_inode(register struct inode *);*/
 extern void minix_put_super(register struct super_block *);
 /*extern void minix_read_inode(register struct inode *);*/

--- a/elks/include/linuxmt/msdos_fs.h
+++ b/elks/include/linuxmt/msdos_fs.h
@@ -147,9 +147,9 @@ cluster_t FATPROC get_cluster(struct inode *inode, cluster_t cluster);
 
 extern int msdos_lookup(struct inode *dir,const char *name,size_t len,
 	struct inode **result);
-extern int msdos_create(struct inode *dir,const char *name,int len,int mode,
+extern int msdos_create(struct inode *dir,const char *name,size_t len,mode_t mode,
 	struct inode **result);
-extern int msdos_mkdir(struct inode *dir,const char *name,int len,int mode);
+extern int msdos_mkdir(struct inode *dir,const char *name,size_t len,mode_t mode);
 extern int msdos_rmdir(struct inode *dir,const char *name,int len);
 extern int msdos_unlink(struct inode *dir,const char *name,int len);
 extern int msdos_rename(struct inode *old_dir,const char *old_name,int old_len,

--- a/elks/include/linuxmt/sched.h
+++ b/elks/include/linuxmt/sched.h
@@ -106,12 +106,9 @@ struct task_struct {
 #define DEPRECATED
 //#define DEPRECATED    __attribute__ ((deprecated))
 
-/* We use typedefs to avoid using struct foobar (*) */
-typedef struct task_struct *__ptask;
-
-extern __ptask task;
-extern __ptask current;
-extern __ptask next_task_slot;
+extern struct task_struct *task;
+extern struct task_struct *current;
+extern struct task_struct *next_task_slot;
 extern int max_tasks;
 extern int task_slots_unused;
 

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -37,11 +37,10 @@ static pid_t get_pid(void)
 struct task_struct *find_empty_process(void)
 {
     register struct task_struct *t;
-    register struct task_struct *currentp = current;
 
     if (task_slots_unused <= 1) {
         printk("Only %d task slots\n", task_slots_unused);
-        if (!task_slots_unused || currentp->uid)
+        if (!task_slots_unused || current->uid)
             return NULL;
     }
     t = next_task_slot;
@@ -51,7 +50,7 @@ struct task_struct *find_empty_process(void)
     }
     next_task_slot = t;
     task_slots_unused--;
-    *t = *currentp;
+    *t = *current;
     t->state = TASK_UNINTERRUPTIBLE;
     t->pid = get_pid();
 #ifdef CONFIG_CPU_USAGE
@@ -151,7 +150,6 @@ pid_t sys_vfork(void)
 #if 1
     return do_fork(0);
 #else
-    register __ptask currentp = current;
     int retval, sc[5];
 
     if ((retval = do_fork(1)) >= 0) {
@@ -164,16 +162,16 @@ pid_t sys_vfork(void)
          * first few bytes at the top of the user stack. Save those
          * bytes in the parent's kernel stack.
          */
-        memcpy_fromfs(sc, (void *)currentp->t_regs.sp, sizeof(sc));
+        memcpy_fromfs(sc, (void *)current->t_regs.sp, sizeof(sc));
         /*
          * Let the child go on first.
          */
-        sleep_on(&currentp->child_wait);
+        sleep_on(&current->child_wait);
         /*
          * By now, the child should have its own user stack. Restore
          * the parent's user stack.
          */
-        memcpy_tofs((void *)currentp->t_regs.sp, sc, sizeof(sc));
+        memcpy_tofs((void *)current->t_regs.sp, sc, sizeof(sc));
     }
     return retval;
 #endif

--- a/elks/kernel/fork.c
+++ b/elks/kernel/fork.c
@@ -9,7 +9,7 @@
 #include <arch/segment.h>
 
 int task_slots_unused;
-__ptask next_task_slot;
+struct task_struct *next_task_slot;
 pid_t last_pid = -1;
 
 static pid_t get_pid(void)

--- a/elks/kernel/sched.c
+++ b/elks/kernel/sched.c
@@ -17,9 +17,9 @@
 
 #define idle_task task[0]
 
-__ptask task;           /* dynamically allocated task array */
-__ptask current;
-__ptask previous;
+struct task_struct *task;           /* dynamically allocated task array */
+struct task_struct *current;
+struct task_struct *previous;
 int max_tasks = MAX_TASKS;
 
 void add_to_runqueue(register struct task_struct *p)
@@ -44,7 +44,7 @@ static void del_from_runqueue(register struct task_struct *p)
 
 static void process_timeout(int __data)
 {
-    register struct task_struct *p = (struct task_struct *) __data;
+    struct task_struct *p = (struct task_struct *) __data;
 
     debug_sched("sched: timeout %d\n", p->pid);
     p->timeout = 0UL;
@@ -59,8 +59,8 @@ static void process_timeout(int __data)
 
 void schedule(void)
 {
-    register __ptask prev;
-    register __ptask next;
+    struct task_struct *prev;
+    struct task_struct *next;
     jiff_t timeout = 0UL;
     struct timer_list timer;
 

--- a/elks/kernel/sched.c
+++ b/elks/kernel/sched.c
@@ -61,8 +61,8 @@ void schedule(void)
 {
     register __ptask prev;
     register __ptask next;
-    struct timer_list timer;
     jiff_t timeout = 0UL;
+    struct timer_list timer;
 
     prev = current;
 

--- a/elks/kernel/sleepwake.c
+++ b/elks/kernel/sleepwake.c
@@ -63,22 +63,18 @@ void finish_wait(struct wait_queue *p)
 
 void wait_set(struct wait_queue *p)
 {
-    register __ptask pcurrent = current;
-
 #ifdef CHECK_SCHED
-    if (pcurrent->waitpt) panic("SCHED: wait_set double wait");
+    if (current->waitpt) panic("SCHED: wait_set double wait");
 #endif
-    pcurrent->waitpt = p;
+    current->waitpt = p;
 }
 
 void wait_clear(struct wait_queue *p)
 {
-    register __ptask pcurrent = current;
-
 #ifdef CHECK_SCHED
-    if (pcurrent->waitpt != p) panic("SCHED: wait_clear wrong waitpt");
+    if (current->waitpt != p) panic("SCHED: wait_clear wrong waitpt");
 #endif
-    pcurrent->waitpt = NULL;
+    current->waitpt = NULL;
 }
 
 static void __sleep_on(register struct wait_queue *p, int state)

--- a/elks/kernel/sys.c
+++ b/elks/kernel/sys.c
@@ -97,12 +97,10 @@ int sys_uname(struct utsname *utsname)
 
 int sys_setgid(gid_t gid)
 {
-    register __ptask currentp = current;
-
     if (suser())
-	currentp->gid = currentp->egid = currentp->sgid = gid;
-    else if ((gid == currentp->gid) || (gid == currentp->sgid))
-	currentp->egid = gid;
+	current->gid = current->egid = current->sgid = gid;
+    else if ((gid == current->gid) || (gid == current->sgid))
+	current->egid = gid;
     else
 	return -EPERM;
     return 0;
@@ -130,13 +128,12 @@ pid_t sys_getpid(int *ppid)
     return twovalues(current->pid, (int *)&current->ppid, ppid);
 }
 
-unsigned short int sys_umask(unsigned short int mask)
+unsigned short int sys_umask(mode_t mask)
 {
-    register __ptask currentp = current;
-    unsigned short int old;
+    mode_t old;
 
-    old = currentp->fs.umask;
-    currentp->fs.umask = mask & ((unsigned short int) S_IRWXUGO);
+    old = current->fs.umask;
+    current->fs.umask = mask & S_IRWXUGO;
     return old;
 }
 
@@ -154,12 +151,10 @@ unsigned short int sys_umask(unsigned short int mask)
 
 int sys_setuid(uid_t uid)
 {
-    register __ptask currentp = current;
-
     if (suser())
-	currentp->uid = currentp->euid = currentp->suid = uid;
-    else if ((uid == currentp->uid) || (uid == currentp->suid))
-	currentp->euid = uid;
+	current->uid = current->euid = current->suid = uid;
+    else if ((uid == current->uid) || (uid == current->suid))
+	current->euid = uid;
     else
 	return -EPERM;
     return 0;
@@ -167,15 +162,13 @@ int sys_setuid(uid_t uid)
 
 int sys_setsid(void)
 {
-    register __ptask currentp = current;
-
-    if (currentp->session == currentp->pid)
+    if (current->session == current->pid)
 	return -EPERM;
     debug_tty("SETSID pgrp %P\n");
-    currentp->session = currentp->pgrp = currentp->pid;
-    currentp->tty = NULL;
+    current->session = current->pgrp = current->pid;
+    current->tty = NULL;
 
-    return currentp->pgrp;
+    return current->pgrp;
 }
 
 #if UNUSED


### PR DESCRIPTION
Removed most uses of `__ptask currentp = current` which was an old optimization for not having to grab a global variable too often, likely from the BCC compiler days. In almost every case, code size improved as GCC was allowed to do its own optimizations and/or not requiring a register variable.

Removed '__ptask` typedef.

Replaced `int mode` with `mode_t mode` and removed `(mode_t)` casts for portability and correctness.



