### PR TITLE
ow-libc: use more eficient method #pragma aux aborts for functions wh…

### DIFF
--- a/elks/include/arch/cdefs.h
+++ b/elks/include/arch/cdefs.h
@@ -25,7 +25,7 @@
 #endif
 
 #ifdef __WATCOMC__
-#define noreturn        __declspec(noreturn)
+#define noreturn        __declspec(aborts)
 #define stdcall         __stdcall
 #define restrict        __restrict
 #define printfesque(n)
@@ -37,8 +37,6 @@
                             static struct _rt_init __based(__segname("YI")) \
                                 __CONCAT(_dtor,fn) = { fn, pri, 0}
 #define __attribute__(n)
-/* force __cdecl calling convention and no register saves in main() arc/argv */
-#pragma aux main "*" modify [ bx cx dx si di ]
 #define __wcfar         __far
 #define __wcnear        __near
 #endif

--- a/libc/include/sys/cdefs.h
+++ b/libc/include/sys/cdefs.h
@@ -9,12 +9,4 @@
 #define __BEGIN_DECLS
 #define __END_DECLS
 
-#ifdef __WATCOMC__
-/*
- * Force no register saves in main(), saves space.
- */
-#pragma aux main "*" modify [ bx cx dx si di ]
-extern int main(int, char **);
-#endif
-
 #endif

--- a/libc/include/sys/rtinit.h
+++ b/libc/include/sys/rtinit.h
@@ -32,8 +32,6 @@ extern struct _rt_init _Start_YI;
 extern struct _rt_init _End_YI;
 
 /* constructor/destructor functions called before main and after exit */
-#pragma aux __InitRtns modify [ bx cx dx si di ]
-#pragma aux __FiniRtns modify [ bx cx dx si di ]
 extern void __InitRtns(void);
 extern void __FiniRtns(void);
 

--- a/libc/watcom/syscall/crt0.c
+++ b/libc/watcom/syscall/crt0.c
@@ -16,11 +16,7 @@
 int _argc;              /* with declaration of main() */
 int _8087;              /* when floating point seen */
 
-/* cstart_ is an external reference created by Watcom C, pulls in asm/segments.asm */
-#pragma aux cstart_ "_*" modify [ bx cx dx si di ]
-extern void cstart_(void);
-
-static noreturn void sys_exit(int status);
+extern void sys_exit(int status);
 #pragma aux sys_exit =         \
     "xchg ax, bx"           \
     "xor ax, ax"            \
@@ -33,7 +29,6 @@ noreturn void _exit(int status)
     sys_exit(status);
 }
 
-#pragma aux exit modify [ bx cx dx si di ]
 noreturn void exit(int status)
 {
     __FiniRtns();
@@ -46,7 +41,6 @@ noreturn void exit(int status)
  *
  * main(ac, av) called by AX, DX (small/medium) or AX, CX:BX (compact/large) model
  */
-#pragma aux main "*" modify [ bx cx dx si di ]
 extern int main(int argc, char **argv);
 
 /* global variables initialized at C startup */
@@ -65,7 +59,6 @@ unsigned int stackavail(void)
     return (_SP() - __stacklow);
 }
 
-#pragma aux premain "*" modify [ bx cx dx si di ]
 #if defined(__SMALL__) || defined(__MEDIUM__)
 static noreturn void premain(void)
 {


### PR DESCRIPTION
…ich no return

for OW version of libc is possible to use more efficient method by #pragma aux aborts or by __declspec(aborts) to optimize code for no return function this method optimize both side caller code and no return function method with __declspec(noreturn) must be used in case that this function is external (non-WATCOM)

remove some hack which try to to remove calling frame but for special case only, now it works in any situation and for any calling convention