### PR TITLE
[kernel] Small code cleanups

### DIFF
--- a/elks/fs/super.c
+++ b/elks/fs/super.c
@@ -250,7 +250,9 @@ int do_umount(kdev_t dev)
 int sys_umount(char *name)
 {
     struct inode *inode;
-    register struct inode *inodep;
+    struct inode *inodep;
+    struct file_operations *fops;
+    struct super_block *sb;
     kdev_t dev;
     int retval;
 
@@ -267,7 +269,7 @@ int sys_umount(char *name)
             return -EACCES;
         }
     } else {
-        register struct super_block *sb = inodep->i_sb;
+        sb = inodep->i_sb;
         if (!sb || inodep != sb->s_mounted) {
             iput(inodep);
             return -EINVAL;
@@ -282,7 +284,6 @@ int sys_umount(char *name)
         return -ENXIO;
     }
     if (!(retval = do_umount(dev)) && dev != ROOT_DEV) {
-        register struct file_operations *fops;
         fops = get_blkfops(MAJOR(dev));
         if (fops && fops->release) fops->release(inodep, NULL);
     }

--- a/elks/kernel/sched.c
+++ b/elks/kernel/sched.c
@@ -35,7 +35,7 @@ static void del_from_runqueue(register struct task_struct *p)
     if (!p->next_run || !p->prev_run)
         panic("SCHED(%d): task not on run-queue, state %d", p->pid, p->state);
     if (p == &idle_task)
-        panic("SCHED: trying to sleep idle task");
+        panic("trying to sleep idle task");
 #endif
     (p->next_run->prev_run = p->prev_run)->next_run = p->next_run;
     p->next_run = p->prev_run = NULL;


### PR DESCRIPTION
Removes precision timer testing from main.c file.

Moves some function declarations to top of function, as required for easy stack use inspection.

Reduce panic string size from kernel messages (more coming).