### PR TITLE
[bioshd] Implement park for ancient MFM/RLL disks

### DIFF
--- a/elks/arch/i86/drivers/block/bios.c
+++ b/elks/arch/i86/drivers/block/bios.c
@@ -222,6 +222,24 @@ int INITPROC bios_gethdinfo(struct drive_infot *drivep) {
     }
     return ndrives;
 }
+
+static void BFPROC bios_disk_park(struct drive_infot *drive)
+{
+    /* int 13 AH=0xC supports only 10 bits for cyl */
+    if (drive->cylinders > 1024 || drive->fdtype != -1) return;
+    BD_AX = 0x0C << 8;
+    BD_CX = ((drive->cylinders & 0xFF) << 8) | ((drive->cylinders & 0x300) >> 2) | 0x1; /* 0x1 = sector */
+    BD_DX = bios_drive_map[drive - drive_info];
+    call_bios(&bdt);
+}
+
+void bios_disk_park_all(void)
+{
+    int i;
+    for (i = 0; i < NUM_DRIVES; ++i)
+        bios_disk_park(&drive_info[i]);
+}
+
 #endif
 
 #ifdef CONFIG_BLK_DEV_BFD_HARD

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -78,7 +78,7 @@ static int fd_count = 0;                /* number of floppy disks */
 static int hd_count = 0;                /* number of hard disks */
 
 static int access_count[NUM_DRIVES];    /* device open count */
-static struct drive_infot drive_info[NUM_DRIVES];   /* operating drive info */
+struct drive_infot drive_info[NUM_DRIVES];   /* operating drive info */
 static struct drive_infot *cache_drive;
 struct drive_infot *last_drive;         /* set to last drivep-> used in read/write */
 extern struct drive_infot fd_types[];   /* BIOS floppy formats */

--- a/elks/include/linuxmt/biosparm.h
+++ b/elks/include/linuxmt/biosparm.h
@@ -87,5 +87,6 @@ void BFPROC bios_copy_ddpt(void);
 struct drive_infot;
 void BFPROC bios_switch_device98(int target, unsigned int device,
         struct drive_infot *drivep);
+void bios_disk_park_all(void);
 
 #endif

--- a/elks/include/linuxmt/genhd.h
+++ b/elks/include/linuxmt/genhd.h
@@ -78,6 +78,7 @@ struct gendisk
 
 extern struct drive_infot *last_drive;  /* set to last drivep-> used in read/write */
 extern unsigned char bios_drive_map[];  /* map drive to BIOS drivenum */
+extern struct drive_infot drive_info[];
 
 extern struct gendisk *gendisk_head;    /* linked list of disks */
 

--- a/elks/kernel/sys.c
+++ b/elks/kernel/sys.c
@@ -4,6 +4,7 @@
  *  Copyright (C) 1991, 1992  Linus Torvalds
  */
 
+#include <linuxmt/biosparm.h>
 #include <linuxmt/config.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/sched.h>
@@ -48,16 +49,25 @@ int sys_reboot(unsigned int magic, unsigned int magic_too, int flag)
 		C_A_D = flag;
 		return 0;
 	    case 0x0123:		/* reboot*/
+#ifdef CONFIG_BLK_DEV_BHD
+		bios_disk_park_all();
+#endif
 		hard_reset_now();
 		printk("Reboot failed\n");
 		/* fall through*/
 	    case 0x6789:		/* shutdown*/
 		sys_kill(1, SIGKILL);
 		sys_kill(-1, SIGKILL);
+#ifdef CONFIG_BLK_DEV_BHD
+		bios_disk_park_all();
+#endif
 		printk("System halted\n");
 		do_exit(0);
 		/* no return*/
 	    case 0xDEAD:		/* poweroff*/
+#ifdef CONFIG_BLK_DEV_BHD
+		bios_disk_park_all();
+#endif
 		apm_shutdown_now();
 		printk("APM shutdown failed\n");
 	}


### PR DESCRIPTION
This patch still requires work before merging IMO, but I wanted to file this PR now to gather some feedback.
I'm running two ST-412 hard disks on my IBM 5150+5161 system so I don't ever have to worry about storage again. I noticed that there doesn't seem to be any support in ELKS for parking hard disks of this vintage, so I took a stab at adding it.
There was some [discussion about this in 2020](https://github.com/ghaerr/elks/issues/437#issuecomment-598273782), but I assume most people playing around with ELKS aren't running disks this old :]

It seems to me that the correct way to do this is to park the drive in `bioshd_release()`.
This does work for unmounting non-root disks, but there is a special case for the root drive, where the drive is remounted as read-only instead, and `bioshd_release` never gets called.
So my hack to ensure all drives are parked when shutting down is to just park every drive in `sys_reboot()`, which feels very hacky.

I'd welcome any advice on a better approach, and any nits/comments on my implementation, as I'm not too familiar with writing kernel code.

Tangentially related, I observed that the userland `reboot` and `shutdown` commands don't seem to unmount all mounted volumes. I have a patch that makes them iterate all mounted volumes to unmount them before a shutdown/reboot, but I'll leave that for another PR, and pending more discussion. Shouldn't the kernel sync/unmount mounted filesystems before shutting down? Or is that generally left to the userspace to handle?