### PR TITLE
[kernel] Fix /bootopts root=df0 failing

### DIFF
--- a/elks/arch/i86/kernel/system.c
+++ b/elks/arch/i86/kernel/system.c
@@ -65,9 +65,6 @@ unsigned int INITPROC setup_arch(void)
 	}
 #endif
 
-	/* Misc */
-	ROOT_DEV = SETUP_ROOT_DEV;
-
 #ifdef SYS_CAPS
 	sys_caps = SYS_CAPS;	/* custom system capabilities */
 #else

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -137,6 +137,7 @@ static void INITPROC early_kernel_init(void)
 #ifdef CONFIG_TIME_TZ
     tz_init(CONFIG_TIME_TZ);        /* parse_options may call tz_init */
 #endif
+    ROOT_DEV = SETUP_ROOT_DEV;      /* default root device from boot loader */
 #ifdef CONFIG_BOOTOPTS
     opts = parse_options();         /* parse options found in /bootops */
 #endif


### PR DESCRIPTION
Fixes bug introduced in #1993.