### PR TITLE
[watcom] Add constructors/finalizers to Watcom C runtime

### DIFF
--- a/elks/include/arch/cdefs.h
+++ b/elks/include/arch/cdefs.h
@@ -30,8 +30,12 @@
 #define restrict        __restrict
 #define printfesque(n)
 #define noinstrument
-#define CONSTRUCTOR(fn,pri)
-#define DESTRUCTOR(fn,pri)
+#define CONSTRUCTOR(fn,pri) void fn(void);                                  \
+                            static struct _rt_init __based(__segname("XI")) \
+                                __CONCAT(_ctor,fn) = { fn, pri, 0}
+#define DESTRUCTOR(fn,pri)  void fn(void);                                  \
+                            static struct _rt_init __based(__segname("YI")) \
+                                __CONCAT(_dtor,fn) = { fn, pri, 0}
 #define __attribute__(n)
 /* force __cdecl calling convention and no register saves in main() arc/argv */
 #pragma aux main "*" modify [ bx cx dx si di ]

--- a/elks/include/arch/cdefs.h
+++ b/elks/include/arch/cdefs.h
@@ -12,13 +12,14 @@
 
 #define __P(x) x        /* always ANSI C */
 
-/* don't require <stdnoreturn.h> */
 #ifdef __GNUC__
-#define noreturn        __attribute__((__noreturn__))
+#define noreturn        __attribute__((__noreturn__)) /* don't require <stdnoreturn.h> */
 #define stdcall         __attribute__((__stdcall__))
 #define restrict        __restrict
 #define printfesque(n)  __attribute__((__format__(__gnu_printf__, n, n + 1)))
 #define noinstrument    __attribute__((no_instrument_function))
+#define CONSTRUCTOR(fn,pri) void fn(void) __attribute__((constructor(pri)))
+#define DESTRUCTOR(fn,pri)  void fn(void) __attribute__((destructor(pri)))
 #define __wcfar
 #define __wcnear
 #endif
@@ -29,6 +30,8 @@
 #define restrict        __restrict
 #define printfesque(n)
 #define noinstrument
+#define CONSTRUCTOR(fn,pri)
+#define DESTRUCTOR(fn,pri)
 #define __attribute__(n)
 /* force __cdecl calling convention and no register saves in main() arc/argv */
 #pragma aux main "*" modify [ bx cx dx si di ]

--- a/libc/debug/instrument.c
+++ b/libc/debug/instrument.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
+#include <sys/rtinit.h>
 #include "debug/instrument.h"
 #include "debug/syms.h"
 
@@ -19,7 +20,8 @@ static size_t max_stack;
 static int count;
 
 /* runs before main and rewrites argc/argv on stack if --ftrace found */
-static noinstrument CONSTRUCTOR(ftrace_checkargs, 120);
+#pragma GCC diagnostic ignored "-Wprio-ctor-dtor"
+static noinstrument CONSTRUCTOR(ftrace_checkargs, _INIT_PRI_FTRACE);
 static noinstrument void ftrace_checkargs(void)
 {
     char **avp = __argv + 1;

--- a/libc/debug/instrument.c
+++ b/libc/debug/instrument.c
@@ -19,8 +19,8 @@ static size_t max_stack;
 static int count;
 
 /* runs before main and rewrites argc/argv on stack if --ftrace found */
-__attribute__((no_instrument_function,constructor(120)))
-static void ftrace_checkargs(void)
+static noinstrument CONSTRUCTOR(ftrace_checkargs, 120);
+static noinstrument void ftrace_checkargs(void)
 {
     char **avp = __argv + 1;
 

--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -118,6 +118,7 @@ FILE *freopen(const char*, const char*, FILE*);
 
 #ifdef __LIBC__
 FILE *__fopen(const char*, int, FILE*, const char*);
+void __stdio_init(void);        /* fwd decl for OWC __LINK_SYMBOL() */
 #endif
 
 int fputs(const char*, FILE*);

--- a/libc/include/stdlib.h
+++ b/libc/include/stdlib.h
@@ -53,7 +53,7 @@ int putenv(char *string);
 char *mktemp(char *template);
 
 noreturn void abort(void);
-int atexit (void (* function) ());
+int atexit (void (*function)(void));
 noreturn void exit(int status);
 noreturn void _exit(int status); /* syscall */
 int system(const char *command);

--- a/libc/include/sys/linksym.h
+++ b/libc/include/sys/linksym.h
@@ -14,10 +14,8 @@
 #endif
 
 #ifdef __WATCOMC__
-//#define __LINK_SYMBOL(sym)  static void __based(__segname("DISCARD")) (*__sym)() = { sym }
-//#define __LINK_SYMBOL(sym)  static void (* __CONCAT(__linksym,sym))() = { sym }
-extern unsigned int __linksym;
-#define __LINK_SYMBOL(sym)    __linksym = (unsigned)sym     /* FIXME use better method */
+extern void __LINK_SYMBOL(void (*sym)());
+#pragma aux __LINK_SYMBOL = __parm [ __ax];
 #endif
 
 #else  /* __ASSEMBLER__ */

--- a/libc/include/sys/linksym.h
+++ b/libc/include/sys/linksym.h
@@ -14,7 +14,10 @@
 #endif
 
 #ifdef __WATCOMC__
-#define __LINK_SYMBOL(sym)      /* FIXME symbol yoink not yet implemented */
+//#define __LINK_SYMBOL(sym)  static void __based(__segname("DISCARD")) (*__sym)() = { sym }
+//#define __LINK_SYMBOL(sym)  static void (* __CONCAT(__linksym,sym))() = { sym }
+extern unsigned int __linksym;
+#define __LINK_SYMBOL(sym)    __linksym = (unsigned)sym     /* FIXME use better method */
 #endif
 
 #else  /* __ASSEMBLER__ */

--- a/libc/include/sys/rtinit.h
+++ b/libc/include/sys/rtinit.h
@@ -1,0 +1,29 @@
+#ifndef __SYS_RTINIT_H
+#define __SYS_RTINIT_H
+/*
+ * Runtime library initialization
+ *
+ * For ia16-elf-gcc and OpenWatcom C
+ */
+
+/*
+ * Constructor/destructor priorities (0=highest, 255=lowest)
+ * Constructors are run 0..255 in priority order before main().
+ * Destructors are run 255..0 in reverse priority order at start of exit(),
+ *   but are skipped if _exit() called directly.
+ * Priorities <= 100 are reserved for library use.
+ */
+#define _INIT_PRI_STDIO     20      /* stdio stream setup/flush */
+#define _INIT_PRI_FTRACE    24      /* --ftrace setup */
+#define _INIT_PRI_ATEXIT    32      /* atexit fini before stdio close */
+#define _INIT_PRI_PROGRAM   101     /* default program-init priority */
+
+#ifdef __WATCOMC__
+struct _rt_init {                   /* stored in XI/YI segments */
+    void (*func)(void);
+    unsigned char priority;
+    unsigned char done;
+};
+#endif
+
+#endif

--- a/libc/include/sys/rtinit.h
+++ b/libc/include/sys/rtinit.h
@@ -24,6 +24,19 @@ struct _rt_init {                   /* stored in XI/YI segments */
     unsigned char priority;
     unsigned char done;
 };
+
+/* XI/YI section start/end for constructor/destructors */
+extern struct _rt_init _Start_XI;
+extern struct _rt_init _End_XI;
+extern struct _rt_init _Start_YI;
+extern struct _rt_init _End_YI;
+
+/* constructor/destructor functions called before main and after exit */
+#pragma aux __InitRtns modify [ bx cx dx si di ]
+#pragma aux __FiniRtns modify [ bx cx dx si di ]
+extern void __InitRtns(void);
+extern void __FiniRtns(void);
+
 #endif
 
 #endif

--- a/libc/misc/atexit.c
+++ b/libc/misc/atexit.c
@@ -7,6 +7,7 @@
 
 #include <stdlib.h>
 #include <errno.h>
+#include <sys/rtinit.h>
 
 #define MAXONEXIT 32            /* C90 requires 32 */
 

--- a/libc/misc/atexit.c
+++ b/libc/misc/atexit.c
@@ -5,6 +5,7 @@
  * Copyright (C) 2022 TK Chia <@tkchia@mastodon.social>
  */
 
+#include <stdlib.h>
 #include <errno.h>
 
 #define MAXONEXIT 32            /* C90 requires 32 */
@@ -14,14 +15,14 @@ typedef void (*vfuncp) (void);
 static int atexit_count;
 static vfuncp atexit_table[MAXONEXIT];
 
-int atexit(vfuncp ptr)
+int atexit (void (*function)(void))
 {
    if (atexit_count >= MAXONEXIT) {
       errno = ENOMEM;
       return -1;
    }
-   if (ptr)
-      atexit_table[atexit_count++] = ptr;
+   if (function)
+      atexit_table[atexit_count++] = function;
    return 0;
 }
 
@@ -30,8 +31,8 @@ int atexit(vfuncp ptr)
  * stdio streams before running atexit( ) termination functions
  */
 #pragma GCC diagnostic ignored "-Wprio-ctor-dtor"
-__attribute__((destructor(100)))
-static void atexit_exit_all(void)
+static DESTRUCTOR(__atexit_fini, 100);
+static void __atexit_fini(void)
 {
    int count = atexit_count - 1;
 

--- a/libc/misc/atexit.c
+++ b/libc/misc/atexit.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <sys/rtinit.h>
+#include <sys/linksym.h>
 
 #define MAXONEXIT 32            /* C90 requires 32 */
 
@@ -16,7 +17,19 @@ typedef void (*vfuncp) (void);
 static int atexit_count;
 static vfuncp atexit_table[MAXONEXIT];
 
-int atexit (void (*function)(void))
+/* atexit functions run prior to stdio destructors */
+#pragma GCC diagnostic ignored "-Wprio-ctor-dtor"
+static DESTRUCTOR(__atexit_fini, _INIT_PRI_ATEXIT);
+static void __atexit_fini(void)
+{
+   int count = atexit_count - 1;
+
+   /* In reverse order */
+   for (; count >= 0; count--)
+      atexit_table[count]();
+}
+
+int atexit(void (*function)(void))
 {
    if (atexit_count >= MAXONEXIT) {
       errno = ENOMEM;
@@ -25,19 +38,4 @@ int atexit (void (*function)(void))
    if (function)
       atexit_table[atexit_count++] = function;
    return 0;
-}
-
-/* NOTE: ensure this priority value is higher (100) than
- * stdio's destructor stdio_close_all (90), do not destroy
- * stdio streams before running atexit( ) termination functions
- */
-#pragma GCC diagnostic ignored "-Wprio-ctor-dtor"
-static DESTRUCTOR(__atexit_fini, 100);
-static void __atexit_fini(void)
-{
-   int count = atexit_count - 1;
-
-   /* In reverse order */
-   for (; count >= 0; count--)
-      atexit_table[count]();
 }

--- a/libc/stdio/_stdio.h
+++ b/libc/stdio/_stdio.h
@@ -2,7 +2,6 @@
 #define	_STDIO_H
 
 #include <stdio.h>
-#include <sys/linksym.h>
 
 extern FILE *__IO_list;		/* For fflush at exit */
 

--- a/libc/stdio/fflush.c
+++ b/libc/stdio/fflush.c
@@ -8,6 +8,8 @@ fflush(FILE *fp)
 {
    int   len, cc, rv=0;
    unsigned char * bstart;
+
+   __LINK_SYMBOL(__stdio_init);
    if (fp == NULL)		/* On NULL flush the lot. */
    {
       if (fflush(stdin))

--- a/libc/stdio/fflush.c
+++ b/libc/stdio/fflush.c
@@ -1,5 +1,6 @@
-#include <errno.h>
 #include <unistd.h>
+#include <errno.h>
+#include <sys/linksym.h>
 
 #include "_stdio.h"
 

--- a/libc/stdio/fputc.c
+++ b/libc/stdio/fputc.c
@@ -4,7 +4,6 @@ int
 fputc(int ch, FILE *fp)
 {
    register int v;
-   __LINK_SYMBOL(__stdio_init);
 
    /* If last op was a read ... note fflush may change fp->mode and ret OK */
    if ((fp->mode & __MODE_READING) && fflush(fp))
@@ -30,8 +29,7 @@ fputc(int ch, FILE *fp)
    fp->mode |= __MODE_WRITING;
 
    /* Unbuffered or Line buffered and end of line */
-   if (((ch == '\n' && (v & _IOLBF)) || (v & _IONBF))
-       && fflush(fp))
+   if (((ch == '\n' && (v & _IOLBF)) || (v & _IONBF)) && fflush(fp))
       return EOF;
 
    /* Can the macro handle this by itself ? */

--- a/libc/stdio/fread.c
+++ b/libc/stdio/fread.c
@@ -16,7 +16,6 @@ size_t fread(void *buf, size_t size, size_t nelm, FILE *fp)
     int v;
     ssize_t len;
     size_t bytes, got = 0;
-    __LINK_SYMBOL(__stdio_init);
 
     v = fp->mode;
 

--- a/libc/stdio/init.c
+++ b/libc/stdio/init.c
@@ -1,8 +1,6 @@
 #include <stdlib.h>
 #include <unistd.h>
-
 #include <sys/rtinit.h>
-#include <sys/cdefs.h>
 #include "_stdio.h"
 
 #pragma GCC diagnostic ignored "-Wprio-ctor-dtor"

--- a/libc/stdio/init.c
+++ b/libc/stdio/init.c
@@ -5,20 +5,12 @@
 #include <sys/cdefs.h>
 #include "_stdio.h"
 
-/* NOTE: ensure this destructor is lower priority (90) than
- * the atexit_do_exit (100) destructor so as to run later.
- */
-
-#include <unistd.h>
-#define errmsg(str) write(STDERR_FILENO, str, sizeof(str) - 1)
-
 #pragma GCC diagnostic ignored "-Wprio-ctor-dtor"
-static DESTRUCTOR(__stdio_fini, 90);
-static void __stdio_fini(void)
+DESTRUCTOR(__stdio_fini, _INIT_PRI_STDIO);
+void __stdio_fini(void)
 {
    FILE *fp;
 
-   //errmsg("__stdio_fini\n");
    fflush(stdout);
    fflush(stderr);
    for (fp = __IO_list; fp; fp = fp->next)
@@ -30,12 +22,10 @@ static void __stdio_fini(void)
       fp->fd = -1;
    }
 }
-
 #pragma GCC diagnostic ignored "-Wprio-ctor-dtor"
-CONSTRUCTOR(__stdio_init, 90);
+CONSTRUCTOR(__stdio_init, _INIT_PRI_STDIO);
 void __stdio_init(void)
 {
-   //errmsg("__stdio_init\n");
    if (isatty(1))
       stdout->mode |= _IOLBF;
 }

--- a/libc/stdio/init.c
+++ b/libc/stdio/init.c
@@ -18,7 +18,7 @@ static void __stdio_fini(void)
 {
    FILE *fp;
 
-   errmsg("__stdio_fini\n");
+   //errmsg("__stdio_fini\n");
    fflush(stdout);
    fflush(stderr);
    for (fp = __IO_list; fp; fp = fp->next)
@@ -35,7 +35,7 @@ static void __stdio_fini(void)
 CONSTRUCTOR(__stdio_init, 90);
 void __stdio_init(void)
 {
-   errmsg("__stdio_init\n");
+   //errmsg("__stdio_init\n");
    if (isatty(1))
       stdout->mode |= _IOLBF;
 }

--- a/libc/stdio/init.c
+++ b/libc/stdio/init.c
@@ -6,9 +6,10 @@
 /* NOTE: ensure this destructor is lower priority (90) than
  * the atexit_do_exit (100) destructor so as to run later.
  */
+
 #pragma GCC diagnostic ignored "-Wprio-ctor-dtor"
-__attribute__((destructor(90)))
-static void stdio_close_all(void)
+static DESTRUCTOR(__stdio_fini, 90);
+static void __stdio_fini(void)
 {
    FILE *fp;
    fflush(stdout);
@@ -24,7 +25,7 @@ static void stdio_close_all(void)
 }
 
 #pragma GCC diagnostic ignored "-Wprio-ctor-dtor"
-__attribute__((constructor(90)))
+CONSTRUCTOR(__stdio_init, 90);
 void __stdio_init(void)
 {
    if (isatty(1))

--- a/libc/stdio/init.c
+++ b/libc/stdio/init.c
@@ -1,17 +1,24 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#include <sys/rtinit.h>
+#include <sys/cdefs.h>
 #include "_stdio.h"
 
 /* NOTE: ensure this destructor is lower priority (90) than
  * the atexit_do_exit (100) destructor so as to run later.
  */
 
+#include <unistd.h>
+#define errmsg(str) write(STDERR_FILENO, str, sizeof(str) - 1)
+
 #pragma GCC diagnostic ignored "-Wprio-ctor-dtor"
 static DESTRUCTOR(__stdio_fini, 90);
 static void __stdio_fini(void)
 {
    FILE *fp;
+
+   errmsg("__stdio_fini\n");
    fflush(stdout);
    fflush(stderr);
    for (fp = __IO_list; fp; fp = fp->next)
@@ -28,6 +35,7 @@ static void __stdio_fini(void)
 CONSTRUCTOR(__stdio_init, 90);
 void __stdio_init(void)
 {
+   errmsg("__stdio_init\n");
    if (isatty(1))
       stdout->mode |= _IOLBF;
 }

--- a/libc/watcom/asm/segments.asm
+++ b/libc/watcom/asm/segments.asm
@@ -46,9 +46,8 @@
 
 BEGTEXT  segment word public 'CODE'
         assume  cs:BEGTEXT
-        int     3h
+        int     3
         nop
-        public __begtext
 __begtext label byte
         assume  cs:nothing
 BEGTEXT  ends

--- a/libc/watcom/asm/segments.asm
+++ b/libc/watcom/asm/segments.asm
@@ -83,6 +83,26 @@ _DATA   ends
 DATA    segment word public 'DATA'
 DATA    ends
 
+XIB     segment word public 'DATA'
+_Start_XI label byte
+        public  "C",_Start_XI
+XIB     ends
+
+XIE     segment word public 'DATA'
+_End_XI label byte
+        public  "C",_End_XI
+XIE     ends
+
+YIB     segment word public 'DATA'
+_Start_YI label byte
+        public  "C",_Start_YI
+YIB     ends
+
+YIE     segment word public 'DATA'
+_End_YI label byte
+        public  "C",_End_YI
+YIE     ends
+
 _BSS    segment word public 'BSS'
         ;extrn   _edata                  : byte  ; end of DATA (start of BSS)
         ;extrn   _end                    : byte  ; end of BSS (start of STACK)

--- a/libc/watcom/asm/segments.asm
+++ b/libc/watcom/asm/segments.asm
@@ -34,7 +34,7 @@
         assume  nothing
 
  ;DGROUP group _NULL,_AFTERNULL,CONST,STRINGS,_DATA,DATA,XIB,XI,XIE,YIB,YI,YIE,_BSS,STACK
- DGROUP group _NULL,_AFTERNULL,CONST,STRINGS,_DATA,DATA,_BSS
+ DGROUP group _NULL,_AFTERNULL,CONST,STRINGS,_DATA,DATA,XIB,XI,XIE,YIB,YI,YIE,_BSS
 
 ; this guarantees that no function pointer will equal NULL
 ; (WLINK will keep segment 'BEGTEXT' in front)
@@ -88,6 +88,9 @@ _Start_XI label byte
         public  "C",_Start_XI
 XIB     ends
 
+XI      segment word public 'DATA'
+XI      ends
+
 XIE     segment word public 'DATA'
 _End_XI label byte
         public  "C",_End_XI
@@ -97,6 +100,9 @@ YIB     segment word public 'DATA'
 _Start_YI label byte
         public  "C",_Start_YI
 YIB     ends
+
+YI      segment word public 'DATA'
+YI      ends
 
 YIE     segment word public 'DATA'
 _End_YI label byte

--- a/libc/watcom/syscall/crt0.c
+++ b/libc/watcom/syscall/crt0.c
@@ -55,7 +55,6 @@ char **__argv;
 char *__program_filename;
 char **environ;
 unsigned int __stacklow;
-unsigned int __linksym;
 
 static unsigned int _SP(void);
 #pragma aux _SP = __value [__sp]

--- a/libc/watcom/syscall/crt0.c
+++ b/libc/watcom/syscall/crt0.c
@@ -9,6 +9,11 @@
 #include <unistd.h>
 #include <errno.h>
 
+#pragma aux __InitRtns modify exact [ bx cx dx si di ]
+#pragma aux __FiniRtns modify exact [ bx cx dx si di ]
+extern void __InitRtns(void);
+extern void __FiniRtns(void);
+
 /* Watcom extern code refs are sym_, extern data refs are _sym */
 
 /* external references created by Watcom C compilation - unused */
@@ -29,6 +34,7 @@ static noreturn void sys_exit(int status);
 
 noreturn void _exit(int status)
 {
+    __FiniRtns();
     sys_exit(status);
 }
 
@@ -66,6 +72,7 @@ unsigned int stackavail(void)
 #if defined(__SMALL__) || defined(__MEDIUM__)
 static noreturn void premain(void)
 {
+    __InitRtns();
     exit(main(__argc, __argv));
 }
 #else
@@ -89,6 +96,7 @@ static noreturn void premain(char __near *newsp, char __near *oldsp, int bx, int
         if (n && !v)
             environ = nap;
     } while (n > 0);
+    __InitRtns();
     exit(main(__argc, __argv));
 }
 #endif

--- a/libc/watcom/syscall/crt0.c
+++ b/libc/watcom/syscall/crt0.c
@@ -6,13 +6,9 @@
  */
 
 #include <sys/cdefs.h>
+#include <sys/rtinit.h>
 #include <unistd.h>
 #include <errno.h>
-
-#pragma aux __InitRtns modify exact [ bx cx dx si di ]
-#pragma aux __FiniRtns modify exact [ bx cx dx si di ]
-extern void __InitRtns(void);
-extern void __FiniRtns(void);
 
 /* Watcom extern code refs are sym_, extern data refs are _sym */
 
@@ -34,12 +30,13 @@ static noreturn void sys_exit(int status);
 
 noreturn void _exit(int status)
 {
-    __FiniRtns();
     sys_exit(status);
 }
 
+#pragma aux exit modify [ bx cx dx si di ]
 noreturn void exit(int status)
 {
+    __FiniRtns();
     _exit(status);
 }
 

--- a/libc/watcom/syscall/crt0.c
+++ b/libc/watcom/syscall/crt0.c
@@ -55,6 +55,7 @@ char **__argv;
 char *__program_filename;
 char **environ;
 unsigned int __stacklow;
+unsigned int __linksym;
 
 static unsigned int _SP(void);
 #pragma aux _SP = __value [__sp]

--- a/libc/watcom/syscall/initrtns.c
+++ b/libc/watcom/syscall/initrtns.c
@@ -1,0 +1,196 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  Initialization and termination of clib.
+*
+* 16 Jul 2024 Port for ELKS by Greg Haerr
+****************************************************************************/
+
+#include <sys/rtinit.h>
+#include <sys/cdefs.h>
+
+#define FAR2NEAR(t,f)   ((t __wcnear *)(long)(f))
+
+extern struct _rt_init _Start_XI;
+extern struct _rt_init _End_XI;
+extern struct _rt_init _Start_YI;
+extern struct _rt_init _End_YI;
+
+typedef void (__wcfar * __wcnear fpfn)(void);
+typedef void (__wcnear * __wcnear npfn)(void);
+typedef struct _rt_init __wcnear *struct_rt_init_ptr;
+
+extern void save_dx( void );
+#pragma aux save_dx = __modify __exact [__dx]
+extern void save_ds( void );
+#pragma aux save_ds = "push ds" __modify __exact [__sp]
+extern void restore_ds( void );
+#pragma aux restore_ds = "pop ds" __modify __exact [__sp]
+#define save_es()
+#define restore_es()
+#define __GETDS()
+
+#if defined(__SMALL__) || defined(__MEDIUM__)
+static void callit_near( npfn *f )
+{
+    if( *f ) {
+        save_dx();
+        save_ds();
+        (void)(**f)();
+        restore_ds();
+    }
+}
+#else
+static void callit_far( fpfn *f )
+{
+    if( *f ) {
+        save_ds();
+        (void)(**f)();
+        restore_ds();
+    }
+}
+#endif
+
+/*
+; - takes priority limit parm in eax, code will run init routines whose
+;       priority is < eax (really al [0-255])
+;       eax==255 -> run all init routines
+;       eax==15  -> run init routines whose priority is <= 15
+;
+*/
+void __InitRtns(void)
+{
+    unsigned char local_limit;
+    struct_rt_init_ptr  pnext;
+    save_ds();
+    save_es();
+    __GETDS();
+
+    local_limit = 255;
+    for( ;; ) {
+        {
+            unsigned char working_limit;
+            struct_rt_init_ptr  pcur;
+
+            pcur = FAR2NEAR( struct _rt_init, &_Start_XI );
+            pnext = FAR2NEAR( struct _rt_init, &_End_XI );
+            working_limit = local_limit;
+
+            // walk list of routines
+            while( pcur < FAR2NEAR( struct _rt_init, &_End_XI ) ) {
+                // if this one hasn't been called
+                if( !pcur->done) {
+                    // if the priority is better than best so far
+                    if( pcur->priority <= working_limit ) {
+                        // remember this one
+                        pnext = pcur;
+                        working_limit = pcur->priority;
+                    }
+                }
+                // advance to next entry
+                pcur++;
+            }
+            // check to see if all done, if we didn't find any
+            // candidates then we can return
+            if( pnext == FAR2NEAR( struct _rt_init, &_End_XI ) ) {
+                break;
+            }
+        }
+#if defined(__SMALL__) || defined(__MEDIUM__)
+        callit_near( (npfn *)&pnext->func );
+#else
+        callit_far( (fpfn *)&pnext->func );
+#endif
+        // mark entry as invoked
+        pnext->done = 1;
+    }
+    restore_es();
+    restore_ds();
+}
+
+/*
+; - takes priority range parms in eax, edx, code will run fini routines whose
+;       priority is >= eax (really al [0-255]) and <= edx (really dl [0-255])
+;       eax==0,  edx=255 -> run all fini routines
+;       eax==16, edx=255 -> run fini routines in range 16..255
+;       eax==16, edx=40  -> run fini routines in range 16..40
+*/
+void __FiniRtns(void)
+{
+    unsigned char local_min_limit;
+    unsigned char local_max_limit;
+    struct_rt_init_ptr  pnext;
+    save_ds();
+    save_es();
+    __GETDS();
+
+    local_min_limit = 0;
+    local_max_limit = 255;
+    for( ;; ) {
+        {
+            unsigned char working_limit;
+            struct_rt_init_ptr  pcur;
+
+            pcur = FAR2NEAR( struct _rt_init, &_Start_YI );
+            pnext = FAR2NEAR( struct _rt_init, &_End_YI );
+            working_limit = local_min_limit;
+
+            // walk list of routines
+            while( pcur < FAR2NEAR( struct _rt_init, &_End_YI ) ) {
+                // if this one hasn't been called
+                if( !pcur->done) {
+                    // if the priority is better than best so far
+                    if( pcur->priority >= working_limit ) {
+                        // remember this one
+                        pnext = pcur;
+                        working_limit = pcur->priority;
+                    }
+                }
+                // advance to next entry
+                pcur++;
+            }
+            // check to see if all done, if we didn't find any
+            // candidates then we can return
+            if( pnext == FAR2NEAR( struct _rt_init, &_End_YI ) ) {
+                break;
+            }
+        }
+        if( pnext->priority <= local_max_limit ) {
+#if defined(__SMALL__) || defined(__MEDIUM__)
+            callit_near( (npfn *)&pnext->func );
+#else
+            callit_far( (fpfn *)&pnext->func );
+#endif
+        }
+        // mark entry as invoked even if we don't call it
+        // if we didn't call it, it is because we don't want to
+        // call finirtns with priority > max_limit, in that case
+        // marking the function as called, won't hurt anything
+        pnext->done = 1;
+    }
+    restore_es();
+    restore_ds();
+}

--- a/libc/watcom/syscall/initrtns.c
+++ b/libc/watcom/syscall/initrtns.c
@@ -34,11 +34,6 @@
 
 #define FAR2NEAR(t,f)   ((t __wcnear *)(long)(f))
 
-extern struct _rt_init _Start_XI;
-extern struct _rt_init _End_XI;
-extern struct _rt_init _Start_YI;
-extern struct _rt_init _End_YI;
-
 typedef void (__wcfar * __wcnear fpfn)(void);
 typedef void (__wcnear * __wcnear npfn)(void);
 typedef struct _rt_init __wcnear *struct_rt_init_ptr;


### PR DESCRIPTION
Much needed, this allows stdio to flush printf output on exit, process atexit-functions on exit, stdio initialization on startup, etc.

Unlike the GCC version which uses specific compiler extensions for constructors and destructors, the ELKS runtime for Watcom places constructor/destructor functions into the XI and YI segments using a macro, then calls the constructor routines before main and destructors at exit.

Constructor priorities range from 0 (high) to 255 (low) and are run in high->low (0->255) order. Destructors are run in reverse (255->0) order.