### PR TITLE
[kernel] Finalize precision timing routines

### DIFF
--- a/elks/arch/i86/lib/prectimer.c
+++ b/elks/arch/i86/lib/prectimer.c
@@ -70,11 +70,11 @@ unsigned int get_time_50ms(void)
     static unsigned int lastcount;
 
     save_flags(flags);
-    clr_irq();
+    clr_irq();                      /* synchronize countdown and jiffies */
+    outb(0, TIMER_CMDS_PORT);       /* latch timer value */
     /* ia16-elf-gcc won't generate 32-bit subtract so use 16-bit and check wrap */
     jdiff = (unsigned)jiffies - (unsigned)lastjiffies;
     lastjiffies = jiffies;          /* 32 bit save required after ~10.9 mins */
-    outb(0, TIMER_CMDS_PORT);       /* latch timer value */
     restore_flags(flags);
 
     lo = inb(TIMER_DATA_PORT);
@@ -84,6 +84,7 @@ unsigned int get_time_50ms(void)
     if (pticks < 0)                 /* wrapped */
         pticks += MAX_PTICK;        /* = MAX_PTICK - count + lastcount */
     lastcount = count;
+
     if (jdiff < 0)                  /* lower half wrapped */
         jdiff = -jdiff;             /* = 0x10000000 - lastjiffies + jiffies */
     if (jdiff >= 2) {

--- a/qemu.sh
+++ b/qemu.sh
@@ -118,6 +118,9 @@ AUDIO="-audiodev pa,id=speaker -machine pcspk-audiodev=speaker"
 
 # Configure QEMU as pure ISA system
 
-exec $QEMU $AUDIO $CONSOLE -nodefaults -name ELKS -machine isapc -cpu 486,tsc -m 4M \
+# uncomment to run native speed if x86 macOS
+#MACOS="-accel hvf"
+
+exec $QEMU $MACOS $AUDIO $CONSOLE -nodefaults -name ELKS -machine isapc -cpu 486,tsc -m 4M \
 $KEYBOARD $QDISPLAY -vga std -rtc base=utc $SERIAL \
 $NET $NETDUMP $IMAGE $DISK2 $@


### PR DESCRIPTION
As per testing and discussion in https://github.com/Mellvik/TLVC/issues/71.

The following changes were made to the precision timing library:
- get_time_10ms removed due to unreliability with no overflow checking
- 8254 PIT countdown read moved directly into get_time_50ms for speed
- get_time_50ms now callable with interrupts enabled or disabled and returns to previous interrupt state
- TIMER_TEST routines moved to safe location, just after kernel_init but before process PID 1 created
- Changed TIMER_TESTs to 30000, 3000 and 300 for better measurements on very fast systems
- Solved QEMU timing problems by running with HVF option for macOS (qemu.sh also updated)

