### PR TITLE
[watcom] correct some C compiler, Librarian and Linker options

### DIFF
--- a/elks/tools/objtools/ewcc
+++ b/elks/tools/objtools/ewcc
@@ -18,29 +18,26 @@ fi
 
 if [ -z "$WATCOM" ]
   then
-    echo "WATCOM= environment variable not set to compiler path"
-    exit
-fi
-
-if [ -z "$WATDIR" ]
-  then
-    echo "WATDIR= environment variable not set to Watcom source directory"
+    echo "WATCOM= environment variable not set"
     exit
 fi
 
 ELKSLIBCINCLUDE=$TOPDIR/libc/include
 ELKSINCLUDE1=$TOPDIR/include
 ELKSINCLUDE2=$TOPDIR/elks/include
-WATCINCLUDE=$WATDIR/bld/hdr/dos/h
+WATCINCLUDE=$WATCOM/h
 
 # owcc options:
+# -bnone                    # no target specific setup
 # -mcmodel={s,m,c,l}        # memory model
 # -march=i86                # 8086 codegen
-# -bos2                     # produce OS/2 exe
 # -std=c99                  # -Wc,-za99
 # -Wc,-zev                  # enable void arithmetic
 # -Wc,-wcd=N                # disable warning N
 # -Wc,-fpi87                # inline 8087 fp
+# -Wc,-x                    # ignore INCLUDE environment variable
+# -fno-stack-check          # don't generate stack check code
+# -fnostdlib                # don't refere standard libraries
 # unused:
 # -mhard-emu-float          # -Wc,-fpi (inline 8087 w/emulation)
 # -msoft-float              # -Wc,-fpc
@@ -48,17 +45,19 @@ WATCINCLUDE=$WATDIR/bld/hdr/dos/h
 # -fpmath
 # -mabi=cdecl               # push all args
 # -fnonconst-initializers   # -Wc,aa
+# -fsigned-char             # plain char is signed (as gcc)
 
 source $TOPDIR/libc/watcom.model
 
 CCFLAGS="\
+    -bnone                          \
     -mcmodel=$MODEL                 \
     -march=i86                      \
     -Os                             \
-    -bos2                           \
     -std=c99                        \
     -Wc,-fpi87                      \
     -Wc,-zev                        \
+    -Wc,-x                          \
     -fno-stack-check                \
     -fnostdlib                      \
     -Wall -Wextra                   \
@@ -92,8 +91,8 @@ fi
 
 for PROG in $@
 do
-    echo owcc -v -c $CCFLAGS -o ${PROG%.c}.obj $PROG
-    owcc -v -c $CCFLAGS -o ${PROG%.c}.obj $PROG
+    echo owcc -c $CCFLAGS -o ${PROG%.c}.obj $PROG
+    owcc -c $CCFLAGS -o ${PROG%.c}.obj $PROG
 done
 
 # dump OBJ file

--- a/elks/tools/objtools/ewlink
+++ b/elks/tools/objtools/ewlink
@@ -18,23 +18,22 @@ fi
 
 if [ -z "$WATCOM" ]
   then
-    echo "WATCOM= environment variable not set to compiler path"
+    echo "WATCOM= environment variable not set"
     exit
 fi
 
 ELKSLIBC=$TOPDIR/libc
 
-# Warning 1008: cannot open os2.lib: No such file or directory
 # Warning 1014: stack segment not found
 
 LDFLAGS="\
     -bos2                           \
     -s                              \
     -fnostdlib                      \
-    -Wl,disable -Wl,1008            \
     -Wl,disable -Wl,1014            \
     -Wl,option -Wl,start=_start_    \
     -Wl,option -Wl,dosseg           \
+    -Wl,option -Wl,nodefaultlibs    \
     -Wl,option -Wl,stack=0x1000     \
     -Wl,option -Wl,heapsize=0x1000  \
     "
@@ -72,8 +71,8 @@ if [ "$OUT" == "" ]
     OUT=${PROG%.obj}.os2
 fi
 
-echo owcc -v $LDFLAGS -o $OUT $@ $ELKSLIBC/libc.lib
-owcc -v $LDFLAGS -o $OUT $@ $ELKSLIBC/libc.lib
+echo owcc $LDFLAGS -o $OUT $@ $ELKSLIBC/libc.lib
+owcc $LDFLAGS -o $OUT $@ $ELKSLIBC/libc.lib
 
 # convert to ELKS a.out format
 #os2toelks -f elks -o $OUT $OUT.os2

--- a/libc/watcom.inc
+++ b/libc/watcom.inc
@@ -1,27 +1,27 @@
 # Makefile include for OpenWatcom build
 
-ifeq "$(WATDIR)" ""
-$(error Must set WATDIR environment variable to top of OpenWatcom C directory)
+ifeq "$(WATCOM)" ""
+$(error WATCOM environment variable not set)
 endif
 
 INCLUDES = -I$(TOPDIR)/libc/include -I$(TOPDIR)/elks/include
-INCLUDES += -I$(WATDIR)/bld/hdr/dos/h
+INCLUDES += -I$(WATCOM)/h
 DEFINES = -D__LIBC__
 LIBOBJS=$(OBJS:.o=.obj)
 
 include $(TOPDIR)/libc/watcom.model
 
 CARCH =\
-    -bos2                           \
+    -bnone                          \
     -mcmodel=$(MODEL)               \
     -march=i86                      \
     -std=c99                        \
     -fno-stack-check                \
-    -Wc,-wcd=303                    \
     -Wc,-fpi87                      \
     -Wc,-zev                        \
+    -Wc,-x                          \
+    -Wc,-wcd=303                    \
     -fnostdlib                      \
-    -v                              \
 
 AARCH=\
     -m$(MODEL)                      \
@@ -38,7 +38,7 @@ ASFLAGS=$(AARCH)
 ARFLAGS_SUB=-n -b -fo
 
 %.obj: %.c
-	$(CC) $(CFLAGS) -c -o $*.obj $<
+	$(CC) -c $(CFLAGS) -o $*.obj $<
 
 %.obj: %.asm
 	$(AS) $(ASFLAGS) $*.asm

--- a/libc/watcom.mk
+++ b/libc/watcom.mk
@@ -29,7 +29,7 @@ SUBDIRS =	\
 all:
 	$(MAKE) -C system -f out.mk COMPILER=watcom LIB=out.lib
 	for DIR in $(SUBDIRS); do $(MAKE) -C $$DIR COMPILER=watcom LIB=out.lib || exit 1; done
-	wlib -l=libc.lst -c -n -b -fo libc.lib */*.lib watcom/*/*.lib
+	wlib -l=libc.lst -c -n -q -b -fo libc.lib */*.lib watcom/*/*.lib
 
 .PHONY: clean
 clean:

--- a/libc/wcenv.sh
+++ b/libc/wcenv.sh
@@ -4,12 +4,9 @@
 #
 # Usage: . ./wcenv.sh
 
-# change to OpenWatcom source tree top
-export WATDIR=/Users/greg/net/open-watcom-v2
-
-#export WATCOM=$WATDIR/rel/binl     # for Linux-32
-#export WATCOM=$WATDIR/rel/binl64   # for Linux-64
-export WATCOM=$WATDIR/rel/bino64    # for macOS
+# change to OpenWatcom installation root it is full path to OpenWatcom location
+# if you use your own OpenWatcom build than it is located in rel subdirectory
+export WATCOM=/Users/greg/net/open-watcom-v2/rel
 
 add_path () {
 	if [[ ":$PATH:" != *":$1:"* ]]; then
@@ -17,6 +14,8 @@ add_path () {
 	fi
 }
 
-add_path "$WATCOM"
+#add_path "$WATCOM/binl"    # for Linux-32
+#add_path "$WATCOM/binl64"  # for Linux-64
+add_path "$WATCOM/bino64"   # for macOS
 
 echo PATH set to $PATH


### PR DESCRIPTION

- remove WATDIR variable as useless and correct use of WATCOM variable which must contain path to OpenWatcom installation not to binaries, it is used by OpenWatcom tools to locate some configuration files etc.

- use neutral target for C compiler, option -bnone instead of target specific -bos2 it ensures that compiler don't define any target specific macros or use any other target specific setup, it uses header files with guards for standard DOS definition (more neutral) not for OS/2

- use -bos2 target for linker only, it define output format as OS/2 New Executable, but for ELKS OpenWatcom use should be better to use wcc and wlink instead of owcc driver, wlinker can specify output format without need to specify OS as with owcc

- enable wlinker message 1008 because disabling it mask unavailable libraries, the issue is correctly resolved by wlink option nodefaultlibs which ignore OpenWatcom standard libraries which can be defined in linking modules, it is suppresed by -fnostdlib for C compiler, now -fnostdlib can be removed but it is not necessary

- suppress use of INCLUDE environment variable by C compiler option -x, it ensure that no other path then command line for headers are used

- suppress all headers printing by removing -v option and adding -q option to wlib