### PR TITLE
[kernel] Cleanup and shorten panic messages to save kernel data space

### DIFF
--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -145,10 +145,10 @@ static void end_request(int uptodate)
     if (req->rq_status != RQ_ACTIVE \
         || (req->rq_cmd != READ && req->rq_cmd != WRITE) \
         || MAJOR(req->rq_dev) != MAJOR_NR) \
-        panic(DEVICE_NAME ": bad request dev %D cmd %d active %d", \
+        panic("I/O req %D,%d,%d", \
             req->rq_dev, req->rq_cmd, req->rq_status); \
     if (req->rq_bh && !EBH(req->rq_bh)->b_locked) \
-        panic(DEVICE_NAME ": not locked");
+        panic("I/O lck %D", req->rq_dev);
 #else
 #define CHECK_REQUEST(req)
 #endif

--- a/elks/arch/i86/drivers/block/ll_rw_blk.c
+++ b/elks/arch/i86/drivers/block/ll_rw_blk.c
@@ -81,7 +81,7 @@ static struct request *get_request(int n, kdev_t dev)
 #ifdef CONFIG_ASYNCIO
             return NULL;
 #else
-            panic("get_request: no inactive requests\n");
+            panic("get_request");   /* no inactive requests */
 #endif
         }
     }
@@ -130,7 +130,7 @@ static struct request *get_request_wait(int n, kdev_t dev)
     /* Try again blocking if no request available */
     return __get_request_wait(n, dev);
 #else
-    panic("get_request: no requests");
+    panic("no reqs");
     return NULL;
 #endif
 }
@@ -162,7 +162,7 @@ static void add_request(struct blk_dev_struct *dev, struct request *req)
         tmp->rq_next = req;
         set_irq();
 #else
-        panic("add_request: non-empty request queue");
+        panic("add_request");   /* non-empty request queue */
 #endif
     }
 }
@@ -235,7 +235,7 @@ void ll_rw_blk(int rw, struct buffer_head *bh)
     if ((major = MAJOR(buffer_dev(bh))) < MAX_BLKDEV)
         dev = blk_dev + major;
     if (!dev || !dev->request_fn)
-        panic("ll_rw_blk: unknown dev %D", buffer_dev(bh));
+        panic("bad blkdev %D", buffer_dev(bh));
     make_request(major, rw, bh);
 }
 

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -88,7 +88,7 @@ static int nr_free_bh, nr_bh;
 #define DCR_COUNT(bh) if(!(--bh->b_count))nr_free_bh++
 #define INR_COUNT(bh) if(!(bh->b_count++))nr_free_bh--
 #define CLR_COUNT(bh) if(bh->b_count)nr_free_bh++
-#define SET_COUNT(bh) if(--nr_free_bh < 0) { panic("get_free_buffer: bad free count"); }
+#define SET_COUNT(bh) if(--nr_free_bh < 0) { panic("buffer free count"); }
 #else
 #define DCR_COUNT(bh) (bh->b_count--)
 #define INR_COUNT(bh) (bh->b_count++)

--- a/elks/fs/inode.c
+++ b/elks/fs/inode.c
@@ -32,7 +32,7 @@ static int nr_free_inodes;
 #define DCR_COUNT(i) if(!(--i->i_count))nr_free_inodes++
 #define INR_COUNT(i) if(!(i->i_count++))nr_free_inodes--
 #define CLR_COUNT(i) if(i->i_count)nr_free_inodes++
-#define SET_COUNT(i) if(--nr_free_inodes < 0) { panic("get_empty_inode: bad free count"); }
+#define SET_COUNT(i) if(--nr_free_inodes < 0) { panic("inode free count"); }
 #else
 #define DCR_COUNT(i) (i->i_count--)
 #define INR_COUNT(i) (i->i_count++)
@@ -323,7 +323,7 @@ struct inode *iget(struct super_block *sb, ino_t inr)
     register struct inode *inode;
     register struct inode *n_ino;
 
-    if (!sb) panic("iget sb 0");
+    if (!sb) panic("iget0");
     debug("iget dev %p ino %lu\n", sb->s_dev, (unsigned long)inr);
 
     n_ino = NULL;

--- a/elks/fs/minix/inode.c
+++ b/elks/fs/minix/inode.c
@@ -262,7 +262,7 @@ unsigned short _minix_bmap(register struct inode *inode, block_t block, int crea
 
 #if UNUSED  /* block always less than 65536 */
     if (block > (7 + 512 + 512 * 512))
-	panic("_minix_bmap: block (%d) >big", block);
+	panic("minix_bmap block %d", block);    /* block # too big */
 #endif
 
     if (block < 7)

--- a/elks/fs/select.c
+++ b/elks/fs/select.c
@@ -63,7 +63,7 @@ void select_wait (struct wait_queue *q)
 		}
 	}
 
-	panic ("select_wait:no slot left");
+	panic ("select_wait");      /* no slot left */
 }
 
 /* Return true if queue is polled */
@@ -79,8 +79,7 @@ int select_poll (struct task_struct * t, struct wait_queue *q)
 		if (p == q) return 1;
 	}
 
-	panic ("select_poll:no slot found\n");
-	return 0;
+	panic ("select_poll");      /* no slot found */
 }
 
 /*

--- a/elks/fs/super.c
+++ b/elks/fs/super.c
@@ -126,7 +126,7 @@ void put_super(kdev_t dev)
     register struct super_operations *sop;
 
     if (dev == ROOT_DEV)
-        panic("put_super: root\n");
+        panic("put_super");
 
     if (!(sb = get_super(dev))) return;
     if (sb->s_covered)
@@ -218,7 +218,7 @@ int do_umount(kdev_t dev)
             }
         }
         else if (sb->s_covered) {
-            if (!sb->s_covered->i_mount) panic("umount: i_mount=NULL\n");
+            if (!sb->s_covered->i_mount) panic("umount");
             if (!fs_may_umount(dev, sb->s_mounted)) retval = -EBUSY;
             else {
                 retval = 0;

--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -138,7 +138,7 @@ void do_exit(int status)
     current->state = TASK_ZOMBIE;
     wake_up(&parent->child_wait);
     schedule();
-    panic("sys_exit\n");
+    panic("sys_exit");
 }
 
 void sys_exit(int status)

--- a/elks/kernel/sched.c
+++ b/elks/kernel/sched.c
@@ -33,9 +33,9 @@ static void del_from_runqueue(register struct task_struct *p)
 {
 #ifdef CHECK_SCHED
     if (!p->next_run || !p->prev_run)
-        panic("SCHED(%d): task not on run-queue, state %d", p->pid, p->state);
+        panic("delrunq %d,%d", p->pid, p->state);   /* task not on run queue */
     if (p == &idle_task)
-        panic("trying to sleep idle task");
+        panic("delrunq idle");                      /* trying to sleep idle task */
 #endif
     (p->next_run->prev_run = p->prev_run)->next_run = p->next_run;
     p->next_run = p->prev_run = NULL;
@@ -70,7 +70,7 @@ void schedule(void)
     if (_gint_count > 1) {      /* neither user nor idle task was running */
         /* Taking a timer IRQ during another IRQ or while in kernel space is
          * quite legal. We just dont switch then */
-         panic("schedule from interrupt\n");
+         panic("schedule from int\n");
     }
 #endif
 

--- a/elks/kernel/sleepwake.c
+++ b/elks/kernel/sleepwake.c
@@ -64,7 +64,7 @@ void finish_wait(struct wait_queue *p)
 void wait_set(struct wait_queue *p)
 {
 #ifdef CHECK_SCHED
-    if (current->waitpt) panic("SCHED: wait_set double wait");
+    if (current->waitpt) panic("wait_set");         /* double wait */
 #endif
     current->waitpt = p;
 }
@@ -72,7 +72,7 @@ void wait_set(struct wait_queue *p)
 void wait_clear(struct wait_queue *p)
 {
 #ifdef CHECK_SCHED
-    if (current->waitpt != p) panic("SCHED: wait_clear wrong waitpt");
+    if (current->waitpt != p) panic("wait_clear");  /* bad wait_queue */
 #endif
     current->waitpt = NULL;
 }
@@ -80,7 +80,7 @@ void wait_clear(struct wait_queue *p)
 static void __sleep_on(register struct wait_queue *p, int state)
 {
 #ifdef CHECK_SCHED
-    if (current == &task[0]) panic("SCHED: trying to sleep idle task on %x", p);
+    if (current == &task[0]) panic("idle task sleep_on %x", p);
 #endif
     debug_sched("sleep: %P waitq %04x\n", p);
     current->state = state;


### PR DESCRIPTION
Reduces kernel .data size by 416 bytes, and panics are rarely if ever seen around here!