### PR TITLE
Create missing STACK segment in LIBC startup code

### DIFF
--- a/elks/tools/objtools/ewlink
+++ b/elks/tools/objtools/ewlink
@@ -24,17 +24,13 @@ fi
 
 ELKSLIBC=$TOPDIR/libc
 
-# Warning 1014: stack segment not found
-
 LDFLAGS="\
     -bos2                           \
     -s                              \
     -fnostdlib                      \
-    -Wl,disable -Wl,1014            \
     -Wl,option -Wl,start=_start_    \
     -Wl,option -Wl,dosseg           \
     -Wl,option -Wl,nodefaultlibs    \
-    -Wl,option -Wl,stack=0x1000     \
     -Wl,option -Wl,heapsize=0x1000  \
     "
 

--- a/libc/watcom/syscall/crt0.c
+++ b/libc/watcom/syscall/crt0.c
@@ -10,6 +10,16 @@
 #include <unistd.h>
 #include <errno.h>
 
+/*
+ * create STACK segment which is required for applications
+ * size is setup by linker to default size 4096 bytes
+ * or to explicitly defined size by linker directive "OPTION STACK=..."
+ */
+#pragma data_seg("STACK","STACK")
+
+/* return back to default data segment */
+#pragma data_seg()
+
 /* Watcom extern code refs are sym_, extern data refs are _sym */
 
 /* external references created by Watcom C compilation - unused */


### PR DESCRIPTION

STACK segment must be defined in startup code for applications.
Size can be setup by linker, but must exists.
Remove disabling of message 1014 by wlink