### PR TITLE
[minor] Update qemu.sh for macOS x86, reformat config.h

### DIFF
--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -89,11 +89,11 @@
  * except when SYS_CAPS is defined for custom installations or emulations.
  */
 #define CAP_PC_AT       (CAP_IRQ8TO15|CAP_IRQ2MAP9)      /* PC/AT capabilities */
-#define CAP_KBD_LEDS    0x04      /* has keyboard LEDs */
-#define CAP_HD_IDE      0x08      /* can do hard drive IDE probes */
-#define CAP_IRQ8TO15    0x10      /* has IRQ 8 through 15 */
-#define CAP_IRQ2MAP9    0x20      /* map IRQ 2 to 9 */
-#define CAP_ALL         0xFF      /* all capabilities if PC/AT only */
+#define CAP_KBD_LEDS    0x04    /* has keyboard LEDs */
+#define CAP_HD_IDE      0x08    /* can do hard drive IDE probes */
+#define CAP_IRQ8TO15    0x10    /* has IRQ 8 through 15 */
+#define CAP_IRQ2MAP9    0x20    /* map IRQ 2 to 9 */
+#define CAP_ALL         0xFF    /* all capabilities if PC/AT only */
 
 /* Don't touch these, unless you really know what you are doing. */
 #define DEF_INITSEG     0x0100  /* initial Image load address by boot code */
@@ -101,65 +101,62 @@
 #define DEF_SETUPSEG    DEF_INITSEG + 0x20
 #define DEF_SYSSIZE     0x2F00
 
+/* DMASEG is a bounce buffer of 1K (=BLOCKSIZE) below the first 64K boundary (=0x1000:0)
+ * for use with the old 8237 DMA controller OR a disk track buffer of 9K (18 ectors).
+ * Following that is the kernel code and data at REL_INITSYS.
+ */
+
 #ifdef CONFIG_ROMCODE
 #if defined(CONFIG_BLK_DEV_BFD) || defined(CONFIG_BLK_DEV_BHD)  /* BIOS disk driver*/
 #define DMASEG          0x80  /* 0x400 bytes floppy sector buffer */
 #ifdef CONFIG_TRACK_CACHE     /* floppy track buffer in low mem */
-#define DMASEGSZ 0x2400       /* SECTOR_SIZE * 18 (9216) */
-#define KERNEL_DATA     0x2C0 /* kernel data segment */
+#define DMASEGSZ      0x2400  /* SECTOR_SIZE * 18 (9216) */
+#define KERNEL_DATA    0x2C0  /* kernel data segment */
 #else
-#define DMASEGSZ 0x040        /* BLOCK_SIZE (1024) */
-#define KERNEL_DATA     0x0C0 /* kernel data segment */
+#define DMASEGSZ       0x040  /* BLOCK_SIZE (1024) */
+#define KERNEL_DATA    0x0C0  /* kernel data segment */
 #endif
 #else
 #define KERNEL_DATA     0x80  /* kernel data segment */
 #endif
 #define SETUP_DATA      CONFIG_ROM_SETUP_DATA
-#endif /* CONFIG_ROMCODE */
+#endif
 
 
 #if (defined(CONFIG_ARCH_IBMPC) || defined(CONFIG_ARCH_8018X)) && !defined(CONFIG_ROMCODE)
 /* Define segment locations of low memory, must not overlap */
 #define DEF_OPTSEG      0x50  /* 0x200 bytes boot options*/
-#define OPTSEGSZ 0x200    /* max size of /bootopts file (1K max) */
+#define OPTSEGSZ       0x200  /* max size of /bootopts file (1K max) */
 #define REL_INITSEG     0x70  /* 0x200 bytes setup data */
 #define DMASEG          0x90  /* 0x400 bytes floppy sector buffer */
-
 #ifdef CONFIG_TRACK_CACHE     /* floppy track buffer in low mem */
-#define DMASEGSZ 0x2400       /* SECTOR_SIZE * 18 (9216) */
-#define REL_SYSSEG      0x2D0 /* kernel code segment */
+#define DMASEGSZ      0x2400  /* SECTOR_SIZE * 18 (9216) */
+#define REL_SYSSEG     0x2D0  /* kernel code segment */
 #else
 #define DMASEGSZ 0x0400       /* BLOCK_SIZE (1024) */
-#define REL_SYSSEG      0x0D0 /* kernel code segment */
+#define REL_SYSSEG     0x0D0  /* kernel code segment */
 #endif
 #define SETUP_DATA      REL_INITSEG
-#endif /* (CONFIG_ARCH_IBMPC || CONFIG_ARCH_8018X) && !CONFIG_ROMCODE */
+#endif
+
 
 #if defined(CONFIG_ARCH_PC98) && !defined(CONFIG_ROMCODE)
 /* Define segment locations of low memory, must not overlap */
 #define DEF_OPTSEG      0x60  /* 0x200 bytes boot options*/
-#define OPTSEGSZ 0x200    /* max size of /bootopts file (1K max) */
+#define OPTSEGSZ       0x200  /* max size of /bootopts file (1K max) */
 #define REL_INITSEG     0x80  /* 0x200 bytes setup data */
 #define DMASEG          0xA0  /* 0x400 bytes floppy sector buffer */
-
 #ifdef CONFIG_TRACK_CACHE     /* floppy track buffer in low mem */
-#define DMASEGSZ 0x2400       /* SECTOR_SIZE * 18 (9216) > SECTOR_SIZE * 8 (8192) */
-#define REL_SYSSEG      0x2E0 /* kernel code segment */
+#define DMASEGSZ      0x2400  /* SECTOR_SIZE * 18 (9216) > SECTOR_SIZE * 8 (8192) */
+#define REL_SYSSEG     0x2E0  /* kernel code segment */
 #else
-#define DMASEGSZ 0x0400       /* BLOCK_SIZE (1024) */
-#define REL_SYSSEG      0x0E0 /* kernel code segment */
+#define DMASEGSZ      0x0400  /* BLOCK_SIZE (1024) */
+#define REL_SYSSEG     0x0E0  /* kernel code segment */
 #endif
 #define SETUP_DATA      REL_INITSEG
-#endif /* CONFIG_ARCH_PC98 && !CONFIG_ROMCODE */
+#endif
 
-
-// DMASEG is a bouncing buffer of 1K (= BLOCKSIZE)
-// below the first 64K boundary (= 0x1000:0)
-// for use with the old 8237 DMA controller
-// OR a floppy track buffer of 9K (18 512-byte sectors)
-
-/*
- * Defines for what uname() should return.
+/* Defines for what uname() should return.
  * The definitions for UTS_RELEASE and UTS_VERSION are now passed as
  * kernel compilation parameters, and should only be used by elks/kernel/version.c
  */

--- a/elks/kernel/sys.c
+++ b/elks/kernel/sys.c
@@ -4,8 +4,8 @@
  *  Copyright (C) 1991, 1992  Linus Torvalds
  */
 
-#include <linuxmt/biosparm.h>
 #include <linuxmt/config.h>
+#include <linuxmt/biosparm.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/sched.h>
 #include <linuxmt/kernel.h>

--- a/elks/tools/objtools/ewcc
+++ b/elks/tools/objtools/ewcc
@@ -40,6 +40,7 @@ WATCINCLUDE=$WATCOM/h
 # -fno-stack-check          # don't generate stack check code
 # -fnostdlib                # don't refere standard libraries
 # unused:
+# -ztNum                    # specify far data threshold (default 32767, or 256 if no Num)
 # -mhard-emu-float          # -Wc,-fpi (inline 8087 w/emulation)
 # -msoft-float              # -Wc,-fpc
 # -Wc,-fpc                  # non-IEEE soft fp

--- a/qemu.sh
+++ b/qemu.sh
@@ -111,16 +111,22 @@ NET="-netdev user,id=mynet,$FWD -device ne2k_isa,irq=12,netdev=mynet"
 # NETDUMP="-net dump"
 
 # Enable PC-Speaker here:
-AUDIO="-audiodev pa,id=speaker -machine pcspk-audiodev=speaker"
+#AUDIO="-audiodev pa,id=speaker -machine pcspk-audiodev=speaker"
 
 # Determine display type ("Darwin" = OSX)
 [ `uname` != 'Darwin' ] && QDISPLAY="-display sdl"
 
 # Configure QEMU as pure ISA system
 
-# uncomment to run native speed if x86 macOS
+# For macOS x86, HVF can be used to increase emulation speed
+# Otherwise, translation block caching of multiple instructions must be turned off
+MACOS="-accel tcg,one-insn-per-tb=on"
 #MACOS="-accel hvf"
+#MACOS="-icount 1"
+#DEBUG="-D logfile -d in_asm,int,unimp,guest_errors"
+#DEBUG="-D logfile -d cpu,in_asm,int,unimp,guest_errors"
+#DEBUG="-D logfile -d out_asm,in_asm,int,unimp,guest_errors"
 
-exec $QEMU $MACOS $AUDIO $CONSOLE -nodefaults -name ELKS -machine isapc -cpu 486,tsc -m 4M \
+exec $QEMU $MACOS $DEBUG $AUDIO $CONSOLE -nodefaults -name ELKS -machine isapc -cpu 486,tsc -m 4M \
 $KEYBOARD $QDISPLAY -vga std -rtc base=utc $SERIAL \
 $NET $NETDUMP $IMAGE $DISK2 $@


### PR DESCRIPTION
Updates `qemu.sh` for proper operation on macOS, it was discovered that QEMU can crash ELKS when not given a `-accel tcg,one-insn-per-tb=on` if `-accel hvf` isn't specificed or available. (Reproduced on macOS only).

Updates config.h with formatting changes for readability.

