### PR TITLE
[build] Don't use dummy boot code in kernel disk image

### DIFF
--- a/Documentation/text/boot.txt
+++ b/Documentation/text/boot.txt
@@ -85,20 +85,14 @@ fs/
 buffer.c	init buffers, may allocate from main memory or extended memory.
 
 ----------------------------------------------------------------------------
-The dummy boot sector contains some parameters at the end:
+The dummy boot sector is all zeros except for the following, which
+are patched by arch/i86/tools/build when the kernel is being built:
 
-(0x1ef)495,496   Segment for setup.S			(SETUPSEG)
-(0x1f1)497      *number of sectors in setup.S		(setup_secs)
-(0x1f2)498,499   root_flags				(ROOTFLAGS)
-(0x1f4)500,501  *size of kernel in 16-byte chunks	(syssize)
-(0x1f6)502,503   swap device				(SWAP_DEV) now elks_flags
-(0x1f8)504,505   ramdisk size				(RAMDISK)
-(0x1fa)506,507   video mode				(SVGA_MODE)
-(0x1fc)508,509  *root device				(root_dev)
-(0x1fe)510,511   constant flag 0xAA55
+(0x1e6)486-489  'ELKS' signature                        (elks_magic)
+(0x1f1)497      number of sectors in setup.S		(setup_secs)
+(0x1f4)500,501  size of kernel in paragraphs            (syssize)
+(0x1fc)508,509  root device				(root_dev)
 
-*patched by arch/i86/tools/build when the kernel is being built.
-Only 497, 500,501 and 508,509 are used at present.
 
 Setup and INITSEG Variables
 ---------------------------
@@ -110,19 +104,21 @@ Setup is ASM code that executes immediately after the boot loader, and
 prior to the kernel. It is located in the 2nd 512 bytes of the kernel image
 on disk (/linux).
 
-The first 512 bytes of the kernel disk image is a dummy boot sector that
-contains preset values for certain setup variable locations. Following that
-is the a.out kernel executable header and then the kernel text, fartext,
+The first 512 bytes of the kernel disk image is a mostly zero sector that
+contains preset values for certain kernel or setup.S variables. This sector
+gets loaded by the boot loader and ends up as the INITSEG data segment for
+setup.S. Following that is the setup.S code for a minimum of 4 sectors, and
+after that the a.out kernel executable header and the kernel text, fartext,
 data and relocation table sections.
 
 When building the kernel image Image, a special tool called build is used to
-concatenate the dummy boot loader, the setup code and the kernel executable
+concatenate the setup data sector, the setup code and the kernel executable
 together. build also writes the sizes of setup and the kernel into INITSEG,
-which at the time is the dummy boot sector.
+the first 512 bytes of the kernel image.
 
 Setup's data segment is at a fixed location and is called INITSEG, and is
-initially the contents of the dummy boot sector. Setup is required to
-perform the relocations from the a.out relocation table on the kernel
+initially the contents of the just loaded first kernel 512 bytes. Setup is
+required to perform the relocations from the a.out relocation table on the kernel
 executable, and also to determine certain hardware configurations easier done
 in assembly, which are saved in it's data segment (INITSEG), which is also
 known to the kernel, since it's at a fixed segment address.
@@ -137,13 +133,13 @@ ELKS "INITSEG" (setup data segment) offsets:
 +------+-----+------+-------------------+--------------------------+------------
 | 0007 |   7 | byte | screen_cols       | screen width             | setup.S
 | 000E |  14 | byte | screen_lines      | screen height            | setup.S
-| 0020 |  32 | byte | cpu_type          | deprecated               | setup.S
+| 0020 |  32 | byte | cpu_type          | UNUSED                   |
 | 002A |  42 | word | mem_kbytes        | base memory size in K    | setup.S
-| 0030 |  48 |16byte| proc_name         | processor name           | setup.S
-| 0050 |  80 |13byte| cpu_id            | cpu id                   | setup.S
+| 0030 |  48 |16byte| proc_name         | UNUSED                   |
+| 0050 |  80 |13byte| cpu_id            | UNUSED                   |
 | 01E2 | 482 | long | part_offset       | partition offset in sects| boot_sect.S
 | 01E2 | 482 | long | part_offset       | partition offset in sects| boot_sect.S
-| 01E6 | 486 | long | elks_magic        | "ELKS"                   | bootsect.S
+| 01E6 | 486 | long | elks_magic        | "ELKS"                   | build.c
 | 01EF | 495 | word | SETUPSEG          | UNUSED                   |
 | 01F1 | 497 | byte | setup_sects       | size in 512-byte sects   | build.c
 | 01F2 | 498 | word | ROOTFLAGS         | UNUSED                   |
@@ -153,7 +149,7 @@ ELKS "INITSEG" (setup data segment) offsets:
 | 01F8 | 504 | word | RAMDISK           | UNUSED                   |
 | 01FA | 506 | word | SVGAMODE          | UNUSED                   |
 | 01FC | 508 | word | root_dev          | BIOS drive or kdev_t     | build.c,boot_sect.S
-| 01FE | 510 | word | boot_flag         | AA55h                    | boot_sect.S
+| 01FE | 510 | word | boot_flag         | UNUSED                   |
 +------+-----+------+-------------------+--------------------------+------------
 
 

--- a/elks/arch/i86/Makefile
+++ b/elks/arch/i86/Makefile
@@ -106,7 +106,7 @@ boot/system:	$(XINCLUDE) $(AARCHIVES) $(ADRIVERS) boot/crt0.o
 ifneq ($(CONFIG_ROMCODE), y)
 
 Image:	toolkit boot/bootsect boot/setup boot/system
-	tools/build boot/bootsect boot/setup boot/system > boot/Image
+	tools/build arg_ignored boot/setup boot/system > boot/Image
 
 nbImage:	Image boot/netbootsect
 	tools/mknbi-elks boot/netbootsect boot/Image boot/nbImage

--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -62,20 +62,18 @@
 !	0x50:	cpu_id		byte[13] cpuid string UNUSED
 !	...
 !	0x1e2:	part_offset	long Sector offset of booted MBR partition
-!	0x1e6:	elks_magic	long "ELKS"
+!	0x1e6:	elks_magic	long "ELKS", written by build tool
 !	0x1ea-0x1ee:		5 bytes UNUSED
 !	0x1ef:	SETUPSEG	word UNUSED
 !	0x1f1:	setup_sects	byte in 512-byte sectors, written by build tool
 !	0x1f2:	ROOTFLAGS	word UNUSED
-!	0x1f4:	syssize		word in paragraphs, written by build tool
-!	0x1f6:	elks_flags	byte EF_xxx
+!	0x1f4:	syssize		word kernel size in paragraphs, written by build tool
+!	0x1f6:	elks_flags	byte EF_AS_BLOB|EF_BIOS_DEV_NUM
 !	0x1f7:			byte UNUSED
 !	0x1f8:	RAMDISK		word UNUSED
 !	0x1fa:	SVGA_MODE	word UNUSED
 !	0x1fc:	root_dev	word Either BIOS boot device or actual kdev_t ROOT_DEV
-!	0x1fe:	boot_flag	word = 0xAA55
-!
-! NOTE! These had better be the same as in bootsect.s!
+!	0x1fe:	boot_flag	word UNUSED (0xAA55 in real boot sector)
 */
 
 #include <linuxmt/config.h>

--- a/elks/arch/i86/tools/build.c
+++ b/elks/arch/i86/tools/build.c
@@ -6,29 +6,18 @@
  */
 
 /*
- * This file builds a disk-image from three different files:
+ * This file builds the /linux system image from two different files:
  *
- * - bootsect: exactly 512 bytes of 8086 machine code, loads the rest
- * - setup: 8086 machine code, sets up system parm
- * - system: 8086 code for actual system
+ * setup: setup.S assembled to a.out format, sets up system parms
+ * system: compiled kernel in a.out format
  *
  * It does some checking that all files are of the correct type, and
  * just writes the result to stdout, removing headers and padding to
  * the right amount. It also writes some system data to stderr.
  */
 
-/*
- * Changes by tytso to allow root device specification
- */
-
 #include <stdio.h>			/* fprintf */
-
-#ifdef __linux__
-#include <sys/sysmacros.h>		/* for major/minor macros */
-#endif
-#include <sys/stat.h>
 #include <sys/types.h>			/* unistd.h needs this */
-
 #include <string.h>
 #include <stdlib.h>			/* contains exit */
 #include <unistd.h>			/* contains read/write */
@@ -44,15 +33,9 @@
 #define MINIX_HEADER 0x20
 #define SUPL_HEADER  0x40
 
-#define N_MAGIC_OFFSET 1024
-
-#ifndef __BFD__
-static int GCC_HEADER = sizeof(struct exec);
-#endif
-
 #define SYS_SIZE DEF_SYSSIZE
 
-#define DEFAULT_MAJOR_ROOT 0x03
+#define DEFAULT_MAJOR_ROOT 0x03         /* BIOS floppy 0 */
 #define DEFAULT_MINOR_ROOT 0x80
 
 /* max nr of sectors of setup: don't change unless you also change bootsect etc
@@ -101,53 +84,26 @@ void die(const char *str)
 
 void usage(void)
 {
-    die("Usage: build bootsect setup system [rootdev] [> image]");
+    die("Usage: build bootsect setup system [> image]");
 }
 
 int main(int argc, char **argv)
 {
     int32_t i, c, id, sz, fsz;
     uint32_t sys_size;
-    char buf[1024];
-
-#ifndef __BFD__
-    struct exec *ex = (struct exec *) buf;
-#endif
-
     unsigned char major_root, minor_root;
-    struct stat sb;
     unsigned char setup_sectors;
+    char buf[1024];
+    struct exec *ex = (struct exec *) buf;
 
-#define ROOTDEV_ARG 4
-
-    if ((argc < ROOTDEV_ARG) || (argc > ROOTDEV_ARG + 1))
-	usage();
-    if (argc > ROOTDEV_ARG) {
-	if (!strcmp(argv[ROOTDEV_ARG], "CURRENT")) {
-	    if (stat("/", &sb)) {
-		perror("/");
-		die("Couldn't stat /");
-	    }
-	    major_root = major(sb.st_dev);
-	    minor_root = minor(sb.st_dev);
-	} else if (strcmp(argv[ROOTDEV_ARG], "FLOPPY")) {
-	    if (stat(argv[ROOTDEV_ARG], &sb)) {
-		perror(argv[ROOTDEV_ARG]);
-		die("Couldn't stat root device.");
-	    }
-	    major_root = major(sb.st_rdev);
-	    minor_root = minor(sb.st_rdev);
-	} else {
-	    major_root = 0;
-	    minor_root = 0;
-	}
-    } else {
-	major_root = DEFAULT_MAJOR_ROOT;
-	minor_root = DEFAULT_MINOR_ROOT;
-    }
+    if (argc != 4)
+        usage();
+    major_root = DEFAULT_MAJOR_ROOT;
+    minor_root = DEFAULT_MINOR_ROOT;
     fprintf(stderr, "Root device is (%d, %d)\n", major_root, minor_root);
     for (i = 0; i < sizeof buf; i++)
 	buf[i] = 0;
+#ifdef USEDUMMYBOOT
     if ((id = open(argv[1], O_RDONLY, 0)) < 0)
 	die("Unable to open 'boot'");
     if (read(id, buf, MINIX_HEADER) != MINIX_HEADER)
@@ -171,12 +127,13 @@ int main(int argc, char **argv)
     if ((*(unsigned short *) (buf + 510)) !=
 	(unsigned short) intel_short(0xAA55))
 	    die("Boot block hasn't got boot flag (0xAA55)");
+    close(id);
+#endif
     buf[root_dev] = (char) minor_root;		/* WRITE root_dev*/
     buf[root_dev+1] = (char) major_root;
-    i = write(1, buf, 512);
+    i = write(1, buf, 512);                     /* this sector becomes INITSEG */
     if (i != 512)
 	die("Write call failed");
-    close(id);
 
     if ((id = open(argv[2], O_RDONLY, 0)) < 0)
 	die("Unable to open 'setup'");
@@ -218,7 +175,7 @@ int main(int argc, char **argv)
 
     if ((id = open(argv[3], O_RDONLY, 0)) < 0)
 	die("Unable to open 'system'");
-#ifndef __BFD__
+
     if (read(id, buf, SUPL_HEADER) != SUPL_HEADER)
 	die("Unable to read header of 'system'");
     if ((ex->a_magic[0] != 0x01) || (ex->a_magic[1] != 0x03)) {
@@ -230,7 +187,7 @@ int main(int argc, char **argv)
 	fsz = intel_long(ex->esh_ftseg);
 	sz += fsz;
     }
-    fprintf(stderr, "System is %d B (%d B code, %d B fartext, %d B data and %u B bss)\n",
+    fprintf(stderr, "Kernel is %d B (%d B code, %d B fartext, %d B data and %u B bss)\n",
 	sz, intel_long(ex->a_text), fsz,
 	intel_long(ex->a_data), (unsigned) intel_long(ex->a_bss));
     sz = ex->a_hdrlen + intel_long(ex->a_text) + intel_long(ex->a_data);
@@ -245,19 +202,12 @@ int main(int argc, char **argv)
     }
 
     lseek(id, 0, 0);
-#else
-    if (fstat(id, &sb)) {
-	perror("fstat");
-	die("Unable to stat 'system'");
-    }
-    sz = sb.st_size;
-    fprintf(stderr, "System is %d kB\n", sz / 1024);
-#endif
+
     sys_size = (sz + 15) / 16;
     fprintf(stderr, "System is %d (%xh paras)\n", sz, sys_size);
     if (sys_size > SYS_SIZE)
 	die("System is too big");
-#ifndef CONFIG_ROMCODE
+#if 0 && !defined(CONFIG_ROMCODE)       /* no longer correct */
     /* compute boot load address to avoid overwriting image at boot relocation time*/
     fsz = (ex->a_hdrlen + (intel_long(ex->a_text) + intel_long(ex->a_data)) + 15) / 16
 	+ REL_SYSSEG;
@@ -286,6 +236,10 @@ int main(int argc, char **argv)
 	sz -= l;
     }
     close(id);
+    if (lseek(1, elks_magic, 0) == elks_magic) {
+	if (write(1, "ELKS", 4) != 4)                   /* WRITE elks_magic */
+	    die("Write failed");
+    }
     if (lseek(1, setup_sects, 0) == setup_sects) {
 	if (write(1, &setup_sectors, 1) != 1)		/* WRITE setup_sectors*/
 	    die("Write of setup sectors failed");

--- a/elks/include/linuxmt/boot.h
+++ b/elks/include/linuxmt/boot.h
@@ -30,6 +30,15 @@
    {bootsect.S, netbootsect.S}) at the start of /linux, then define
    constants giving the offsets of various fields within /linux.
 
+   The "dummy" boot sector is no longer built or executed. Instead, the values
+   below correspond to offsets in the 512-byte setup.S data segment, known as INITSEG.
+   These values are initialized then shared with Linux kernel at startup through the
+   same segment. The tools/build utility writes a 512-byte sector of zeros
+   prepended to the setup and kernel images, with the elks_magic, setup_sects,
+   and syssize fields filled in, which are then either checked by the real
+   boot sector (elks_magic) or shared with setup.S for relocating the kernel
+   (setup_sects and syssize) at boot.
+
    The fields in /linux are mainly based on an old version of the Linux/x86
    Boot Protocol (https://www.kernel.org/doc/html/latest/x86/boot.html).
    Fields which are specific to ELKS are indicated below.  */
@@ -42,12 +51,12 @@
 #define proc_name	0x30		/* 16 bytes processor name string*/
 #define cpu_id		0x50		/* 13 bytes cpu id string*/
 #define part_offset	0x1e2		/* long sector offset of booted partition*/
-#define elks_magic	0x1e6		/* long "ELKS" (45 4c 4b 53) checked by bootsect.S*/
+#define elks_magic	0x1e6		/* long "ELKS" (45 4c 4b 53) checked by boot sector*/
 #define setup_sects	0x1f1		/* byte 512-byte sectors used by setup.S*/
 #define syssize		0x1f4		/* word paragraph kernel size used by setup.S*/
 #define elks_flags	0x1f6		/* byte ELKS flags, BLOB and BIOS_DRV*/
 #define root_dev	0x1fc		/* word BIOS drive or kdev_t ROOT_DEV*/
-#define boot_flag	0x1fe		/* word constant AA55h*/
+#define boot_flag	0x1fe		/* word constant AA55h checked by boot sector*/
 #endif
 
 #endif


### PR DESCRIPTION
Removes never-executed "dummy" boot sector from build and use in building the kernel disk image. 

Updates documentation on actual variables set or used in the setup.S data segment, which remains the first sector in the kernel disk image.

Cleans up tools/build system-building tool.

Cleans up system image build Makefile and associated directories.