### PR TITLE
[kernel] Reduce precision time routines single routine

### DIFF
--- a/elks/arch/i86/lib/prectimer.c
+++ b/elks/arch/i86/lib/prectimer.c
@@ -29,7 +29,7 @@
 #error Incorrect MAX_PTICK!
 #endif
 
-static unsigned int lastjiffies;    /* only 16 bits required within ~10.9s */
+static unsigned int lastjiffies;    /* only 16 bits required within ~10.9 mins */
 
 /*
  * Each PIT count (ptick) is 0.8381 usecs each for 10ms jiffies timer (= 1/11932)

--- a/elks/arch/i86/lib/prectimer.c
+++ b/elks/arch/i86/lib/prectimer.c
@@ -37,8 +37,8 @@ static unsigned int lastjiffies;    /* only 16 bits required within ~10.9 mins *
  * To display a ptick in usecs use ptick * 838 / 1000U (= 1 mul, 1 div )
  *
  * Return type   Name           Resolution  Max
- * unsigned long get_ptime      0.838us     42.85s (uncaught overflow at ~10.9s)
- * unsigned long jiffies        10m        497 days(=2^32 jiffies)
+ * unsigned long get_ptime      0.838us     42.85s (uncaught overflow at ~10.9 mins)
+ * unsigned long jiffies        10ms        497 days (=2^32 jiffies)
  */
 
 /* return up to 42.85 seconds in pticks, return 0 if overflow, no check > ~10.9 mins */

--- a/elks/include/linuxmt/prectimer.h
+++ b/elks/include/linuxmt/prectimer.h
@@ -6,13 +6,9 @@
 #define CONFIG_PREC_TIMER   0   /* =1 to include %k precision timer printk format */
 #define TIMER_TEST          0   /* =1 to include timer_*() test routines */
 
-/* all routines return pticks = 0.8381 usecs */
-unsigned int get_time_10ms(void);   /* < 10ms measurements */
-unsigned int get_time_50ms(void);   /* < 50ms measurements */
-unsigned long get_time(void);       /* < 1 hr measurements */
+/* returns pticks in 0.838us resolution, 0.838 microseconds to 42.85 seconds  */
+unsigned long get_ptime(void);
 
-/* timer test routines */
-void timer_10ms(void);
-void timer_50ms(void);
-void timer_4s(void);
-void timer_test(void);
+/* internal test routines */
+void test_ptime_idle_loop(void);
+void test_ptime_print(void);

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -88,22 +88,23 @@ static void INITPROC early_kernel_init(void);
 #if TIMER_TEST
 void testloop(unsigned timer)
 {
-        unsigned int pticks, x = timer;
+        unsigned long pticks;
+        unsigned int x = timer;
         int i;
-        static unsigned int a[10];
+        static unsigned long a[10];
 
 #if 1
-        get_time_50ms();
+        get_ptime();
         for (i=0; i<10; i++)
-            a[i] = get_time_50ms();
+            a[i] = get_ptime();
         for (i=0; i<10; i++)
-            printk("%d,", a[i]);
+            printk("%ld,", a[i]);
         printk("\n");
 #endif
-        get_time_50ms();
+        get_ptime();
         while (x--) asm("nop");
-        pticks = get_time_50ms();
-        printk("hptimer %u: %k (%u)\n", timer, pticks, pticks);
+        pticks = get_ptime();
+        printk("ptime %u: %lk (%lu)\n", timer, pticks, pticks);
 }
 #endif
 
@@ -119,6 +120,7 @@ void start_kernel(void)
 
 #if TIMER_TEST
     /* run tests before 2nd process created for stability */
+    test_ptime_print();
     testloop(30000);
     testloop(3000);
     testloop(300);
@@ -133,6 +135,9 @@ void start_kernel(void)
      * We are now the idle task. We won't run unless no other process can run.
      */
     while (1) {
+#if TIMER_TEST
+        test_ptime_idle_loop();
+#endif
         schedule();
 #ifdef CONFIG_TIMER_INT0F
         int0F();        /* simulate timer interrupt hooked on IRQ 7 */

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -107,10 +107,10 @@ static void numout(unsigned long v, int width, unsigned int base, int type,
     Decimal = 0;
 #if CONFIG_PREC_TIMER
     int Msecs = 0;
-    /* display 1/1193182s get_time*() pticks in range 0.838usec through 42.94sec */
+    /* display 1/1193182s get_time*() pticks in range 0.838usec through 42.85sec */
     if (type == 'k') {                  /* format works w/limited ranges only */
         Decimal = 3;
-        if (v > 51130563UL)             /* = 2^32 / 84 high max range ~42.94s */
+        if (v > 51130563UL)             /* = 2^32 / 84 high max range = ~42.85s */
             v = 0;                      /* ... displays 0us */
         if (v > 5125259UL) {            /* = 2^32 / 838 */
             v = v * 84UL;


### PR DESCRIPTION
Pursuant to continued discussion in https://github.com/Mellvik/TLVC/issues/71#issuecomment-2282811530.

The following changes are made to the precision timing routines:
- get_time_10ms and get_time routines removed.
- get_time_50ms routine renamed get_ptime
- get_ptime returns continuous 0.838us precision from 0.838us to ~42 seconds.
- get_ptime returns `unsigned long` to allow for greater elapsed time. However, if elapsed time is known to be < 50ms, the returned value can be cast to `unsigned int` for use without the trouble of subsequent 32-bit handling.
- get_ptime returns 0 on overflow: elapsed time > 42.85 seconds.
- Sub-10ms handling within get_ptime is very quick and only uses unsigned int and no multiplies/divide.
- Corrected bug on jiffies overflow on elapsed time over ~32 seconds.
- Noticed that 5 through 9 seconds is correctly displayed as 5000.000ms through 9999.999ms. Currently not fixed as would add quite a bit of code in `printk` formatting routine. 1-4 seconds and 10+ seconds displayed properly.

Tested on QEMU and timings are consistent.

Next step will be to start working on user mode C library version of `get_ptime` which will share almost the same code, except for the method of reading kernel jiffies.