### PR TITLE
[kernel/libc] Allow for concurrent operation of libc and kernel precision timer

### DIFF
--- a/elks/arch/i86/lib/prectimer.c
+++ b/elks/arch/i86/lib/prectimer.c
@@ -55,10 +55,10 @@ unsigned long get_ptime(void)
     /* 16-bit subtract handles low word wrap automatically */
     jdiff = (unsigned)jiffies - (unsigned)lastjiffies;
     lastjiffies = (unsigned)jiffies; /* 16 bit save works for ~10.9 mins */
-    restore_flags(flags);
-
     lo = inb(TIMER_DATA_PORT);
     hi = inb(TIMER_DATA_PORT) << 8;
+    restore_flags(flags);
+
     count = lo | hi;
     pticks = lastcount - count;
     if ((int)pticks < 0)            /* wrapped */

--- a/libc/debug/Makefile
+++ b/libc/debug/Makefile
@@ -12,7 +12,6 @@ OBJS = \
 	stacktrace.o \
 	printreg.o \
 	prectimer.o \
-	ptostr.o \
 	# end of list
 
 #OBJS += rdtsc.o

--- a/libc/debug/prectimer.c
+++ b/libc/debug/prectimer.c
@@ -52,6 +52,8 @@ static unsigned int lastjiffies;    /* only 16 bits required within ~10.9 mins *
 #ifndef __KERNEL__
 static unsigned short __far *pjiffies;  /* only access low order jiffies word */
 
+#define errmsg(str)     write(STDERR_FILENO, str, sizeof(str) - 1)
+
 void init_ptime(void)
 {
     int fd, offset, kds;
@@ -59,12 +61,12 @@ void init_ptime(void)
     __LINK_SYMBOL(ptostr);
     fd = open("/dev/kmem", O_RDONLY);
     if (fd < 0) {
-        printf("No /dev/kmem\n");
+        errmsg("No kmem\n");
         return;
     }
     if (ioctl(fd, MEM_GETDS, &kds) < 0 ||
         ioctl(fd, MEM_GETJIFFADDR, &offset) < 0) {
-        printf("No ioctl mem_getds\n");
+        errmsg("No mem ioctl\n");
     } else {
         pjiffies = _MK_FP(kds, offset);
     }
@@ -101,10 +103,10 @@ unsigned long get_ptime(void)
     jdiff = (unsigned)jiffies - (unsigned)lastjiffies;
     lastjiffies = (unsigned)jiffies; /* 16 bit save works for ~10.9 mins */
 #endif
-    restore_flags(flags);
-
     lo = inb(TIMER_DATA_PORT);
     hi = inb(TIMER_DATA_PORT) << 8;
+    restore_flags(flags);
+
     count = lo | hi;
     pticks = lastcount - count;
     if ((int)pticks < 0)            /* wrapped */

--- a/libc/misc/Makefile
+++ b/libc/misc/Makefile
@@ -28,6 +28,7 @@ OBJS = \
 	lltostr.o \
 	mktemp.o \
 	popen.o \
+	ptostr.o \
 	putenv.o \
 	qsort.o \
 	rand.o \

--- a/libc/misc/ptostr.c
+++ b/libc/misc/ptostr.c
@@ -1,19 +1,19 @@
 /*
  * Convert precision timing pticks (=0.838us) to string for printf %k format.
+ * This routine is normally weak linked into vfprintf by a get_ptime reference.
  */
 
 static char dec_string[] = "0123456789 ";
 
 void ptostr(unsigned long v, char *buf)
 {
-    unsigned long dvr;
     int c, vch, i;
-    int Msecs, Decimal, Zero;
-    int width = 0;
+    int Msecs, Decimal, Zero, width;
+    unsigned long dvr;
 
     i = 10;
     dvr = 1000000000L;
-    Zero = 0;
+    width = Zero = 0;
     Msecs = 0;
     /* display 1/1193182s get_time*() pticks in range 0.838usec through 42.85sec */
     Decimal = 3;


### PR DESCRIPTION
The 8254 PIT countdown register is changed to be read during the interrupts disabled critical section, which allows for concurrent use of the precision timer get_ptime function from both the kernel and an application process performing measurements at the same time. This may be useful when measuring the ktcp main loop and also looking at a NIC driver packet read/write response time, for instance.

Discussed briefly in #1963 and https://github.com/Mellvik/TLVC/issues/71.

Moves `ptostr` routine into libc/misc with the other numeric to string conversion routines.
Use `write` rather than `printf` for errors in init_ptime() to keep dependencies down.
