### PR TITLE
[kernel] Fix kernel data overwrite bug while parsing /bootopts

### DIFF
--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -187,7 +187,7 @@ void arch_setup_sighandler_stack(register struct task_struct *t,
  * with IP pointing to ret_from_syscall, and current->t_xregs.ksp pointing
  * to si on the kernel stack. Values for the child stack si, di and bp can
  * be anything because their final value will be taken from the task structure
- * in the case of fork(), or will be initialized at the begining of the target
+ * in the case of fork(), or will be initialized at the beginning of the target
  * function in the case of kfork_proc().
  */
 

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -70,13 +70,13 @@ static int args = 2;	/* room for argc and av[0] */
 static int envs;
 static int argv_slen;
 #ifdef CONFIG_SYS_NO_BININIT
-static char *argv_init[80] = { NULL, binshell, NULL };
+static char *argv_init[MAX_INIT_SLEN] = { NULL, binshell, NULL };
 #else
 /* argv_init doubles as sptr data for sys_execv later*/
-static char *argv_init[80] = { NULL, bininit, NULL };
+static char *argv_init[MAX_INIT_SLEN] = { NULL, bininit, NULL };
 #endif
 #if ENV
-static char *envp_init[MAX_INIT_ENVS+1];
+static char *envp_init[MAX_INIT_ENVS];
 #endif
 static unsigned char options[OPTSEGSZ];
 

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -587,12 +587,11 @@ static void INITPROC finalize_options(void)
 
 #if ENV
 	/* set ROOTDEV environment variable for rc.sys fsck*/
-	if (envs < MAX_INIT_ENVS)
-		envp_init[envs++] = root_dev_name(ROOT_DEV);
-	if (running_qemu && envs < MAX_INIT_ENVS)
-		envp_init[envs++] = (char *)"QEMU=1";
-	if (envs >= MAX_INIT_ENVS)
+	if (envs + running_qemu >= MAX_INIT_ENVS)
 		panic(errmsg_initenvs);
+	envp_init[envs++] = root_dev_name(ROOT_DEV);
+	if (running_qemu)
+		envp_init[envs++] = (char *)"QEMU=1";
 #endif
 
 #if DEBUG

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -29,8 +29,15 @@
 
 #include <linuxmt/debug.h>
 
-#define MAX_INIT_ARGS	8
-#define MAX_INIT_ENVS	8
+#define MAX_INIT_ARGS	6       /* max # arguments to /bin/init or init= program */
+#define MAX_INIT_ENVS	12      /* max # environ variables passed to /bin/init */
+#define MAX_INIT_SLEN   80      /* max # words of args + environ passed to /bin/init */
+
+#define STR(x)          __STRING(x)
+/* bootopts error message are duplicated below so static here for space */
+char errmsg_initargs[] = "init args > " STR(MAX_INIT_ARGS);
+char errmsg_initenvs[] = "init envs > " STR(MAX_INIT_ENVS);
+char errmsg_initslen[] = "init words > " STR(MAX_INIT_SLEN);
 
 int root_mountflags;
 struct netif_parms netif_parms[MAX_ETHS] = {
@@ -108,7 +115,7 @@ void testloop(unsigned timer)
 }
 #endif
 
-/* this procedure called using temp stack then switched, no temp vars allowed */
+/* this procedure called using temp stack then switched, no local vars allowed */
 void start_kernel(void)
 {
     early_kernel_init();        /* read bootopts using kernel interrupt stack */
@@ -559,13 +566,13 @@ static int INITPROC parse_options(void)
 		 */
 		if (!strchr(line,'=')) {    /* no '=' means init argument*/
 			if (args >= MAX_INIT_ARGS)
-				break;
+				panic(errmsg_initargs);
 			argv_init[args++] = line;
 		}
 #if ENV
 		else {
 			if (envs >= MAX_INIT_ENVS)
-				break;
+				panic(errmsg_initenvs);
 			envp_init[envs++] = line;
 		}
 #endif
@@ -578,11 +585,15 @@ static void INITPROC finalize_options(void)
 {
 	int i;
 
+#if ENV
 	/* set ROOTDEV environment variable for rc.sys fsck*/
 	if (envs < MAX_INIT_ENVS)
 		envp_init[envs++] = root_dev_name(ROOT_DEV);
 	if (running_qemu && envs < MAX_INIT_ENVS)
 		envp_init[envs++] = (char *)"QEMU=1";
+	if (envs >= MAX_INIT_ENVS)
+		panic(errmsg_initenvs);
+#endif
 
 #if DEBUG
 	printk("args: ");
@@ -624,6 +635,8 @@ static void INITPROC finalize_options(void)
 #endif
 	/*argv_init[args+2+envs] = NULL;*/
 	argv_slen = q - (char *)argv_init;
+	if (argv_slen > sizeof(argv_init))
+		panic(errmsg_initslen);
 }
 
 /* return whitespace-delimited string*/


### PR DESCRIPTION
Fixes problem found during discussion in https://github.com/Mellvik/TLVC/issues/76.

When parsing /bootopts, trying to pass more than 6 arguments to /bin/init (or init=), setting more than 12 environment variables, or having an init command line > 80 words (160 bytes) caused data corruption. Now, a message is displayed and the system halted. It was thought better to halt the system than continue with /bootopts options ignored, especially as the boot screen sometimes scrolls by rather quickly.