### PR TITLE
[kernel] Update examples for precision timer

### DIFF
--- a/elks/include/linuxmt/prectimer.h
+++ b/elks/include/linuxmt/prectimer.h
@@ -3,6 +3,9 @@
  * 2 Aug 2024 Greg Haerr
  */
 
+#define CONFIG_PREC_TIMER   0   /* =1 to include %k precision timer printk format */
+#define TIMER_TEST          0   /* =1 to include timer_*() test routines */
+
 /* all routines return pticks = 0.8381 usecs */
 unsigned int get_time_10ms(void);   /* < 10ms measurements */
 unsigned int get_time_50ms(void);   /* < 50ms measurements */

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -114,14 +114,14 @@ void start_kernel(void)
     /*
      * We are now the idle task. We won't run unless no other process can run.
      */
-#ifdef TIMER_TEST
+#if TIMER_TEST
     timer_test();
     testloop(10000);
     testloop(3000);
     testloop(500);
 #endif
     while (1) {
-#ifdef TIMER_TEST
+#if TIMER_TEST
         timer_50ms();
 #else
         schedule();

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -85,7 +85,7 @@ static void init_task(void);
 static void INITPROC kernel_banner(seg_t start, seg_t end, seg_t init, seg_t extra);
 static void INITPROC early_kernel_init(void);
 
-#ifdef TIMER_TEST
+#if TIMER_TEST
 void testloop(unsigned timer)
 {
         unsigned pticks, x = timer;

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -85,6 +85,18 @@ static void init_task(void);
 static void INITPROC kernel_banner(seg_t start, seg_t end, seg_t init, seg_t extra);
 static void INITPROC early_kernel_init(void);
 
+#ifdef TIMER_TEST
+void testloop(unsigned timer)
+{
+        unsigned pticks, x = timer;
+
+        get_time_10ms();
+        while (x--) outb(x, 0x80);
+        pticks = get_time_10ms();
+        printk("hptimer %u: %k (%u)\n", timer, pticks, pticks);
+}
+#endif
+
 /* this procedure called using temp stack then switched, no temp vars allowed */
 void start_kernel(void)
 {
@@ -102,16 +114,23 @@ void start_kernel(void)
     /*
      * We are now the idle task. We won't run unless no other process can run.
      */
+#ifdef TIMER_TEST
+    timer_test();
+    testloop(10000);
+    testloop(3000);
+    testloop(500);
+#endif
     while (1) {
-        /***unsigned int pticks = get_time_10ms();
-        printk("%u,%u = %k\n", pticks, (unsigned)jiffies, pticks);***/
-
+#ifdef TIMER_TEST
+        timer_50ms();
+#else
         schedule();
 #ifdef CONFIG_TIMER_INT0F
         int0F();        /* simulate timer interrupt hooked on IRQ 7 */
 #else
         idle_halt();    /* halt until interrupt to save power */
 #endif
+#endif /* TIMER_TEST */
     }
 }
 

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -37,11 +37,10 @@
 #include <linuxmt/ntty.h>
 #include <linuxmt/debug.h>
 #include <linuxmt/signal.h>
+#include <linuxmt/prectimer.h>
 #include <arch/segment.h>
 #include <arch/irq.h>
 #include <stdarg.h>
-
-#define CONFIG_PREC_TIMER   0   /* =1 to include %k precision timer printk format */
 
 dev_t dev_console;
 


### PR DESCRIPTION
Small changes to precision timer for easier debugging.

- Bugfix to get_timer_50ms routine (lines 78-80)
- Move TIMER_TEST and CONFIG_PREC_TIMER to single header file: linuxmt/prectimer.h 
- Routines return 0 rather than 0xFFFF on timer overflow for easier-to-recognize error
- Added timer testing to init/main.c when TIMER_TEST defined

@Mellvik, this fixes a bug in get_timer_50ms but you're not (yet) using it, so no need to update sources for testing discussion in https://github.com/Mellvik/TLVC/issues/71#issuecomment-2273408225. I'm pushing the samples mostly so as to more easily help me debug the issue you're having on the 40Mhz 386.