### PR TITLE
Remove OpenWatcom default symbols and residual code from libc

### DIFF
--- a/elks/tools/objtools/ewcc
+++ b/elks/tools/objtools/ewcc
@@ -33,6 +33,7 @@ WATCINCLUDE=$WATCOM/h
 # -march=i86                # 8086 codegen
 # -std=c99                  # -Wc,-za99
 # -Wc,-zev                  # enable void arithmetic
+# -Wc,-zls                  # remove automatically inserted symbols
 # -Wc,-wcd=N                # disable warning N
 # -Wc,-fpi87                # inline 8087 fp
 # -Wc,-x                    # ignore INCLUDE environment variable
@@ -57,6 +58,7 @@ CCFLAGS="\
     -std=c99                        \
     -Wc,-fpi87                      \
     -Wc,-zev                        \
+    -Wc,-zls                        \
     -Wc,-x                          \
     -fno-stack-check                \
     -fnostdlib                      \

--- a/elks/tools/objtools/ewlink
+++ b/elks/tools/objtools/ewlink
@@ -24,18 +24,15 @@ fi
 
 ELKSLIBC=$TOPDIR/libc
 
-# Warning 1014: stack segment not found
-
 LDFLAGS="\
     -bos2                           \
     -s                              \
     -fnostdlib                      \
-    -Wl,disable -Wl,1014            \
-    -Wl,option -Wl,start=_start_    \
+    -Wl,option -Wl,start=_start     \
     -Wl,option -Wl,dosseg           \
     -Wl,option -Wl,nodefaultlibs    \
-    -Wl,option -Wl,stack=0x1000     \
     -Wl,option -Wl,heapsize=0x1000  \
+    -Wl,library -Wl,$TOPDIR/libc/libc.lib \
     "
 
 while true; do
@@ -71,8 +68,8 @@ if [ "$OUT" == "" ]
     OUT=${PROG%.obj}.os2
 fi
 
-echo owcc $LDFLAGS -o $OUT $@ $ELKSLIBC/libc.lib
-owcc $LDFLAGS -o $OUT $@ $ELKSLIBC/libc.lib
+echo owcc $LDFLAGS -o $OUT $@
+owcc $LDFLAGS -o $OUT $@
 
 # convert to ELKS a.out format
 #os2toelks -f elks -o $OUT $OUT.os2

--- a/libc/watcom.inc
+++ b/libc/watcom.inc
@@ -19,12 +19,14 @@ CARCH =\
     -fno-stack-check                \
     -Wc,-fpi87                      \
     -Wc,-zev                        \
+    -Wc,-zls                        \
     -Wc,-x                          \
     -Wc,-wcd=303                    \
     -fnostdlib                      \
 
 AARCH=\
     -m$(MODEL)                      \
+    -zq                             \
     -0                              \
     -fp0                            \
     -fpi87                          \
@@ -35,7 +37,7 @@ AS=wasm
 
 CFLAGS=$(CARCH) $(INCLUDES) $(DEFINES) -Wall -Os
 ASFLAGS=$(AARCH)
-ARFLAGS_SUB=-n -b -fo
+ARFLAGS_SUB=-n -q -b -fo
 
 %.obj: %.c
 	$(CC) -c $(CFLAGS) -o $*.obj $<

--- a/libc/watcom/asm/fchop87.asm
+++ b/libc/watcom/asm/fchop87.asm
@@ -44,7 +44,7 @@
 include mdef.inc
 include math87.inc
 
-        xrefp           __8087  ; indicate that NDP instructions are present
+;        xrefp           __8087  ; indicate that NDP instructions are present
 
         modstart fchop87
 

--- a/libc/watcom/asm/segments.asm
+++ b/libc/watcom/asm/segments.asm
@@ -25,61 +25,12 @@
 ;*
 ;*  ========================================================================
 ;*
-;* Description:  Watcom C segment ordering and null pointer section offsets
+;* Description:  Watcom C segment ordering for init/fini LIBC
 ;*
 ;*****************************************************************************
 
 
-        name    cstart
-        assume  nothing
-
- DGROUP group _NULL,_AFTERNULL,CONST,STRINGS,_DATA,DATA,XIB,XI,XIE,YIB,YI,YIE,_BSS
-
-; this guarantees that no function pointer will equal NULL
-; (WLINK will keep segment 'BEGTEXT' in front)
-; This segment must be at least 2 bytes in size to avoid confusing the
-; signal function.
-; need a symbol defined here to prevent the dead code elimination from
-; eliminating the segment.
-; (the int 3h is useful for quickly revealing jumps to NULL code pointers)
-
-BEGTEXT  segment word public 'CODE'
-        assume  cs:BEGTEXT
-        int     3
-        nop
-__begtext label byte
-        assume  cs:nothing
-BEGTEXT  ends
-
-_TEXT   segment word public 'CODE'
-
-FAR_DATA segment byte public 'FAR_DATA'
-FAR_DATA ends
-
-        assume  ds:DGROUP
-
-_NULL   segment para public 'BEGDATA'
-__nullarea label word
-        db      'nul'
-        db      0
-        public  __nullarea
-_NULL   ends
-
-_AFTERNULL segment word public 'BEGDATA'
-        ;dw      0                       ; nullchar for string at address 0
-_AFTERNULL ends
-
-CONST   segment word public 'DATA'
-CONST   ends
-
-STRINGS segment word public 'DATA'
-STRINGS ends
-
-_DATA   segment word public 'DATA'
-_DATA   ends
-
-DATA    segment word public 'DATA'
-DATA    ends
+DGROUP  group XIB,XI,XIE,YIB,YI,YIE
 
 XIB     segment word public 'DATA'
 _Start_XI label byte
@@ -107,57 +58,4 @@ _End_YI label byte
         public  "C",_End_YI
 YIE     ends
 
-_BSS    segment word public 'BSS'
-        ;extrn   _edata                  : byte  ; end of DATA (start of BSS)
-        ;extrn   _end                    : byte  ; end of BSS (start of STACK)
-_BSS    ends
-
-;STACK_SIZE      equ     1000h
-;STACK   segment para stack 'STACK'
-        ;db      (STACK_SIZE) dup(?)
-;STACK   ends
-
-        assume  nothing
-        public  _cstart_
-
-        assume  cs:_TEXT
-
-_cstart_ proc near
-        dw      __begtext               ; make sure dead code elimination
-                                        ; doesn't kill BEGTEXT segment
-_cstart_ endp
-
-if 0
-        INIT_VAL        equ 0101h
-        NUM_VAL         equ 16
-NullAssign      db      '*** NULL assignment detected',0
-;       don't touch AL in __exit, it has the return code
-__exit  proc
-        public  "C",__exit
-        push    ax                      ; save return code on stack
-        mov     dx,DGROUP
-        mov     ds,dx
-        cld                             ; check lower region for altered values
-        lea     di,__nullarea           ; set es:di for scan
-        mov     es,dx
-        mov     cx,NUM_VAL
-        mov     ax,INIT_VAL
-        repe    scasw
-        je      L7
-;
-; low memory has been altered
-;
-        pop     bx                      ; restore return code
-        mov     ax,offset NullAssign    ; point to msg
-        mov     dx,cs                   ; . . .
-
-; input: ( char __far *msg, int rc ) always in registers
-;       DX:AX - far pointer to message to print
-;       BX    - exit code
-
-__exit  endp
-endif
-
-_TEXT   ends
-
-        end     _cstart_
+        end


### PR DESCRIPTION
- remove OpenWatcom default CRTL symbols by -zls option, they are not necessary for ELKS libc
- remove all special segments except init/fini segments used by LIBC code, because this code is not used by ELKS libc
- change entry point **`_start_`** symbol to gcc **`_start`** for compatibility