### PR TITLE
add STACK segment for OW libc

### DIFF
--- a/elks/tools/objtools/ewlink
+++ b/elks/tools/objtools/ewlink
@@ -24,13 +24,9 @@ fi
 
 ELKSLIBC=$TOPDIR/libc
 
-# Warning 1014: stack segment not found
-
 LDFLAGS="\
     -bos2                           \
     -s                              \
-    -fnostdlib                      \
-    -Wl,disable -Wl,1014            \
     -Wl,option -Wl,start=_start_    \
     -Wl,option -Wl,dosseg           \
     -Wl,option -Wl,nodefaultlibs    \

--- a/libc/watcom/asm/segments.asm
+++ b/libc/watcom/asm/segments.asm
@@ -33,7 +33,7 @@
         name    cstart
         assume  nothing
 
- DGROUP group _NULL,_AFTERNULL,CONST,STRINGS,_DATA,DATA,XIB,XI,XIE,YIB,YI,YIE,_BSS
+DGROUP group _NULL,_AFTERNULL,CONST,STRINGS,_DATA,DATA,XIB,XI,XIE,YIB,YI,YIE,_BSS,STACK
 
 ; this guarantees that no function pointer will equal NULL
 ; (WLINK will keep segment 'BEGTEXT' in front)
@@ -113,9 +113,9 @@ _BSS    segment word public 'BSS'
 _BSS    ends
 
 ;STACK_SIZE      equ     1000h
-;STACK   segment para stack 'STACK'
+STACK   segment para stack 'STACK'
         ;db      (STACK_SIZE) dup(?)
-;STACK   ends
+STACK   ends
 
         assume  nothing
         public  _cstart_


### PR DESCRIPTION

Add **`STACK`** segment to **`segments.asm`** and remove disabling of OW linker message about missing stack
**`ewlink`** - remove compiler option **`-fnostdlib`** it is not used for linker, linker uses directive **`option nodefaultlibs`**