### PR TITLE
[disasm] Fix sign extension bug when disassembling large RAM segment offsets

### DIFF
--- a/elks/include/linuxmt/memory.h
+++ b/elks/include/linuxmt/memory.h
@@ -28,7 +28,7 @@ word_t fmemcmpw (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg, s
 /* macros for far pointers (a la Turbo C++ and Open Watcom) */
 #define _FP_SEG(fp)     ((unsigned)((unsigned long)(void __far *)(fp) >> 16))
 #define _FP_OFF(fp)     ((unsigned)(unsigned long)(void __far *)(fp))
-#define _MK_FP(seg,off)	((void __far *)((((unsigned long)(seg)) << 16) | (off)))
+#define _MK_FP(seg,off) ((void __far *)((((unsigned long)(seg)) << 16) | ((unsigned int)(off))))
 
 /* unreal mode, A20 gate management */
 int check_unreal_mode(void);	/* check if unreal mode capable, returns > 0 on success */

--- a/elkscmd/debug/dis.c
+++ b/elkscmd/debug/dis.c
@@ -69,7 +69,7 @@ char * noinstrument getsegsymbol(int seg)
     return buf;
 }
 
-#define peekb(cs,ip)  (*(unsigned char __far *)(((unsigned long)(cs) << 16) | (int)(ip)))
+#define peekb(cs,ip)  (*(unsigned char __far *)(((unsigned long)(cs) << 16) | (unsigned int)(ip)))
 
 static int nextbyte_mem(int cs, int ip)
 {


### PR DESCRIPTION
Also updates _MK_FP kernel macro for good measure.