### PR TITLE
[kernel] Calculate then reduce kernel temp startup stack size

### DIFF
--- a/elks/arch/i86/kernel/Makefile
+++ b/elks/arch/i86/kernel/Makefile
@@ -40,7 +40,7 @@ OBJS  = strace.o system.o irq.o irqtab.o process.o \
 
 ifeq ($(CONFIG_ARCH_IBMPC), y)
 OBJS += irq-8259.o timer-8254.o
-#OBJS += divzero.o
+OBJS += divzero.o
 endif
 
 ifeq ($(CONFIG_ARCH_PC98), y)

--- a/elks/arch/i86/kernel/divzero.c
+++ b/elks/arch/i86/kernel/divzero.c
@@ -8,7 +8,7 @@
  * 19 Aug 24 Greg Haerr
  */
 
-static char div0msg[] = { "Divide by zero\n" };
+static char div0msg[] = { "Divide fault\n" };
 
 void div0_handler(int i, struct pt_regs *regs)
 {

--- a/elks/arch/i86/kernel/irq.c
+++ b/elks/arch/i86/kernel/irq.c
@@ -125,12 +125,15 @@ void INITPROC irq_init(void)
 
 #ifdef CONFIG_ARCH_IBMPC
     /* catch INT 0 divide by zero/divide overflow hardware fault */
-    /*irq_action[IDX_DIVZERO] = div0_handler;
-      int_handler_add(IDX_DIVZERO, 0x00, _irqit);*/
+#if 1
     /* install direct panic-only DIV fault handler until known that
      * the _irqit version doesn't overwrite the stack
      */
     int_handler_add(IDX_DIVZERO, 0x00, div0_handler_panic);
+#else
+    irq_action[IDX_DIVZERO] = div0_handler;
+    int_handler_add(IDX_DIVZERO, 0x00, _irqit);
+#endif
 #endif
 
 #if defined(CONFIG_TIMER_INT0F) || defined(CONFIG_TIMER_INT1C)

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -424,6 +424,7 @@ div0_handler_panic:
 	.data
 	.global	_gint_count
 	.global	endistack
+	.global	endtstack
 	.global	istack
 	.global	tstack
 	.extern	current
@@ -445,5 +446,6 @@ endistack:
 	.skip ISTACK_BYTES,0	// interrupt stack
 istack:
 
-	.skip 256,0		// startup temp stack
+endtstack:
+	.skip TSTACK_BYTES,0	// startup temp stack
 tstack:

--- a/elks/arch/i86/kernel/strace.c
+++ b/elks/arch/i86/kernel/strace.c
@@ -183,4 +183,19 @@ void trace_end(unsigned int retval)
         check_kstack(n);
 }
 
+#if UNUSED
+void check_tstack(void)
+{
+    int i;
+
+    /* calc temp stack usage */
+    for (i=0; i<TSTACK_BYTES/2; i++) {
+        if (endtstack[i] != 0)
+            break;
+    }
+    i = (TSTACK_BYTES/2 - i) << 1;
+    printk("tstack usage %d\n", i);
+}
+#endif
+
 #endif /* CONFIG_TRACE */

--- a/elks/include/arch/segment.h
+++ b/elks/include/arch/segment.h
@@ -6,6 +6,7 @@
 extern seg_t kernel_cs, kernel_ds;
 extern short *_endtext, *_endftext, *_enddata, *_endbss;
 extern short endistack[];
+extern short endtstack[];
 extern unsigned int heapsize;
 
 #endif

--- a/elks/include/linuxmt/limits.h
+++ b/elks/include/linuxmt/limits.h
@@ -17,6 +17,7 @@
 #endif
 
 #define ISTACK_BYTES    512     /* Size of interrupt stack */
+#define TSTACK_BYTES    128     /* Size of temp startup stack */
 
 #define KSTACK_GUARD    100     /* bytes before CHECK_KSTACK overflow warning */
 

--- a/elks/include/linuxmt/trace.h
+++ b/elks/include/linuxmt/trace.h
@@ -45,8 +45,9 @@
 #ifndef __ASSEMBLER__
 extern int tracing;
 
-extern void trace_begin(void);
-extern void trace_end(unsigned int retval);
+void trace_begin(void);
+void trace_end(unsigned int retval);
+void check_tstack(void);
 #endif
 
 #endif


### PR DESCRIPTION
The measured temp stack sized used was 86 bytes, so this PR lowers the 256 bytes to 128.

The DIV fault handler code is slightly reconfigured, as an `asm("int $0")` was used add an INT 0 execution during early kernel startup to maximize stack usage.