### PR TITLE
remove nonsense, author used incorrect OpenWatcom configuration

### DIFF
--- a/elks/tools/objtools/os2toelks.c
+++ b/elks/tools/objtools/os2toelks.c
@@ -18,10 +18,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#if defined(__WATCOMC__) && defined(__LINUX__)
-#undef O_BINARY  /* Work around OpenWatcom libc bug. */
-#endif
-
 #ifndef O_BINARY
 #define O_BINARY 0
 #endif


### PR DESCRIPTION
Problem was that author used OS/2 headers instead of Linux headers for building Linux executable. 
OW define O_BINARY for Linux target as 0 and for OS/2 target as 0x200