### PR TITLE
[bootopts] Add heap= option for dynamic sizing of kernel heap

### DIFF
--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -58,7 +58,7 @@ include $(TOPDIR)/Make.defs
 VERSION     = 0	# (0-255)
 PATCHLEVEL  = 8	# (0-255)
 SUBLEVEL    = 0	# (0-255)
-PRE         = -pre2
+PRE         = -pre3
 
 #########################################################################
 # Specify the architecture we will use.

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -214,7 +214,7 @@ int INITPROC buffer_init(void)
     debug_setcallback(1, list_buffer_status);   /* ^O will generate buffer list */
 #endif
 
-    if (!(L1buf = heap_alloc(nr_map_bufs * BLOCK_SIZE, HEAP_TAG_BUFHEAD|HEAP_TAG_CLEAR)))
+    if (!(L1buf = heap_alloc(nr_map_bufs * BLOCK_SIZE, HEAP_TAG_CACHE|HEAP_TAG_CLEAR)))
         return 1;
 
     buffer_heads = heap_alloc(bufs_to_alloc * sizeof(struct buffer_head),

--- a/elks/include/arch/system.h
+++ b/elks/include/arch/system.h
@@ -4,9 +4,11 @@
 #include <linuxmt/types.h>
 #include <linuxmt/init.h>
 
-extern byte_t sys_caps;		/* system capabilities bits*/
+extern byte_t sys_caps;     /* system capabilities bits*/
+extern seg_t membase;       /* start and end segment of available main memory */
+extern seg_t memend;
 
-extern void INITPROC setup_arch(seg_t *,seg_t *);
+extern unsigned int INITPROC setup_arch(void);
 extern void hard_reset_now(void);
 extern void apm_shutdown_now(void);
 

--- a/elks/include/linuxmt/heap.h
+++ b/elks/include/linuxmt/heap.h
@@ -23,7 +23,7 @@
 #define HEAP_TAG_PIPE    0x06   /* open pipe buffers */
 #define HEAP_TAG_INODE   0x07   /* system inodes */
 #define HEAP_TAG_FILE    0x08   /* system open files */
-
+#define HEAP_TAG_CACHE   0x09   /* L1 cache buffer */
 
 // TODO: move free list node from header to body
 // to reduce overhead for allocated block

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -32,6 +32,7 @@
 #define MAX_INIT_ARGS	6       /* max # arguments to /bin/init or init= program */
 #define MAX_INIT_ENVS	12      /* max # environ variables passed to /bin/init */
 #define MAX_INIT_SLEN   80      /* max # words of args + environ passed to /bin/init */
+#define MAX_UMB         3       /* max umb= segments in /bootopts */
 
 #define STR(x)          __STRING(x)
 /* bootopts error message are duplicated below so static here for space */
@@ -52,7 +53,6 @@ int tracing;
 int nr_ext_bufs, nr_xms_bufs, nr_map_bufs;
 char running_qemu;
 static int boot_console;
-static seg_t membase, memend;
 static char bininit[] = "/bin/init";
 static char binshell[] = "/bin/sh";
 #ifdef CONFIG_SYS_NO_BININIT
@@ -78,6 +78,11 @@ static char *argv_init[MAX_INIT_SLEN] = { NULL, bininit, NULL };
 #if ENV
 static char *envp_init[MAX_INIT_ENVS];
 #endif
+static struct umbseg {  /* saves umb= lines during /bootopts parse */
+    seg_t base;
+    segext_t len;
+} umbseg[MAX_UMB], *nextumb = umbseg;
+static segext_t umbtotal;
 static unsigned char options[OPTSEGSZ];
 
 extern int boot_rootdev;
@@ -89,14 +94,14 @@ static char * INITPROC option(char *s);
 
 static void INITPROC early_kernel_init(void);
 static void INITPROC kernel_init(void);
-static void INITPROC kernel_banner(seg_t start, seg_t end, seg_t init, seg_t extra);
+static void INITPROC kernel_banner(seg_t init, seg_t extra);
 static void init_task(void);
 
 /* this procedure called using temp stack then switched, no local vars allowed */
 void start_kernel(void)
 {
     printk("START\n");
-    early_kernel_init();        /* read bootopts using kernel interrupt stack */
+    early_kernel_init();        /* read bootopts using kernel temp stack */
     task = heap_alloc(max_tasks * sizeof(struct task_struct),
         HEAP_TAG_TASK|HEAP_TAG_CLEAR);
     if (!task) panic("No task mem");
@@ -125,8 +130,10 @@ void start_kernel(void)
 
 static void INITPROC early_kernel_init(void)
 {
-    setup_arch(&membase, &memend);  /* initializes kernel heap */
-    mm_init(membase, memend);       /* parse_options may call seg_add */
+    unsigned int endbss;
+    struct umbseg *p;
+
+    /* Note: no memory allocation available until after heap_init */
     tty_init();                     /* parse_options may call rs_setbaud */
 #ifdef CONFIG_TIME_TZ
     tz_init(CONFIG_TIME_TZ);        /* parse_options may call tz_init */
@@ -134,6 +141,21 @@ static void INITPROC early_kernel_init(void)
 #ifdef CONFIG_BOOTOPTS
     opts = parse_options();         /* parse options found in /bootops */
 #endif
+
+    /* create near heap at end of kernel bss */
+    heap_init();                    /* init near memory allocator */
+    endbss = setup_arch();          /* sets membase and memend globals */
+    heap_add((void *)endbss, heapsize);
+    mm_init(membase, memend);       /* init far/main memory allocator */
+
+    /* now able to add umb memory segments */
+    for (p = umbseg; p < &umbseg[MAX_UMB]; p++) {
+        if (p->base) {
+            debug("umb segment from %x to %x\n", p->base, p->base + p->len);
+            seg_add(p->base, p->base + p->len);
+            umbtotal += p->len;
+        }
+    }
 }
 
 static void INITPROC kernel_init(void)
@@ -183,10 +205,10 @@ static void INITPROC kernel_init(void)
     seg_t s = 0, e = 0;
 #endif
 
-    kernel_banner(membase, memend, s, e - s);
+    kernel_banner(s, e - s);
 }
 
-static void INITPROC kernel_banner(seg_t start, seg_t end, seg_t init, seg_t extra)
+static void INITPROC kernel_banner(seg_t init, seg_t extra)
 {
 #ifdef CONFIG_ARCH_IBMPC
     printk("PC/%cT class machine, ", (sys_caps & CAP_PC_AT) ? 'A' : 'X');
@@ -206,12 +228,13 @@ static void INITPROC kernel_banner(seg_t start, seg_t end, seg_t init, seg_t ext
            system_utsname.release,
            (unsigned)_endtext, (unsigned)_endftext, (unsigned)_enddata,
            (unsigned)_endbss - (unsigned)_enddata, heapsize);
-    printk("Kernel text %x:0, ", kernel_cs);
+    printk("Kernel text %x ", kernel_cs);
 #ifdef CONFIG_FARTEXT_KERNEL
-    printk("ftext %x:0, init %x:0, ", (unsigned)((long)kernel_init >> 16), init);
+    printk("ftext %x init %x ", (unsigned)((long)kernel_init >> 16), init);
 #endif
-    printk("data %x:0, top %x:0, %uK free\n",
-           kernel_ds, end, (int) ((end - start + extra) >> 6));
+    printk("data %x end %x top %x %u+%u+%uK free\n",
+           kernel_ds, membase, memend, (int) ((memend - membase) >> 6),
+           extra >> 6, umbtotal >> 6);
 }
 
 static void INITPROC try_exec_process(const char *path)
@@ -375,19 +398,20 @@ static void INITPROC parse_nic(char *line, struct netif_parms *parms)
     }
 }
 
+/* umb= settings have to be saved and processed after parse_options */
 static void INITPROC parse_umb(char *line)
 {
 	char *p = line-1; /* because we start reading at p+1 */
-	seg_t base, end;
-	segext_t len;
+	seg_t base;
 
 	do {
 		base = (seg_t)simple_strtol(p+1, 16);
 		if((p = strchr(p+1, ':'))) {
-			len = (segext_t)simple_strtol(p+1, 16);
-			end = base + len;
-			debug("umb segment from %x to %x\n", base, end);
-			seg_add(base, end);
+			if (nextumb < &umbseg[MAX_UMB]) {
+				nextumb->len = (segext_t)simple_strtol(p+1, 16);
+				nextumb->base = base;
+				nextumb++;
+			}
 		}
 	} while((p = strchr(p+1, ',')));
 }
@@ -400,6 +424,8 @@ static void INITPROC parse_umb(char *line)
  *
  * This routine also checks for options meant for the kernel.
  * These options are not given to init - they are for internal kernel use only.
+ *
+ * Note: no memory allocations allowed from this routine!
  */
 static int INITPROC parse_options(void)
 {
@@ -500,6 +526,10 @@ static int INITPROC parse_options(void)
 		}
 		if (!strncmp(line,"cache=",6)) {
 			nr_map_bufs = (int)simple_strtol(line+6, 10);
+			continue;
+		}
+		if (!strncmp(line,"heap=",5)) {
+			heapsize = (unsigned int)simple_strtol(line+5, 10);
 			continue;
 		}
 		if (!strncmp(line,"task=",5)) {

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -53,6 +53,7 @@ int tracing;
 int nr_ext_bufs, nr_xms_bufs, nr_map_bufs;
 char running_qemu;
 static int boot_console;
+static segext_t umbtotal;
 static char bininit[] = "/bin/init";
 static char binshell[] = "/bin/sh";
 #ifdef CONFIG_SYS_NO_BININIT
@@ -82,7 +83,6 @@ static struct umbseg {  /* saves umb= lines during /bootopts parse */
     seg_t base;
     segext_t len;
 } umbseg[MAX_UMB], *nextumb = umbseg;
-static segext_t umbtotal;
 static unsigned char options[OPTSEGSZ];
 
 extern int boot_rootdev;

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -6,19 +6,16 @@
 #wd0=10,0x300,0xCC00,0x80
 #3c0=11,0x330,,0x80
 #comirq=,,7,10
-#buf=8			# L2
-#cache=4
 #xmsbuf=2975
 #umb=0xC000:0x800,0xD000:0x1000
-#task=16
-#inode=96
-#file=64
-#sync=30		# secs
+#task=16 buf=64 cache=8 file=64 inode=96 heap=44000 # std
+#task=6 buf=8 cache=4 file=20 inode=24 heap=15000 n # min w/no rc.sys
+#sync=30
 #init=/bin/init 3 n	# muser serial no rc.sys
-#init=/bin/sh		# singleuser sh
-#root=hda1 ro		# root hd partition 1 readonly
+#init=/bin/sash		# singleuser sh
+#root=df0
+#root=hda1 ro
 #kstack
 #strace
-#root=df0
 #debug net=ne0
 #console=ttyS0,19200 3

--- a/elkscmd/sys_utils/meminfo.c
+++ b/elkscmd/sys_utils/meminfo.c
@@ -98,7 +98,7 @@ void dump_heap(int fd)
 	word_t total_free = 0;
 	long total_segsize = 0;
 	static char *heaptype[] =
-        { "free", "SEG ", "DRVR", "TTY ", "TASK", "BUFH", "PIPE", "INOD", "FILE" };
+        { "free", "MEM ", "DRVR", "TTY ", "TASK", "BUFH", "PIPE", "INOD", "FILE", "CACH"};
 	static char *segtype[] =
         { "free", "CSEG", "DSEG", "DDAT", "FDAT", "BUF ", "RDSK" };
 
@@ -126,7 +126,7 @@ void dump_heap(int fd)
                 segflags == SEG_FLAG_DDAT || segflags == SEG_FLAG_FDAT));
 		tty = (tag == HEAP_TAG_TTY || tag == HEAP_TAG_DRVR);
 		buffer = (tag == HEAP_TAG_SEG && segflags == SEG_FLAG_EXTBUF)
-            || tag == HEAP_TAG_BUFHEAD || tag == HEAP_TAG_PIPE;
+            || tag == HEAP_TAG_BUFHEAD || tag == HEAP_TAG_CACHE || tag == HEAP_TAG_PIPE;
 		system = (tag == HEAP_TAG_TASK || tag == HEAP_TAG_INODE || tag == HEAP_TAG_FILE);
 
 		if (allflag ||


### PR DESCRIPTION
Here you go @toncho11 and @FrenkelS: this new /bootopts option will allow ELKS to boot up with a minimum of extra kernel resources, allowing for a usable contiguous block of memory ~500Kb for Doom, and more if UMB memory is available.

Adds `heap=` /bootopts option to set the size of the internal kernel heap at startup. By default, ELKS will try to reserve up to 64k of memory for use in its heap allocator for runtime kernel resources. In practice, because of the existing static data from the compiled C routines, this amounts to a ~45k heap. My testing shows that the kernel is stable lowering this to 15k when tasks, buffers, cache, and nodes are also lowered, thus saving ~30k memory, which is then available for user programs, e.g. Doom.

Here's a screenshot of `meminfo` running directly after boot with the reduced resource options in effect:
<img width="832" alt="meminfo" src="https://github.com/user-attachments/assets/da041c3a-3d68-4095-bd9d-dfc6ce042468">

Notice at the bottom right there's 492K of 520k available, with the largest block being 499,888 bytes. If the kernel were to be recompiled with minimal drivers (e.g. no networking), this could be made even larger.

I have modified the default /bootopts to include both the "normal" settings for kernel resources and the example used to generate the display above, to make it easy to play with. Be aware that no checking is done on the heap size passed, and passing a value too low can cause system instability or crashes. I played around and found 15000 as a working lower limit, given the other option values.

Here's the defaults:
```
task=16 buf=64 cache=8 file=64 inode=96 heap=44000
```
And the minimal system:
```
task=6 buf=8 cache=4 file=20 inode=24 heap=15000 n
```
Notice the 'n' at the end of the line, that passes 'n' to /bin/init which means don't run ./etc/rc.sys on startup, which also saves memory fragmentation at the cost of the clock not being set and auto-mounts not processed, etc.

Feel free to play around with these resource settings, depending on what Doom requires.

The startup boot screen is slightly changed: at the bottom right, it now displays the largest contiguous block of memory before running /bin/init, followed by the released "INITPROC" code segment, followed by the UMB memory configured. Since the startup screen is tight on space, This might be shown as "509+9+64K free" which means 509k contiguous main memory plus a 9k free block plus a 64k UMB free block. It also shows the number of tasks, files, inodes and heap for reference.

Here's the changed startup screen (note we've moved to v0.8.0-pre3):
<img width="832" alt="boot" src="https://github.com/user-attachments/assets/596d4c10-6bb5-4dd6-af76-8392eed58a13">

Other enhancements include showing "MEM" instead of "SEG" in `meminfo` for easier understanding, and "CACH" instead of "BUFH" to differentiate cache= L1 buffers from L2 buf= buffers.