### PR TITLE
[libc] Add precision timer routines to C library

### DIFF
--- a/elks/arch/i86/drivers/char/mem.c
+++ b/elks/arch/i86/drivers/char/mem.c
@@ -249,6 +249,9 @@ int kmem_ioctl(struct inode *inode, struct file *file, int cmd, char *arg)
     case MEM_GETHEAP:
 	retword = (unsigned short) &_heap_all;
 	break;
+    case MEM_GETJIFFADDR:
+	retword = (unsigned short) &jiffies;
+        break;
     case MEM_GETUPTIME:
 #ifdef CONFIG_CPU_USAGE
 	retword = (unsigned short) &uptime;

--- a/elks/include/linuxmt/mem.h
+++ b/elks/include/linuxmt/mem.h
@@ -10,6 +10,7 @@
 #define MEM_GETUPTIME	8
 #define MEM_GETFARTEXT  9
 #define MEM_GETMAXTASKS 10
+#define MEM_GETJIFFADDR 11
 
 struct mem_usage {
 	unsigned int free_memory;

--- a/elks/include/linuxmt/prectimer.h
+++ b/elks/include/linuxmt/prectimer.h
@@ -3,12 +3,18 @@
  * 2 Aug 2024 Greg Haerr
  */
 
-#define CONFIG_PREC_TIMER   0   /* =1 to include %k precision timer printk format */
 #define TIMER_TEST          0   /* =1 to include timer_*() test routines */
 
 /* returns pticks in 0.838us resolution, 0.838 microseconds to 42.85 seconds  */
 unsigned long get_ptime(void);
+void init_ptime(void);
 
 /* internal test routines */
 void test_ptime_idle_loop(void);
 void test_ptime_print(void);
+
+#ifdef __GNUC__
+/* silence GCC warning when %k used in printf - FIXME not ideal */
+#pragma GCC diagnostic ignored "-Wformat"
+#pragma GCC diagnostic ignored "-Wformat-extra-args"
+#endif

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -42,6 +42,8 @@
 #include <arch/irq.h>
 #include <stdarg.h>
 
+#define CONFIG_PREC_TIMER   1   /* =1 to include %k precision timer printk format */
+
 dev_t dev_console;
 
 #ifdef CONFIG_CONSOLE_SERIAL

--- a/elkscmd/ktcp/Makefile
+++ b/elkscmd/ktcp/Makefile
@@ -16,13 +16,6 @@ all:	ktcp
 ktcp:	$(OBJS)
 	$(LD) $(LDFLAGS) -maout-heap=32768 -maout-stack=3072  -o ktcp $(OBJS) $(LDLIBS)
 
-lint:
-	@for FILE in *.c ; do \
-		echo '===>' "$${FILE}" ; \
-		splint -weak -D__KERNEL__ $(LOCALFLAGS) "$${FILE}" \
-			2>&1 > "$${FILE}.lint" ; \
-	done
-
 install: ktcp
 	$(INSTALL) ktcp $(DESTDIR)/bin
 

--- a/elkscmd/ktcp/ktcp.c
+++ b/elkscmd/ktcp/ktcp.c
@@ -33,6 +33,7 @@
 #include "netconf.h"
 #include "deveth.h"
 #include "arp.h"
+#include <linuxmt/prectimer.h>
 
 ipaddr_t local_ip;
 ipaddr_t gateway_ip;
@@ -72,6 +73,7 @@ void ktcp_run(void)
     int count;
     int loopagain = 0;
 
+    //init_ptime();
     while (1) {
 	if (tcp_timeruse > 0 || tcpcb_need_push > 0 || loopagain ||
 	    cbs_in_time_wait > 0 || cbs_in_user_timeout > 0) {
@@ -103,6 +105,7 @@ void ktcp_run(void)
 		return;
 	}
 
+	//printf("pticks %lk\n", get_ptime());
 	Now = timer_get_time();
 
 	/* expire timeouts*/

--- a/libc/debug/Makefile
+++ b/libc/debug/Makefile
@@ -11,14 +11,11 @@ OBJS = \
 	syms.o \
 	stacktrace.o \
 	printreg.o \
+	prectimer.o \
 	ptostr.o \
 	# end of list
 
 #OBJS += rdtsc.o
-
-ifeq ($(CONFIG_ARCH_IBMPC), y)
-OBJS += prectimer.o
-endif
 
 all: $(LIB)
 

--- a/libc/debug/Makefile
+++ b/libc/debug/Makefile
@@ -11,6 +11,8 @@ OBJS = \
 	syms.o \
 	stacktrace.o \
 	printreg.o \
+	prectimer.o \
+	ptostr.o \
 	# end of list
 
 #OBJS += rdtsc.o

--- a/libc/debug/Makefile
+++ b/libc/debug/Makefile
@@ -11,11 +11,14 @@ OBJS = \
 	syms.o \
 	stacktrace.o \
 	printreg.o \
-	prectimer.o \
 	ptostr.o \
 	# end of list
 
 #OBJS += rdtsc.o
+
+ifeq ($(CONFIG_ARCH_IBMPC), y)
+OBJS += prectimer.o
+endif
 
 all: $(LIB)
 

--- a/libc/debug/prectimer.c
+++ b/libc/debug/prectimer.c
@@ -22,6 +22,13 @@
 #include <unistd.h>
 #include <fcntl.h>
 #define printk printf
+
+/* FIXME values for IBM PC only, included for non-ifdef'd libc multi-arch compilation */
+#ifndef TIMER_CMDS_PORT
+#define TIMER_CMDS_PORT 0x43
+#define TIMER_DATA_PORT 0x40
+#endif
+
 #endif
 
 /*

--- a/libc/debug/prectimer.c
+++ b/libc/debug/prectimer.c
@@ -1,0 +1,167 @@
+/*
+ * Precision timer routines for IBM PC and compatibles
+ * 2 Aug 2024 Greg Haerr
+ *
+ * Use 8254 PIT to measure elapsed time in pticks = 0.8381 usecs.
+ */
+
+#include <linuxmt/prectimer.h>
+#include <linuxmt/sched.h>
+#include <linuxmt/kernel.h>
+#include <arch/param.h>
+#include <arch/ports.h>
+#include <arch/irq.h>
+#include <arch/io.h>
+
+#ifndef __KERNEL__
+#include <linuxmt/mem.h>
+#include <linuxmt/memory.h>
+#include <sys/linksym.h>
+#include <sys/ioctl.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#define printk printf
+#endif
+
+/*
+ * Each ptick corresponds to the elapsed time for a countdown in the 8254 PIT.
+ * The PC master oscillator frequency is 14.31818 MHz, and is divided
+ * by 12 for the PIT input frequency: 14.31818/12 = 1.1931818 Mhz. Divide
+ * that by 1000 and you get 11932 for the PIT countdown start value;
+ * 1/11932 = 0.8381 usecs per PIT 'ptick'.
+ */
+#define MAX_PTICK        11932U     /* PIT reload value for 10ms (100 HZ) */
+
+/* error check with master PIT frequency */
+#define PITFREQ         11931818L   /* PIT input frequency * 10 */
+#define PITTICK         ((5+(PITFREQ/(HZ)))/10)
+#if PITTICK != MAX_PTICK
+#error Incorrect MAX_PTICK!
+#endif
+
+static unsigned int lastjiffies;    /* only 16 bits required within ~10.9 mins */
+
+#ifndef __KERNEL__
+static unsigned short __far *pjiffies;  /* only access low order jiffies word */
+
+void init_ptime(void)
+{
+    int fd, offset, kds;
+
+    __LINK_SYMBOL(ptostr);
+    fd = open("/dev/kmem", O_RDONLY);
+    if (fd < 0) {
+        printf("No /dev/kmem\n");
+        return;
+    }
+    if (ioctl(fd, MEM_GETDS, &kds) < 0 ||
+        ioctl(fd, MEM_GETJIFFADDR, &offset) < 0) {
+        printf("No ioctl mem_getds\n");
+    } else {
+        pjiffies = _MK_FP(kds, offset);
+    }
+    close(fd);
+}
+#endif
+
+/*
+ * Each PIT count (ptick) is 0.8381 usecs each for 10ms jiffies timer (= 1/11932)
+ *
+ * To display a ptick in usecs use ptick * 838 / 1000U (= 1 mul, 1 div )
+ *
+ * Return type   Name           Resolution  Max
+ * unsigned long get_ptime      0.838us     42.85s (uncaught overflow at ~10.9 mins)
+ * unsigned long jiffies        10ms        497 days (=2^32 jiffies)
+ */
+
+/* return up to 42.85 seconds in pticks, return 0 if overflow, no check > ~10.9 mins */
+unsigned long get_ptime(void)
+{
+    unsigned int pticks, jdiff;
+    unsigned int lo, hi, count;
+    flag_t flags;
+    static unsigned int lastcount;
+
+    save_flags(flags);
+    clr_irq();                      /* synchronize countdown and jiffies */
+    outb(0, TIMER_CMDS_PORT);       /* latch timer value */
+    /* 16-bit subtract handles low word wrap automatically */
+#ifndef __KERNEL__
+    jdiff = *pjiffies - (unsigned)lastjiffies;
+    lastjiffies = *pjiffies;        /* 16 bit save works for ~10.9 mins */
+#else
+    jdiff = (unsigned)jiffies - (unsigned)lastjiffies;
+    lastjiffies = (unsigned)jiffies; /* 16 bit save works for ~10.9 mins */
+#endif
+    restore_flags(flags);
+
+    lo = inb(TIMER_DATA_PORT);
+    hi = inb(TIMER_DATA_PORT) << 8;
+    count = lo | hi;
+    pticks = lastcount - count;
+    if ((int)pticks < 0)            /* wrapped */
+        pticks += MAX_PTICK;        /* = MAX_PTICK - count + lastcount */
+    lastcount = count;
+
+    if (jdiff < 2)                  /* < 10ms: 1..11931 */
+        return pticks;
+    if (jdiff < 4286)               /* < ~42.86s */
+        return (jdiff - 1) * (unsigned long)MAX_PTICK + pticks;
+    return 0;                       /* overflow displays 0s */
+}
+
+#if TIMER_TEST
+
+#ifdef __KERNEL__
+void test_ptime_idle_loop(void)
+{
+    static int v;
+    unsigned long timeout = jiffies + v;
+    unsigned long pticks = get_ptime();
+    printk("%lu %u = %lk\n", pticks, (unsigned)lastjiffies, pticks);
+    if (++v > 5) v = 0;
+    /* idle_halt() must be commented out to vary timings */
+    while (jiffies < timeout)
+        ;
+}
+#endif
+
+void test_ptime_print(void)
+{
+    printk("1 = %k\n", 1);
+    printk("2 = %k\n", 2);
+    printk("3 = %k\n", 3);
+    printk("100 = %k\n", 100);
+    printk("500 = %k\n", 500);
+    printk("1000 = %k\n", 1000);
+    printk("1192 = %k\n", 1192);
+    printk("1193 = %k\n", 1193);
+    printk("1194 = %k\n", 1194);
+    printk("10000 = %k\n", 10000);
+    printk("59659 = %k\n", 59659U);
+    printk("59660 = %k\n", 59660U);
+    printk("59661 = %k\n", 59661U);
+    printk("100000 = %lk\n", 100000L);
+    printk("5*59660 = %lk\n", 5*59660L);
+    printk("359953 = %lk\n", 359953L);
+    printk("19*59660 = %lk\n", 19*59660L);
+    printk("20*59660 = %lk\n", 20*59660L);
+    printk("21*59660 = %lk\n", 21*59660L);
+    printk("60*59660 = %lk\n", 60*59660L);
+    printk("84*59660 = %lk\n", 84*59660L);
+    printk("400*11932 = %lk\n", 400*11932L);
+    printk("500*11932 = %lk\n", 500*11932L);
+    printk("600*11932 = %lk\n", 600*11932L);
+    printk("900*11932 = %lk\n", 900*11932L);
+    printk("1000*11932 = %lk\n", 1000*11932L);
+    printk("600*59660 = %lk\n", 600*59660L);
+    printk("3000000 = %lk\n", 3000000L);
+    printk("30000000 = %lk\n", 30000000UL);
+    printk("35995300 = %lk\n", 35995300UL);
+    printk("36000000 = %lk\n", 36000000UL);
+    printk("51000000 = %lk\n", 51000000UL);
+    printk("51130563 = %lk\n", 51130563UL);
+    printk("51130564 = %lk\n", 51130564UL);
+}
+#endif

--- a/libc/debug/ptostr.c
+++ b/libc/debug/ptostr.c
@@ -1,0 +1,59 @@
+/*
+ * Precision timing pticks (=0.838us) output from 'k' format.
+ */
+
+static char hex_string[] = "0123456789ABCDEF 0123456789abcdef ";
+
+void ptostr(unsigned long v, char *buf)
+{
+    unsigned long dvr;
+    int c, vch, i;
+    int Msecs, Decimal, Zero;
+    int width = 0;
+
+    i = 10;
+    dvr = 1000000000L;
+    Zero = 0;
+    Msecs = 0;
+    /* display 1/1193182s get_time*() pticks in range 0.838usec through 42.85sec */
+    Decimal = 3;
+    if (v > 51130563UL)             /* = 2^32 / 84 high max range = ~42.85s */
+        v = 0;                      /* ... displays 0us */
+    if (v > 5125259UL) {            /* = 2^32 / 838 */
+        v = v * 84UL;
+        Decimal = 2;                /* display xx.xx secs */
+    } else
+        v = v * 838UL;              /* convert to nanosecs w/o 32-bit overflow */
+    if (v > 1000000000UL) {         /* display x.xxx secs */
+        v /= 1000000UL;             /* divide using _udivsi3 for speed */
+    } else if (v > 1000000UL) {
+        v /= 1000UL;                /* display xx.xxx msecs */
+        Msecs = 1;
+    } else {
+        Msecs = 2;                  /* display xx.xxx usecs */
+    }
+
+    vch = 0;
+    do {
+        c = (int)(v / dvr);
+        v %= dvr;
+        dvr /= 10U;
+        if (c || (i <= width) || (i < 2)) {
+            if (i > width)
+                width = i;
+            if (!Zero && !c && (i > 1))
+                c = 16;
+            else
+                Zero = 1;
+            if (vch)
+                *buf++ = vch;
+            vch = *(hex_string + c);
+            if (i == Decimal) *buf++ = '.';
+        }
+    } while (--i);
+    *buf++ = vch;
+    if (Msecs)
+        *buf++ = (Msecs == 1? 'm': 'u');
+    *buf++ = 's';
+        *buf = '\0';
+}

--- a/libc/debug/ptostr.c
+++ b/libc/debug/ptostr.c
@@ -1,8 +1,8 @@
 /*
- * Precision timing pticks (=0.838us) output from 'k' format.
+ * Convert precision timing pticks (=0.838us) to string for printf %k format.
  */
 
-static char hex_string[] = "0123456789ABCDEF 0123456789abcdef ";
+static char dec_string[] = "0123456789 ";
 
 void ptostr(unsigned long v, char *buf)
 {
@@ -42,12 +42,12 @@ void ptostr(unsigned long v, char *buf)
             if (i > width)
                 width = i;
             if (!Zero && !c && (i > 1))
-                c = 16;
+                c = 10;
             else
                 Zero = 1;
             if (vch)
                 *buf++ = vch;
-            vch = *(hex_string + c);
+            vch = *(dec_string + c);
             if (i == Decimal) *buf++ = '.';
         }
     } while (--i);
@@ -55,5 +55,5 @@ void ptostr(unsigned long v, char *buf)
     if (Msecs)
         *buf++ = (Msecs == 1? 'm': 'u');
     *buf++ = 's';
-        *buf = '\0';
+    *buf = '\0';
 }

--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -143,6 +143,7 @@ void dtostr(double val, int style, int preci, char *buf);
 /* use this macro to link in libc %e,%f,%g printf/sprintf support into user program */
 #define __STDIO_PRINT_FLOATS    __LINK_SYMBOL(dtostr)
 #endif
+void ptostr(unsigned long pticks, char *buf);
 
 #define stdio_pending(fp) ((fp)->bufread>(fp)->bufpos)
 

--- a/libc/stdio/vfprintf.c
+++ b/libc/stdio/vfprintf.c
@@ -218,6 +218,7 @@ vfprintf(FILE *op, const char *fmt, va_list ap)
 	 case 'k':		/* Pticks */
 	  usproc:
 	    l = lval? va_arg(ap, unsigned long) : (unsigned long)va_arg(ap, unsigned int);
+#ifndef __WATCOMC__
 	    if (*fmt == 'k') {
 		if (_weaken(ptostr)) {
 		    (_weaken(ptostr))(l, ptmp);
@@ -226,6 +227,7 @@ vfprintf(FILE *op, const char *fmt, va_list ap)
 		}
 		/* if precision timing not linked in, display as unsigned */
 	    }
+#endif
 	    ptmp = ultostr(l, radix);
 	    if( hash && radix == 8 ) { width = strlen(ptmp)+1; pad='0'; }
 	    goto printit;


### PR DESCRIPTION
Precision timing can now be used in `ktcp` and any other applications running on IBM PC.

Expands implementation discussed in https://github.com/Mellvik/TLVC/issues/71.

- Adds `init_ptime()` and `get_ptime()` functions for user mode. `init_ptime` required before first call to `get_ptime`
- Adds MEM_GETJIFFADDR for kernel jiffies access
- No need for global CONFIG_PREC_TIMER, defined only in kernel printk for future use in decreasing kernel size (adds ~351 bytes). User and kernel mode precision timing don't require config changes and rebuilds, just call functions
- User mode precision timing can be used only within one running application at a time
- Kernel precision timing can be compiled in but can't be used at same time as application; this could be enhanced to allow both to be used simultaneously, at the cost of moving the 8254 countdown read to inside the disabled interrupts critical section. May do that after more testing.
- `ptostr` routine used to format %k output similarly to `dtostr` processing for floats
- %k/ptostr handled through weak symbol linking in C library; only pulls in extra printf/vfprintf code if/when get_ptime called (adds ~34 bytes for weak link checking to standard printf)
- Must use with standard printf, not tiny_printf.c which some apps use. Could be added to tiny_printf if needed.
- Sample main loop timing code included in `ktcp` but commented out
- debug/prectimer.c is almost identical to kernel prectimer.c and will be combined to same file after more testing

Tested on QEMU using `ktcp`, `net start` and `telnet localhost`.