### PR TITLE
[watcom] Add option processing to ewcc and ewlink

### DIFF
--- a/elks/tools/objtools/ewcc
+++ b/elks/tools/objtools/ewcc
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 #
-# ewcc - OpenWatcom wcc script for ELKS
+# ewcc - OpenWatcom owcc/wcc script for ELKS
 #
-# Usage: ewcc filename.c
+# Usage: ewcc [-{owcc option}] [--{option}(wcc -Wc,option)] file.c
 #   produces filename.obj
 #
-# 3 Jun 2024 Compact model only for now
+# 3 Jun 2024 Initial version
+# 3 Jul 2024 Added -options for owcc and --options for wcc
 #
 set -e
 
@@ -27,13 +28,6 @@ if [ -z "$WATDIR" ]
     exit
 fi
 
-if [ $# -eq 0 ]
-  then
-    echo "Usage: ewcc <filename>.c"
-    exit
-fi
-
-PROG=$1
 ELKSLIBCINCLUDE=$TOPDIR/libc/include
 ELKSINCLUDE=$TOPDIR/elks/include
 WATCINCLUDE=$WATDIR/bld/hdr/dos/h
@@ -64,6 +58,29 @@ CCFLAGS="\
     -I$ELKSINCLUDE                  \
     -I$WATCINCLUDE                  \
     "
+
+while true; do
+  case "$1" in
+    --*)
+        a=${1:1}
+        echo "Adding -Wc,$a"
+        CCFLAGS="$CCFLAGS -Wc,$a"
+        shift ;;
+    -*)
+        echo "Adding $1"
+        CCFLAGS="$CCFLAGS $1"
+        shift ;;
+    *)  break ;;
+  esac
+done
+
+if [ $# -eq 0 ]
+  then
+    echo "Usage: ewcc [-{owcc option}] [--{option}(wcc -Wc,option)] file.c"
+    exit
+fi
+
+PROG=$1
 
 owcc -v -c -Wall -Wextra -Os $CCFLAGS -o ${PROG%.c}.obj $PROG
 

--- a/elks/tools/objtools/ewcc
+++ b/elks/tools/objtools/ewcc
@@ -32,28 +32,36 @@ ELKSLIBCINCLUDE=$TOPDIR/libc/include
 ELKSINCLUDE=$TOPDIR/elks/include
 WATCINCLUDE=$WATDIR/bld/hdr/dos/h
 
+# owcc options:
+# -mcmodel={s,m,c,l}        # memory model
+# -march=i86                # 8086 codegen
+# -bos2                     # produce OS/2 exe
+# -std=c99                  # -Wc,-za99
+# -Wc,-zev                  # enable void arithmetic
+# -Wc,-wcd=N                # disable warning N
+# -Wc,-fpi87                # inline 8087 fp
+# unused:
+# -mhard-emu-float          # -Wc,-fpi (inline 8087 w/emulation)
+# -msoft-float              # -Wc,-fpc
+# -Wc,-fpc                  # non-IEEE soft fp
 # -fpmath
 # -mabi=cdecl               # push all args
-# -msoft-float              # -Wc,-fpc
-# -Wc,-fpc                  # soft fp
-# -mhard-emu-float          # -Wc,-fpi
-# -Wc,-fpi87                # inline 8087 fp
-# -Wc,-zev                  # enable void arithmetic
-# -std=c99                  # -Wc,-za99
 # -fnonconst-initializers   # -Wc,aa
 
 source $TOPDIR/libc/watcom.model
 
 CCFLAGS="\
-    -bos2                           \
     -mcmodel=$MODEL                 \
     -march=i86                      \
+    -Os                             \
+    -bos2                           \
     -std=c99                        \
-    -fno-stack-check                \
-    -Wc,-wcd=303                    \
     -Wc,-fpi87                      \
     -Wc,-zev                        \
+    -fno-stack-check                \
     -fnostdlib                      \
+    -Wall -Wextra                   \
+    -Wc,-wcd=303                    \
     -I$ELKSLIBCINCLUDE              \
     -I$ELKSINCLUDE                  \
     -I$WATCINCLUDE                  \
@@ -82,7 +90,7 @@ fi
 
 PROG=$1
 
-owcc -v -c -Wall -Wextra -Os $CCFLAGS -o ${PROG%.c}.obj $PROG
+owcc -v -c $CCFLAGS -o ${PROG%.c}.obj $PROG
 
 # dump OBJ file
 #omfdump ${PROG%.c}.obj

--- a/elks/tools/objtools/ewlink
+++ b/elks/tools/objtools/ewlink
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 #
-# ewlink - OpenWatcom wlink script for ELKS
+# ewlink - OpenWatcom owcc/wlink script for ELKS
 #
-# Usage: ewlink file1.obj file2.obj ...
+# Usage: ewlink [--heap N] [--stack N] [-{owcc option}] file1.obj file2.obj ...
 #   produces file1.os2 (for OS/2) and file1 (for ELKS)
 #
-# 3 Jun 2024 Compact model only for now
+# 3 Jun 2024 Initial version
+# 3 Jul 2024 Added -options for owcc and --options for wlink
 #
 set -e
 
@@ -24,12 +25,6 @@ fi
 if [ -z "$WATDIR" ]
   then
     echo "WATDIR= environment variable not set to Watcom source directory"
-    exit
-fi
-
-if [ $# -eq 0 ]
-  then
-    echo "Usage: ewcc <filename>.c"
     exit
 fi
 
@@ -77,6 +72,29 @@ LDFLAGS="\
     -Wl,option -Wl,stack=0x1000     \
     -Wl,option -Wl,heapsize=0x1000  \
     "
+
+while true; do
+  case "$1" in
+    --stack)
+        LDFLAGS="$LDFLAGS -Wl,option -Wl,stack=$2"
+        shift
+        shift ;;
+    --heap)
+        LDFLAGS="$LDFLAGS -Wl,option -Wl,heapsize=$2"
+        shift
+        shift ;;
+    -*)
+        LDFLAGS="$LDFLAGS $1"
+        shift ;;
+    *)  break ;;
+  esac
+done
+
+if [ $# -eq 0 ]
+  then
+    echo "Usage: ewlink [--heap N] [--stack N] [-{owcc option}] file1.obj file2.obj ..."
+    exit
+fi
 
 PROG=$1
 OUT=${PROG%.obj}

--- a/elks/tools/objtools/ewlink
+++ b/elks/tools/objtools/ewlink
@@ -22,49 +22,15 @@ if [ -z "$WATCOM" ]
     exit
 fi
 
-if [ -z "$WATDIR" ]
-  then
-    echo "WATDIR= environment variable not set to Watcom source directory"
-    exit
-fi
-
 ELKSLIBC=$TOPDIR/libc
-ELKSLIBCINCLUDE=$TOPDIR/libc/include
-ELKSINCLUDE=$TOPDIR/elks/include
-WATCINCLUDE=$WATDIR/bld/hdr/dos/h
-
-# -fpmath
-# -mabi=cdecl               # push all args
-# -msoft-float              # -Wc,-fpc
-# -Wc,-fpc                  # soft fp
-# -mhard-emu-float          # -Wc,-fpi
-# -Wc,-fpi87                # inline 8087 fp
-# -Wc,-zev                  # enable void arithmetic
-# -std=c99                  # -Wc,-za99
-# -fnonconst-initializers   # -Wc,aa
-
-source $TOPDIR/libc/watcom.model
-
-CCFLAGS="\
-    -bos2                           \
-    -mcmodel=$MODEL                 \
-    -march=i86                      \
-    -std=c99                        \
-    -fno-stack-check                \
-    -Wc,-wcd=303                    \
-    -Wc,-fpi87                      \
-    -Wc,-zev                        \
-    -fnostdlib                      \
-    -I$ELKSLIBCINCLUDE              \
-    -I$ELKSINCLUDE                  \
-    -I$WATCINCLUDE                  \
-    "
 
 # Warning 1008: cannot open os2.lib: No such file or directory
 # Warning 1014: stack segment not found
 
 LDFLAGS="\
-    -bos2 -s                        \
+    -bos2                           \
+    -s                              \
+    -fnostdlib                      \
     -Wl,disable -Wl,1008            \
     -Wl,disable -Wl,1014            \
     -Wl,option -Wl,start=_start_    \
@@ -99,7 +65,7 @@ fi
 PROG=$1
 OUT=${PROG%.obj}
 
-owcc -v -bos2 $CCFLAGS $LDFLAGS -o $OUT.os2 $@ $ELKSLIBC/libc.lib
+owcc -v $LDFLAGS -o $OUT.os2 $@ $ELKSLIBC/libc.lib
 
 # convert to ELKS a.out format
 #os2toelks -f elks -o $OUT $OUT.os2


### PR DESCRIPTION
Adds the ability to specify an application's heap and stack size to `ewlink`, and allows for passing through compile or link options to `owcc` from ewcc or ewlink by specifying the unmodified owcc dash option. 

Example: `ewcc -O2 ...` results in `owcc -O2 ...`.

When using `ewcc`, a dash-prefixed wcc option (e.g. `-zt1024`) can be passed to `wcc` by prefixing a second dash, which then slightly translates the option before passing to wcc.

Example: `ewcc --zt1024 ...` results in `owcc -Wc,-zt1024 ...`. 

(Note that `owcc` does not accept `wcc` options directly , they must be prefixed with `-Wc,...`).

`ewlink` accepts `--stack N` and `--heap N` (with N as decimal or hex if 0x prefixed) and creates the appropriate option for `wlink`.