### PR TITLE
[CI] Disable second PR run of Github actions, run only on push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,12 +7,12 @@ on:
       - '!.github/workflows/cross.yml'
       - '!.github/workflows/ow-libc.yml'
       - '!tools/*'
-  pull_request:
-    paths:
-      - '**'
-      - '!.github/workflows/cross.yml'
-      - '!.github/workflows/ow-libc.yml'
-      - '!tools/*'
+# pull_request:
+#   paths:
+#     - '**'
+#     - '!.github/workflows/cross.yml'
+#     - '!.github/workflows/ow-libc.yml'
+#     - '!tools/*'
 
 jobs:
   build:


### PR DESCRIPTION
Removes the normally unneeded 2nd run of Continuous Integration checking on PRs. CI will only be run on pushes, thus saving processing time.