### PR TITLE
[kernel] Move hd/fd bios driver routines into far BFPROC to free up .text space

### DIFF
--- a/elks/arch/i86/drivers/block/bios.c
+++ b/elks/arch/i86/drivers/block/bios.c
@@ -66,7 +66,7 @@ static unsigned long __far *vec1E = _MK_FP(0, 0x1E << 2);
  * as well try it -- Some XT controllers are happy with it.. [AC]
  */
 
-void bios_disk_reset(int drive)
+void BFPROC bios_disk_reset(int drive)
 {
 #ifdef CONFIG_ARCH_PC98
     BD_AX = BIOSHD_RESET | drive;
@@ -78,7 +78,7 @@ void bios_disk_reset(int drive)
     /* ignore errors with carry set*/
 }
 
-int bios_disk_rw(unsigned cmd, unsigned num_sectors, unsigned drive,
+int BFPROC bios_disk_rw(unsigned cmd, unsigned num_sectors, unsigned drive,
         unsigned cylinder, unsigned head, unsigned sector, unsigned seg, unsigned offset)
 {
 #ifdef CONFIG_ARCH_PC98
@@ -342,13 +342,13 @@ int INITPROC bios_getfdinfo(struct drive_infot *drivep)
 #endif
 
 /* set our DDPT sectors per track value*/
-void bios_set_ddpt(int max_sectors)
+void BFPROC bios_set_ddpt(int max_sectors)
 {
         DDPT[SPT] = (unsigned char) max_sectors;
 }
 
 /* get the diskette drive parameter table from INT 1E and point to our RAM copy of it*/
-void bios_copy_ddpt(void)
+void BFPROC bios_copy_ddpt(void)
 {
         unsigned long oldvec = *vec1E;
 
@@ -380,7 +380,8 @@ void bios_copy_ddpt(void)
 
 #ifdef CONFIG_ARCH_PC98
 /* switch device */
-void bios_switch_device98(int target, unsigned int device, struct drive_infot *drivep)
+void BFPROC bios_switch_device98(int target, unsigned int device,
+    struct drive_infot *drivep)
 {
     bios_drive_map[target + DRIVE_FD0] =
         (device | (bios_drive_map[target + DRIVE_FD0] & 0x0F));

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -103,13 +103,13 @@ static struct gendisk bioshd_gendisk = {
     NULL                        /* next */
 };
 
-static void set_cache_invalid(void)
+static void BFPROC set_cache_invalid(void)
 {
     cache_drive = NULL;
 }
 
 #ifdef CONFIG_BLK_DEV_BFD
-static int read_sector(int drive, int cylinder, int sector)
+static int BFPROC read_sector(int drive, int cylinder, int sector)
 {
     int count = 2;              /* one retry on probe or boot sector read */
 
@@ -128,7 +128,7 @@ static int read_sector(int drive, int cylinder, int sector)
     return 1;                   /* error */
 }
 
-static void probe_floppy(int target, struct hd_struct *hdp)
+static void BFPROC probe_floppy(int target, struct hd_struct *hdp)
 {
     /* Check for disk type */
 
@@ -500,7 +500,7 @@ static int bioshd_ioctl(struct inode *inode, struct file *file, unsigned int cmd
 }
 
 /* calculate CHS and sectors remaining for track read */
-static void get_chst(struct drive_infot *drivep, sector_t *start_sec, unsigned int *c,
+static void BFPROC get_chst(struct drive_infot *drivep, sector_t *start_sec, unsigned int *c,
         unsigned int *h, unsigned int *s, unsigned int *t, int fulltrack)
 {
     sector_t start = *start_sec;
@@ -530,7 +530,7 @@ static void get_chst(struct drive_infot *drivep, sector_t *start_sec, unsigned i
 }
 
 /* do disk I/O, return # sectors read/written */
-static int do_readwrite(struct drive_infot *drivep, sector_t start, char *buf,
+static int BFPROC do_readwrite(struct drive_infot *drivep, sector_t start, char *buf,
         ramdesc_t seg, int cmd, unsigned int count)
 {
     int drive, error, errs;
@@ -599,7 +599,7 @@ static sector_t cache_startsector;
 static sector_t cache_endsector;
 
 /* read from start sector to end of track into DMASEG track buffer, no retries*/
-static void do_readtrack(struct drive_infot *drivep, sector_t start)
+static void BFPROC do_readtrack(struct drive_infot *drivep, sector_t start)
 {
     unsigned int cylinder, head, sector, num_sectors;
     int drive = drivep - drive_info;
@@ -639,7 +639,7 @@ static void do_readtrack(struct drive_infot *drivep, sector_t start)
 }
 
 /* check whether cache is valid for one sector*/
-static int cache_valid(struct drive_infot *drivep, sector_t start, char *buf,
+static int BFPROC cache_valid(struct drive_infot *drivep, sector_t start, char *buf,
         ramdesc_t seg)
 {
     unsigned int offset;
@@ -658,7 +658,7 @@ static int cache_tries;
 static int cache_hits;
 
 /* read from cache, return # sectors read*/
-static int do_cache_read(struct drive_infot *drivep, sector_t start, char *buf,
+static int BFPROC do_cache_read(struct drive_infot *drivep, sector_t start, char *buf,
         ramdesc_t seg, int cmd)
 {
     if (cmd == READ) {
@@ -676,7 +676,7 @@ static int do_cache_read(struct drive_infot *drivep, sector_t start, char *buf,
 }
 #endif
 
-static void do_bioshd_request(void)
+static void BFPROC do_bioshd_request2(void)
 {
     struct drive_infot *drivep;
     struct request *req;
@@ -751,4 +751,9 @@ next_block:
         end_request(1);
     }
     spin_timer(0);
+}
+
+static void do_bioshd_request(void)
+{
+    do_bioshd_request2();
 }

--- a/elks/include/linuxmt/biosparm.h
+++ b/elks/include/linuxmt/biosparm.h
@@ -29,6 +29,13 @@
  * Hacked up for Linux/8086 Alan Cox Feb 1996
  */
 
+/* places some of this driver in the far text section */
+#if defined(CONFIG_FARTEXT_KERNEL) && !defined(__STRICT_ANSI__)
+#define BFPROC __far __attribute__ ((far_section, noinline, section (".fartext.bf")))
+#else
+#define BFPROC
+#endif
+
 struct biosparms {
     unsigned short irq;         /* 0 */
     unsigned short ax;          /* 2 */
@@ -72,12 +79,13 @@ struct biosparms {
 
 int call_bios(struct biosparms *);
 
-void bios_disk_reset(int drive);
-int bios_disk_rw(unsigned cmd, unsigned num_sectors, unsigned drive,
+void BFPROC bios_disk_reset(int drive);
+int BFPROC bios_disk_rw(unsigned cmd, unsigned num_sectors, unsigned drive,
         unsigned cylinder, unsigned head, unsigned sector, unsigned seg, unsigned offset);
-void bios_set_ddpt(int max_sectors);
-void bios_copy_ddpt(void);
+void BFPROC bios_set_ddpt(int max_sectors);
+void BFPROC bios_copy_ddpt(void);
 struct drive_infot;
-void bios_switch_device98(int target, unsigned int device, struct drive_infot *drivep);
+void BFPROC bios_switch_device98(int target, unsigned int device,
+        struct drive_infot *drivep);
 
 #endif

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -179,7 +179,7 @@ tui/ttyinfo                     :tui                            :1440k
 tui/sl                          :tui                    :1200k
 tui/ttyclock                    :tui            :360c   :1200k
 tui/ttypong                     :tui                            :1440k
-tui/ttytetris                   :tui            :360k
+tui/ttytetris                   :tui            :360c
 busyelks/busyelks               :busyelks
 inet/httpd/sample_index.html ::var/www/index.html :net
 ktcp/ktcp                       :net


### PR DESCRIPTION
Even though this enhancement only increased the kernel size by 208 bytes, the 360k floppy ran out of space and `ttytetris` had to be moved to the 360k compressed floppy.