### PR TITLE
[kernel] Display number of tasks, files and inodes at boot

### DIFF
--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -235,7 +235,8 @@ static void INITPROC kernel_banner(seg_t start, seg_t end, seg_t init, seg_t ext
     printk("8018X machine, ");
 #endif
 
-    printk("syscaps %x, %uK base ram\n", sys_caps, SETUP_MEM_KBYTES);
+    printk("syscaps %x, %uK base ram, %d tasks, %d files, %d inodes\n",
+        sys_caps, SETUP_MEM_KBYTES, max_tasks, nr_file, nr_inode);
     printk("ELKS %s (%u text, %u ftext, %u data, %u bss, %u heap)\n",
            system_utsname.release,
            (unsigned)_endtext, (unsigned)_endftext, (unsigned)_enddata,


### PR DESCRIPTION
Display will be useful for upcoming enhancements to allow further customization of decreasing the RAM usage of the kernel.