### PR TITLE
[watcom] Fix malloc/realloc/free, add execl, execle, execlp, execlpe

### DIFF
--- a/libc/include/malloc.h
+++ b/libc/include/malloc.h
@@ -21,11 +21,11 @@ void *alloca(size_t);
 /* remove __MINI_MALLOC__ and always use real malloc for libc routines*/
 //#define __MINI_MALLOC__
 
-void *__mini_malloc(size_t size);
+void __wcnear *__mini_malloc(size_t size);
 #endif
 
 #ifdef __MINI_MALLOC__
-extern void *(*__alloca_alloc)(size_t);
+extern void __wcnear *(*__alloca_alloc)(size_t);
 #define malloc(x) ((*__alloca_alloc)(x))
 #endif
 

--- a/libc/include/unistd.h
+++ b/libc/include/unistd.h
@@ -43,10 +43,10 @@ int _sbrk(int increment, void **pnewbrk);       /* syscall */
 int close (int fildes);
 int dup (int fildes);
 int dup2 (int oldfd, int newfd);
-int execl(const char *fname, const char *arg1, ...);
-int execle(const char *fname, const char *arg0, ...);
-int execlp(const char *fname, const char *arg0, ...);
-int execlpe(const char *fname, const char *arg0, ...);
+int execl(const char *fname, const char *arg0, ... /*, (char *)0 */);
+int execle(const char *fname, const char *arg0, ... /*, (char *)0, char *envp[] */);
+int execlp(const char *fname, const char *arg0, ... /*, (char *)0 */);
+int execlpe(const char *fname, const char *arg0, ... /*, (char *)0, char *envp[] */);
 int execv(const char *fname, char **argv);
 int execve(const char *fname, char **argv, char **envp);
 int execvp(const char *fname, char **argv);

--- a/libc/malloc/__alloca_alloc.c
+++ b/libc/malloc/__alloca_alloc.c
@@ -1,5 +1,5 @@
 #include <malloc.h>
 
 #ifdef __MINI_MALLOC__
-void *(*__alloca_alloc)(size_t) = __mini_malloc;
+void __wcnear *(*__alloca_alloc)(size_t) = __mini_malloc;
 #endif

--- a/libc/malloc/__freed_list.c
+++ b/libc/malloc/__freed_list.c
@@ -1,3 +1,3 @@
 #include "_malloc.h"
 
-mem  *__freed_list = 0;
+mem  __wcnear *__freed_list = 0;

--- a/libc/malloc/__mini_malloc.c
+++ b/libc/malloc/__mini_malloc.c
@@ -4,7 +4,7 @@
 
 #include "_malloc.h"
 
-void *
+void __wcnear *
 __mini_malloc(size_t size)
 {
 	mem *ptr;
@@ -34,5 +34,5 @@ __mini_malloc(size_t size)
 
 	m_size(ptr) = size;
 	__noise("CREATE", ptr);
-	return ptr + 1;
+	return (void __wcnear *)(ptr + 1);
 }

--- a/libc/malloc/_malloc.h
+++ b/libc/malloc/_malloc.h
@@ -11,7 +11,7 @@ typedef union mem_cell
 } mem;
 
 #ifdef VERBOSE
-void __noise(char *y, mem *x);
+void __noise(char *y, mem __wcnear *x);
 #else
 #define __noise(y,x)
 #endif
@@ -20,6 +20,6 @@ void __noise(char *y, mem *x);
 #define m_next(p)  ((p) [1].next)	/* For malloc and alloca */
 #define m_size(p)  ((p) [0].size)	/* For malloc */
 
-extern mem *__freed_list;
+extern mem __wcnear *__freed_list;
 
 #endif

--- a/libc/malloc/alloca.c
+++ b/libc/malloc/alloca.c
@@ -6,14 +6,13 @@
 /* This alloca is based on the same concept as the EMACS fallback alloca.
  * It should probably be considered Copyright the FSF under the GPL.
  */
-static mem *alloca_stack = 0;
+static mem __wcnear *alloca_stack = 0;
 
 void *
-alloca(size)
-size_t size;
+alloca(size_t size)
 {
    auto char probe;		/* Probes stack depth: */
-   register mem *hp;
+   register mem __wcnear *hp;
 
    /*
     * Reclaim garbage, defined as all alloca'd storage that was allocated
@@ -23,7 +22,7 @@ size_t size;
    for (hp = alloca_stack; hp != 0;)
       if (m_deep(hp) < &probe)
       {
-	 register mem *np = m_next(hp);
+	 register mem __wcnear *np = m_next(hp);
 	 free((void *) hp);	/* Collect garbage.  */
 	 hp = np;		/* -> next header.  */
       }
@@ -34,7 +33,7 @@ size_t size;
    if (size == 0)
       return 0;			/* No allocation required.  */
 
-   hp = (mem *) (*__alloca_alloc) (sizeof(mem)*2 + size);
+   hp = (mem __wcnear *) (*__alloca_alloc) (sizeof(mem)*2 + size);
    if (hp == 0)
       return hp;
 

--- a/libc/malloc/free.c
+++ b/libc/malloc/free.c
@@ -6,8 +6,8 @@
 void
 free(void * ptr)
 {
-	register mem *top;
-	register mem *chk = (mem *) ptr;
+	register mem __wcnear *top;
+	register mem __wcnear *chk = (mem __wcnear *) ptr;
 
 	if (chk == 0)
 		return;		/* free(NULL) - be nice */
@@ -16,7 +16,7 @@ free(void * ptr)
 #ifdef __MINI_MALLOC__
  try_this:;
 #endif
-	top = (mem *) sbrk(0);
+	top = (mem __wcnear *) sbrk(0);
 	if (chk + m_size(chk) == top) {
 		__noise("FREE brk", chk);
 		brk(top - m_size(chk));
@@ -38,7 +38,7 @@ free(void * ptr)
 			m_next(chk) = __freed_list;
 			__freed_list = chk;
 		} else {
-			register mem *prev;
+			register mem __wcnear *prev;
 			prev = __freed_list;
 			for (top = __freed_list; top && top > chk;
 			     prev = top, top = m_next(top)) ;

--- a/libc/malloc/malloc.c
+++ b/libc/malloc/malloc.c
@@ -22,16 +22,16 @@
  * circular list of all the free blocks in memory
  */
 
-static mem *chunk_list = 0;
+static mem __wcnear *chunk_list = 0;
 
 /*
  * This function takes a pointer to a block of memory and inserts it into
  * the chain of memory chunks
  */
 static void
-__insert_chunk(mem *mem_chunk)
+__insert_chunk(mem __wcnear *mem_chunk)
 {
-   register mem *p1, *p2;
+   register mem __wcnear *p1, __wcnear *p2;
    if (chunk_list == 0)		/* Simple case first */
    {
       chunk_list = mem_chunk;
@@ -132,7 +132,7 @@ __insert_chunk(mem *mem_chunk)
 static mem *
 __search_chunk(unsigned int mem_size)
 {
-   register mem *p1, *p2;
+   register mem __wcnear *p1, __wcnear *p2;
    if (chunk_list == 0)		/* Simple case first */
       return 0;
 
@@ -187,7 +187,7 @@ __search_chunk(unsigned int mem_size)
 void *
 malloc(size_t size)
 {
-   register mem *ptr = 0;
+   register mem __wcnear *ptr = 0;
    register unsigned int sz;
 
    if (size == 0)

--- a/libc/malloc/malloc.c
+++ b/libc/malloc/malloc.c
@@ -129,7 +129,7 @@ __insert_chunk(mem __wcnear *mem_chunk)
  * when found, if the chunk is too big it'll be split, and pointer to the
  * chunk returned. If none is found NULL is returned.
  */
-static mem *
+static mem __wcnear *
 __search_chunk(unsigned int mem_size)
 {
    register mem __wcnear *p1, __wcnear *p2;

--- a/libc/malloc/noise.c
+++ b/libc/malloc/noise.c
@@ -17,7 +17,7 @@ phex(unsigned int val)
 }
 
 void
-__noise(char *y, mem * x)
+__noise(char *y, mem __wcnear *x)
 {
     int saved_errno = errno;
     write(2, "Malloc ", 7);

--- a/libc/watcom/syscall/execl.c
+++ b/libc/watcom/syscall/execl.c
@@ -1,0 +1,7 @@
+#include <unistd.h>
+
+int
+execl(const char *fname, const char *arg0, ... /*, (char *)0 */)
+{
+    return execve(fname, (char **)&arg0, environ);
+}

--- a/libc/watcom/syscall/execle.c
+++ b/libc/watcom/syscall/execle.c
@@ -1,0 +1,10 @@
+#include <unistd.h>
+
+int
+execle(const char *fname, const char *arg0, ... /*, (char *)0, char *envp[] */)
+{
+    char **envp = (char **)&arg0;
+
+    while(*envp) envp++;
+    return execve(fname, (char **)&arg0, envp+1);
+}

--- a/libc/watcom/syscall/execlp.c
+++ b/libc/watcom/syscall/execlp.c
@@ -1,0 +1,7 @@
+#include <unistd.h>
+
+int
+execlp(const char *fname, const char *arg0, ... /*, (char *)0 */)
+{
+    return execvp(fname, (char **)&arg0);
+}

--- a/libc/watcom/syscall/execlpe.c
+++ b/libc/watcom/syscall/execlpe.c
@@ -1,0 +1,10 @@
+#include <unistd.h>
+
+int
+execlpe(const char *fname, const char *arg0, ... /*, (char *)0, char *envp[] */)
+{
+    char **envp = (char **)&arg0;
+
+    while(*envp) envp++;
+    return execvpe(fname, (char **)&arg0, envp+1);
+}


### PR DESCRIPTION
After debugging malloc/realloc/free compiled with Watcom and adding the execl family calls, lots of ELKS programs now compile and run in large (or other) model. 

Tested are `sash`, `od`, `hd`, `kilo`, `miniterm` and `ed`. 

The compilations are done using `ewcc` and `ewlink` and mostly done for testing new system calls and the C Library.

