### PR TITLE
[watcom] Update ewcc/ewlink, add many system calls

### DIFF
--- a/elks/tools/objtools/ewcc
+++ b/elks/tools/objtools/ewcc
@@ -2,7 +2,7 @@
 #
 # ewcc - OpenWatcom owcc/wcc script for ELKS
 #
-# Usage: ewcc [-{owcc option}] [--{option}(wcc -Wc,option)] file.c
+# Usage: ewcc [-{owcc option}] [--{option}(wcc -Wc,option)] file.c ...
 #   produces filename.obj
 #
 # 3 Jun 2024 Initial version
@@ -29,7 +29,8 @@ if [ -z "$WATDIR" ]
 fi
 
 ELKSLIBCINCLUDE=$TOPDIR/libc/include
-ELKSINCLUDE=$TOPDIR/elks/include
+ELKSINCLUDE1=$TOPDIR/include
+ELKSINCLUDE2=$TOPDIR/elks/include
 WATCINCLUDE=$WATDIR/bld/hdr/dos/h
 
 # owcc options:
@@ -63,7 +64,8 @@ CCFLAGS="\
     -Wall -Wextra                   \
     -Wc,-wcd=303                    \
     -I$ELKSLIBCINCLUDE              \
-    -I$ELKSINCLUDE                  \
+    -I$ELKSINCLUDE1                 \
+    -I$ELKSINCLUDE2                 \
     -I$WATCINCLUDE                  \
     "
 
@@ -84,13 +86,15 @@ done
 
 if [ $# -eq 0 ]
   then
-    echo "Usage: ewcc [-{owcc option}] [--{option}(wcc -Wc,option)] file.c"
+    echo "Usage: ewcc [-{owcc option}] [--{option}(wcc -Wc,option)] file.c ..."
     exit
 fi
 
-PROG=$1
-
-owcc -v -c $CCFLAGS -o ${PROG%.c}.obj $PROG
+for PROG in $@
+do
+    echo owcc -v -c $CCFLAGS -o ${PROG%.c}.obj $PROG
+    owcc -v -c $CCFLAGS -o ${PROG%.c}.obj $PROG
+done
 
 # dump OBJ file
 #omfdump ${PROG%.c}.obj

--- a/elks/tools/objtools/ewlink
+++ b/elks/tools/objtools/ewlink
@@ -2,7 +2,7 @@
 #
 # ewlink - OpenWatcom owcc/wlink script for ELKS
 #
-# Usage: ewlink [--heap N] [--stack N] [-{owcc option}] file1.obj file2.obj ...
+# Usage: ewlink [-o binary] [--heap N] [--stack N] [-{owcc option}] file1.obj ...
 #   produces file1.os2 (for OS/2) and file1 (for ELKS)
 #
 # 3 Jun 2024 Initial version
@@ -49,6 +49,10 @@ while true; do
         LDFLAGS="$LDFLAGS -Wl,option -Wl,heapsize=$2"
         shift
         shift ;;
+    -o)
+        OUT=$2
+        shift
+        shift ;;
     -*)
         LDFLAGS="$LDFLAGS $1"
         shift ;;
@@ -58,14 +62,18 @@ done
 
 if [ $# -eq 0 ]
   then
-    echo "Usage: ewlink [--heap N] [--stack N] [-{owcc option}] file1.obj file2.obj ..."
+    echo "Usage: ewlink [-o binary] [--heap N] [--stack N] [-{owcc option}] file1.obj ..."
     exit
 fi
 
-PROG=$1
-OUT=${PROG%.obj}
+if [ "$OUT" == "" ]
+  then
+    PROG=$1
+    OUT=${PROG%.obj}.os2
+fi
 
-owcc -v $LDFLAGS -o $OUT.os2 $@ $ELKSLIBC/libc.lib
+echo owcc -v $LDFLAGS -o $OUT $@ $ELKSLIBC/libc.lib
+owcc -v $LDFLAGS -o $OUT $@ $ELKSLIBC/libc.lib
 
 # convert to ELKS a.out format
 #os2toelks -f elks -o $OUT $OUT.os2

--- a/libc/include/watcom/syselks.h
+++ b/libc/include/watcom/syselks.h
@@ -72,7 +72,7 @@ typedef int syscall_res;
 #define SYS_write                 4
 #define SYS_open                  5
 #define SYS_close                 6
-#define SYS_waitpid               7
+#define SYS_wait4                 7
 //#define SYS_creat               8
 #define SYS_link                  9
 #define SYS_unlink               10

--- a/libc/watcom/syscall/access.c
+++ b/libc/watcom/syscall/access.c
@@ -1,0 +1,40 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS access() implementation.
+*
+****************************************************************************/
+
+#include <unistd.h>
+#include "watcom/syselks.h"
+
+int access( const char *filename, int mode )
+{
+    sys_setseg(filename);
+    syscall_res res = sys_call2( SYS_access, (unsigned)filename, mode );
+    __syscall_return( int, res );
+}

--- a/libc/watcom/syscall/chdir.c
+++ b/libc/watcom/syscall/chdir.c
@@ -1,0 +1,40 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS chdir() implementation.
+*
+****************************************************************************/
+
+#include <unistd.h>
+#include "watcom/syselks.h"
+
+int chdir( const char *__path )
+{
+    sys_setseg(__path);
+    syscall_res res = sys_call1( SYS_chdir, (unsigned)__path );
+    __syscall_return( int, res );
+}

--- a/libc/watcom/syscall/chmod.c
+++ b/libc/watcom/syscall/chmod.c
@@ -1,0 +1,40 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS chmod() implementation.
+*
+****************************************************************************/
+
+#include <sys/stat.h>
+#include "watcom/syselks.h"
+
+int chmod( const char *__path, mode_t __mode )
+{
+    sys_setseg(__path);
+    syscall_res res = sys_call2( SYS_chmod, (unsigned)__path, __mode );
+    __syscall_return( int, res );
+}

--- a/libc/watcom/syscall/chown.c
+++ b/libc/watcom/syscall/chown.c
@@ -1,0 +1,40 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS chown() implementation.
+*
+****************************************************************************/
+
+#include <unistd.h>
+#include "watcom/syselks.h"
+
+int chown( const char *__path, uid_t __owner, gid_t __group )
+{
+    sys_setseg(__path);
+    syscall_res res = sys_call3( SYS_chown, (unsigned)__path, __owner, __group );
+    __syscall_return( int, res );
+}

--- a/libc/watcom/syscall/dup.c
+++ b/libc/watcom/syscall/dup.c
@@ -1,0 +1,39 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS dup() implementation.
+*
+****************************************************************************/
+
+#include <unistd.h>
+#include "watcom/syselks.h"
+
+int dup( int __oldfd )
+{
+    syscall_res res = sys_call1( SYS_dup, __oldfd );
+    __syscall_return( int, res );
+}

--- a/libc/watcom/syscall/dup2.c
+++ b/libc/watcom/syscall/dup2.c
@@ -1,0 +1,39 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS dup2() implementation.
+*
+****************************************************************************/
+
+#include <unistd.h>
+#include "watcom/syselks.h"
+
+int dup2( int __oldfd, int __newfd )
+{
+    syscall_res res = sys_call2( SYS_dup2, __oldfd, __newfd );
+    __syscall_return( int, res );
+}

--- a/libc/watcom/syscall/fork.c
+++ b/libc/watcom/syscall/fork.c
@@ -1,0 +1,39 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS fork() implementation.
+*
+****************************************************************************/
+
+#include <unistd.h>
+#include "watcom/syselks.h"
+
+pid_t fork( void )
+{
+    syscall_res res = sys_call0( SYS_fork );
+    __syscall_return( pid_t, res );
+}

--- a/libc/watcom/syscall/getgid.c
+++ b/libc/watcom/syscall/getgid.c
@@ -1,0 +1,40 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS getgid() implementation.
+*
+****************************************************************************/
+
+#include <unistd.h>
+#include "watcom/syselks.h"
+
+gid_t _getgid( int *egid)
+{
+    sys_setseg(egid);
+    syscall_res res = sys_call1( SYS_getgid, (unsigned)egid );
+    __syscall_return( gid_t, res );
+}

--- a/libc/watcom/syscall/gettimeofday.c
+++ b/libc/watcom/syscall/gettimeofday.c
@@ -1,0 +1,14 @@
+/****************************************************************************
+*
+* Description:  ELKS gettimeofday() system call.
+*
+****************************************************************************/
+
+#include "watcom/syselks.h"
+
+int gettimeofday(struct timeval * restrict __tv, void * restrict __tzp)
+{
+    sys_setseg(__tv);
+    syscall_res res = sys_call2(SYS_gettimeofday, (unsigned)__tv, (unsigned)__tzp);
+    __syscall_return(int, res);
+}

--- a/libc/watcom/syscall/getuid.c
+++ b/libc/watcom/syscall/getuid.c
@@ -1,0 +1,40 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS getuid() implementation.
+*
+****************************************************************************/
+
+#include <unistd.h>
+#include "watcom/syselks.h"
+
+gid_t _getuid( int *euid)
+{
+    sys_setseg(euid);
+    syscall_res res = sys_call1( SYS_getuid, (unsigned)euid );
+    __syscall_return( uid_t, res );
+}

--- a/libc/watcom/syscall/kill.c
+++ b/libc/watcom/syscall/kill.c
@@ -1,0 +1,39 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS kill() implementation.
+*
+****************************************************************************/
+
+#include <signal.h>
+#include "watcom/syselks.h"
+
+int kill( pid_t __pid, int __sig )
+{
+    syscall_res res = sys_call2( SYS_kill, __pid, __sig );
+    __syscall_return( int, res );
+}

--- a/libc/watcom/syscall/link.c
+++ b/libc/watcom/syscall/link.c
@@ -1,0 +1,40 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS link() implementation.
+*
+****************************************************************************/
+
+#include <unistd.h>
+#include "watcom/syselks.h"
+
+int link( const char *__path1, const char *__path2 )
+{
+    sys_setseg(__path1);
+    syscall_res res = sys_call2( SYS_link, (unsigned)__path1, (unsigned)__path2 );
+    __syscall_return( int, res );
+}

--- a/libc/watcom/syscall/lstat.c
+++ b/libc/watcom/syscall/lstat.c
@@ -1,0 +1,40 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS lstat() implementation.
+*
+****************************************************************************/
+
+#include <sys/stat.h>
+#include "watcom/syselks.h"
+
+int lstat( const char *filename, struct stat * __buf )
+{
+    sys_setseg(__buf);
+    syscall_res res = sys_call2( SYS_lstat, (unsigned)filename, (unsigned)__buf );
+    __syscall_return( int, res );
+}

--- a/libc/watcom/syscall/mkdir.c
+++ b/libc/watcom/syscall/mkdir.c
@@ -1,0 +1,40 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS mkdir() implementation.
+*
+****************************************************************************/
+
+#include <sys/stat.h>
+#include "watcom/syselks.h"
+
+int mkdir( const char *__path, mode_t __mode )
+{
+    sys_setseg(__path);
+    syscall_res res = sys_call2( SYS_mkdir, (unsigned)__path, __mode );
+    __syscall_return( int, res );
+}

--- a/libc/watcom/syscall/mknod.c
+++ b/libc/watcom/syscall/mknod.c
@@ -1,0 +1,40 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS mknod() implementation.
+*
+****************************************************************************/
+
+#include <sys/stat.h>
+#include "watcom/syselks.h"
+
+int mknod( const char *__path, mode_t __mode, dev_t __dev )
+{
+    sys_setseg(__path);
+    syscall_res res = sys_call3( SYS_mknod, (unsigned)__path, __mode, __dev );
+    __syscall_return( int, res );
+}

--- a/libc/watcom/syscall/readlink.c
+++ b/libc/watcom/syscall/readlink.c
@@ -1,0 +1,40 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS readlink() implementation.
+*
+****************************************************************************/
+
+#include <unistd.h>
+#include "watcom/syselks.h"
+
+int readlink( const char *__path, char *__buf, size_t __bufsiz )
+{
+    sys_setseg(__buf);
+    syscall_res res = sys_call3( SYS_readlink, (unsigned)__path, (unsigned)__buf, __bufsiz );
+    __syscall_return( int, res );
+}

--- a/libc/watcom/syscall/rename.c
+++ b/libc/watcom/syscall/rename.c
@@ -1,0 +1,40 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS rename() implementation.
+*
+****************************************************************************/
+
+#include <stdio.h>
+#include "watcom/syselks.h"
+
+int rename( const char *__old, const char *__new )
+{
+    sys_setseg(__old);
+    syscall_res res = sys_call2( SYS_rename, (unsigned)__old, (unsigned)__new );
+    __syscall_return( int, res );
+}

--- a/libc/watcom/syscall/rmdir.c
+++ b/libc/watcom/syscall/rmdir.c
@@ -1,0 +1,40 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS rmdir() implementation.
+*
+****************************************************************************/
+
+#include <unistd.h>
+#include "watcom/syselks.h"
+
+int rmdir( const char *__path )
+{
+    sys_setseg(__path);
+    syscall_res res = sys_call1( SYS_rmdir, (unsigned)__path );
+    __syscall_return( int, res );
+}

--- a/libc/watcom/syscall/setsid.c
+++ b/libc/watcom/syscall/setsid.c
@@ -1,0 +1,39 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS setsid() implementation.
+*
+****************************************************************************/
+
+#include <unistd.h>
+#include "watcom/syselks.h"
+
+pid_t setsid( void )
+{
+    syscall_res res = sys_call0( SYS_setsid );
+    __syscall_return( int, res );
+}

--- a/libc/watcom/syscall/symlink.c
+++ b/libc/watcom/syscall/symlink.c
@@ -1,0 +1,40 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS symlink() implementation.
+*
+****************************************************************************/
+
+#include <unistd.h>
+#include "watcom/syselks.h"
+
+int symlink( const char *__pname, const char *__slink )
+{
+    sys_setseg(__pname);
+    syscall_res res = sys_call2( SYS_symlink, (unsigned)__pname, (unsigned)__slink );
+    __syscall_return( int, res );
+}

--- a/libc/watcom/syscall/umask.c
+++ b/libc/watcom/syscall/umask.c
@@ -1,0 +1,39 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS umask() implementation.
+*
+****************************************************************************/
+
+#include <sys/stat.h>
+#include "watcom/syselks.h"
+
+mode_t umask( mode_t __cmask )
+{
+    syscall_res res = sys_call1( SYS_umask, __cmask );
+    __syscall_return( mode_t, res );
+}

--- a/libc/watcom/syscall/utime.c
+++ b/libc/watcom/syscall/utime.c
@@ -1,0 +1,40 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS utime() implementation.
+*
+****************************************************************************/
+
+#include <utime.h>
+#include "watcom/syselks.h"
+
+int utime( const char *__path, struct utimbuf * __times )
+{
+    sys_setseg(__path);
+    syscall_res res = sys_call2( SYS_utime, (unsigned)__path, (unsigned)__times );
+    __syscall_return( int, res );
+}

--- a/libc/watcom/syscall/vfork.c
+++ b/libc/watcom/syscall/vfork.c
@@ -1,0 +1,39 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS vfork() implementation.
+*
+****************************************************************************/
+
+#include <unistd.h>
+#include "watcom/syselks.h"
+
+pid_t vfork( void )
+{
+    syscall_res res = sys_call0( SYS_vfork );
+    __syscall_return( pid_t, res );
+}

--- a/libc/watcom/syscall/wait4.c
+++ b/libc/watcom/syscall/wait4.c
@@ -1,0 +1,43 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS waitpid() implementation.
+*
+****************************************************************************/
+
+#include <sys/types.h>
+#include <sys/wait.h>
+#include "watcom/syselks.h"
+
+pid_t wait4( pid_t __pid, int *__stat_loc, int __options, struct rusage *rusage )
+{
+    if (__stat_loc)
+        sys_setseg(__stat_loc);
+    syscall_res res = sys_call4( SYS_wait4, __pid, (unsigned)__stat_loc, __options,
+        (unsigned)rusage );
+    __syscall_return( pid_t, res );
+}


### PR DESCRIPTION
`ewcc` is enhanced to allow multiple .c files on the command line.
`ewlink -o binary` allows specifying an output binary file.

Added lots of system calls for the Watcom C based ELKS C library. Ongoing testing by compiling various ELKS applications in elkscmd/.