### PR TITLE
[watcom] Change \e to \033 in TUI for OWC

### DIFF
--- a/elkscmd/file_utils/more.c
+++ b/elkscmd/file_utils/more.c
@@ -11,9 +11,9 @@
 #include <termios.h>
 #include "futils.h"
 
-#define MORE_STRING  "\e[7m--More--\e[0m"
-#define END_STRING   "\e[7m(END)\e[0m"
-#define CLEAR_SCREEN "\e[H\e[2J"
+#define MORE_STRING  "\033[7m--More--\033[0m"
+#define END_STRING   "\033[7m(END)\033[0m"
+#define CLEAR_SCREEN "\033[H\033[2J"
 
 #define WRITE(fd,str)   write(fd, str, strlen(str))
 

--- a/elkscmd/misc_utils/kilo.c
+++ b/elkscmd/misc_utils/kilo.c
@@ -689,7 +689,7 @@ void editorQueryString(char* prompt, char *buffer){
 
 void clearScreen() //function to clear the screen
 {
-  const char *CLEAR_SCREEN_ANSI = "\e[1;1H\e[2J";
+  const char *CLEAR_SCREEN_ANSI = "\033[1;1H\033[2J";
   write(STDOUT_FILENO, CLEAR_SCREEN_ANSI, 10);
 }
 

--- a/elkscmd/sys_utils/man.c
+++ b/elkscmd/sys_utils/man.c
@@ -45,11 +45,11 @@
 #define DEFAULT_EXTRA1	"ELKS Embeddable Linux Kernel Subset"
 
 /* font translations to ANSI sequences (\fB -> bold, \fI -> underline) */
-#define ANSI_NORMAL	 "\e[0m"	/* no attribute */
-#define ANSI_BOLD	 "\e[1m"	/* bold */
-#define ANSI_UNDERLINE   "\e[4m"	/* underline (normal on console for now) */
-//#define ANSI_UNDERLINE "\e[7m"	/* reverse video */
-//#define ANSI_UNDERLINE "\e[32m"	/* green */
+#define ANSI_NORMAL	 "\033[0m"	/* no attribute */
+#define ANSI_BOLD	 "\033[1m"	/* bold */
+#define ANSI_UNDERLINE   "\033[4m"	/* underline (normal on console for now) */
+//#define ANSI_UNDERLINE "\033[7m"	/* reverse video */
+//#define ANSI_UNDERLINE "\033[32m"	/* green */
 
 FILE * ofd;
 FILE * ifd;

--- a/elkscmd/tui/cons.c
+++ b/elkscmd/tui/cons.c
@@ -26,7 +26,7 @@ static const int ansi_colors[16] = {30, 34, 32, 36, 31, 35, 33, 37,
 
 static char *attr_to_ansi(char *buf, unsigned int attr)
 {
-    sprintf(buf, "\e[%d;%dm",
+    sprintf(buf, "\033[%d;%dm",
         ansi_colors[attr & 0x0F], ansi_colors[(attr & 0x70) >> 4] + 10);
     return buf;
 }
@@ -41,7 +41,7 @@ static void display(void)
     unsigned short __far *chattr = MK_FP(0xb800, 0);
     char buf[16];
 
-    fputs("\e[H", stdout);
+    fputs("\033[H", stdout);
     for (r=0; r<LINES; r++) {
         a = -1;
         for (c=0; c<COLS; c++) {
@@ -57,7 +57,7 @@ static void display(void)
         }
         putc(r == LINES - 1 ? '\r' : '\n', stdout);
     }
-    fputs("\e[1;0;0m", stdout);
+    fputs("\033[1;0;0m", stdout);
     fflush(stdout);
 }
 

--- a/elkscmd/tui/curses.c
+++ b/elkscmd/tui/curses.c
@@ -66,42 +66,42 @@ int addch(int ch)
 
 int mvaddch(int y, int x, int ch)
 {
-    printf("\e[%d;%dH%c", y+1, x+1, ch);
+    printf("\033[%d;%dH%c", y+1, x+1, ch);
     return OK;
 }
 
 /* cursor on/off */
 void curs_set(int visibility)
 {
-    printf("\e[?25%c", visibility? 'h': 'l');
+    printf("\033[?25%c", visibility? 'h': 'l');
 }
 
 /* clear screen */
 void erase()
 {
-    printf("\e[H\e[2J");
+    printf("\033[H\033[2J");
 }
 
 void move(int y, int x)
 {
     //y += yoff;
     //x += xoff;
-    printf("\e[%d;%dH", y+1, x+1);
+    printf("\033[%d;%dH", y+1, x+1);
 }
 
 void clrnl(void)
 {
-    printf("\e[0K\n");
+    printf("\033[0K\n");
 }
 
 void clrtoeos(void)
 {
-    printf("\e[0J");
+    printf("\033[0J");
 }
 
 void clrtoeol(void)
 {
-    printf("\e[0K");
+    printf("\033[0K");
 }
 
 void printw(char *fmt, ...)

--- a/elkscmd/tui/curses2.c
+++ b/elkscmd/tui/curses2.c
@@ -110,11 +110,11 @@ void attron(int a)
     if (fg == -1) fg = 39; else fg = ansi_colors[fg];
     if (bg == -1) bg = 39; else bg = ansi_colors[bg];
     if (bg == 39)
-        printf("\e[%dm", fg);
-    else printf("\e[%d;%dm", fg, bg+10);
+        printf("\033[%dm", fg);
+    else printf("\033[%d;%dm", fg, bg+10);
 }
 
 void attroff(int a)
 {
-    printf("\e[1;0;0m");
+    printf("\033[1;0;0m");
 }

--- a/elkscmd/tui/curses3.c
+++ b/elkscmd/tui/curses3.c
@@ -48,11 +48,11 @@ void wattroff(WINDOW *w, int a)
 
 void wbkgdset(WINDOW *w, int a)
 {
-    printf("\e[7m");
+    printf("\033[7m");
     attron(a);
 }
 
 void wrefresh(WINDOW *w)
 {
-    printf("\e[m");
+    printf("\033[m");
 }

--- a/elkscmd/tui/fm.c
+++ b/elkscmd/tui/fm.c
@@ -28,8 +28,8 @@
 
 #define ISODD(x) ((x) & 1)
 
-#define REV     "\e[7m"
-#define OFF     "\e[0m"
+#define REV     "\033[7m"
+#define OFF     "\033[0m"
 #define SP      OFF " " REV
 #define HELP    REV \
     "Z quit" SP "C cd" SP "D dir first" SP "S size sort" SP "T time sort" SP \
@@ -750,7 +750,7 @@ begin:
 	for (;;) {
 		redraw(path);
         if (once) {
-            info("\e[7m? for help\e[0m");
+            info("\033[7m? for help\033[0m");
             once = 0;
         }
 nochange:

--- a/elkscmd/tui/tetris-util.c
+++ b/elkscmd/tui/tetris-util.c
@@ -36,7 +36,7 @@
 void
 clear_term(void)
 {
-     puts("\e[2J");
+     puts("\033[2J");
 
      return;
 }
@@ -44,7 +44,7 @@ clear_term(void)
 void
 set_cursor(Bool b)
 {
-     printf("\e[?25%c", ((b) ? 'h' : 'l'));
+     printf("\033[?25%c", ((b) ? 'h' : 'l'));
 
      return;
 }
@@ -69,7 +69,7 @@ set_color(int color)
      case Score:   fg = 37; bg = 49; break;
      }
 
-     printf("\e[%d;%dm", fg, bg);
+     printf("\033[%d;%dm", fg, bg);
 
      return;
 }
@@ -78,7 +78,7 @@ void
 printxy(int color, int x, int y, char *str)
 {
      set_color(color);
-     printf("\e[%d;%dH%s", ++x, ++y, str);
+     printf("\033[%d;%dH%s", ++x, ++y, str);
      set_color(0);
 
      return;

--- a/elkscmd/tui/tty-cp437.c
+++ b/elkscmd/tui/tty-cp437.c
@@ -50,9 +50,9 @@ static char *attr_to_ansi(char *buf, unsigned int attr)
     int bg = (attr & 0x70) >> 4;        /*  8 bg colors */
 
     if (fg_pal256 && !iselksconsole) {
-        sprintf(buf, "\e[38;5;%dm\e[%dm", fg_pal256[fg], ansi_colors[bg] + 10);
+        sprintf(buf, "\033[38;5;%dm\033[%dm", fg_pal256[fg], ansi_colors[bg] + 10);
     } else {
-        sprintf(buf, "\e[%d;%dm", fg_pal16[fg], ansi_colors[bg] + 10);
+        sprintf(buf, "\033[%d;%dm", fg_pal16[fg], ansi_colors[bg] + 10);
     }
     return buf;
 }
@@ -129,7 +129,7 @@ void tty_output_screen(int flush)
     unsigned short *chattr = (unsigned short *)video_ram;
     char buf[16];
 
-    fputs("\e[?25l\e[H", stdout);      /* cursor off, home */
+    fputs("\033[?25l\033[H", stdout);   /* cursor off, home */
     for (r=0; r<LINES; r++) {
         a = -1;
         for (c=0; c<COLS; c++) {
@@ -143,7 +143,7 @@ void tty_output_screen(int flush)
         }
         putc(r == LINES - 1 ? '\r' : '\n', stdout);
     }
-    fputs("\e[1;0;0m", stdout);        /* reset attrs, cursor left off */
+    fputs("\033[1;0;0m", stdout);       /* reset attrs, cursor left off */
     if (flush)
         fflush(stdout);
 }

--- a/elkscmd/tui/tty.c
+++ b/elkscmd/tui/tty.c
@@ -14,13 +14,13 @@ int _tty_flags;
 int iselksconsole;
 
 #define WRITE(FD, SLIT)             write(FD, SLIT, strlen(SLIT))
-#define ENABLE_SAFE_PASTE           "\e[?2004h"
-#define ENABLE_MOUSE_TRACKING       "\e[?1000;1002;1015;1006h"
-#define ENABLE_ALL_MOUSE_TRACKING   "\e[?1000;1003;1015;1006h"
-#define DISABLE_MOUSE_TRACKING      "\e[?1000;1002;1003;1015;1006l"
-#define RESET_VIDEO                 "\e[1;0;0m\e[?25h\n"
-#define PROBE_DISPLAY_SIZE          "\e7\e[9979;9979H\e[6n\e8"
-#define GOTO_LASTLINE               "\e[26;0H\e[0J"
+#define ENABLE_SAFE_PASTE           "\033[?2004h"
+#define ENABLE_MOUSE_TRACKING       "\033[?1000;1002;1015;1006h"
+#define ENABLE_ALL_MOUSE_TRACKING   "\033[?1000;1003;1015;1006h"
+#define DISABLE_MOUSE_TRACKING      "\033[?1000;1002;1003;1015;1006l"
+#define RESET_VIDEO                 "\033[1;0;0m\033[?25h\n"
+#define PROBE_DISPLAY_SIZE          "\0337\033[9979;9979H\033[6n\0338"
+#define GOTO_LASTLINE               "\033[26;0H\033[0J"
 
 static void onkilled(int sig)
 {

--- a/elkscmd/tui/ttyinfo.c
+++ b/elkscmd/tui/ttyinfo.c
@@ -24,7 +24,7 @@ typedef int bool;
 #define CTRL(C)                ((C) ^ 0b01000000)
 
 #define WRITE(FD, SLIT)             write(FD, SLIT, strlen(SLIT))
-#define PROBE_DISPLAY_SIZE          "\e7\e[9979;9979H\e[6n\e8"
+#define PROBE_DISPLAY_SIZE          "\0337\033[9979;9979H\033[6n\0338"
 
 /**
  * Returns dimensions of controlling terminal.

--- a/elkscmd/tui/unikey.c
+++ b/elkscmd/tui/unikey.c
@@ -542,7 +542,7 @@ int ansi_to_unimouse(char *buf, int n, int *x, int *y, int *modkeys, int *status
     static long lasttick;
     static int lastkey;
 
-    if (!startswith(buf, "\e[<") || (buf[n-1] != 'm' && buf[n-1] != 'M'))
+    if (!startswith(buf, "\033[<") || (buf[n-1] != 'm' && buf[n-1] != 'M'))
         return -1;
     p = buf + 3;
     if (!isdigit(*p)) return -1;
@@ -586,7 +586,7 @@ int ansi_dsr(char *buf, int n, int *cols, int *rows)
     char *p;
     int r, c;
 
-    if (n < 6 || !startswith(buf, "\e[") || buf[n-1] != 'R')
+    if (n < 6 || !startswith(buf, "\033[") || buf[n-1] != 'R')
         return -1;
     p = buf + 2;
     r = getparm(p, 0);
@@ -600,7 +600,7 @@ int ansi_dsr(char *buf, int n, int *cols, int *rows)
 }
 
 #define WRITE(FD, SLIT)             write(FD, SLIT, strlen(SLIT))
-#define PROBE_DISPLAY_SIZE          "\e7\e[9979;9979H\e[6n\e8"
+#define PROBE_DISPLAY_SIZE          "\0337\033[9979;9979H\033[6n\0338"
 
 /* probe display size - only uses DSR for now, for ELKS/UNIX compatibility */
 int tty_getsize(int *cols, int *rows)


### PR DESCRIPTION
Watcom C doesn't recognize \e in string literals, replaced with \033.