### PR TITLE
[boot] Add enhanced debug display to setup.S for early startup debugging

### DIFF
--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -81,7 +81,10 @@
 #include <linuxmt/boot.h>
 
 // Relocating loader debug option
-#define DEBUG_LOADER	0
+debug_output    =       0       // display various register values during execution
+serial_output   =       0       // use INT 14 serial instead of INT 10 console out
+debug_loader    =       0       // display relocations
+
 
 // Signature words to ensure LILO loaded us right
 #define SIG1	0xAA55
@@ -103,6 +106,27 @@
 	.arch i8086, nojumps
 	.code16
 	.text
+	.section .text
+	.section .text.const
+	.section .text
+
+	.macro	.hex4sp	reg,msg
+	.if	debug_output
+	push	%ax
+	.ifnb	\msg
+	.section .text.const
+1:	.ascii	"\msg","\0"
+	.section .text
+	push	%ax		// in case reg is AX
+	mov	$1b,%ax
+	call	csputs
+	pop	%ax
+	.endif
+	mov	\reg,%ax
+	call	hex4sp
+	pop	%ax
+	.endif
+	.endm
 
 	.global _start
 _start:
@@ -128,7 +152,16 @@ _start:
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Entry point for kernels loaded from DISK
 
+	.hex4sp	%ss,"\nSETUP boot SS:"
+	.hex4sp	%sp,"SP:"
+	.hex4sp	$INITSEG,"\nDEF_INITSEG:"
+	.hex4sp	$REL_INITSEG,"-> REL_INITSEG:"
+	.hex4sp	$SETUPSEG,"DEF_SETUPSEG:"
+	.hex4sp	$SYSSEG,"\nDEF_SYSSEG: "
+	.hex4sp	$REL_SYSSEG,"-> REL_SYSSEG: "
+
 // Check signature at end of setup
+	cli
 	mov	$SETUPSEG,%ax	// DS = setup CS
 	mov	%ax,%ds
 	cmpw	$SIG1,setup_sig1
@@ -141,8 +174,7 @@ no_sig:	lea	no_sig_mess,%si
 1:                             // And halt
 	jmp	1b
 
-no_sig_mess:	.ascii	"No ELKS setup signature found ..."
-		.byte	0x00
+no_sig_mess:	.ascii	"No ELKS setup signature found ...\0"
 
 // If setup and kernel were loaded as a blob, we need to separate them out,
 // then move to our own stack
@@ -156,17 +188,21 @@ chk_blob:
 				// lower address to a higher one
 	mov	setup_sects,%al	// find start of a.out kernel
 	xor	%ah,%ah
+	.hex4sp	%ax,"\nSetup sectors "
 	mov	$5,%cl
 	shl	%cl,%ax
 	add	$SETUPSEG,%ax
 	mov	syssize,%bp
+	.hex4sp	%bp,"System paras "
+	.hex4sp	%ax,"a.out seg "
+
 	mov	%bp,%cx		// first move the last sub-64KiB piece in place
 	and	$0x0fff,%cx
-	xor	%cx,%bp
+	xor	%cx,%bp		// and $0xf000,%bp
 	mov	%ax,%dx
 	add	%bp,%dx
 	mov	%dx,%ds
-	lea	SYSSEG(%bp),%dx
+	lea	SYSSEG(%bp),%dx	// move %bp,dx; add $SYSSEG,%dx
 	mov	%dx,%es
 	jcxz	move_kernel_in_64ks
 	shl	%cx
@@ -176,6 +212,12 @@ chk_blob:
 	dec	%si
 	shl	%si
 	mov	%si,%di
+	.hex4sp	%ds,"\nCopy a.out to DEF_SYSSEG (last) DS:"
+	.hex4sp	%si,"SI:"
+	.hex4sp	%es,"ES:"
+	.hex4sp	%di,"DI:"
+	.hex4sp	%cx,"CX:"
+
 	rep
 	movsw
 move_kernel_in_64ks:
@@ -190,6 +232,11 @@ move_kernel_in_64ks:
 	mov	$0x80,%ch
 	mov	$0xfffe,%si
 	mov	%si,%di
+	.hex4sp	%ds,"\nCopy a.out to DEF_SYSSEG (64K)  DS:"
+	.hex4sp	%si,"SI:"
+	.hex4sp	%es,"ES:"
+	.hex4sp	%di,"DI:"
+
 	rep
 	movsw
 	jmp	move_kernel_in_64ks
@@ -198,7 +245,10 @@ done_move_kernel:
 	cld
 	mov	$INITSEG,%ax
 	mov	%ax,%ss
-	mov	$0x4000-12,%sp
+	//mov	$0x4000-12,%sp
+	mov	$0x1000,%sp	// 2K stack: 0x0800 setup size + 0x0800 stack
+	.hex4sp	%ss,"\nNew INIT SS:"
+	.hex4sp	%sp,"SP:"
 
 no_blob:
 #endif
@@ -268,13 +318,9 @@ err_loop:
 
 
 msg_aout_err:
-	.byte 13,10
-	.ascii "ERROR: Wrong kernel a.out format"
-	.byte 0
+	.ascii "\r\nERROR: Wrong kernel a.out format\0"
 msg_too_big:
-	.byte 13,10
-	.ascii "ERROR: kernel size > 64k"
-	.byte 0
+	.ascii "\r\nERROR: kernel size > 64k\0"
 
 aout_ok:
 	mov 10,%cx		// 10 = hiword hdr.a_text size
@@ -358,10 +404,15 @@ size_error:
 	mov $8,%cl     // to words
 	shl %cl,%ax
 	mov %ax,%cx
-
 	mov $512,%si   // skip raw sector
 	xor %di,%di
 	cld
+	.hex4sp	%ds,"\nCopy DEF_SETUPSEG code to high mem DS:"
+	.hex4sp	%si,"SI:"
+	.hex4sp	%es,"ES:"
+	.hex4sp	%di,"DI:"
+	.hex4sp	%cx,"CX:"
+
 	rep
 	movsw
 
@@ -370,6 +421,8 @@ size_error:
 	mov %es,%ax
 	mov %ax,%ss   // automatic CLI for next instruction
 	xor %sp,%sp
+	.hex4sp	%ss,"\nNew HMEM SS:"
+	.hex4sp	%sp,"SP:"
 
 	push %ax
 	mov $_next1,%ax
@@ -388,6 +441,12 @@ _next1:
 	xor	%di,%di
 	mov	$256,%cx
 	cld
+	.hex4sp	%ds,"\nCopy DEF_INITSEG data to REL_INITSEG DS:"
+	.hex4sp	%si,"SI:"
+	.hex4sp	%es,"ES:"
+	.hex4sp	%di,"DI:"
+	.hex4sp	%cx,"CX:"
+
 	rep
 	movsw
 
@@ -414,8 +473,7 @@ sys_hdr_bad:
 1:                       // halt
 	jmp 1b
 sys_hdr_msg:
-	.ascii "Bad system header!"
-	.byte 0
+	.ascii "Bad system header!\0"
 
 // System header is good
 
@@ -456,12 +514,20 @@ sys_hdr_good:
 	mov $REL_SYSSEG,%ax
 	mov %ax,%es
 	mov %ax,-18(%bp) // save .text segment
+	.ifeq debug_output
 	call hex4sp
+	.endif
 	add %dx,%ax      // add code paragraphs
 	mov %ax,-20(%bp) // save .data start in case no .fartext
 	xor %di,%di
 
 	mov -2(%bp),%cx  // code size in bytes
+	.hex4sp	%ds,"\nCopy DEF_SYSSEG .text to  REL_SYSSEG DS:"
+	.hex4sp	%si,"SI:"
+	.hex4sp	%es,"ES:"
+	.hex4sp	%di,"DI:"
+	.hex4sp	%cx,"CX:"
+
 	cld
 	rep
 	movsb
@@ -498,7 +564,15 @@ sys_hdr_good:
 	mov %ax,%es
 	mov %ax,-20(%bp)  // save .fartext segment
 	xor %di,%di
+
+	.ifeq debug_output
 	call hex4sp
+	.endif
+	.hex4sp	%ds,"\nCopy DEF_SYSSEG .ftext to REL_SYSSEG DS:"
+	.hex4sp	%si,"SI:"
+	.hex4sp	%es,"ES:"
+	.hex4sp	%di,"DI:"
+	.hex4sp	%cx,"CX:"
 
 	rep
 	movsb
@@ -530,9 +604,17 @@ sys_no_far_text:
 	mov %ax,%es
 	mov %ax,-22(%bp) // save .data segment
 	xor %di,%di
-	call hex4sp
-
 	mov -4(%bp),%cx  // data size
+
+	.ifeq debug_output
+	call hex4sp
+	.endif
+	.hex4sp	%ds,"\nCopy DEF_SYSSEG .data to  REL_SYSSEG DS:"
+	.hex4sp	%si,"SI:"
+	.hex4sp	%es,"ES:"
+	.hex4sp	%di,"DI:"
+	.hex4sp	%cx,"CX:"
+
 	rep
 	movsb
 
@@ -605,7 +687,22 @@ data_reloc:
 	mov -18(%bp),%ax   // kernel .text segment
 	push %ax
 	push %cx
-	lret
+
+	.hex4sp	%ss,"Done SS:"
+	.hex4sp	%ds,"DS/ES:"
+	.hex4sp	%bx,".text size:"
+	.hex4sp	%di,".fartext size:"
+	.hex4sp	%si,".data size:"
+	.hex4sp	%ax,"\nJump CS:"
+	.hex4sp	%cx,"entry:"
+	.if debug_output
+	.ifeq serial_output // if not serial output
+	xor %ah,%ah         // read key press
+	int $0x16
+	.endif
+	.endif
+
+	lret               // jump to REL_SYSSEG:_start to start kernel
 
 // Relocate segment at ES: from relocation record at DS:SI
 relocat:
@@ -631,7 +728,9 @@ relocat:
 
 	mov -22(%bp),%ax   // kernel .data segment
 3:
-#if DEBUG_LOADER
+	mov %ax,%es:(%di)
+
+	.if debug_loader
 	push %ax           // display [seg:off=val]
 	mov $'[',%ax
 	call putc
@@ -649,8 +748,8 @@ relocat:
 	mov $']',%ax
 	call putc
 	pop %ax
-#endif
-	mov %ax,%es:(%di)
+	.endif
+
 	ret
 9:
 	jmp sys_hdr_bad
@@ -678,6 +777,29 @@ puts:	lodsb
 	test	%al,%al
 	jnz	1b
 	ret
+
+.if debug_output
+// Write AL to console, convert LF -> CR LF
+putcc:	cmp	$'\n',%al
+	jnz	1f
+	push	%ax
+	mov	$'\r',%al
+	call	putc
+	pop	%ax
+1:	jmp	putc
+
+// Write CS:AX asciiz string to console
+csputs:	push	%bx
+	mov	%ax,%bx
+1:	mov	%cs:(%bx),%al
+	test	%al,%al
+	jz	2f
+	call	putcc
+	inc	%bx
+	jmp	1b
+2:	pop	%bx
+	ret
+.endif
 
 // Output hex nibble, byte and word. All registers saved.
 hex1:	push %ax
@@ -721,8 +843,7 @@ hex4sp: call hex4
 	ret
 
 hello_mess:
-	.ascii "\r\nELKS Setup "
-	.byte 0
+	.ascii "\r\nELKS Setup \0"
 
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Architecture specific routines for IBM PC
@@ -794,18 +915,26 @@ novga:	mov	%al,14		// CGA 25 rows
 #endif
 	ret
 
-// Write AL to console, save all other registers
-putc:	push %bx
+// Write AL to console, save all registers
+putc:	push %ax
+	push %bx
 	push %cx
 	push %dx
-	push %bp        // some BIOS may destroy BP
+	push %bp        	// some BIOS may destroy BP
+	.if serial_output
+	mov $1,%ah
+	xor %dx,%dx		// COM1
+	int $0x14		// serial out
+	.else
 	mov $0x0E,%ah
-	mov $7,%bx      // page 0
-	int $0x10
+	mov $7,%bx		// page 0
+	int $0x10		// console out
+	.endif
 	pop %bp
 	pop %dx
 	pop %cx
 	pop %bx
+	pop %ax
 	ret
 
 // include code to determine early CPU types


### PR DESCRIPTION
Adds significant optional debug display output to early `setup` operation, allowing one to both see, debug and learn about early ELKS kernel startup directly after being handed control by the boot sector.

Adds the ability to display output to serial COM1 instead of the console. If debugging on and going to console, allows waiting for a keypress so that contents are not quickly scrolled past.

The debugging output logs all block memory copies and stack switches during startup, for much greater visibility into the selection of DEF_INITSYS, REL_INITSYS, and other pretty arcane stuff in config.h. Update boot.txt documentation coming.

Here's an example of the setup debug display on the console, awaiting a keypress before starting the kernel:
<img width="832" alt="ELKS setup debug" src="https://github.com/user-attachments/assets/0d70d43a-ad4c-444f-9fff-f36a22c4d93a">


@Mellvik, this is the first in a series of PRs for issues discussed in https://github.com/Mellvik/TLVC/issues/76 for enhancing our kernels by being able to more easily see what is going on. Feel free to port them over to TLVC. I've tried to make it such that files might be able to be ported directly over, with the exception of possible ELKS/TLVC naming or magic numbers.