### PR TITLE
[libc] Don't export non-standard types from header files

### DIFF
--- a/elks/include/arch/types.h
+++ b/elks/include/arch/types.h
@@ -12,6 +12,7 @@ typedef signed short int        __s16;
 typedef unsigned long int       __u32;
 typedef signed long int         __s32;
 
+#if defined(__KERNEL__) || defined(__LIBC__)
 /* 8086 types */
 typedef __u8                    byte_t;
 typedef __u16                   word_t;
@@ -41,6 +42,7 @@ struct xregs {
 struct uregs {
     __u16       bp, ip, cs, f;
 };
+#endif
 
 #ifndef NULL
 #define NULL        ((void *) 0)

--- a/elks/include/linuxmt/net.h
+++ b/elks/include/linuxmt/net.h
@@ -1,7 +1,6 @@
 #ifndef __LINUXMT_NET_H
 #define __LINUXMT_NET_H
 
-#include <linuxmt/types.h>
 #include <linuxmt/config.h>
 #include <linuxmt/socket.h>
 
@@ -18,6 +17,7 @@ typedef enum {
     SS_DISCONNECTING
 } socket_state;
 
+#ifdef __KERNEL__
 struct socket {
     unsigned char state;
     unsigned char flags;
@@ -70,6 +70,7 @@ struct proto_ops {
     int (*getsocketopt) ();
     int (*fcntl) ();
 };
+#endif
 
 /* careful: option names are close to public SO_ options in socket.h */
 #define SF_CLOSING	(1 << 0) /* inet */

--- a/elks/include/linuxmt/stat.h
+++ b/elks/include/linuxmt/stat.h
@@ -1,7 +1,6 @@
 #ifndef __LINUXMT_STAT_H
 #define __LINUXMT_STAT_H
 
-#include "types.h"
 #include <arch/stat.h>
 
 #define S_IFMT  00170000

--- a/elks/include/linuxmt/types.h
+++ b/elks/include/linuxmt/types.h
@@ -4,38 +4,37 @@
 #include <arch/types.h>
 
 typedef __u16                   dev_t;
-typedef __u16                   block_t;
-
-typedef __u32                   block32_t;
-typedef __u32                   sector_t;
-typedef __s32                   cluster_t;
-
 typedef __u16                   pid_t;
 typedef __u16                   uid_t;
 typedef __u16                   gid_t;
-
-typedef __u32                   ino_t;
-
 typedef __u16                   mode_t;
 typedef __u16                   nlink_t;
-typedef __u16                   umode_t;
+
+typedef __u32                   ino_t;
+typedef __u32                   time_t;
 
 typedef __s32                   off_t;
 typedef __s32                   loff_t;
-
-typedef __u16                   sig_t;
-typedef __s16                   sem_t;
 
 typedef __u32                   tcflag_t;
 typedef __u32                   speed_t;
 typedef __u8                    cc_t;
 
-typedef __u32                   jiff_t;
-typedef __u32                   time_t;
-typedef __u32                   fd_mask_t;
-
 #include <linuxmt/posix_types.h>
 
 typedef __kernel_fd_set         fd_set;
+
+#if defined(__KERNEL__) || defined(__LIBC__)
+typedef __u16                   block_t;
+typedef __u32                   block32_t;
+typedef __u32                   sector_t;
+typedef __s32                   cluster_t;
+
+typedef __u16                   sig_t;
+typedef __s16                   sem_t;
+
+typedef __u32                   jiff_t;
+typedef __u32                   fd_mask_t;
+#endif
 
 #endif

--- a/elkscmd/disk_utils/df.c
+++ b/elkscmd/disk_utils/df.c
@@ -11,17 +11,16 @@
  * Ported to ELKS by Greg Haerr May 2020
  */
 
+#define __LIBC__            /* get all typedefs */
 #include <stdio.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <limits.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <unistd.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <dirent.h>
+#include <sys/stat.h>
 #include <sys/mount.h>
 #include <linuxmt/minix_fs.h>
 #include <linuxmt/fs.h>

--- a/elkscmd/sys_utils/meminfo.c
+++ b/elkscmd/sys_utils/meminfo.c
@@ -9,6 +9,7 @@
  * This file may be distributed under the terms of the GNU General Public
  * License v2, or at your option any later version.
  */
+#define __LIBC__            /* get all typedefs */
 #include <linuxmt/types.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/mem.h>

--- a/elkscmd/test/other/test_fd.c
+++ b/elkscmd/test/other/test_fd.c
@@ -1,6 +1,7 @@
 /*
  * fdtest - A program to test floppy disk I/O speed in user space
  */
+#define __LIBC__            /* get all typedefs */
 #include <stdio.h>
 #include <time.h>
 #include <signal.h>

--- a/libc/include/malloc.h
+++ b/libc/include/malloc.h
@@ -31,6 +31,6 @@ extern void __wcnear *(*__alloca_alloc)(size_t);
 
 /* alloc from main memory */
 void __far *fmemalloc(unsigned long size);
-int _fmemalloc(int paras, seg_t *pseg);
+int _fmemalloc(int paras, unsigned short *pseg);
 
 #endif

--- a/libc/watcom/syscall/fmemalloc.c
+++ b/libc/watcom/syscall/fmemalloc.c
@@ -7,7 +7,7 @@
 #include <malloc.h>
 #include "watcom/syselks.h"
 
-int _fmemalloc( int __paras, seg_t *__pseg )
+int _fmemalloc( int __paras, unsigned short *__pseg )
 {
     sys_setseg(__pseg);
     syscall_res res = sys_call2( SYS_fmemalloc, __paras, (unsigned)__pseg);


### PR DESCRIPTION
Previously, certain non-standard C typedefs used within the ELKS kernel were exported via its C library header files. This caused name collision for some projects.

Corrects problems seen in https://github.com/FrenkelS/doomtd3/pull/12 with `sector_t` and `seg_t` typedefs.

