### PR TITLE
[kernel] Fix kernel crash calling get_ide_data

### DIFF
--- a/elks/include/linuxmt/init.h
+++ b/elks/include/linuxmt/init.h
@@ -3,6 +3,7 @@
 
 /* Assorted initializers */
 
+#include <linuxmt/config.h>
 #include <linuxmt/types.h>
 
 #if defined(CONFIG_FARTEXT_KERNEL) && !defined(__STRICT_ANSI__)


### PR DESCRIPTION
Fixes #1952.

Fixes crash during HD init when calling `get_ide_data`, due to improperly configured header file that missed far call INITPROC declaration of get_ide_data.
