### PR TITLE
[kernel] Add precision time measurement routines with printk formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,11 @@ image:
 images:
 	$(MAKE) -C image images
 
+kimage: kernel image
+
+kernel:
+	$(MAKE) -C elks
+
 kclean:
 	$(MAKE) -C elks kclean
 

--- a/elks/arch/i86/lib/Makefile
+++ b/elks/arch/i86/lib/Makefile
@@ -57,8 +57,11 @@ OBJS2 = $(SRCS2:.s=.o)
 
 SRCS3 = \
 	bitops.c \
-	prectimer.c \
 	# end of list
+
+ifeq ($(CONFIG_ARCH_IBMPC), y)
+SRCS3 += prectimer.c
+endif
 
 OBJS3 = $(SRCS3:.c=.o)
 

--- a/elks/arch/i86/lib/Makefile
+++ b/elks/arch/i86/lib/Makefile
@@ -57,6 +57,7 @@ OBJS2 = $(SRCS2:.s=.o)
 
 SRCS3 = \
 	bitops.c \
+	prectimer.c \
 	# end of list
 
 OBJS3 = $(SRCS3:.c=.o)

--- a/elks/arch/i86/lib/prectimer.c
+++ b/elks/arch/i86/lib/prectimer.c
@@ -1,0 +1,164 @@
+#include <linuxmt/prectimer.h>
+#include <linuxmt/sched.h>
+#include <linuxmt/kernel.h>
+#include <arch/param.h>
+#include <arch/ports.h>
+#include <arch/irq.h>
+#include <arch/io.h>
+
+/*
+ * Precision timer routines
+ * 2 Aug 2024 Greg Haerr
+ */
+
+#define TIMER_TEST      0   /* =1 to include timer_*() test routines */
+
+/*
+ * Each ptick corresponds to the elapsed time for a countdown in the 8254 PIT.
+ * The PC master oscillator frequency is 14.31818 MHz, and is divided
+ * by 12 for the PIT input frequency: 14.31818/12 = 1.1931818 Mhz. Divide
+ * that by 1000 and you get 11932 for the PIT countdown start value;
+ * 1/11932 = 0.8381 usecs per PIT 'ptick'.
+ */
+#define MAX_PTICK        11932      /* PIT reload value for 10ms (100 HZ) */
+
+/* error check with master PIT frequency */
+#define PITFREQ         11931818L   /* PIT input frequency * 10 */
+#define PITTICK         ((5+(PITFREQ/(HZ)))/10)
+#if PITTICK != MAX_PTICK
+#error Incorrect MAX_PTICK!
+#endif
+
+static unsigned long lastjiffies;
+
+/*
+ * Each PIT count (ptick) is 0.8381 usecs each for 10ms jiffies timer (= 1/11932)
+ *
+ * To display a ptick in usecs use ptick * 838 / 1000 (= 1 mul, 1 div )
+ *
+ * Return type   Name           Resolution  Max
+ * unsigned int  get_time_10ms  pticks      10ms  (< 11932 pticks)
+ * unsigned int  get_time_50ms  pticks      50ms  (< 5 jiffies = 59660 pticks)
+ * unsigned long get_time       pticks      1 hr  (< 359953 jiffies = 2^32 / 11932)
+ * unsigned long jiffies        jiffies   497 days(< 2^32 jiffies)
+ */
+
+/* read PIT diff count, returns < 11932 pticks (10ms), no overflow checking */
+unsigned int get_time_10ms(void)
+{
+    unsigned int lo, hi, count;
+    int pdiff;
+    static unsigned int lastcount;
+
+    outb(0, TIMER_CMDS_PORT);       /* latch timer value */
+    lo = inb(TIMER_DATA_PORT);
+    hi = inb(TIMER_DATA_PORT) << 8;
+    count = lo | hi;
+    pdiff = lastcount - count;
+    if (pdiff < 0)                  /* wrapped */
+        pdiff += MAX_PTICK;         /* = MAX_PTICK - count + lastcount */
+    lastcount = count;
+    return pdiff;
+}
+
+/* count up to 5 jiffies in pticks, returns < 59960 pticks (50ms), w/overflow check */
+unsigned int get_time_50ms(void)
+{
+    int jdiff;
+    unsigned int pticks;
+
+    clr_irq();
+    jdiff = (unsigned)jiffies - (unsigned)lastjiffies;
+    lastjiffies = jiffies;          /* 32 bit save required after ~10.9 mins */
+    outb(0, TIMER_CMDS_PORT);       /* latch timer value */
+    set_irq();
+
+    pticks = get_time_10ms();
+    if (jdiff < 0)                  /* lower half wrapped */
+        jdiff = -jdiff;             /* = 0x10000000 - lastjiffies + jiffies */
+    if (jdiff >= 2) {
+        if (jdiff >= 5)
+            return 0xffff;          /* overflow */
+        return jdiff * 11932U + pticks;
+    }
+    return pticks;
+}
+
+/* return unknown elapsed time in pticks, precision < 50ms then ~10ms accuracy */
+unsigned long get_time(void)
+{
+    unsigned int pticks;
+    static unsigned long lasttime;
+
+    clr_irq();                  /* for saving lasttime below */
+    lasttime = lastjiffies;
+    pticks = get_time_50ms();
+    if (pticks != 0xffff)
+        return pticks;          /* < 50ms */
+    /* current jiffies is in lastjiffies, last jiffies is in lasttime */
+    return (lastjiffies - lasttime) * MAX_PTICK;
+}
+
+#if TIMER_TEST
+/* sample timer routines */
+void timer_10ms(void)
+{
+    unsigned int pticks;
+
+    pticks = get_time_10ms();
+    printk("%u %u = %k\n", pticks, (unsigned)jiffies, pticks);
+}
+
+void timer_50ms(void)
+{
+    unsigned long timeout = jiffies + 4;
+    unsigned int pticks = get_time_50ms();
+    unsigned int usecs = pticks * 838UL / 1000;     /* use unsigned _udivsi3 for speed */
+    unsigned int usecs2 = pticks * 8381UL / 10000;  /* use unsigned _udivsi3 for speed */
+    printk("%u %u = %u,%u usecs = %k\n", pticks, (unsigned)lastjiffies, usecs, usecs2, pticks);
+    while (jiffies < timeout)
+        ;
+}
+
+void timer_4s(void)
+{
+    unsigned long timeout = jiffies + 400;
+    unsigned long pticks = get_time();
+    printk("%lu %u = %lk\n", pticks, (unsigned)lastjiffies, pticks);
+    while (jiffies < timeout)
+        ;
+}
+
+void timer_test(void)
+{
+    printk("1 = %k\n", 1);
+    printk("2 = %k\n", 2);
+    printk("3 = %k\n", 3);
+    printk("100 = %k\n", 100);
+    printk("500 = %k\n", 500);
+    printk("1000 = %k\n", 1000);
+    printk("1192 = %k\n", 1192);
+    printk("1193 = %k\n", 1193);
+    printk("1194 = %k\n", 1194);
+    printk("10000 = %k\n", 10000);
+    printk("59959 = %k\n", 59959U);
+    printk("59960 = %k\n", 59960U);
+    printk("59961 = %k\n", 59961U);
+    printk("100000 = %lk\n", 100000L);
+    printk("5*59960 = %lk\n", 5*59960L);
+    printk("359953 = %lk\n", 359953L);
+    printk("19*59960 = %lk\n", 19*59960L);
+    printk("20*59960 = %lk\n", 20*59960L);
+    printk("21*59960 = %lk\n", 21*59960L);
+    printk("60*59960 = %lk\n", 60*59960L);
+    printk("84*59960 = %lk\n", 84*59960L);
+    printk("600*59960 = %lk\n", 600*59960L);
+    printk("3000000 = %lk\n", 3000000L);
+    printk("30000000 = %lk\n", 30000000UL);
+    printk("35995300 = %lk\n", 35995300UL);
+    printk("36000000 = %lk\n", 36000000UL);
+    printk("51000000 = %lk\n", 51000000UL);
+    printk("51130563 = %lk\n", 51130563UL);
+    printk("51130564 = %lk\n", 51130564UL);
+}
+#endif

--- a/elks/arch/i86/lib/prectimer.c
+++ b/elks/arch/i86/lib/prectimer.c
@@ -61,7 +61,7 @@ unsigned int get_time_10ms(void)
     return pdiff;
 }
 
-/* count up to 5 jiffies in pticks, returns < 59960 pticks (50ms), w/overflow check */
+/* count up to 5 jiffies in pticks, returns < 59660 pticks (50ms), w/overflow check */
 unsigned int get_time_50ms(void)
 {
     int jdiff;
@@ -141,18 +141,18 @@ void timer_test(void)
     printk("1193 = %k\n", 1193);
     printk("1194 = %k\n", 1194);
     printk("10000 = %k\n", 10000);
-    printk("59959 = %k\n", 59959U);
-    printk("59960 = %k\n", 59960U);
-    printk("59961 = %k\n", 59961U);
+    printk("59659 = %k\n", 59659U);
+    printk("59660 = %k\n", 59660U);
+    printk("59661 = %k\n", 59661U);
     printk("100000 = %lk\n", 100000L);
-    printk("5*59960 = %lk\n", 5*59960L);
+    printk("5*59660 = %lk\n", 5*59660L);
     printk("359953 = %lk\n", 359953L);
-    printk("19*59960 = %lk\n", 19*59960L);
-    printk("20*59960 = %lk\n", 20*59960L);
-    printk("21*59960 = %lk\n", 21*59960L);
-    printk("60*59960 = %lk\n", 60*59960L);
-    printk("84*59960 = %lk\n", 84*59960L);
-    printk("600*59960 = %lk\n", 600*59960L);
+    printk("19*59660 = %lk\n", 19*59660L);
+    printk("20*59660 = %lk\n", 20*59660L);
+    printk("21*59660 = %lk\n", 21*59660L);
+    printk("60*59660 = %lk\n", 60*59660L);
+    printk("84*59660 = %lk\n", 84*59660L);
+    printk("600*59660 = %lk\n", 600*59660L);
     printk("3000000 = %lk\n", 3000000L);
     printk("30000000 = %lk\n", 30000000UL);
     printk("35995300 = %lk\n", 35995300UL);

--- a/elks/include/linuxmt/prectimer.h
+++ b/elks/include/linuxmt/prectimer.h
@@ -1,0 +1,15 @@
+/*
+ * Precision timer routines
+ * 2 Aug 2024 Greg Haerr
+ */
+
+/* all routines return pticks = 0.8381 usecs */
+unsigned int get_time_10ms(void);   /* < 10ms measurements */
+unsigned int get_time_50ms(void);   /* < 50ms measurements */
+unsigned long get_time(void);       /* < 1 hr measurements */
+
+/* timer test routines */
+void timer_10ms(void);
+void timer_50ms(void);
+void timer_4s(void);
+void timer_test(void);

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -14,6 +14,7 @@
 #include <linuxmt/trace.h>
 #include <linuxmt/devnum.h>
 #include <linuxmt/heap.h>
+#include <linuxmt/prectimer.h>
 #include <arch/system.h>
 #include <arch/segment.h>
 #include <arch/ports.h>
@@ -102,6 +103,9 @@ void start_kernel(void)
      * We are now the idle task. We won't run unless no other process can run.
      */
     while (1) {
+        /***unsigned int pticks = get_time_10ms();
+        printk("%u,%u = %k\n", pticks, (unsigned)jiffies, pticks);***/
+
         schedule();
 #ifdef CONFIG_TIMER_INT0F
         int0F();        /* simulate timer interrupt hooked on IRQ 7 */


### PR DESCRIPTION
This PR adds precision real time measurement capabilities to the kernel programmer based on the 8254 hardware programmable interrupt timer which produces the clock interrupt every 10ms. This is pursuant to the discussion at https://github.com/Mellvik/TLVC/issues/71 where it was deemed a requirement to measure elapsed real time at much smaller than 10ms intervals.

The precision timer library routines allow time measurement between 0.838 usecs called a "ptick" (4 cycles on a 4.77Mhz 8088, about 1/3 of an average instruction) and ~42.9 seconds, with various precisions. Due to the way the timing countdown is implemented in hardware, it is not possible to keep the same 0.838us resolution across 0-43 seconds using the same routines with precision, so measurement is available in three distinct routines:
- get_time_10ms() - fastest precise results for intervals guaranteed to be < 10ms (=1-11932 pticks up to a 10ms jiffie)
- get_time_50ms() - fairly precise results at intervals < 50ms, returned as 16-bits for speed, returns 0xffff on overflow
- get_timer() - returns fair precision at intervals < 50ms, then 10ms precision up to ~43 seconds

In general, when starting a timing measurement, to avoid unknown overflow and/or bad results, it would be best to start with get_timer() then work downward until the timing measurement is known. (Note that get_timer returns a 32-bit result whereas the other routines return 16-bits). When measuring elapsed real time, the kernel can take quite a bit longer than thought given hardware interrupts taking place during the timer measurement. Currently, these routines have to disable then reenable interrupts so should not be used within a routine with interrupts disabled (kernel interrupt handlers run with interrupts enabled so this isn't normally a problem). This will be improved in another commit.

In addition, when CONFIG_PREC_TIMER is enabled in printk.c, two new `%k` and `%lk` printk formats allow for displaying the elapsed pticks returned from any of the precision timer routines and automatically display the output in microseconds (us), milliseconds (ms) or seconds (s). If not enabled the raw ptick value is displayed, which must be carefully multiplied by 838 to convert pticks to nanoseconds. The following is an example of using the precision timer library:
```
get_time_10ms();  // record current hardware timer count
... // do something taking less than 10ms
unsigned int pticks = get_time_10ms();  // measure elapsed time difference
printk("%k", pticks);  // output displayed automatically in us, ms or s
```
With a little more work, it should be possible to calculate the amount of time the get_time_10ms() routine itself takes, so that can be subtracted from the returned elapsed time for an even more accurate measurement.

For now, precision timing is only available on IBM PC, but could be made to work on other architectures by changing some constants. This might be done at a later time depending on the usefulness of the tool.

In addition, this PR adds `make kernel` which will perform a kernel build only (no libc or applications) for speed, and `make kimage` which makes the kernel only then an image quickly.

Note: these routines have only been tested on QEMU, not real hardware.