### PR TITLE
[watcom] Remove OpenWatcom default symbols and residual code (dup #1944)

### DIFF
--- a/elks/tools/objtools/ewcc
+++ b/elks/tools/objtools/ewcc
@@ -33,6 +33,7 @@ WATCINCLUDE=$WATCOM/h
 # -march=i86                # 8086 codegen
 # -std=c99                  # -Wc,-za99
 # -Wc,-zev                  # enable void arithmetic
+# -Wc,-zls                  # remove automatically inserted symbols
 # -Wc,-wcd=N                # disable warning N
 # -Wc,-fpi87                # inline 8087 fp
 # -Wc,-x                    # ignore INCLUDE environment variable
@@ -57,6 +58,7 @@ CCFLAGS="\
     -std=c99                        \
     -Wc,-fpi87                      \
     -Wc,-zev                        \
+    -Wc,-zls                        \
     -Wc,-x                          \
     -fno-stack-check                \
     -fnostdlib                      \

--- a/elks/tools/objtools/ewlink
+++ b/elks/tools/objtools/ewlink
@@ -27,11 +27,12 @@ ELKSLIBC=$TOPDIR/libc
 LDFLAGS="\
     -bos2                           \
     -s                              \
-    -Wl,option -Wl,start=_start_    \
+    -Wl,option -Wl,start=_start     \
     -Wl,option -Wl,dosseg           \
     -Wl,option -Wl,nodefaultlibs    \
     -Wl,option -Wl,stack=0x1000     \
     -Wl,option -Wl,heapsize=0x1000  \
+    -Wl,library -Wl,$TOPDIR/libc/libc.lib \
     "
 
 while true; do
@@ -67,8 +68,8 @@ if [ "$OUT" == "" ]
     OUT=${PROG%.obj}.os2
 fi
 
-echo owcc $LDFLAGS -o $OUT $@ $ELKSLIBC/libc.lib
-owcc $LDFLAGS -o $OUT $@ $ELKSLIBC/libc.lib
+echo owcc $LDFLAGS -o $OUT $@
+owcc $LDFLAGS -o $OUT $@
 
 # convert to ELKS a.out format
 #os2toelks -f elks -o $OUT $OUT.os2

--- a/elks/tools/objtools/ewlink
+++ b/elks/tools/objtools/ewlink
@@ -24,6 +24,12 @@ fi
 
 ELKSLIBC=$TOPDIR/libc
 
+# wlink options for debugging:
+# -Wl,option -Wl,map              # produce mapfile (or use -fm=file.map)
+# -Wl,option -Wl,verbose          # more detail in mapfile
+# -Wl,option -Wl,static           # show static variables in mapfile
+# -Wl,option -Wl,eliminate        # enable dead code elimination
+
 LDFLAGS="\
     -bos2                           \
     -s                              \

--- a/libc/watcom.inc
+++ b/libc/watcom.inc
@@ -19,12 +19,14 @@ CARCH =\
     -fno-stack-check                \
     -Wc,-fpi87                      \
     -Wc,-zev                        \
+    -Wc,-zls                        \
     -Wc,-x                          \
     -Wc,-wcd=303                    \
     -fnostdlib                      \
 
 AARCH=\
     -m$(MODEL)                      \
+    -zq                             \
     -0                              \
     -fp0                            \
     -fpi87                          \
@@ -35,7 +37,7 @@ AS=wasm
 
 CFLAGS=$(CARCH) $(INCLUDES) $(DEFINES) -Wall -Os
 ASFLAGS=$(AARCH)
-ARFLAGS_SUB=-n -b -fo
+ARFLAGS_SUB=-n -q -b -fo
 
 %.obj: %.c
 	$(CC) -c $(CFLAGS) -o $*.obj $<

--- a/libc/watcom/asm/fchop87.asm
+++ b/libc/watcom/asm/fchop87.asm
@@ -44,7 +44,7 @@
 include mdef.inc
 include math87.inc
 
-        xrefp           __8087  ; indicate that NDP instructions are present
+;       xrefp           __8087  ; indicate that NDP instructions are present
 
         modstart fchop87
 

--- a/libc/watcom/asm/segments.asm
+++ b/libc/watcom/asm/segments.asm
@@ -49,15 +49,10 @@ BEGTEXT  segment word public 'CODE'
         assume  cs:BEGTEXT
         int     3
         int     3
-        public _start
-_start:
-if _MODEL and _BIG_CODE
-        extrn _start_crt0:far
-        jmpf _start_crt0
-else
-        extrn _start_crt0:near
-        jmp _start_crt0
-endif
+_start  label   byte
+        public  _start
+        xrefp   _start_crt0
+        dojmp   _start_crt0
         assume  cs:nothing
 BEGTEXT  ends
 
@@ -69,10 +64,10 @@ FAR_DATA ends
         assume  ds:DGROUP
 
 _NULL   segment para public 'BEGDATA'
-__nullarea label word
+;       public  __nullarea
+;__nullarea label word
         db      'nul'
         db      0
-        public  __nullarea
 _NULL   ends
 
 _AFTERNULL segment word public 'BEGDATA'
@@ -119,7 +114,7 @@ YIE     ends
 
 _BSS    segment word public 'BSS'
         ;extrn   _edata                  : byte  ; end of DATA (start of BSS)
-        ;extrn   _end                    : byte  ; end of BSS (start of STACK)
+        ;extrn   _end                    : byte  ; end of BSS  (start of HEAP/STACK)
 _BSS    ends
 
 ;STACK_SIZE      equ     1000h

--- a/libc/watcom/asm/segments.asm
+++ b/libc/watcom/asm/segments.asm
@@ -37,6 +37,9 @@ include mdef.inc
 
 DGROUP group _NULL,_AFTERNULL,CONST,STRINGS,_DATA,DATA,XIB,XI,XIE,YIB,YI,YIE,_BSS,STACK
 
+if (_MODEL and _BIG_CODE) eq 0
+
+; BEGTEXT section used in near code (small and compact) models only
 ; this guarantees that no function pointer will equal NULL
 ; (WLINK will keep segment 'BEGTEXT' in front)
 ; This segment must be at least 2 bytes in size to avoid confusing the
@@ -55,6 +58,8 @@ _start  label   byte
         dojmp   _start_crt0
         assume  cs:nothing
 BEGTEXT  ends
+
+endif
 
 _TEXT   segment word public 'CODE'
 

--- a/libc/watcom/asm/segments.asm
+++ b/libc/watcom/asm/segments.asm
@@ -51,7 +51,7 @@ BEGTEXT  segment word public 'CODE'
         int     3
         public _start
 _start:
-if _BIG_CODE
+if _MODEL and _BIG_CODE
         extrn _start_crt0:far
         jmpf _start_crt0
 else
@@ -130,7 +130,6 @@ STACK   ends
         assume  nothing
 
 if 0
-        assume  cs:_TEXT
         INIT_VAL        equ 0101h
         NUM_VAL         equ 16
 NullAssign      db      '*** NULL assignment detected',0

--- a/libc/watcom/asm/segments.asm
+++ b/libc/watcom/asm/segments.asm
@@ -25,12 +25,14 @@
 ;*
 ;*  ========================================================================
 ;*
-;* Description:  Watcom C segment ordering and null pointer section offsets
+;* Description:  Watcom C segment ordering and null pointer and init/fini libc
 ;*
 ;*****************************************************************************
 
 
-        name    cstart
+include mdef.inc
+
+        name    segments
         assume  nothing
 
 DGROUP group _NULL,_AFTERNULL,CONST,STRINGS,_DATA,DATA,XIB,XI,XIE,YIB,YI,YIE,_BSS,STACK
@@ -46,8 +48,16 @@ DGROUP group _NULL,_AFTERNULL,CONST,STRINGS,_DATA,DATA,XIB,XI,XIE,YIB,YI,YIE,_BS
 BEGTEXT  segment word public 'CODE'
         assume  cs:BEGTEXT
         int     3
-        nop
-__begtext label byte
+        int     3
+        public _start
+_start:
+if _BIG_CODE
+        extrn _start_crt0:far
+        jmpf _start_crt0
+else
+        extrn _start_crt0:near
+        jmp _start_crt0
+endif
         assume  cs:nothing
 BEGTEXT  ends
 
@@ -118,16 +128,9 @@ STACK   segment para stack 'STACK'
 STACK   ends
 
         assume  nothing
-        public  _cstart_
-
-        assume  cs:_TEXT
-
-_cstart_ proc near
-        dw      __begtext               ; make sure dead code elimination
-                                        ; doesn't kill BEGTEXT segment
-_cstart_ endp
 
 if 0
+        assume  cs:_TEXT
         INIT_VAL        equ 0101h
         NUM_VAL         equ 16
 NullAssign      db      '*** NULL assignment detected',0
@@ -160,4 +163,4 @@ endif
 
 _TEXT   ends
 
-        end     _cstart_
+        end

--- a/libc/watcom/syscall/crt0.c
+++ b/libc/watcom/syscall/crt0.c
@@ -154,7 +154,7 @@ noreturn void _start_crt0(void) { _crt0(); }
 
 #else
 
-/* program entry point for far code models */
+/* actual program entry point for far code (medium and large) models */
 #pragma aux _start "*"
 noreturn void _start(void) { _crt0(); }
 #endif

--- a/libc/watcom/syscall/crt0.c
+++ b/libc/watcom/syscall/crt0.c
@@ -55,7 +55,8 @@ unsigned int stackavail(void)
     return (_SP() - __stacklow);
 }
 
-#if defined(__SMALL__) || defined(__MEDIUM__)
+#if defined(__SMALL__) || defined(__MEDIUM__)   /* near data models */
+/* no argv/environ rewrite */
 static noreturn void premain(void)
 {
     __InitRtns();
@@ -89,7 +90,7 @@ static noreturn void premain(char __near *newsp, char __near *oldsp, int bx, int
 
 /* DX contains program stack size at startup */
 noreturn static void _crt0(void);
-#if defined(__SMALL__) || defined(__MEDIUM__)
+#if defined(__SMALL__) || defined(__MEDIUM__)   /* near data models */
 #pragma aux _crt0 =         \
     "mov ax,sp"             \
     "sub ax,dx"             \
@@ -108,7 +109,9 @@ noreturn static void _crt0(void);
     "mov word ptr __program_filename, bx"       \
     "push ax"               \
     "call premain";
+
 #else
+
 #pragma aux _crt0 =         \
     "mov ax,sp"             \
     "sub ax,dx"             \
@@ -144,6 +147,14 @@ noreturn static void _crt0(void);
     "call premain";
 #endif
 
-/* program entry point from _start */
+#if defined(__SMALL__) || defined(__COMPACT__)  /* near code models */
+/* jumped from _start for prevention of zero near function address */
 #pragma aux _start_crt0 "*"
 noreturn void _start_crt0(void) { _crt0(); }
+
+#else
+
+/* program entry point for far code models */
+#pragma aux _start "*"
+noreturn void _start(void) { _crt0(); }
+#endif

--- a/libc/watcom/syscall/crt0.c
+++ b/libc/watcom/syscall/crt0.c
@@ -12,10 +12,6 @@
 
 /* Watcom extern code refs are sym_, extern data refs are _sym */
 
-/* external references created by Watcom C compilation - unused */
-int _argc;              /* with declaration of main() */
-int _8087;              /* when floating point seen */
-
 extern void sys_exit(int status);
 #pragma aux sys_exit =         \
     "xchg ax, bx"           \
@@ -148,5 +144,6 @@ noreturn static void _crt0(void);
     "call premain";
 #endif
 
-/* actual program entry point */
-noreturn void _start(void) { _crt0(); }
+/* program entry point from _start */
+#pragma aux _start_crt0 "*"
+noreturn void _start_crt0(void) { _crt0(); }

--- a/libc/watcom/syscall/initrtns.c
+++ b/libc/watcom/syscall/initrtns.c
@@ -48,7 +48,7 @@ extern void restore_ds( void );
 #define restore_es()
 #define __GETDS()
 
-#if defined(__SMALL__) || defined(__MEDIUM__)
+#if defined(__SMALL__) || defined(__COMPACT__)  /* near code models */
 static void callit_near( npfn *f )
 {
     if( *f ) {
@@ -114,7 +114,7 @@ void __InitRtns(void)
                 break;
             }
         }
-#if defined(__SMALL__) || defined(__MEDIUM__)
+#if defined(__SMALL__) || defined(__COMPACT__)  /* near code models */
         callit_near( (npfn *)&pnext->func );
 #else
         callit_far( (fpfn *)&pnext->func );
@@ -174,7 +174,7 @@ void __FiniRtns(void)
             }
         }
         if( pnext->priority <= local_max_limit ) {
-#if defined(__SMALL__) || defined(__MEDIUM__)
+#if defined(__SMALL__) || defined(__COMPACT__)  /* near code models */
             callit_near( (npfn *)&pnext->func );
 #else
             callit_far( (fpfn *)&pnext->func );


### PR DESCRIPTION
Adds @jmalak's enhancements from closed #1944, with a few other modifications. Thank you, @jmalak, what do you think of these changes?

- remove OpenWatcom default CRTL symbols by -zls option, they are not necessary for ELKS libc
- change entry point _`start_` symbol to gcc `_start` for compatibility
- change ewlink to include libc using `-Wl,library` option
- removes forced `__8087` reference for now
- removes `__begtext` kluge used to force BEGINTEXT to be included in link
- Moves default `_start` to BEGINTEXT segment at offset 2

Moving `_start` to watcom/asm/segments.asm allows future plan to allow creation of very small executables without constructors/destructors, null pointer checks or argc/argv pointer rewriting by changing the executable entry point using `-Wl,start=` option and small changes to crt0.c