### PR TITLE
[kernel,cmds] Fix tty SIGINT not handled when using sercat

### DIFF
--- a/elks/arch/i86/drivers/char/ntty.c
+++ b/elks/arch/i86/drivers/char/ntty.c
@@ -335,6 +335,8 @@ again:
                 break;
             ch = chq_wait_rd(&tty->inq, nonblock);
             if (ch < 0) {
+                if (current->signal)
+                    return -EINTR;
                 if (!icanon && vtime) {
                     if (jiffies < timeout) {
                         schedule();

--- a/elkscmd/sys_utils/sercat.c
+++ b/elkscmd/sys_utils/sercat.c
@@ -51,17 +51,31 @@ void copyfile(int ifd, int ofd)
 
 int main(int argc, char **argv)
 {
+    char *port = NULL;
+    char *tty;
+
 	if (argc > 1 && !strcmp(argv[1], "-v")) {
 		verbose = 1;
 		argc--;
 		argv++;
 	}
-	if (argc > 1) {
-		if ((fd = open(argv[1], O_RDONLY|O_EXCL)) < 0) {
-			perror(argv[1]);
+	if (argc > 1)
+        port = argv[1];
+    else {
+        /* default to /dev/ttyS0 if not run from serial port and no argument */
+        if (strncmp(ttyname(STDIN_FILENO), "/dev/ttyS", 9) != 0)
+            port = "/dev/ttyS0";
+    }
+    if (port) {
+		if ((fd = open(port, O_RDONLY|O_EXCL)) < 0) {
+			perror(port);
 			return 1;
 		}
 	} else fd = STDIN_FILENO;
+    tty = ttyname(fd);
+    errmsg("Reading from ");
+    errstr(tty);
+    errmsg("\n");
 
 	if (tcgetattr(fd, &org) >= 0) {
 		new = org;

--- a/elkscmd/sys_utils/sercat.c
+++ b/elkscmd/sys_utils/sercat.c
@@ -1,7 +1,7 @@
 /*
  * sercat.c - serial cat (for testing)
  *
- *	sercat [-v] [serial device] [> file]
+ *  sercat [-v] [serial device] [> file]
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -14,7 +14,7 @@
 
 #define DEFAULT_PORT "/dev/ttyS0"
 #define BUF_SIZE 4096
-#define CTRL_D	04
+#define CTRL_D  04
 
 #define errmsg(str) write(STDERR_FILENO, str, sizeof(str) - 1)
 #define errstr(str) write(STDERR_FILENO, str, strlen(str))
@@ -26,27 +26,27 @@ struct termios org, new;
 
 void sig_handler(int sig)
 {
-	errmsg("Interrupt\n");
-	tcsetattr(fd, TCSAFLUSH, &org);
-	close(fd);
-	exit(1);
+    errmsg("Interrupt\n");
+    tcsetattr(fd, TCSAFLUSH, &org);
+    close(fd);
+    exit(1);
 }
 
 void copyfile(int ifd, int ofd)
 {
-	int n;
+    int n;
 
-	while ((n = read(ifd, readbuf, BUF_SIZE)) > 0) {
-		if (n == 1 && readbuf[0] == CTRL_D)
-			return;
-		if (verbose) {
-			char *p = itoa(n);
-			errstr(p);
-			errmsg("  bytes read\n");
-		}
-		write(ofd, readbuf, n);
-	}
-	if (n < 0) perror("read");
+    while ((n = read(ifd, readbuf, BUF_SIZE)) > 0) {
+        if (n == 1 && readbuf[0] == CTRL_D)
+            return;
+        if (verbose) {
+            char *p = itoa(n);
+            errstr(p);
+            errmsg("  bytes read\n");
+        }
+        write(ofd, readbuf, n);
+    }
+    if (n < 0) perror("read");
 }
 
 int main(int argc, char **argv)
@@ -54,12 +54,12 @@ int main(int argc, char **argv)
     char *port = NULL;
     char *tty;
 
-	if (argc > 1 && !strcmp(argv[1], "-v")) {
-		verbose = 1;
-		argc--;
-		argv++;
-	}
-	if (argc > 1)
+    if (argc > 1 && !strcmp(argv[1], "-v")) {
+        verbose = 1;
+        argc--;
+        argv++;
+    }
+    if (argc > 1)
         port = argv[1];
     else {
         /* default to /dev/ttyS0 if not run from serial port and no argument */
@@ -67,30 +67,30 @@ int main(int argc, char **argv)
             port = "/dev/ttyS0";
     }
     if (port) {
-		if ((fd = open(port, O_RDONLY|O_EXCL)) < 0) {
-			perror(port);
-			return 1;
-		}
-	} else fd = STDIN_FILENO;
+        if ((fd = open(port, O_RDONLY|O_EXCL)) < 0) {
+            perror(port);
+            return 1;
+        }
+    } else fd = STDIN_FILENO;
     tty = ttyname(fd);
     errmsg("Reading from ");
     errstr(tty);
     errmsg("\n");
 
-	if (tcgetattr(fd, &org) >= 0) {
-		new = org;
-		new.c_lflag &= ~(ICANON | ISIG | ECHO | ECHOE | ECHONL);
-		new.c_iflag &= ~(ICRNL);
-		new.c_cflag |= CS8 | CREAD;
-		new.c_cc[VMIN] = 255;			/* min bytes to read if VTIME = 0*/
-		new.c_cc[VTIME] = 1;			/* intercharacter timeout if VMIN > 0, timeout if VMIN = 0*/
-		tcsetattr(fd, TCSAFLUSH, &new);
-	} else errmsg("Can't set termios\n");
-	signal(SIGINT, sig_handler);
+    if (tcgetattr(fd, &org) >= 0) {
+        new = org;
+        new.c_lflag &= ~(ICANON | ISIG | ECHO | ECHOE | ECHONL);
+        new.c_iflag &= ~(ICRNL);
+        new.c_cflag |= CS8 | CREAD;
+        new.c_cc[VMIN] = 255;           /* min bytes to read if VTIME = 0*/
+        new.c_cc[VTIME] = 1;            /* intercharacter timeout if VMIN > 0, timeout if VMIN = 0*/
+        tcsetattr(fd, TCSAFLUSH, &new);
+    } else errmsg("Can't set termios\n");
+    signal(SIGINT, sig_handler);
 
-	copyfile(fd, STDOUT_FILENO);
+    copyfile(fd, STDOUT_FILENO);
 
-	tcsetattr(fd, TCSAFLUSH, &org);
-	close(fd);
-	return 0;
+    tcsetattr(fd, TCSAFLUSH, &org);
+    close(fd);
+    return 0;
 }


### PR DESCRIPTION
Fixes ^C not terminating `sercat` found by @RNRetailer discussed in https://github.com/ghaerr/elks/issues/1974#issuecomment-2307927945.

Also changed `sercat` so that when run with no arguments, /dev/ttyS0 is automatically selected for the serial port, when run from the direct console. When run from a serial port, that serial port will be selected, otherwise a command argument must be specified.

`sercat` will either terminate when ^D is received from the serial port, or additionally, if not being run from a serial port, a ^C will terminate the program.