### PR TITLE
[cmds] Unmount all volumes in shutdown & reboot

### DIFF
--- a/elkscmd/sys_utils/reboot.c
+++ b/elkscmd/sys_utils/reboot.c
@@ -15,16 +15,33 @@
 #include <time.h>
 #include <sys/mount.h>
 #include <sys/select.h>
+#include <linuxmt/limits.h>
+
+int try_unmount(dev_t dev)
+{
+	struct statfs statfs;
+	if (ustatfs(dev, &statfs, UF_NOFREESPACE) < 0) {
+		return 0;
+	}
+	if (umount(statfs.f_mntonname)) {
+		perror("umount");
+		return 1;
+	}
+	return 0;
+}
 
 int main(int argc, char **argv)
 {
+	int i, ret;
+	int force = 1;
+	if (argc < 2 || argv[1][0] != '-' || argv[1][1] != 'f')
+		force = 0;
+
 	sync();
-	if (umount("/") < 0) {
+	for (i = NR_SUPER - 1; i >= 0; --i) {
+		ret = try_unmount(i);
 		/* -f forces reboot even if mount fails */
-		if (argc < 2 || argv[1][0] != '-' || argv[1][1] != 'f')	 {
-			perror("umount");
-			return 1;
-		}
+		if (ret && !force) return 1;
 	}
 	sleep(3);
 	if (reboot(0x1D1E,0xC0DE,0x0123)) {

--- a/elkscmd/sys_utils/shutdown.c
+++ b/elkscmd/sys_utils/shutdown.c
@@ -18,13 +18,28 @@
 #include <unistd.h>
 #include <errno.h>
 #include <sys/mount.h>
+#include <linuxmt/limits.h>
+
+int try_unmount(dev_t dev)
+{
+	struct statfs statfs;
+	if (ustatfs(dev, &statfs, UF_NOFREESPACE) < 0) {
+		return 0;
+	}
+	if (umount(statfs.f_mntonname)) {
+		perror("umount");
+		return 1;
+	}
+	return 0;
+}
 
 int main(int argc, char **argv)
 {
+	int i, ret;
 	sync();
-	if (umount("/")) {
-		perror("umount");
-		return 1;
+	for (i = NR_SUPER - 1; i >= 0; --i) {
+		ret = try_unmount(i);
+		if (ret) return 1;
 	}
 	sleep(3);
 	if (reboot(0x1D1E,0xC0DE,0x6789)) {


### PR DESCRIPTION
Somewhat related to #1977, there was some [discussion of moving this functionality to the kernel](https://github.com/ghaerr/elks/pull/1977#issuecomment-2311504681), but here is the userspace implementation I have currently.

It now unmounts all mounted volumes, instead of only the root volume when you invoke `shutdown` or `reboot`