### PR TITLE
[build] Use CI actions/upload-artifacts@v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,103 +45,103 @@ jobs:
         run: ./build.sh auto allimages
 
       - name: upload
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: fd1440.img
           path: image/fd1440.img
 
       - name: upload2
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: fd360-minix.img
           path: image/fd360-minix.img
 
       - name: upload3
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: fd720-minix.img
           path: image/fd720-minix.img
 
       - name: upload4
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: fd1200-minix.img
           path: image/fd1200-minix.img
 
       - name: upload5
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: fd1440-minix.img
           path: image/fd1440-minix.img
 
       - name: upload6
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: fd2880-minix.img
           path: image/fd2880-minix.img
 
       - name: upload7
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: hd32-minix.img
           path: image/hd32-minix.img
 
       - name: upload8
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: hd32mbr-minix.img
           path: image/hd32mbr-minix.img
 
       - name: upload9
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: fd360-fat.img
           path: image/fd360-fat.img
 
       - name: upload10
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: fd720-fat.img
           path: image/fd720-fat.img
 
       - name: upload11
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: fd1200-fat.img
           path: image/fd1200-fat.img
 
       - name: upload12
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: fd1440-fat.img
           path: image/fd1440-fat.img
 
       - name: upload13
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: fd2880-fat.img
           path: image/fd2880-fat.img
 
       - name: upload14
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: hd32-fat.img
           path: image/hd32-fat.img
 
       - name: upload15
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: hd32mbr-fat.img
           path: image/hd32mbr-fat.img
 
       - name: upload16
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: hd64-minix.img
           path: image/hd64-minix.img
 
       - name: upload17
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: fd1232.img
           path: image/fd1232.img


### PR DESCRIPTION
Updates CI to use v4 as Github has deprecated v1. This allows the automated CI to continuing operating during push commits to the repository. I received notification of the previous failure due to deprecation when committing #2003.

@tyama501, on PR #2003, did you happen to notice whether the Gitub CI ran the test(s) when you pushed each commit to the PR? I noticed that it did not run on my end as I thought it was supposed to. If it did not run, then I will reenable the 'pull-request:' section of main.yml. I had thought that the 'push:' section would work for non-maintainer pushes as part of a PR, like they do for me.