### PR TITLE
[kernel] Retab some source files - no functional changes

### DIFF
--- a/Documentation/text/boot.txt
+++ b/Documentation/text/boot.txt
@@ -2,96 +2,101 @@ The finished Image file consists of the boot sector, setup code, and kernel
 concatenated together. Each is rounded up to a multiple of 512 bytes (i.e.
 starts on a fresh sector)
 
-	Sector 1:	dummy boot sector and setup data (1 512-byte sector)
-	Sector 2..n:	setup	(setup_sects 512-byte sectors in size)
-	Sector n+1..m:	kernel	(sys_size paragraphs in size)
+    Sector 1:       dummy boot sector and setup data (1 512-byte sector)
+    Sector 2..n:    setup   (setup_sects 512-byte sectors in size)
+    Sector n+1..m:  kernel  (sys_size paragraphs in size)
 
 Note that sectors are counted from 1 but tracks from 0, just to be
 confusing :-)
 
 REAL BOOT SECTOR:
 
-elkscmd/boot/
-boot_sect.S	first sector on floppy disk, or first sector of HD boot partition
-		loaded by the PC's BIOS at BOOTSEG:0 (0x07C0:0))
+elkscmd/boot/boot_sect.S
+        first sector on floppy disk, or first sector of HD boot partition
+        loaded by the PC's BIOS at BOOTSEG:0 (0x07C0:0))
 
-		if MINIX FS, boot loads second 512-byte sector from boot disk.
-		That second boot sector then loads second inode which is the /linux
-		Image (boot,setup,kernel) at DEF_INITSEG (0x0100:0).
-		if boot options is configured, up to a single sector of boot
-		options is read from /bootopts into DEF_OPTSEG (0x0050:0)
-		for later processing by the kernel.
+        if MINIX FS, boot loads second 512-byte sector from boot disk.
+        That second boot sector then loads second inode which is the /linux
+        Image (boot,setup,kernel) at DEF_INITSEG (0x0100:0).
+        if boot options is configured, up to a single sector of boot
+        options is read from /bootopts into DEF_OPTSEG (0x0050:0)
+        for later processing by the kernel.
 
-		if FAT FS, reads root directory entries looking for LINUX,
-		and loads its image (boot,setup,kernel) at DEF_INITSEG (0x0100:0).
+        if FAT FS, reads root directory entries looking for LINUX,
+        and loads its image (boot,setup,kernel) at DEF_INITSEG (0x0100:0).
 
-		Boot then jumps to setup.S at DEF_INITSEG+20 (0x120:0), which is
-		the start of setup.S code segment, 0x200 (512) bytes after
-		the setup.S data segment (which is the dummy boot sector).
+        Boot then jumps to setup.S at DEF_INITSEG+20 (0x120:0), which is
+        the start of setup.S code segment, 0x200 (512) bytes after
+        the setup.S data segment (which is the dummy boot sector).
 
 
 DUMMY BOOT SECTOR:
 
-arch/i86/boot/
-bootsect.S	first 512 bytes on disk Image; contains preset values
-		of INITSEG (setup data segment) variables.
+arch/i86/boot/bootsect.S
+        first 512 bytes on disk Image; contains preset values
+        of INITSEG (setup data segment) variables.
 
 SETUP CODE:
 
-setup.S		Setup gains control from the boot sector at DEF_INITSEG+20 (0x0120:0)
-		which is DEF_SETUPSEG, its code segment.
+arch/i86/boot/setup.S
+        Setup gains control from the boot sector at DEF_INITSEG+20 (0x0120:0)
+        which is DEF_SETUPSEG, its code segment.
 
-		Setup first copies the kernel image including header and relocation data
-		to DEF_SYSSEG (0x1300:0).
+        Setup first copies the kernel image including header and relocation data
+        to DEF_SYSSEG (0x1300:0).
 
-		Setup gets some system/hardware params, and stores them in the
-		dummy boot block which was loaded at DEF_INITSEG (0x0100:0).
+        Setup gets some system/hardware params, and stores them in the
+        dummy boot block which was loaded at DEF_INITSEG (0x0100:0).
 
-		Setup then copies its code segment (itself) up to high memory.
+        Setup then copies its code segment (itself) up to high memory.
 
-		Setup then copies its data segment with the various updated
-		system parameters (DEF_INITSEG) to REL_INITSEG (normally 0x0070:0).
-		This final segment will be used by the kernel to access them (=INITSEG).
+        Setup then copies its data segment with the various updated
+        system parameters (DEF_INITSEG) to REL_INITSEG (normally 0x0070:0).
+        This final segment will be used by the kernel to access them (=INITSEG).
 
-		Setup then copies the saved kernel image at DEF_SYSSEG to
-		REL_SYSSEG (0x00D0:0 or 0x02D0:0) depending on whether disk track
-		caching is used, as DMASEG and track caching are just after INITSEG.
-		The kernel text, fartext and data sections are relocated using
-		the a.out header entries in this final location.
+        Setup then copies the saved kernel image at DEF_SYSSEG to
+        REL_SYSSEG (0x00D0:0 or 0x02D0:0) depending on whether disk track
+        caching is used, as DMASEG and track caching are just after INITSEG.
+        The kernel text, fartext and data sections are relocated using
+        the a.out header entries in this final location.
 
-		Finally, setup jumps to REL_SYSSEG:_start (the kernel entry point).
+        Finally, setup jumps to REL_SYSSEG:_start (the kernel entry point).
 
 
 (Note: .S files are preprocessed to .s before being assembled)
 
 KERNEL:
 
-crt0.s		Kernel startup code, entry point _start.
-		puts parameters passed in registers from setup into global
-		storage, zeros bss and calls start_kernel
-init/main.c	start_kernel, immediately calls kernel_init,
-		which starts kernel initialization. If boot options
-		is configured, reads boot options from DEF_OPTSEG (0x0050:0).
-arch/i86/kernel/
-system.c	setup_arch. Allocates kernel data segment, which follows
-		the kernel code segment. The kernel local heap is also
-		initialized, and the root device global is set from
-		the INITSEG data location.
+arch/i86/boot/crt0.S
+        Kernel startup code, entry point _start.
+        puts parameters passed in registers from setup into global
+        storage, zeros bss and calls start_kernel
 
-arch/i86/mm/
-malloc.c	init memory manager.
+init/main.c
+        start_kernel, immediately calls kernel_init,
+        which starts kernel initialization. If boot options
+        is configured, reads boot options from DEF_OPTSEG (0x0050:0).
 
-fs/
-buffer.c	init buffers, may allocate from main memory or extended memory.
+arch/i86/kernel/system.c
+        setup_arch. Allocates kernel data segment, which follows
+        the kernel code segment. The kernel local heap is also
+        initialized, and the root device global is set from
+        the INITSEG data location.
+
+arch/i86/mm/malloc.c
+        init memory manager.
+
+fs/buffer.c
+        init buffers, may allocate from main memory or extended memory.
 
 ----------------------------------------------------------------------------
 The dummy boot sector is all zeros except for the following, which
 are patched by arch/i86/tools/build when the kernel is being built:
 
 (0x1e6)486-489  'ELKS' signature                        (elks_magic)
-(0x1f1)497      number of sectors in setup.S		(setup_secs)
+(0x1f1)497      number of sectors in setup.S            (setup_secs)
 (0x1f4)500,501  size of kernel in paragraphs            (syssize)
-(0x1fc)508,509  root device				(root_dev)
+(0x1fc)508,509  root device                             (root_dev)
 
 
 Setup and INITSEG Variables
@@ -178,45 +183,45 @@ ELKS memory at boot and detailed boot description
  |  top of 640k ram      A000:0000 A0000 A0000        @640K
  +-------------------------------------------------------------------------------------------+
 
-1	BIOS loads disk sector 1 (bios_sect.S) to 07C0:0000
-2	bios_sect.S copies itself to high memory 9000:0000 (8000:0000 on QEMU)
-	bios_sect stack grows down from 9000:0000
+1   BIOS loads disk sector 1 (bios_sect.S) to 07C0:0000
+2   bios_sect.S copies itself to high memory 9000:0000 (8000:0000 on QEMU)
+    bios_sect stack grows down from 9000:0000
 
-	MINIX bios_sect calls payload at 9000:0200 (minix_boot.S, tiny model CS=DS=SS)
-	bios_sect .text and .data is ~03F6, linked with minix_boot.o is 1K boot sector
-	payload .data (offset after .text and .rodata) starts around 9000:03F6 to 9000:1406
-3	payload reads MINIX superblock/fs and loads /linux as blob to 0100:0000 (DEF_INIT)
-4	payload reads MINIX superblock/fs and loads /bootopts sector to 0050:0000 (DEF_OPTSEG)
-	boot_sect saves elks_flags (and other?) to 0100:0000 (DEF_INIT, which is SETUP data seg)
-		set by boot_sect: elks_flags
-		set by build: setup_sect, syssize
-5	boot_sect checks ELKS setup signature and jumps to setup code seg 0120:0000 (DEF_INIT+20)
+    MINIX bios_sect calls payload at 9000:0200 (minix_boot.S, tiny model CS=DS=SS)
+    bios_sect .text and .data is ~03F6, linked with minix_boot.o is 1K boot sector
+    payload .data (offset after .text and .rodata) starts around 9000:03F6 to 9000:1406
+3   payload reads MINIX superblock/fs and loads /linux as blob to 0100:0000 (DEF_INIT)
+4   payload reads MINIX superblock/fs and loads /bootopts sector to 0050:0000 (DEF_OPTSEG)
+    boot_sect saves elks_flags (and other?) to 0100:0000 (DEF_INIT, which is SETUP data seg)
+        set by boot_sect: elks_flags
+        set by build: setup_sect, syssize
+5   boot_sect checks ELKS setup signature and jumps to setup code seg 0120:0000 (DEF_INIT+20)
 
-	FAT bios_sect reads FAT BPB within itself at 9000:0000 and loads FAT root dir at 9000:0200
-	boot_sect .text is ~01E2, .data starts at ~01f7, standalone size is 512 byte boot sector
-3	boot_sect reads FAT root dir to load LINUX as blob to 0100:0000 (DEF_INIT)
-(4)		no room to load BOOTOPTS sector to 0050:0000 (DEF_OPTSEG)
-	boot_sect saves elks_flags (and other?) to 0100:0000 (DEF_INIT, which is SETUP data seg)
-5	boot_sect checks ELKS setup signature and jumps to setup code seg 0120:0000 (DEF_INIT+20)
-	setup uses root dir at 9000:0200 and BPB at 9000:0000 to load BOOTOPTS sector to 0050:0000
+    FAT bios_sect reads FAT BPB within itself at 9000:0000 and loads FAT root dir at 9000:0200
+    boot_sect .text is ~01E2, .data starts at ~01f7, standalone size is 512 byte boot sector
+3   boot_sect reads FAT root dir to load LINUX as blob to 0100:0000 (DEF_INIT)
+(4)     no room to load BOOTOPTS sector to 0050:0000 (DEF_OPTSEG)
+    boot_sect saves elks_flags (and other?) to 0100:0000 (DEF_INIT, which is SETUP data seg)
+5   boot_sect checks ELKS setup signature and jumps to setup code seg 0120:0000 (DEF_INIT+20)
+    setup uses root dir at 9000:0200 and BPB at 9000:0000 to load BOOTOPTS sector to 0050:0000
 
-6	setup CS at 0120:0000 (DEF_INIT+20) checks ELKS sig and copies kernel to 1300:0 (DEF_SYSSEG)
-6+	FAT only - setup reads high mem root dir 9000:0200 to get BOOTOPTS cluster
-		uses high mem BPB at 9000:0000 for secs_per_cluster, etc
-7	setup copies its code segment from 0120:0000 (DEF_INIT+2) to high memory 9000:0 (8000 qemu)
-8	setup now at 9000:0000 copies its data seg from 0100:0 (DEF_INIT) to 0700:0 (REL_INITSEG)
-9	setup copies&relocates kernel from 1300:0000 (DEF_SYSSEG) to 02D0:0000 (REL_SYSSEG)
-	DMASEG starts after 0700:0000 (REL_INITSEG) at 0900:0000 to 02D0:0000 (REL_SYSSEG)
-9+	finally, setup jumps to kernel at 02D0:0000 (REL_SYSSEG)
+6   setup CS at 0120:0000 (DEF_INIT+20) checks ELKS sig and copies kernel to 1300:0 (DEF_SYSSEG)
+6+  FAT only - setup reads high mem root dir 9000:0200 to get BOOTOPTS cluster
+        uses high mem BPB at 9000:0000 for secs_per_cluster, etc
+7   setup copies its code segment from 0120:0000 (DEF_INIT+2) to high memory 9000:0 (8000 qemu)
+8   setup now at 9000:0000 copies its data seg from 0100:0 (DEF_INIT) to 0700:0 (REL_INITSEG)
+9   setup copies&relocates kernel from 1300:0000 (DEF_SYSSEG) to 02D0:0000 (REL_SYSSEG)
+    DMASEG starts after 0700:0000 (REL_INITSEG) at 0900:0000 to 02D0:0000 (REL_SYSSEG)
+9+  finally, setup jumps to kernel at 02D0:0000 (REL_SYSSEG)
 
 Current kernel is 80K in size (=14000h)
 Boot loader:
-	0100:0000 DEF_INIT @4K
-		+ 1400:0000 size of kernel (80K)
-	1500:0000 end of 80K kernel
-	3000:0000 max end of 188K kernel @192K
+    0100:0000 DEF_INIT @4K
+        + 1400:0000 size of kernel (80K)
+    1500:0000 end of 80K kernel
+    3000:0000 max end of 188K kernel @192K
 Setup.S:
-	1300:0000 DEF_SYSSEG @76K
-		+ 1400:0000 size of kernel (80K)
-	2700:0000 end of 80K kernel
-	4200:0000 max end of 188K kernel @264K
+    1300:0000 DEF_SYSSEG @76K
+        + 1400:0000 size of kernel (80K)
+    2700:0000 end of 80K kernel
+    4200:0000 max end of 188K kernel @264K

--- a/elks/arch/i86/boot/crt0.S
+++ b/elks/arch/i86/boot/crt0.S
@@ -1,14 +1,14 @@
 #include <linuxmt/config.h>
 
-//	Assembler boot strap hooks. This is called by setup
+//      Assembler boot strap hooks. This is called by setup
 
-	.arch i8086, nojumps
-	.code16
-	.text
+        .arch i8086, nojumps
+        .code16
+        .text
 
-	.global _start
-	.extern	start_kernel
-	.global early_putchar
+        .global _start
+        .extern start_kernel
+        .global early_putchar
 
 _start:
 
@@ -20,80 +20,80 @@ _start:
 !   SI, Data size
 !   DX, BSS size
 */
-	mov	%bx,_endtext
-	mov	%di,_endftext
-	mov	%si,_enddata
-	add	%dx,%si
-	mov	%si,_endbss
+        mov     %bx,_endtext
+        mov     %di,_endftext
+        mov     %si,_enddata
+        add     %dx,%si
+        mov     %si,_endbss
 
 // Start cleaning BSS. Still using setup.S stack
 
-	mov	_enddata,%di	// start of BSS
-	mov	%dx,%cx		// CX = BSS size
-	xor	%ax,%ax
-	shr	$1,%cx
-	cld
-	rep
-	stosw
+        mov     _enddata,%di    // start of BSS
+        mov     %dx,%cx         // CX = BSS size
+        xor     %ax,%ax
+        shr     $1,%cx
+        cld
+        rep
+        stosw
 
 // End cleaning BSS
 
-	mov	%cs,kernel_cs
-	mov	%ds,kernel_ds
+        mov     %cs,kernel_cs
+        mov     %ds,kernel_ds
 
 // Set SS:SP to kernel interrupt stack for temporary use
 
-	mov	%ds,%ax
-	mov	%ax,%ss		// SS=ES=DS
-	mov	$tstack,%sp     // can't use kernel interrupt stack, must have temp stack
+        mov     %ds,%ax
+        mov     %ax,%ss         // SS=ES=DS
+        mov     $tstack,%sp     // can't use kernel interrupt stack, must have temp stack
 
-	call	start_kernel	// fall through into breakpoint if returns
+        call    start_kernel    // fall through into breakpoint if returns
 
-	.global int3
-int3:	int	$3		// C breakpoint for emu86
-	ret
+        .global int3
+int3:   int     $3              // C breakpoint for emu86
+        ret
 
 #ifndef CONFIG_ARCH_PC98
 early_putchar:
-	mov   %sp,%bx
-	mov   2(%bx),%al
-	mov   $0x0E,%ah
-	mov   $0x0007,%bx
-	push  %bp               // some BIOS may destroy BP
-	int   $0x10
-	pop   %bp
-	ret
+        mov   %sp,%bx
+        mov   2(%bx),%al
+        mov   $0x0E,%ah
+        mov   $0x0007,%bx
+        push  %bp               // some BIOS may destroy BP
+        int   $0x10
+        pop   %bp
+        ret
 #endif
 
-//	Segment beginnings
+//      Segment beginnings
 
 // Zero for NULL pointers (near and far)
 // Will be linked as first section in data segment
-	.section .nildata
-	.word 	0
-	.word	0
+        .section .nildata
+        .word   0
+        .word   0
 
-	.data
-	.global _endtext
-	.global _endftext
-	.global _enddata
-	.global _endbss
-	.extern	kernel_cs
-	.extern	kernel_ds
-	.extern	tstack
+        .data
+        .global _endtext
+        .global _endftext
+        .global _enddata
+        .global _endbss
+        .extern kernel_cs
+        .extern kernel_ds
+        .extern tstack
 
 _endtext:
-	.word	0
+        .word   0
 
 _endftext:
-	.word	0
+        .word   0
 
 _enddata:
-	.word	0
+        .word   0
 
 _endbss:
-	.word	0
+        .word   0
 
-	.bss
-	.p2align 1
+        .bss
+        .p2align 1
 _sbss:

--- a/elks/arch/i86/kernel/irq-8018x.c
+++ b/elks/arch/i86/kernel/irq-8018x.c
@@ -17,8 +17,7 @@
 #include <arch/irq.h>
 
 /*
- *	Low level interrupt handling for the X86 8018X
- *	platforms
+ *  Low level interrupt handling for the X86 8018X platforms
  */
 
 void initialize_irq(void)

--- a/elks/arch/i86/kernel/irq-8259.c
+++ b/elks/arch/i86/kernel/irq-8259.c
@@ -13,21 +13,21 @@
 
 #ifdef CONFIG_ARCH_PC98
 #undef inb_p
-#define inb_p	inb		/* no delay using I/O port 0x80 */
+#define inb_p   inb             /* no delay using I/O port 0x80 */
 #endif
 
 /*
- *	Low level interrupt handling for the X86 PC/XT and PC/AT platform
+ *  Low level interrupt handling for the X86 PC/XT and PC/AT platform
  */
 
 void initialize_irq(void)
 {
 #if NOTNEEDED   /* not needed on IBM PC as BIOS initializes IRQ 2 */
-    if (sys_caps & CAP_IRQ2MAP9) {	/* PC/AT or greater */
-	save_flags(flags);
-	clr_irq();
-	enable_irq(2);		/* Cascade slave PIC */
-	restore_flags(flags);
+    if (sys_caps & CAP_IRQ2MAP9) {      /* PC/AT or greater */
+        save_flags(flags);
+        clr_irq();
+        enable_irq(2);          /* Cascade slave PIC */
+        restore_flags(flags);
     }
 #endif
 }
@@ -38,22 +38,22 @@ void enable_irq(unsigned int irq)
 
     mask = ~(1 << (irq & 7));
     if (irq < 8) {
-	unsigned char cache_21 = inb_p(PIC1_DATA);
-	cache_21 &= mask;
-	outb(cache_21, PIC1_DATA);
+        unsigned char cache_21 = inb_p(PIC1_DATA);
+        cache_21 &= mask;
+        outb(cache_21, PIC1_DATA);
     } else {
-	unsigned char cache_A1 = inb_p(PIC2_DATA);
-	cache_A1 &= mask;
-	outb(cache_A1, PIC2_DATA);
+        unsigned char cache_A1 = inb_p(PIC2_DATA);
+        cache_A1 &= mask;
+        outb(cache_A1, PIC2_DATA);
     }
 }
 
 int remap_irq(int irq)
 {
     if ((unsigned int)irq > 15 || (irq > 7 && !(sys_caps & CAP_IRQ8TO15)))
-	return -EINVAL;
+        return -EINVAL;
     if (irq == 2 && (sys_caps & CAP_IRQ2MAP9))
-	irq = 9;			/* Map IRQ 9/2 over */
+        irq = 9;                /* Map IRQ 9/2 over */
     return irq;
 }
 
@@ -62,15 +62,15 @@ int remap_irq(int irq)
 int irq_vector (int irq)
 {
 #ifdef CONFIG_ARCH_PC98
-	// IRQ 0-7  are mapped to vectors INT 08h-0Fh
-	// IRQ 8-15 are mapped to vectors INT 10h-17h
+        // IRQ 0-7  are mapped to vectors INT 08h-0Fh
+        // IRQ 8-15 are mapped to vectors INT 10h-17h
 
-	return irq + 0x08;
+        return irq + 0x08;
 #else
-	// IRQ 0-7  are mapped to vectors INT 08h-0Fh
-	// IRQ 8-15 are mapped to vectors INT 70h-77h
+        // IRQ 0-7  are mapped to vectors INT 08h-0Fh
+        // IRQ 8-15 are mapped to vectors INT 70h-77h
 
-	return irq + ((irq >= 8) ? 0x68 : 0x08);
+        return irq + ((irq >= 8) ? 0x68 : 0x08);
 #endif
 }
 
@@ -82,13 +82,13 @@ void disable_irq(unsigned int irq)
     save_flags(flags);
     clr_irq();
     if (irq < 8) {
-	unsigned char cache_21 = inb_p(PIC1_DATA);
-	cache_21 |= mask;
-	outb(cache_21, PIC1_DATA);
+        unsigned char cache_21 = inb_p(PIC1_DATA);
+        cache_21 |= mask;
+        outb(cache_21, PIC1_DATA);
     } else {
-	unsigned char cache_A1 = inb_p(PIC2_DATA);
-	cache_A1 |= mask;
-	outb(cache_A1, PIC2_DATA);
+        unsigned char cache_A1 = inb_p(PIC2_DATA);
+        cache_A1 |= mask;
+        outb(cache_A1, PIC2_DATA);
     }
     restore_flags(flags);
 }

--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -5,27 +5,27 @@
 #include <arch/ports.h>
 #include <arch/irq.h>
 
-	.arch	i8086, nojumps
-	.code16
-	.text
+        .arch   i8086, nojumps
+        .code16
+        .text
 
 //------------------------------------------------------------------------------
 // Save BIOS IRQ 0 timer vector
 // void save_timer_irq(void)
 //------------------------------------------------------------------------------
 
-	.global	save_timer_irq
+        .global save_timer_irq
 save_timer_irq:
-	push	%es
-	xor	%ax,%ax
-	mov	%ax,%es		// ES -> interrupt table
-	mov	$8*4,%bx	// INT 8 (IRQ 0) vector
-	mov	%es:(%bx),%ax	// get the old timer intr
-	mov	%ax,org_irq0
-	mov	%es:2(%bx),%ax
-	mov	%ax,org_irq0+2
-	pop	%es
-	ret
+        push    %es
+        xor     %ax,%ax
+        mov     %ax,%es         // ES -> interrupt table
+        mov     $8*4,%bx        // INT 8 (IRQ 0) vector
+        mov     %es:(%bx),%ax   // get the old timer intr
+        mov     %ax,org_irq0
+        mov     %es:2(%bx),%ax
+        mov     %ax,org_irq0+2
+        pop     %es
+        ret
 
 //------------------------------------------------------------------------------
 // Set interrupt vector
@@ -35,32 +35,32 @@ save_timer_irq:
 // arg2: function offset (word)
 // arg3: function segment (word)
 
-	.global int_vector_set
+        .global int_vector_set
 int_vector_set:
-	mov %sp,%bx
-	mov 6(%bx),%dx  // arg3
-	mov 4(%bx),%cx  // arg2
-	mov 2(%bx),%bx  // arg1
+        mov %sp,%bx
+        mov 6(%bx),%dx  // arg3
+        mov 4(%bx),%cx  // arg2
+        mov 2(%bx),%bx  // arg1
 
-	shl $1,%bx
-	shl $1,%bx
+        shl $1,%bx
+        shl $1,%bx
 
-	push %ds
-	xor %ax,%ax
-	mov %ax,%ds
+        push %ds
+        xor %ax,%ax
+        mov %ax,%ds
 
-	pushf
-	cli
-	mov %cx,0(%bx)
-	mov %dx,2(%bx)
-	popf
+        pushf
+        cli
+        mov %cx,0(%bx)
+        mov %dx,2(%bx)
+        popf
 
-	pop %ds
-	ret
+        pop %ds
+        ret
 
 //------------------------------------------------------------------------------
 //
-//	IRQ and IRQ return paths for Linux 8086
+//      IRQ and IRQ return paths for Linux 8086
 //
 // The execution thread will not return from the function call.
 // Instead, the address pushed in the stack will be used to get
@@ -68,158 +68,158 @@ int_vector_set:
 
 /*
 !
-!	On entry CS:IP is all we can trust
+!       On entry CS:IP is all we can trust
 !
-!	There are three possible cases to cope with
+!       There are three possible cases to cope with
 !
-!	Syscall or Interrupted user mode (_gint_count == 0)
-!		Switch to process's kernel stack
-!		Optionally, check (SS == current->t_regs.ss)
-!		and panic on failure
-!		On return, task switch allowed
+!       Syscall or Interrupted user mode (_gint_count == 0)
+!               Switch to process's kernel stack
+!               Optionally, check (SS == current->t_regs.ss)
+!               and panic on failure
+!               On return, task switch allowed
 !
-!	Interrupted kernel mode, interrupted kernel task
-!		or second interrupt (_gint_count == 1)
-!		Switch to interrupt stack
-!		On return, no task switch allowed
+!       Interrupted kernel mode, interrupted kernel task
+!               or second interrupt (_gint_count == 1)
+!               Switch to interrupt stack
+!               On return, no task switch allowed
 !
-!	Interrupted interrupt service routine (_gint_count > 1)
-!		Already using interrupt stack, keep using it
-!		On return, no task switch allowed
+!       Interrupted interrupt service routine (_gint_count > 1)
+!               Already using interrupt stack, keep using it
+!               On return, no task switch allowed
 !
-!	We do all of this to avoid per process interrupt stacks and
-!	related nonsense. This way we need only one dedicated int stack
+!       We do all of this to avoid per process interrupt stacks and
+!       related nonsense. This way we need only one dedicated int stack
 !
 */
-	.global	ret_from_syscall
-	.extern	schedule
-	.extern	do_signal
-	.extern	do_IRQ
-	.extern	syscall
-	.extern	stack_check
-	.extern	trace_begin
-	.extern	trace_end
-	.extern	panic
+        .global ret_from_syscall
+        .extern schedule
+        .extern do_signal
+        .extern do_IRQ
+        .extern syscall
+        .extern stack_check
+        .extern trace_begin
+        .extern trace_end
+        .extern panic
 
-	.global _irqit
+        .global _irqit
 _irqit:
 //
-//	Make room
+//      Make room
 //
-	push	%ds
-	push	%si
-	push	%di
+        push    %ds
+        push    %si
+        push    %di
 //
-//	Recover kernel data segment
-//	Was pushed by the CALLF of the dynamic handler
-//	TODO: BP is better for stack work
+//      Recover kernel data segment
+//      Was pushed by the CALLF of the dynamic handler
+//      TODO: BP is better for stack work
 //
-	mov	%sp,%si
-	mov	%ss:8(%si),%ds
+        mov     %sp,%si
+        mov     %ss:8(%si),%ds
 //
-//	Determine which stack to use
+//      Determine which stack to use
 //
-	cmpw	$1,_gint_count
-	jc	utask		// We were in user mode
-	jz	itask		// Using a process's kernel stack
-ktask:				// Already using interrupt stack
+        cmpw    $1,_gint_count
+        jc      utask           // We were in user mode
+        jz      itask           // Using a process's kernel stack
+ktask:                          // Already using interrupt stack
 //
-//	Already using interrupt stack, keep using it
+//      Already using interrupt stack, keep using it
 //
-	sub	$8,%si		// 14 offsets less 6 already on stack
-	jmp	save_regs
+        sub     $8,%si          // 14 offsets less 6 already on stack
+        jmp     save_regs
 //
-//	Using a process's kernel stack, switch to interrupt stack
+//      Using a process's kernel stack, switch to interrupt stack
 //
 itask:
-	mov	$istack-14,%si  // 14 offsets 0-13 of SI below
-	jmp	save_regs
+        mov     $istack-14,%si  // 14 offsets 0-13 of SI below
+        jmp     save_regs
 //
-//	User mode case
+//      User mode case
 //
 utask:
-	mov	current,%si
+        mov     current,%si
 #ifdef CHECK_SS
 //
-//	We were in user mode, first confirm
+//      We were in user mode, first confirm
 //
-	mov	%ss,%di
-	cmp	TASK_USER_SS(%si),%di // entry SS = current->t_regs.ss?
-	je	utask1		// User using the right stack
+        mov     %ss,%di
+        cmp     TASK_USER_SS(%si),%di // entry SS = current->t_regs.ss?
+        je      utask1          // User using the right stack
 //
-//	System got crazy
+//      System got crazy
 //
-	mov	$pmsg,%ax
-	push	%ax
-	call	panic
+        mov     $pmsg,%ax
+        push    %ax
+        call    panic
 utask1:
 #endif
 //
-//	Switch to kernel stack
+//      Switch to kernel stack
 //
-	add	$TASK_USER_DI,%si
+        add     $TASK_USER_DI,%si
 //
-//	Save segment, index, BP and SP registers
+//      Save segment, index, BP and SP registers
 //
 save_regs:
-	incw	_gint_count
-	pop	(%si)		// DI
-	pop	2(%si)		// SI
-	pop	8(%si)		// DS
-	pop	%di		// Return offset is actually a pointer to the IRQ number
-	pop	%ds		// Return segment of the dynamic handler = kernel DS
-	push	%bp		// BP
-	mov	%sp,10(%si)	// SP
-	mov	%ss,12(%si)	// SS
-	mov	%es,6(%si)	// ES
-	mov	%ax,4(%si)	// orig_ax
+        incw    _gint_count
+        pop     (%si)           // DI
+        pop     2(%si)          // SI
+        pop     8(%si)          // DS
+        pop     %di             // Return offset is actually a pointer to the IRQ number
+        pop     %ds             // Return segment of the dynamic handler = kernel DS
+        push    %bp             // BP
+        mov     %sp,10(%si)     // SP
+        mov     %ss,12(%si)     // SS
+        mov     %es,6(%si)      // ES
+        mov     %ax,4(%si)      // orig_ax
 //
-//	Load new segment and SP registers
+//      Load new segment and SP registers
 //
-	mov	%si,%sp
-	mov	%ds,%si
-	mov	%si,%ss
-	mov	%si,%es
+        mov     %si,%sp
+        mov     %ds,%si
+        mov     %si,%ss
+        mov     %si,%es
 //
-//	Save remaining registers
+//      Save remaining registers
 //
-	push	%dx		// DX
-	push	%cx		// CX
-	push	%bx		// BX
-	push	%ax		// AX
+        push    %dx             // DX
+        push    %cx             // CX
+        push    %bx             // BX
+        push    %ax             // AX
 //
-//	ds:[di] has IRQ number
+//      ds:[di] has IRQ number
 //
-	movb	(%di),%al
-	cmpb	$IDX_SYSCALL,%al
-	jne	updct
+        movb    (%di),%al
+        cmpb    $IDX_SYSCALL,%al
+        jne     updct
 //
-//	----------PROCESS SYSCALL----------
+//      ----------PROCESS SYSCALL----------
 //
-	sti
-	call	stack_check	// Check user mode stack
+        sti
+        call    stack_check     // Check user mode stack
 
 #ifdef CONFIG_TRACE
-	call	trace_begin
+        call    trace_begin
 #endif
 
-	pop	%ax		// get syscall function code in AX
-	call	syscall
-	push	%ax		// syscall return value in ax
+        pop     %ax             // get syscall function code in AX
+        call    syscall
+        push    %ax             // syscall return value in ax
 
 #ifdef CONFIG_TRACE
-	// strace.c must be compiled with tail optimization off to protect top of stack
-	call	trace_end       // syscall return value is top of stack
+        // strace.c must be compiled with tail optimization off to protect top of stack
+        call    trace_end       // syscall return value is top of stack
 #endif
 
 //
-//	Restore registers
+//      Restore registers
 //
-	call	do_signal
-	cli
-	jmp	restore_regs
+        call    do_signal
+        cli
+        jmp     restore_regs
 //
-//	Done.
+//      Done.
 //
 
 //
@@ -228,169 +228,169 @@ save_regs:
 // Switch to kernel stack specified by 'current' and return ax=0 into user mode.
 //
 ret_from_syscall:
-	mov	current,%bx	// Ensure we have the
-	lea	TASK_USER_BX(%bx),%sp // right kernel SP
-	xor	%ax,%ax		// Just in case we are starting a new task
-	push	%ax
-	cli
-	jmp	restore_regs
+        mov     current,%bx     // Ensure we have the
+        lea     TASK_USER_BX(%bx),%sp // right kernel SP
+        xor     %ax,%ax         // Just in case we are starting a new task
+        push    %ax
+        cli
+        jmp     restore_regs
 /*
 !
-!	----------PROCESS INTERRUPT----------
+!       ----------PROCESS INTERRUPT----------
 */
 updct:
 //
-//	Call the C code
+//      Call the C code
 //
-	sti			// Reenable interrupts
-	mov	%sp,%bx		// Get pointer to pt_regs
-	cbw
-	push	%ax		// IRQ for later
+        sti                     // Reenable interrupts
+        mov     %sp,%bx         // Get pointer to pt_regs
+        cbw
+        push    %ax             // IRQ for later
 
-	push	%bx		// Register base
-	push	%ax		// IRQ number
-	call	do_IRQ		// Do the work
-	pop	%ax		// Clean parameters
-	pop	%bx
+        push    %bx             // Register base
+        push    %ax             // IRQ number
+        call    do_IRQ          // Do the work
+        pop     %ax             // Clean parameters
+        pop     %bx
 
-	pop	%ax		// Saved IRQ
-	cli			// Disable interrupts to avoid reentering ISR
+        pop     %ax             // Saved IRQ
+        cli                     // Disable interrupts to avoid reentering ISR
 
 #if defined(CONFIG_ARCH_IBMPC) || defined(CONFIG_ARCH_PC98)
 //
-//	Determine if trap or interrupt
+//      Determine if trap or interrupt
 //
-	cmp	$16,%ax
-	jge	was_trap	// Traps need no reset
+        cmp     $16,%ax
+        jge     was_trap        // Traps need no reset
 
 #if defined(CONFIG_BLK_DEV_BFD) && !defined(CONFIG_ARCH_PC98)
-	or	%ax,%ax		// Is int #0?
-	jnz	do_eoi
+        or      %ax,%ax         // Is int #0?
+        jnz     do_eoi
 
 //
-//	IRQ 0 (timer) has to go on to the bios for some systems
+//      IRQ 0 (timer) has to go on to the bios for some systems
 //
-	decw	bios_call_cnt	// Will call bios int?
-	jne	do_eoi
-	movw	$5,bios_call_cnt
-	pushf
-	lcall	*org_irq0
-	jmp	was_trap	// EOI already sent by bios int
+        decw    bios_call_cnt   // Will call bios int?
+        jne     do_eoi
+        movw    $5,bios_call_cnt
+        pushf
+        lcall   *org_irq0
+        jmp     was_trap        // EOI already sent by bios int
 #endif
 
 //
-//	Send EOI to interrupt controller
+//      Send EOI to interrupt controller
 //
 do_eoi:
-	cmp	$8,%ax
-	mov	$0x20,%al	// EOI
-	jb	a6		// IRQ on low chip
+        cmp     $8,%ax
+        mov     $0x20,%al       // EOI
+        jb      a6              // IRQ on low chip
 /*
 !
-!	Reset secondary 8259 if we have taken an AT rather
-!	than XT irq. We also have to prod the primay
-!	controller EOI..
+!       Reset secondary 8259 if we have taken an AT rather
+!       than XT irq. We also have to prod the primay
+!       controller EOI..
 !
 */
-	out	%al,$PIC2_CMD		// Ack on secondary controller
-	jmp	a5
-a5:	jmp	a6
-a6:	out	%al,$PIC1_CMD		// Ack on primary controller
+        out     %al,$PIC2_CMD           // Ack on secondary controller
+        jmp     a5
+a5:     jmp     a6
+a6:     out     %al,$PIC1_CMD           // Ack on primary controller
 
 #elif defined(CONFIG_ARCH_8018X)
 //
-//	Determine if trap or interrupt
+//      Determine if trap or interrupt
 //
-	cmp	$16,%ax
-	jge	was_trap	// Traps need no reset
+        cmp     $16,%ax
+        jge     was_trap        // Traps need no reset
 
-	mov $0x8000, %ax // set the NSPEC bit on the
-	mov $0xff02, %dx // EOI register so the ICU
-	out %ax, %dx // acks the highest priority interrupt
+        mov $0x8000, %ax // set the NSPEC bit on the
+        mov $0xff02, %dx // EOI register so the ICU
+        out %ax, %dx // acks the highest priority interrupt
 #endif
 
 //
-//	And a trap does no hardware work
+//      And a trap does no hardware work
 //
 was_trap:
 //
-//	Look at rescheduling
+//      Look at rescheduling
 //
-	cmpw	$1,_gint_count
-	jne	restore_regs	// No
-//	cmp	$0,_need_resched // Schedule needed ?
-//	je	restore_regs	// No
+        cmpw    $1,_gint_count
+        jne     restore_regs    // No
+//      cmp     $0,_need_resched // Schedule needed ?
+//      je      restore_regs    // No
 //
 // This path will return directly to user space
 //
-	sti			// Enable interrupts to help fast devices
-	call	schedule	// Task switch
-	call	do_signal	// Check signals
-	cli
+        sti                     // Enable interrupts to help fast devices
+        call    schedule        // Task switch
+        call    do_signal       // Check signals
+        cli
 //
-//	Restore registers and return
+//      Restore registers and return
 //
 restore_regs:
-	decw	_gint_count
-	pop	%ax
-	pop	%bx
-	pop	%cx
-	pop	%dx
-	pop	%di
-	pop	%si
-	pop	%bp		// discard orig_AX
-	pop	%es
-	pop	%ds
-	pop	%bp		// SP
-	pop	%ss
-	mov	%bp,%sp
-	pop	%bp		// user BP
+        decw    _gint_count
+        pop     %ax
+        pop     %bx
+        pop     %cx
+        pop     %dx
+        pop     %di
+        pop     %si
+        pop     %bp             // discard orig_AX
+        pop     %es
+        pop     %ds
+        pop     %bp             // SP
+        pop     %ss
+        mov     %bp,%sp
+        pop     %bp             // user BP
 //
-//	Iret restores CS:IP and F (thus including the interrupt bit)
+//      Iret restores CS:IP and F (thus including the interrupt bit)
 //
-	iret
+        iret
 
 /*
- *	tswitch()
+ *      tswitch()
  *
- *	This function can only be called with SS=DS=kernel DS and
- *	CS=kernel CS. SS:SP is the relevant kernel stack. Thus we don't need
- *	to arse about with segment registers. The kernel isn't relocating.
+ *      This function can only be called with SS=DS=kernel DS and
+ *      CS=kernel CS. SS:SP is the relevant kernel stack. Thus we don't need
+ *      to arse about with segment registers. The kernel isn't relocating.
  *
- *	tswitch() saves the "previous" task registers and state. It in effect
- *	freezes a copy of the caller context. Then restores the "current"
- *	context and returns running the current task.
+ *      tswitch() saves the "previous" task registers and state. It in effect
+ *      freezes a copy of the caller context. Then restores the "current"
+ *      context and returns running the current task.
  */
 
-	.global	tswitch
+        .global tswitch
 tswitch:
-	push	%bp		// schedule()'s bp
-	push	%es		// required for gcc-ia16
-	push	%di
-	push	%si
-	mov	previous,%bx
-	mov	%sp,TASK_KRNL_SP(%bx)
-	mov	current,%bx
-	mov	TASK_KRNL_SP(%bx),%sp
-	pop	%si
-	pop	%di
-	pop	%es
-	pop	%bp		// BP of schedule()
-	ret
+        push    %bp             // schedule()'s bp
+        push    %es             // required for gcc-ia16
+        push    %di
+        push    %si
+        mov     previous,%bx
+        mov     %sp,TASK_KRNL_SP(%bx)
+        mov     current,%bx
+        mov     TASK_KRNL_SP(%bx),%sp
+        pop     %si
+        pop     %di
+        pop     %es
+        pop     %bp             // BP of schedule()
+        ret
 
 // setsp(void *sp) - set stack pointer
-	.global setsp
+        .global setsp
 setsp:
-	pop	%bx		// return address
-	pop	%ax
-	mov	%ax,%sp
-	jmp	*%bx
+        pop     %bx             // return address
+        pop     %ax
+        mov     %ax,%sp
+        jmp     *%bx
 
 // Halt - wait for next interrupt to save CPU power
-	.global idle_halt
+        .global idle_halt
 idle_halt:
-	hlt
-	ret
+        hlt
+        ret
 
         .global div0_handler_panic
 // Divide Fault hander - just panic for now
@@ -406,46 +406,46 @@ div0_handler_panic:
         mov     %sp,%bx
         mov     %ss:12(%bx),%ds
 
-	mov	$dmsg,%ax
-	push	%ax
-	call    panic
-	pop	%ax
-1:	hlt
-	jmp	1b
+        mov     $dmsg,%ax
+        push    %ax
+        call    panic
+        pop     %ax
+1:      hlt
+        jmp     1b
 
 //      pop     %ds                     // restore regs
 //      pop     %dx
 //      pop     %cx
 //      pop     %bx
 //      pop     %ax
-//      add     $4,%sp          	// skip the trampoline lcall
+//      add     $4,%sp                  // skip the trampoline lcall
 //      iret
 
-	.data
-	.global	_gint_count
-	.global	endistack
-	.global	endtstack
-	.global	istack
-	.global	tstack
-	.extern	current
-	.extern	previous
+        .data
+        .global _gint_count
+        .global endistack
+        .global endtstack
+        .global istack
+        .global tstack
+        .extern current
+        .extern previous
 
 bios_call_cnt:                  // call BIOS IRQ 0 handler every 5th interrupt
-	.word	5
-org_irq0:			// original BIOS IRQ 0 vector
-	.long	0
-_gint_count:			// General interrupts count. Start with 1
-	.word	1		// because init_task() is in kernel mode
+        .word   5
+org_irq0:                       // original BIOS IRQ 0 vector
+        .long   0
+_gint_count:                    // General interrupts count. Start with 1
+        .word   1               // because init_task() is in kernel mode
 #ifdef CHECK_SS
-pmsg:	.ascii "Running unknown code\0"
+pmsg:   .ascii "Running unknown code\0"
 #endif
-dmsg:	.ascii 	"DIVIDE FAULT\0"
+dmsg:   .ascii  "DIVIDE FAULT\0"
 
-	.p2align 1
+        .p2align 1
 endistack:
-	.skip ISTACK_BYTES,0	// interrupt stack
+        .skip ISTACK_BYTES,0    // interrupt stack
 istack:
 
 endtstack:
-	.skip TSTACK_BYTES,0	// startup temp stack
+        .skip TSTACK_BYTES,0    // startup temp stack
 tstack:

--- a/elks/arch/i86/kernel/strace.h
+++ b/elks/arch/i86/kernel/strace.h
@@ -53,25 +53,25 @@
  *  2+           Data Type
  */
 
-#define P_NONE		  0	/* No parameters                        */
-#define P_DATA		  1	/* Generic Data                         */
-#define P_POINTER	  2	/* Generic Data Pointer                 */
-#define P_PDATA 	  3	/* Pointer to Generic Data              */
+#define P_NONE            0     /* No parameters                        */
+#define P_DATA            1     /* Generic Data                         */
+#define P_POINTER         2     /* Generic Data Pointer                 */
+#define P_PDATA           3     /* Pointer to Generic Data              */
 
-#define P_UCHAR 	  4	/* Unsigned Char                        */
-#define P_SCHAR 	  5	/* Signed Char                          */
-#define P_STR		  6	/* String                               */
-#define P_PSTR  	  7	/* Pointer to String                    */
+#define P_UCHAR           4     /* Unsigned Char                        */
+#define P_SCHAR           5     /* Signed Char                          */
+#define P_STR             6     /* String                               */
+#define P_PSTR            7     /* Pointer to String                    */
 
-#define P_USHORT	  8	/* Unsigned Short Int                   */
-#define P_SSHORT	  9	/* Signed Short Int                     */
-#define P_PUSHORT 	 10	/* Pointer to Unsigned Short Int        */
-#define P_PSSHORT 	 11	/* Pointer to Signed Short Int          */
+#define P_USHORT          8     /* Unsigned Short Int                   */
+#define P_SSHORT          9     /* Signed Short Int                     */
+#define P_PUSHORT        10     /* Pointer to Unsigned Short Int        */
+#define P_PSSHORT        11     /* Pointer to Signed Short Int          */
 
-#define P_ULONG 	 12	/* Unsigned Long Int                    */
-#define P_SLONG 	 13	/* Signed Long Int                      */
-#define P_PULONG 	 14	/* Pointer to Unsigned Long Int         */
-#define P_PSLONG	 15	/* Pointer to Signed Long Int           */
+#define P_ULONG          12     /* Unsigned Long Int                    */
+#define P_SLONG          13     /* Signed Long Int                      */
+#define P_PULONG         14     /* Pointer to Unsigned Long Int         */
+#define P_PSLONG         15     /* Pointer to Signed Long Int           */
 
 #define ENTRY(name, info)   { name, info }
 #define packinfo(n, a, b, c) (unsigned)(n | (a << 4) | (b << 8) | (c << 12))

--- a/elks/arch/i86/kernel/system.c
+++ b/elks/arch/i86/kernel/system.c
@@ -13,65 +13,65 @@
 #include <arch/io.h>
 
 seg_t membase, memend;  /* start and end segment of available main memory */
-unsigned int heapsize;	/* max size of kernel near heap */
+unsigned int heapsize;  /* max size of kernel near heap */
 byte_t sys_caps;        /* system capabilities bits */
 
 unsigned int INITPROC setup_arch(void)
 {
-	unsigned int endbss, heapsegs;
+    unsigned int endbss, heapsegs;
 
 #ifdef CONFIG_HW_COMPAQFAST
-	outb_p(1,0xcf);	/* Switch COMPAQ Deskpro to high speed */
+    outb_p(1,0xcf); /* Switch COMPAQ Deskpro to high speed */
 #endif
 
-	/*
-	 * Extend kernel data segment to maximum of 64K to make room for local heap.
-	 *
-	 * Set membase to beginning of available main memory, which
-	 * is directly after end of the kernel data segment.
-	 *
-	 * Set memend to end of available main memory.
-	 * If ramdisk configured, subtract space for it from end of memory.
-	 *
-	 * Calculate heapsize for near heap allocator.
-	 * Return start address for near heap allocator.
-	 */
+    /*
+     * Extend kernel data segment to maximum of 64K to make room for local heap.
+     *
+     * Set membase to beginning of available main memory, which
+     * is directly after end of the kernel data segment.
+     *
+     * Set memend to end of available main memory.
+     * If ramdisk configured, subtract space for it from end of memory.
+     *
+     * Calculate heapsize for near heap allocator.
+     * Return start address for near heap allocator.
+     */
 
-	/* Start heap allocations at even addresses */
-	endbss = (unsigned int)(_endbss + 1) & ~1;
+    /* Start heap allocations at even addresses */
+    endbss = (unsigned int)(_endbss + 1) & ~1;
 
-	/* Calculate size of heap, which extends end of kernel data segment */
+    /* Calculate size of heap, which extends end of kernel data segment */
 #ifdef SETUP_HEAPSIZE
-	heapsize = SETUP_HEAPSIZE;			/* may also be set via heap= in /bootopts */
+    heapsize = SETUP_HEAPSIZE;          /* may also be set via heap= in /bootopts */
 #endif
-	if (heapsize) {
-		heapsegs = (1 + ~endbss) >> 4;	/* max possible heap in segments*/
-		if ((heapsize >> 4) < heapsegs)	/* allow if less than max*/
-			heapsegs = heapsize >> 4;
-		membase = kernel_ds + heapsegs + (((unsigned int) (_endbss+15)) >> 4);
-		heapsize = heapsegs << 4;
-	} else {
-		membase = kernel_ds + 0x1000;
-		heapsize = 1 + ~endbss;
-	}
-	debug("endbss %x heap %x kdata size %x\n", endbss, heapsize, (membase-kernel_ds)<<4);
+    if (heapsize) {
+        heapsegs = (1 + ~endbss) >> 4;  /* max possible heap in segments*/
+        if ((heapsize >> 4) < heapsegs) /* allow if less than max*/
+            heapsegs = heapsize >> 4;
+        membase = kernel_ds + heapsegs + (((unsigned int) (_endbss+15)) >> 4);
+        heapsize = heapsegs << 4;
+    } else {
+        membase = kernel_ds + 0x1000;
+        heapsize = 1 + ~endbss;
+    }
+    debug("endbss %x heap %x kdata size %x\n", endbss, heapsize, (membase-kernel_ds)<<4);
 
-	memend = SETUP_MEM_KBYTES << 6;
+    memend = SETUP_MEM_KBYTES << 6;
 
 #if defined(CONFIG_RAMDISK_SEGMENT) && (CONFIG_RAMDISK_SEGMENT > 0)
-	if (CONFIG_RAMDISK_SEGMENT <= memend) {
-		/* reduce top of memory by size of ram disk*/
-		memend -= CONFIG_RAMDISK_SECTORS << 5;
-	}
+    if (CONFIG_RAMDISK_SEGMENT <= memend) {
+        /* reduce top of memory by size of ram disk*/
+        memend -= CONFIG_RAMDISK_SECTORS << 5;
+    }
 #endif
 
 #ifdef SYS_CAPS
-	sys_caps = SYS_CAPS;	/* custom system capabilities */
+    sys_caps = SYS_CAPS;    /* custom system capabilities */
 #else
-	byte_t arch_cpu = SETUP_CPU_TYPE;
-	if (arch_cpu > 5)		/* IBM PC/AT capabilities */
-		sys_caps = CAP_ALL;
-	debug("arch %d sys_caps %02x\n", arch_cpu, sys_caps);
+    byte_t arch_cpu = SETUP_CPU_TYPE;
+    if (arch_cpu > 5)       /* IBM PC/AT capabilities */
+        sys_caps = CAP_ALL;
+    debug("arch %d sys_caps %02x\n", arch_cpu, sys_caps);
 #endif
 
     return endbss;                      /* used as start address in near heap init */
@@ -94,35 +94,35 @@ void hard_reset_now(void)
 {
 #ifdef CONFIG_ARCH_IBMPC
     asm("mov $0x40,%ax\n\t"
-	"mov %ax,%ds\n\t"
-	"movw $0x1234,0x72\n\t"
-	"ljmp $0xFFFF,$0\n\t"
-	);
+        "mov %ax,%ds\n\t"
+        "movw $0x1234,0x72\n\t"
+        "ljmp $0xFFFF,$0\n\t"
+    );
 #endif
 }
 
 /*
- *	Use Advanced Power Management to power off system
- *	For details on how this code works, see
- *	http://wiki.osdev.org/APM
+ *  Use Advanced Power Management to power off system
+ *  For details on how this code works, see
+ *  http://wiki.osdev.org/APM
  */
 void apm_shutdown_now(void)
 {
 #ifdef CONFIG_ARCH_IBMPC
     asm("movw $0x5301,%ax\n\t"
-	"xorw %bx,%bx\n\t"
-	"int $0x15\n\t"
-	"jc apm_error\n\t"
-	"movw $0x5308,%ax\n\t"
-	"movw $1,%bx\n\t"
-	"movw $1,%cx\n\t"
-	"int $0x15\n\t"
-	"jc apm_error\n\t"
-	"movw $0x5307,%ax\n\t"
-	"movw $1,%bx\n\t"
-	"movw $3,%cx\n\t"
-	"int $0x15\n\t"
-	"apm_error:\n\t"
-	);
+        "xorw %bx,%bx\n\t"
+        "int $0x15\n\t"
+        "jc apm_error\n\t"
+        "movw $0x5308,%ax\n\t"
+        "movw $1,%bx\n\t"
+        "movw $1,%cx\n\t"
+        "int $0x15\n\t"
+        "jc apm_error\n\t"
+        "movw $0x5307,%ax\n\t"
+        "movw $1,%bx\n\t"
+        "movw $3,%cx\n\t"
+        "int $0x15\n\t"
+        "apm_error:\n\t"
+    );
 #endif
 }

--- a/elks/arch/i86/kernel/timer-8254.c
+++ b/elks/arch/i86/kernel/timer-8254.c
@@ -51,19 +51,19 @@ void enable_timer_tick(void)
     outb (TIMER_MODE2, TIMER_CMDS_PORT);
 
 #ifdef CONFIG_ARCH_IBMPC
-    outb (TIMER_LO_BYTE, TIMER_DATA_PORT);	/* LSB */
-    outb (TIMER_HI_BYTE, TIMER_DATA_PORT);	/* MSB */
+    outb (TIMER_LO_BYTE, TIMER_DATA_PORT);      /* LSB */
+    outb (TIMER_HI_BYTE, TIMER_DATA_PORT);      /* MSB */
 #endif
 
 #ifdef CONFIG_ARCH_PC98
     if (peekb(0x501, 0) & 0x80) {
-	printk("Timer clock frequncy for 8MHz system is set.\n");
-	outb (TIMER_LO_BYTE_8M, TIMER_DATA_PORT);   /* LSB */
-	outb (TIMER_HI_BYTE_8M, TIMER_DATA_PORT);   /* MSB */
+        printk("Timer clock frequncy for 8MHz system is set.\n");
+        outb (TIMER_LO_BYTE_8M, TIMER_DATA_PORT);   /* LSB */
+        outb (TIMER_HI_BYTE_8M, TIMER_DATA_PORT);   /* MSB */
     } else {
-	printk("Timer clock frequncy for 5MHz system is set.\n");
-	outb (TIMER_LO_BYTE_5M, TIMER_DATA_PORT);   /* LSB */
-	outb (TIMER_HI_BYTE_5M, TIMER_DATA_PORT);   /* MSB */
+        printk("Timer clock frequncy for 5MHz system is set.\n");
+        outb (TIMER_LO_BYTE_5M, TIMER_DATA_PORT);   /* LSB */
+        outb (TIMER_HI_BYTE_5M, TIMER_DATA_PORT);   /* MSB */
     }
 #endif
 }

--- a/elks/arch/i86/tools/build.c
+++ b/elks/arch/i86/tools/build.c
@@ -16,11 +16,11 @@
  * the right amount. It also writes some system data to stderr.
  */
 
-#include <stdio.h>			/* fprintf */
-#include <sys/types.h>			/* unistd.h needs this */
+#include <stdio.h>                      /* fprintf */
+#include <sys/types.h>                  /* unistd.h needs this */
 #include <string.h>
-#include <stdlib.h>			/* contains exit */
-#include <unistd.h>			/* contains read/write */
+#include <stdlib.h>                     /* contains exit */
+#include <unistd.h>                     /* contains read/write */
 #include <fcntl.h>
 #include <stdint.h>
 
@@ -100,103 +100,103 @@ int main(int argc, char **argv)
     minor_root = DEFAULT_MINOR_ROOT;
     fprintf(stderr, "Root device is (%d, %d)\n", major_root, minor_root);
     for (i = 0; i < sizeof buf; i++)
-	buf[i] = 0;
+        buf[i] = 0;
 #ifdef USEDUMMYBOOT
     if ((id = open(argv[1], O_RDONLY, 0)) < 0)
-	die("Unable to open 'boot'");
+        die("Unable to open 'boot'");
     if (read(id, buf, MINIX_HEADER) != MINIX_HEADER)
-	die("Unable to read header of 'boot'");
+        die("Unable to read header of 'boot'");
     if (((uint32_t *) buf)[0] != intel_long(0x04100301))
-	die("Non-Minix header of 'boot'");
+        die("Non-Minix header of 'boot'");
     if (((uint32_t *) buf)[1] != intel_long(MINIX_HEADER))
-	die("Non-Minix header of 'boot'");
+        die("Non-Minix header of 'boot'");
     if (((uint32_t *) buf)[3] != 0)
-	die("Illegal data segment in 'boot'");
+        die("Illegal data segment in 'boot'");
     if (((uint32_t *) buf)[4] != 0)
-	die("Illegal bss in 'boot'");
+        die("Illegal bss in 'boot'");
     if (((uint32_t *) buf)[5] != 0)
-	die("Non-Minix header of 'boot'");
+        die("Non-Minix header of 'boot'");
     if (((uint32_t *) buf)[7] != 0)
-	die("Illegal symbol table in 'boot'");
+        die("Illegal symbol table in 'boot'");
     i = read(id, buf, sizeof buf);
     fprintf(stderr, "Boot sector %d bytes.\n", i);
     if (i != 512)
-	die("Boot block must be exactly 512 bytes");
+        die("Boot block must be exactly 512 bytes");
     if ((*(unsigned short *) (buf + 510)) !=
-	(unsigned short) intel_short(0xAA55))
-	    die("Boot block hasn't got boot flag (0xAA55)");
+        (unsigned short) intel_short(0xAA55))
+            die("Boot block hasn't got boot flag (0xAA55)");
     close(id);
 #endif
-    buf[root_dev] = (char) minor_root;		/* WRITE root_dev*/
+    buf[root_dev] = (char) minor_root;          /* WRITE root_dev*/
     buf[root_dev+1] = (char) major_root;
     i = write(1, buf, 512);                     /* this sector becomes INITSEG */
     if (i != 512)
-	die("Write call failed");
+        die("Write call failed");
 
     if ((id = open(argv[2], O_RDONLY, 0)) < 0)
-	die("Unable to open 'setup'");
+        die("Unable to open 'setup'");
     if (read(id, buf, MINIX_HEADER) != MINIX_HEADER)
-	die("Unable to read header of 'setup'");
+        die("Unable to read header of 'setup'");
     if (((uint32_t *) buf)[0] != intel_long(0x04100301))
-	die("Non-Minix header of 'setup'");
+        die("Non-Minix header of 'setup'");
     if (((uint32_t *) buf)[1] != intel_long(MINIX_HEADER))
-	die("Non-Minix header of 'setup'");
+        die("Non-Minix header of 'setup'");
     if (((uint32_t *) buf)[3] != 0)
-	die("Illegal data segment in 'setup'");
+        die("Illegal data segment in 'setup'");
     if (((uint32_t *) buf)[4] != 0)
-	die("Illegal bss in 'setup'");
+        die("Illegal bss in 'setup'");
     if (((uint32_t *) buf)[5] != 0)
-	die("Non-Minix header of 'setup'");
+        die("Non-Minix header of 'setup'");
     if (((uint32_t *) buf)[7] != 0)
-	die("Illegal symbol table in 'setup'");
+        die("Illegal symbol table in 'setup'");
     for (i = 0; (c = read(id, buf, sizeof buf)) > 0; i += c)
-	if (write(1, buf, c) != c)
-	    die("Write call failed");
+        if (write(1, buf, c) != c)
+            die("Write call failed");
     if (c != 0)
-	die("read-error on 'setup'");
+        die("read-error on 'setup'");
     close(id);
     setup_sectors = (unsigned char) ((i + 511) / 512);
     /* for compatibility with LILO */
     if (setup_sectors < SETUP_SECTS)
-	setup_sectors = SETUP_SECTS;
+        setup_sectors = SETUP_SECTS;
     fprintf(stderr, "Setup is %d bytes (%d sectors).\n", i, setup_sectors);
     for (c = 0; c < sizeof(buf); c++)
-	buf[c] = '\0';
+        buf[c] = '\0';
     while (i < setup_sectors * 512) {
-	c = setup_sectors * 512 - i;
-	if (c > sizeof(buf))
-	    c = sizeof(buf);
-	if (write(1, buf, c) != c)
-	    die("Write call failed");
-	i += c;
+        c = setup_sectors * 512 - i;
+        if (c > sizeof(buf))
+            c = sizeof(buf);
+        if (write(1, buf, c) != c)
+            die("Write call failed");
+        i += c;
     }
 
     if ((id = open(argv[3], O_RDONLY, 0)) < 0)
-	die("Unable to open 'system'");
+        die("Unable to open 'system'");
 
     if (read(id, buf, SUPL_HEADER) != SUPL_HEADER)
-	die("Unable to read header of 'system'");
+        die("Unable to read header of 'system'");
     if ((ex->a_magic[0] != 0x01) || (ex->a_magic[1] != 0x03)) {
-	die("Non-MINIX header of 'system'");
+        die("Non-MINIX header of 'system'");
     }
     fsz = 0;
     sz = intel_long(ex->a_text) + intel_long(ex->a_data) + intel_long(ex->a_bss);
     if (ex->a_hdrlen == SUPL_HEADER) {
-	fsz = intel_long(ex->esh_ftseg);
-	sz += fsz;
+        fsz = intel_long(ex->esh_ftseg);
+        sz += fsz;
     }
     fprintf(stderr, "Kernel is %d B (%d B code, %d B fartext, %d B data and %u B bss)\n",
-	sz, intel_long(ex->a_text), fsz,
-	intel_long(ex->a_data), (unsigned) intel_long(ex->a_bss));
+        sz, intel_long(ex->a_text), fsz,
+        intel_long(ex->a_data), (unsigned) intel_long(ex->a_bss));
     sz = ex->a_hdrlen + intel_long(ex->a_text) + intel_long(ex->a_data);
     if (ex->a_hdrlen == SUPL_HEADER) {
-	    sz += fsz;
-	    sz += intel_long(ex->a_trsize) + intel_long(ex->a_drsize)
-	       + intel_long(ex->esh_ftrsize);
+            sz += fsz;
+            sz += intel_long(ex->a_trsize) + intel_long(ex->a_drsize)
+               + intel_long(ex->esh_ftrsize);
     }
     if (intel_long(ex->a_data) + intel_long(ex->a_bss) > 65535) {
-	fprintf(stderr, "Image too large.\n");
-	exit(1);
+        fprintf(stderr, "Image too large.\n");
+        exit(1);
     }
 
     lseek(id, 0, 0);
@@ -204,7 +204,7 @@ int main(int argc, char **argv)
     sys_size = (sz + 15) / 16;
     fprintf(stderr, "System is %d B (0x%x paras)\n", sz, sys_size);
     if (sys_size > DEF_SYSMAX)
-	die("System is too big");
+        die("System is too big");
 #ifndef CONFIG_ROMCODE
     /* display start and end setup.S copy address for informational purposes */
     fsz = (ex->a_hdrlen + (intel_long(ex->a_text) + intel_long(ex->a_data)) + 15) / 16;
@@ -215,40 +215,40 @@ int main(int argc, char **argv)
     fsz += REL_SYSSEG;
     fprintf(stderr, "Load segment start 0x%x end 0x%x\n", DEF_SYSSEG, fsz);
     if (DEF_SYSSEG < REL_SYSSEG + 0x1000) {
-	fprintf(stderr, "Warning: Load segment too low for REL_SYSSEG at %x, increase DEF_SYSSEG\n", REL_SYSSEG);
+        fprintf(stderr, "Warning: Load segment too low for REL_SYSSEG at %x, increase DEF_SYSSEG\n", REL_SYSSEG);
     }
 #endif
     while (sz > 0) {
-	int32_t l, n;
+        int32_t l, n;
 
-	l = sz;
-	if (l > sizeof(buf))
-	    l = sizeof(buf);
-	if ((n = read(id, buf, l)) != l) {
-	    if (n == -1)
-		perror(argv[1]);
-	    else
-		fprintf(stderr, "Unexpected EOF\n");
-	    die("Can't read 'system'");
-	}
-	if (write(1, buf, l) != l)
-	    die("Write failed");
-	sz -= l;
+        l = sz;
+        if (l > sizeof(buf))
+            l = sizeof(buf);
+        if ((n = read(id, buf, l)) != l) {
+            if (n == -1)
+                perror(argv[1]);
+            else
+                fprintf(stderr, "Unexpected EOF\n");
+            die("Can't read 'system'");
+        }
+        if (write(1, buf, l) != l)
+            die("Write failed");
+        sz -= l;
     }
     close(id);
     if (lseek(1, elks_magic, 0) == elks_magic) {
-	if (write(1, "ELKS", 4) != 4)                   /* WRITE elks_magic */
-	    die("Write failed");
+        if (write(1, "ELKS", 4) != 4)                   /* WRITE elks_magic */
+            die("Write failed");
     }
     if (lseek(1, setup_sects, 0) == setup_sects) {
-	if (write(1, &setup_sectors, 1) != 1)		/* WRITE setup_sectors*/
-	    die("Write of setup sectors failed");
+        if (write(1, &setup_sectors, 1) != 1)           /* WRITE setup_sectors*/
+            die("Write of setup sectors failed");
     }
     if (lseek(1, syssize, 0) == syssize) {
-	buf[0] = (sys_size & 0xff);			/* WRITE sys_size*/
-	buf[1] = ((sys_size >> 8) & 0xff);
-	if (write(1, buf, 2) != 2)
-	    die("Write failed");
+        buf[0] = (sys_size & 0xff);                     /* WRITE sys_size*/
+        buf[1] = ((sys_size >> 8) & 0xff);
+        if (write(1, buf, 2) != 2)
+            die("Write failed");
     }
     return 0;
 }

--- a/elks/fs/select.c
+++ b/elks/fs/select.c
@@ -52,34 +52,34 @@ struct wait_queue select_queue;  /* magic queue - see sleepwake.c */
 
 void select_wait (struct wait_queue *q)
 {
-	int n;
-	struct wait_queue **p;
+    int n;
+    struct wait_queue **p;
 
-	for (n = 0; n < MAX_POLLFD; n++) {
-		p = &(current->poll [n]);
-		if (!*p) {
-			*p = q;
-			return;
-		}
-	}
+    for (n = 0; n < MAX_POLLFD; n++) {
+        p = &(current->poll [n]);
+        if (!*p) {
+            *p = q;
+            return;
+        }
+    }
 
-	panic ("select_wait");      /* no slot left */
+    panic ("select_wait");      /* no slot left */
 }
 
 /* Return true if queue is polled */
 
 int select_poll (struct task_struct * t, struct wait_queue *q)
 {
-	int n;
-	struct wait_queue *p;
+    int n;
+    struct wait_queue *p;
 
-	for (n = 0; n < MAX_POLLFD; n++) {
-		p = t->poll [n];
-		if (!p) return 0;
-		if (p == q) return 1;
-	}
+    for (n = 0; n < MAX_POLLFD; n++) {
+        p = t->poll [n];
+        if (!p) return 0;
+        if (p == q) return 1;
+    }
 
-	panic ("select_poll");      /* no slot found */
+    panic ("select_poll");      /* no slot found */
 }
 
 /*
@@ -104,13 +104,13 @@ static int check(int flag, register struct file *file)
     register struct file_operations *fops;
 
     if ((fops = file->f_op) && fops->select)
-	return (fops->select(file->f_inode, file, flag));
+        return (fops->select(file->f_inode, file, flag));
 
     return (flag != SEL_EX);
 }
 
 static int do_select(int n, fd_set * in, fd_set * out, fd_set * ex,
-		     fd_set * res_in, fd_set * res_out, fd_set * res_ex)
+                     fd_set * res_in, fd_set * res_out, fd_set * res_ex)
 {
     fd_set set;
     int count = -1;
@@ -120,11 +120,11 @@ static int do_select(int n, fd_set * in, fd_set * out, fd_set * ex,
     set = *in | *out | *ex;
     filp = current->files.fd;
     for (i = 0; set && (i < n); i++, set >>= 1) {
-	if ((int)set & 1) {
-	    if ((*filp == NULL) || ((*filp)->f_inode == NULL)) return -EBADF;
-	    count = i;
-	}
-	filp++;
+        if ((int)set & 1) {
+            if ((*filp == NULL) || ((*filp)->f_inode == NULL)) return -EBADF;
+            count = i;
+        }
+        filp++;
     }
     n = count + 1;
     count = 0;
@@ -138,25 +138,25 @@ static int do_select(int n, fd_set * in, fd_set * out, fd_set * ex,
     memset (current->poll, 0, sizeof (struct wait_queue *) * MAX_POLLFD);
     filp = current->files.fd;
     for (i = 0; i < n; i++, filp++) {
-	if (*filp) {
-	    if (FD_ISSET(i, in) && check(SEL_IN, *filp)) {
-		FD_SET(i, res_in);
-		count++;
-	    }
-	    if (FD_ISSET(i, out) && check(SEL_OUT, *filp)) {
-		FD_SET(i, res_out);
-		count++;
-	    }
-	    if (FD_ISSET(i, ex) && check(SEL_EX, *filp)) {
-		FD_SET(i, res_ex);
-		count++;
-	    }
-	}
+        if (*filp) {
+            if (FD_ISSET(i, in) && check(SEL_IN, *filp)) {
+                FD_SET(i, res_in);
+                count++;
+            }
+            if (FD_ISSET(i, out) && check(SEL_OUT, *filp)) {
+                FD_SET(i, res_out);
+                count++;
+            }
+            if (FD_ISSET(i, ex) && check(SEL_EX, *filp)) {
+                FD_SET(i, res_ex);
+                count++;
+            }
+        }
     }
     if (!count && current->timeout && !(current->signal /* & ~currentp->blocked */ )) {
-	debug_sched("select(%P): timeout %lx\n", current->timeout);
-	schedule();
-	goto repeat;
+        debug_sched("select(%P): timeout %lx\n", current->timeout);
+        schedule();
+        goto repeat;
     }
 
     memset (current->poll, 0, sizeof (struct wait_queue *) * MAX_POLLFD);
@@ -173,8 +173,8 @@ static int do_select(int n, fd_set * in, fd_set * out, fd_set * ex,
 static int get_fd_set(register fd_set * fs_pointer, register fd_set * fdset)
 {
     if (fs_pointer)
-	return verified_memcpy_fromfs((char *) fdset, fs_pointer,
-				      sizeof(fd_set));
+        return verified_memcpy_fromfs((char *) fdset, fs_pointer,
+                                      sizeof(fd_set));
 
     memset(fdset, 0, sizeof(fd_set));
     return 0;
@@ -192,7 +192,7 @@ static void zero_fd_set(fd_set * fdset)
 
 
 int sys_select(int n, fd_set * inp, fd_set * outp, fd_set * exp,
-	       register struct timeval *tvp)
+               register struct timeval *tvp)
 {
     int error;
     fd_set res_in, in;
@@ -203,16 +203,16 @@ int sys_select(int n, fd_set * inp, fd_set * outp, fd_set * exp,
     if (n > NR_OPEN) n = NR_OPEN;
     error = -EINVAL;
     if ((n < 0) || (error = get_fd_set(inp, &in)) ||
-	(error = get_fd_set(outp, &out)) || (error = get_fd_set(exp, &ex)))
-	goto outl;
+        (error = get_fd_set(outp, &out)) || (error = get_fd_set(exp, &ex)))
+        goto outl;
     timeout = ~0UL;
     if (tvp) {
-	error = verify_area(VERIFY_WRITE, tvp, sizeof(*tvp));
-	if (error) goto outl;
+        error = verify_area(VERIFY_WRITE, tvp, sizeof(*tvp));
+        if (error) goto outl;
 
-	timeout = ROUND_UP(get_user_long(&tvp->tv_usec), (1000000 / HZ));
-	timeout += get_user_long(&tvp->tv_sec) * (jiff_t) HZ;
-	if (timeout) timeout += jiffies + 1UL;
+        timeout = ROUND_UP(get_user_long(&tvp->tv_usec), (1000000 / HZ));
+        timeout += get_user_long(&tvp->tv_sec) * (jiff_t) HZ;
+        if (timeout) timeout += jiffies + 1UL;
     }
     zero_fd_set(&res_in);
     zero_fd_set(&res_out);
@@ -222,13 +222,13 @@ int sys_select(int n, fd_set * inp, fd_set * outp, fd_set * exp,
 
     current->timeout = 0UL;
     if (!error && (current->signal /* & ~current->blocked */ ))
-	error = -EINTR;
-	else {
-		/* update arrays even after timeout - see issue #213 */
-		set_fd_set(inp, &res_in);
-		set_fd_set(outp, &res_out);
-		set_fd_set(exp, &res_ex);
-	}
+        error = -EINTR;
+        else {
+                /* update arrays even after timeout - see issue #213 */
+                set_fd_set(inp, &res_in);
+                set_fd_set(outp, &res_out);
+                set_fd_set(exp, &res_ex);
+        }
 
   outl:
     return error;

--- a/elks/include/linuxmt/boot.h
+++ b/elks/include/linuxmt/boot.h
@@ -6,25 +6,25 @@
  */
 
 /* Root flags */
-#define RF_NONE 	0
-#define RF_RO		1
+#define RF_NONE         0
+#define RF_RO           1
 
-#define ROOTFLAGS	RF_NONE
+#define ROOTFLAGS       RF_NONE
 
 /* ELKS flags */
-#define EF_NONE		0
-#define EF_AS_BLOB	0x01		/* says that setup and kernel are
-					   loaded as one blob at SETUPSEG:0,
-					   and setup may need to move kernel
-					   to SYSSEG:0 */
-#define EF_BIOS_DEV_NUM	0x02		/* says that root_dev does not give
-					   a <major, minor> block device
-					   number, but only a BIOS drive
-					   number (and possibly other
-					   information); setup or kernel
-					   should use this drive number to
-					   figure out the correct root
-					   device */
+#define EF_NONE         0
+#define EF_AS_BLOB      0x01            /* says that setup and kernel are
+                                           loaded as one blob at SETUPSEG:0,
+                                           and setup may need to move kernel
+                                           to SYSSEG:0 */
+#define EF_BIOS_DEV_NUM 0x02            /* says that root_dev does not give
+                                           a <major, minor> block device
+                                           number, but only a BIOS drive
+                                           number (and possibly other
+                                           information); setup or kernel
+                                           should use this drive number to
+                                           figure out the correct root
+                                           device */
 
 /* If we are not building the (dummy) boot sector (elks/elks/arch/i86/boot/
    {bootsect.S, netbootsect.S}) at the start of /linux, then define
@@ -44,19 +44,19 @@
    Fields which are specific to ELKS are indicated below.  */
 
 #ifndef DUMMYBOOT
-#define screen_cols	7		/* byte screen width*/
-#define screen_lines	14		/* byte screen height*/
-#define cpu_type	0x20		/* byte cpu type*/
-#define mem_kbytes	0x2a		/* word base memory size in Kbytes*/
-#define proc_name	0x30		/* 16 bytes processor name string*/
-#define cpu_id		0x50		/* 13 bytes cpu id string*/
-#define part_offset	0x1e2		/* long sector offset of booted partition*/
-#define elks_magic	0x1e6		/* long "ELKS" (45 4c 4b 53) checked by boot sector*/
-#define setup_sects	0x1f1		/* byte 512-byte sectors used by setup.S*/
-#define syssize		0x1f4		/* word paragraph kernel size used by setup.S*/
-#define elks_flags	0x1f6		/* byte ELKS flags, BLOB and BIOS_DRV*/
-#define root_dev	0x1fc		/* word BIOS drive or kdev_t ROOT_DEV*/
-#define boot_flag	0x1fe		/* word constant AA55h checked by boot sector*/
+#define screen_cols     7               /* byte screen width*/
+#define screen_lines    14              /* byte screen height*/
+#define cpu_type        0x20            /* byte cpu type*/
+#define mem_kbytes      0x2a            /* word base memory size in Kbytes*/
+#define proc_name       0x30            /* 16 bytes processor name string*/
+#define cpu_id          0x50            /* 13 bytes cpu id string*/
+#define part_offset     0x1e2           /* long sector offset of booted partition*/
+#define elks_magic      0x1e6           /* long "ELKS" (45 4c 4b 53) checked by boot sector*/
+#define setup_sects     0x1f1           /* byte 512-byte sectors used by setup.S*/
+#define syssize         0x1f4           /* word paragraph kernel size used by setup.S*/
+#define elks_flags      0x1f6           /* byte ELKS flags, BLOB and BIOS_DRV*/
+#define root_dev        0x1fc           /* word BIOS drive or kdev_t ROOT_DEV*/
+#define boot_flag       0x1fe           /* word constant AA55h checked by boot sector*/
 #endif
 
 #endif

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -22,15 +22,15 @@
 #include <arch/io.h>
 
 /*
- *	System variable setups
+ *  System variable setups
  */
 #define ENV             1       /* allow environ variables as bootopts*/
 #define DEBUG           0       /* display parsing at boot*/
 
 #include <linuxmt/debug.h>
 
-#define MAX_INIT_ARGS	6       /* max # arguments to /bin/init or init= program */
-#define MAX_INIT_ENVS	12      /* max # environ variables passed to /bin/init */
+#define MAX_INIT_ARGS   6       /* max # arguments to /bin/init or init= program */
+#define MAX_INIT_ENVS   12      /* max # environ variables passed to /bin/init */
 #define MAX_INIT_SLEN   80      /* max # words of args + environ passed to /bin/init */
 #define MAX_UMB         3       /* max umb= segments in /bootopts */
 
@@ -67,7 +67,7 @@ static char *init_command = bininit;
  * Parse /bootopts startup options
  */
 static char opts;
-static int args = 2;	/* room for argc and av[0] */
+static int args = 2;    /* room for argc and av[0] */
 static int envs;
 static int argv_slen;
 #ifdef CONFIG_SYS_NO_BININIT
@@ -175,7 +175,7 @@ static void INITPROC kernel_init(void)
 #endif
 
     inode_init();
-    if (buffer_init())	/* also enables xms and unreal mode if configured and possible*/
+    if (buffer_init())  /* also enables xms and unreal mode if configured and possible*/
         panic("No buf mem");
 
 #ifdef CONFIG_ARCH_IBMPC
@@ -266,8 +266,8 @@ static void INITPROC do_init_task(void)
         num = sys_open(s="/dev/console", O_RDWR, 0);
         if (num < 0)
             printk("Unable to open %s (error %d)\n", s, num);
-        sys_dup(num);		/* open stdout*/
-        sys_dup(num);		/* open stderr*/
+        sys_dup(num);       /* open stdout*/
+        sys_dup(num);       /* open stderr*/
     //}
 
 #ifdef CONFIG_BOOTOPTS
@@ -284,7 +284,7 @@ static void INITPROC do_init_task(void)
 #endif /* CONFIG_BOOTOPTS */
 
     printk("No init - running %s\n", binshell);
-    current->ppid = 1;			/* turns off auto-child reaping*/
+    current->ppid = 1;          /* turns off auto-child reaping*/
     try_exec_process(binshell);
     try_exec_process("/bin/sash");
     panic("No init or sh found");
@@ -298,8 +298,8 @@ static void init_task(void)
 
 #ifdef CONFIG_BOOTOPTS
 static struct dev_name_struct {
-	const char *name;
-	int num;
+    const char *name;
+    int num;
 } devices[] = {
 	/* the 4 partitionable drives must be first */
 	{ "hda",     DEV_HDA },
@@ -324,23 +324,23 @@ static struct dev_name_struct {
  */
 static char * INITPROC root_dev_name(int dev)
 {
-	int i;
-#define NAMEOFF	13
-	static char name[18] = "ROOTDEV=/dev/";
+    int i;
+#define NAMEOFF 13
+    static char name[18] = "ROOTDEV=/dev/";
 
-	for (i=0; i<5; i++) {
-		if (devices[i].num == (dev & 0xfff0)) {
-			strcpy(&name[NAMEOFF], devices[i].name);
-			if (i < 4) {
-				if (dev & 0x07) {
-					name[NAMEOFF+3] = '0' + (dev & 7);
-					name[NAMEOFF+4] = '\0';
-				}
-			}
-			return name;
-		}
-	}
-	return NULL;
+    for (i=0; i<5; i++) {
+        if (devices[i].num == (dev & 0xfff0)) {
+            strcpy(&name[NAMEOFF], devices[i].name);
+            if (i < 4) {
+                if (dev & 0x07) {
+                    name[NAMEOFF+3] = '0' + (dev & 7);
+                    name[NAMEOFF+4] = '\0';
+                }
+            }
+            return name;
+        }
+    }
+    return NULL;
 }
 
 /*
@@ -348,41 +348,41 @@ static char * INITPROC root_dev_name(int dev)
  */
 static int INITPROC parse_dev(char * line)
 {
-	int base = 0;
-	struct dev_name_struct *dev = devices;
+    int base = 0;
+    struct dev_name_struct *dev = devices;
 
-	if (strncmp(line,"/dev/",5) == 0)
-		line += 5;
-	do {
-		int len = strlen(dev->name);
-		if (strncmp(line,dev->name,len) == 0) {
-			line += len;
-			base = dev->num;
-			break;
-		}
-		dev++;
-	} while (dev->name);
-	return (base + atoi(line));
+    if (strncmp(line,"/dev/",5) == 0)
+        line += 5;
+    do {
+        int len = strlen(dev->name);
+        if (strncmp(line,dev->name,len) == 0) {
+            line += len;
+            base = dev->num;
+            break;
+        }
+        dev++;
+    } while (dev->name);
+    return (base + atoi(line));
 }
 
 static void INITPROC comirq(char *line)
 {
 #if defined(CONFIG_ARCH_IBMPC) && defined(CONFIG_CHAR_DEV_RS)
-	int i;
-	char *l, *m, c;
+    int i;
+    char *l, *m, c;
 
-	l = line;
-	for (i = 0; i < MAX_SERIAL; i++) {	/* assume decimal digits only */
-		m = l;
-		while ((*l) && (*l != ',')) l++;
-		c = *l;		/* ensure robust eol handling */
-		if (l > m) {
-			*l = '\0';
-			set_serial_irq(i, (int)simple_strtol(m, 0));
-		}
-		if (!c) break;
-		l++;
-	}
+    l = line;
+    for (i = 0; i < MAX_SERIAL; i++) {  /* assume decimal digits only */
+        m = l;
+        while ((*l) && (*l != ',')) l++;
+        c = *l;     /* ensure robust eol handling */
+        if (l > m) {
+            *l = '\0';
+            set_serial_irq(i, (int)simple_strtol(m, 0));
+        }
+        if (!c) break;
+        l++;
+    }
 #endif
 }
 
@@ -404,19 +404,19 @@ static void INITPROC parse_nic(char *line, struct netif_parms *parms)
 /* umb= settings have to be saved and processed after parse_options */
 static void INITPROC parse_umb(char *line)
 {
-	char *p = line-1; /* because we start reading at p+1 */
-	seg_t base;
+    char *p = line-1; /* because we start reading at p+1 */
+    seg_t base;
 
-	do {
-		base = (seg_t)simple_strtol(p+1, 16);
-		if((p = strchr(p+1, ':'))) {
-			if (nextumb < &umbseg[MAX_UMB]) {
-				nextumb->len = (segext_t)simple_strtol(p+1, 16);
-				nextumb->base = base;
-				nextumb++;
-			}
-		}
-	} while((p = strchr(p+1, ',')));
+    do {
+        base = (seg_t)simple_strtol(p+1, 16);
+        if((p = strchr(p+1, ':'))) {
+            if (nextumb < &umbseg[MAX_UMB]) {
+                nextumb->len = (segext_t)simple_strtol(p+1, 16);
+                nextumb->base = base;
+                nextumb++;
+            }
+        }
+    } while((p = strchr(p+1, ',')));
 }
 
 /*
@@ -435,231 +435,231 @@ static void INITPROC parse_umb(char *line)
  */
 static int INITPROC parse_options(void)
 {
-	char *line = (char *)options;
-	char *next;
+    char *line = (char *)options;
+    char *next;
 
-	/* copy /bootopts loaded by boot loader at 0050:0000*/
-	fmemcpyb(options, kernel_ds, 0, DEF_OPTSEG, sizeof(options));
+    /* copy /bootopts loaded by boot loader at 0050:0000*/
+    fmemcpyb(options, kernel_ds, 0, DEF_OPTSEG, sizeof(options));
 
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
-	/* check file starts with ## and max len 511 bytes*/
-	if (*(unsigned short *)options != 0x2323 || options[OPTSEGSZ-1])
-		return 0;
+    /* check file starts with ## and max len 511 bytes*/
+    if (*(unsigned short *)options != 0x2323 || options[OPTSEGSZ-1])
+        return 0;
 
-	next = line;
-	while ((line = next) != NULL && *line) {
-		if ((next = option(line)) != NULL) {
-			if (*line == '#') {	/* skip line after comment char*/
-				next = line;
-				while (*next != '\n' && *next != '\0')
-					next++;
-				continue;
-			} else *next++ = 0;
-		}
-		if (*line == 0)		/* skip spaces and linefeeds*/
-			continue;
-		debug("'%s',", line);
-		/*
-		 * check for kernel options first..
-		 */
-		if (!strncmp(line,"root=",5)) {
-			int dev = parse_dev(line+5);
-			debug("root %s=%D\n", line+5, dev);
-			ROOT_DEV = (kdev_t)dev;
-			boot_rootdev = dev;    /* stop translation in device_setup*/
-			continue;
-		}
-		if (!strncmp(line,"console=",8)) {
-			int dev = parse_dev(line+8);
-			char *p = strchr(line+8, ',');
-			if (p) {
-				*p++ = 0;
+    next = line;
+    while ((line = next) != NULL && *line) {
+        if ((next = option(line)) != NULL) {
+            if (*line == '#') { /* skip line after comment char*/
+                next = line;
+                while (*next != '\n' && *next != '\0')
+                    next++;
+                continue;
+            } else *next++ = 0;
+        }
+        if (*line == 0)     /* skip spaces and linefeeds*/
+            continue;
+        debug("'%s',", line);
+        /*
+         * check for kernel options first..
+         */
+        if (!strncmp(line,"root=",5)) {
+            int dev = parse_dev(line+5);
+            debug("root %s=%D\n", line+5, dev);
+            ROOT_DEV = (kdev_t)dev;
+            boot_rootdev = dev;    /* stop translation in device_setup*/
+            continue;
+        }
+        if (!strncmp(line,"console=",8)) {
+            int dev = parse_dev(line+8);
+            char *p = strchr(line+8, ',');
+            if (p) {
+                *p++ = 0;
 #ifdef CONFIG_CHAR_DEV_RS
-				/* set serial console baud rate*/
-				rs_setbaud(dev, simple_strtol(p, 10));
+                /* set serial console baud rate*/
+                rs_setbaud(dev, simple_strtol(p, 10));
 #endif
-			}
+            }
 
 
-			debug("console %s=%D,", line+8, dev);
-			boot_console = dev;
-			continue;
-		}
-		if (!strcmp(line,"ro")) {
-			root_mountflags |= MS_RDONLY;
-			continue;
-		}
-		if (!strcmp(line,"rw")) {
-			root_mountflags &= ~MS_RDONLY;
-			continue;
-		}
-		if (!strcmp(line,"debug")) {
-			dprintk_on = 1;
-			continue;
-		}
-		if (!strcmp(line,"strace")) {
-			tracing |= TRACE_STRACE;
-			continue;
-		}
-		if (!strcmp(line,"kstack")) {
-			tracing |= TRACE_KSTACK;
-			continue;
-		}
-		if (!strncmp(line,"init=",5)) {
-			line += 5;
-			init_command = argv_init[1] = line;
-			continue;
-		}
-		if (!strncmp(line,"ne0=",4)) {
-			parse_nic(line+4, &netif_parms[ETH_NE2K]);
-			continue;
-		}
-		if (!strncmp(line,"wd0=",4)) {
-			parse_nic(line+4, &netif_parms[ETH_WD]);
-			continue;
-		}
-		if (!strncmp(line,"3c0=",4)) {
-			parse_nic(line+4, &netif_parms[ETH_EL3]);
-			continue;
-		}
-		if (!strncmp(line,"buf=",4)) {
-			nr_ext_bufs = (int)simple_strtol(line+4, 10);
-			continue;
-		}
-		if (!strncmp(line,"xmsbuf=",7)) {
-			nr_xms_bufs = (int)simple_strtol(line+7, 10);
-			continue;
-		}
-		if (!strncmp(line,"cache=",6)) {
-			nr_map_bufs = (int)simple_strtol(line+6, 10);
-			continue;
-		}
-		if (!strncmp(line,"heap=",5)) {
-			heapsize = (unsigned int)simple_strtol(line+5, 10);
-			continue;
-		}
-		if (!strncmp(line,"task=",5)) {
-			max_tasks = (int)simple_strtol(line+5, 10);
-			continue;
-		}
-		if (!strncmp(line,"inode=",6)) {
-			nr_inode = (int)simple_strtol(line+6, 10);
-			continue;
-		}
-		if (!strncmp(line,"file=",5)) {
-			nr_file = (int)simple_strtol(line+5, 10);
-			continue;
-		}
-		if (!strncmp(line,"comirq=",7)) {
-			comirq(line+7);
-			continue;
-		}
-		if (!strncmp(line,"umb=",4)) {
-			parse_umb(line+4);
-			continue;
-		}
-		if (!strncmp(line,"TZ=",3)) {
-			tz_init(line+3);
-			/* fall through and add line to environment */
-		}
-		
-		/*
-		 * Then check if it's an environment variable or an init argument.
-		 */
-		if (!strchr(line,'=')) {    /* no '=' means init argument*/
-			if (args < MAX_INIT_ARGS)
-			    argv_init[args++] = line;
-			else printk(errmsg_initargs);
-		}
+            debug("console %s=%D,", line+8, dev);
+            boot_console = dev;
+            continue;
+        }
+        if (!strcmp(line,"ro")) {
+            root_mountflags |= MS_RDONLY;
+            continue;
+        }
+        if (!strcmp(line,"rw")) {
+            root_mountflags &= ~MS_RDONLY;
+            continue;
+        }
+        if (!strcmp(line,"debug")) {
+            dprintk_on = 1;
+            continue;
+        }
+        if (!strcmp(line,"strace")) {
+            tracing |= TRACE_STRACE;
+            continue;
+        }
+        if (!strcmp(line,"kstack")) {
+            tracing |= TRACE_KSTACK;
+            continue;
+        }
+        if (!strncmp(line,"init=",5)) {
+            line += 5;
+            init_command = argv_init[1] = line;
+            continue;
+        }
+        if (!strncmp(line,"ne0=",4)) {
+            parse_nic(line+4, &netif_parms[ETH_NE2K]);
+            continue;
+        }
+        if (!strncmp(line,"wd0=",4)) {
+            parse_nic(line+4, &netif_parms[ETH_WD]);
+            continue;
+        }
+        if (!strncmp(line,"3c0=",4)) {
+            parse_nic(line+4, &netif_parms[ETH_EL3]);
+            continue;
+        }
+        if (!strncmp(line,"buf=",4)) {
+            nr_ext_bufs = (int)simple_strtol(line+4, 10);
+            continue;
+        }
+        if (!strncmp(line,"xmsbuf=",7)) {
+            nr_xms_bufs = (int)simple_strtol(line+7, 10);
+            continue;
+        }
+        if (!strncmp(line,"cache=",6)) {
+            nr_map_bufs = (int)simple_strtol(line+6, 10);
+            continue;
+        }
+        if (!strncmp(line,"heap=",5)) {
+            heapsize = (unsigned int)simple_strtol(line+5, 10);
+            continue;
+        }
+        if (!strncmp(line,"task=",5)) {
+            max_tasks = (int)simple_strtol(line+5, 10);
+            continue;
+        }
+        if (!strncmp(line,"inode=",6)) {
+            nr_inode = (int)simple_strtol(line+6, 10);
+            continue;
+        }
+        if (!strncmp(line,"file=",5)) {
+            nr_file = (int)simple_strtol(line+5, 10);
+            continue;
+        }
+        if (!strncmp(line,"comirq=",7)) {
+            comirq(line+7);
+            continue;
+        }
+        if (!strncmp(line,"umb=",4)) {
+            parse_umb(line+4);
+            continue;
+        }
+        if (!strncmp(line,"TZ=",3)) {
+            tz_init(line+3);
+            /* fall through and add line to environment */
+        }
+
+        /*
+         * Then check if it's an environment variable or an init argument.
+         */
+        if (!strchr(line,'=')) {    /* no '=' means init argument*/
+            if (args < MAX_INIT_ARGS)
+                argv_init[args++] = line;
+            else printk(errmsg_initargs);
+        }
 #if ENV
-		else {
-			if (envs < MAX_INIT_ENVS)
-			    envp_init[envs++] = line;
-			else printk(errmsg_initenvs);
-		}
+        else {
+            if (envs < MAX_INIT_ENVS)
+                envp_init[envs++] = line;
+            else printk(errmsg_initenvs);
+        }
 #endif
-	}
-	debug("\n");
-	return 1;	/* success*/
+    }
+    debug("\n");
+    return 1;   /* success*/
 }
 
 static void INITPROC finalize_options(void)
 {
-	int i;
+    int i;
 
 #if ENV
-	/* set ROOTDEV environment variable for rc.sys fsck*/
-	if (envs + running_qemu < MAX_INIT_ENVS) {
-	    envp_init[envs++] = root_dev_name(ROOT_DEV);
-	    if (running_qemu)
-		    envp_init[envs++] = (char *)"QEMU=1";
+    /* set ROOTDEV environment variable for rc.sys fsck*/
+    if (envs + running_qemu < MAX_INIT_ENVS) {
+        envp_init[envs++] = root_dev_name(ROOT_DEV);
+        if (running_qemu)
+            envp_init[envs++] = (char *)"QEMU=1";
     } else printk(errmsg_initenvs);
 #endif
 
 #if DEBUG
-	printk("args: ");
-	for (i=1; i<args; i++)
-		printk("'%s'", argv_init[i]);
-	printk("\n");
+    printk("args: ");
+    for (i=1; i<args; i++)
+        printk("'%s'", argv_init[i]);
+    printk("\n");
 
 #if ENV
-	printk("envp: ");
-	for (i=0; i<envs; i++)
-		printk("'%s'", envp_init[i]);
-	printk("\n");
+    printk("envp: ");
+    for (i=0; i<envs; i++)
+        printk("'%s'", envp_init[i]);
+    printk("\n");
 #endif
 #endif
 
-	/* convert argv array to stack array for sys_execv*/
-	args--;
-	argv_init[0] = (char *)args;        	/* 0 = argc*/
-	char *q = (char *)&argv_init[args+2+envs+1];
-	for (i=1; i<=args; i++) {                   /* 1..argc = av*/
-		char *p = argv_init[i];
-		char *savq = q;
-		while ((*q++ = *p++) != 0)
-			;
-		argv_init[i] = (char *)(savq - (char *)argv_init);
-	}
-	/*argv_init[args+1] = NULL;*/               /* argc+1 = 0*/
+    /* convert argv array to stack array for sys_execv*/
+    args--;
+    argv_init[0] = (char *)args;            /* 0 = argc*/
+    char *q = (char *)&argv_init[args+2+envs+1];
+    for (i=1; i<=args; i++) {                   /* 1..argc = av*/
+        char *p = argv_init[i];
+        char *savq = q;
+        while ((*q++ = *p++) != 0)
+            ;
+        argv_init[i] = (char *)(savq - (char *)argv_init);
+    }
+    /*argv_init[args+1] = NULL;*/               /* argc+1 = 0*/
 #if ENV
-	if (envs) {
-		for (i=0; i<envs; i++) {
-			char *p = envp_init[i];
-			char *savq = q;
-			while ((*q++ = *p++) != 0)
-				;
-			argv_init[args+2+i] = (char *)(savq - (char *)argv_init);
-		}
+    if (envs) {
+        for (i=0; i<envs; i++) {
+            char *p = envp_init[i];
+            char *savq = q;
+            while ((*q++ = *p++) != 0)
+                ;
+            argv_init[args+2+i] = (char *)(savq - (char *)argv_init);
+        }
 
-	}
+    }
 #endif
-	/*argv_init[args+2+envs] = NULL;*/
-	argv_slen = q - (char *)argv_init;
-	if (argv_slen > sizeof(argv_init))
-		panic(errmsg_initslen);
+    /*argv_init[args+2+envs] = NULL;*/
+    argv_slen = q - (char *)argv_init;
+    if (argv_slen > sizeof(argv_init))
+        panic(errmsg_initslen);
 }
 
 /* return whitespace-delimited string*/
 static char * INITPROC option(char *s)
 {
-	char *t = s;
-	if (*s == '#')
-		return s;
-	for(; *s != ' ' && *s != '\t' && *s != '\r' && *s != '\n'; ++s, ++t) {
-		if (*s == '\0')
-			return NULL;
-		if (*s == '"') {
-			s++;
-			while (*s != '"') {
-				if (*s == '\0')
-					return NULL;
-				*t++ = *s++;
-			}
-			*t++ = 0;
-			break;
-		}
-	}
-	return s;
+    char *t = s;
+    if (*s == '#')
+        return s;
+    for(; *s != ' ' && *s != '\t' && *s != '\r' && *s != '\n'; ++s, ++t) {
+        if (*s == '\0')
+            return NULL;
+        if (*s == '"') {
+            s++;
+            while (*s != '"') {
+                if (*s == '\0')
+                    return NULL;
+                *t++ = *s++;
+            }
+            *t++ = 0;
+            break;
+        }
+    }
+    return s;
 }
 #endif /* CONFIG_BOOTOPTS*/

--- a/elks/kernel/sys.c
+++ b/elks/kernel/sys.c
@@ -69,18 +69,18 @@ int sys_uname(struct utsname *utsname)
 int sys_setgid(gid_t gid)
 {
     if (suser())
-	current->gid = current->egid = current->sgid = gid;
+        current->gid = current->egid = current->sgid = gid;
     else if ((gid == current->gid) || (gid == current->sgid))
-	current->egid = gid;
+        current->egid = gid;
     else
-	return -EPERM;
+        return -EPERM;
     return 0;
 }
 
 static int twovalues(int retval, int *copyval, int *copyaddr)
 {
     if (verified_memcpy_tofs(copyaddr, copyval, sizeof(int)) != 0)
-	return -EFAULT;
+        return -EFAULT;
     return retval;
 }
 
@@ -123,18 +123,18 @@ unsigned short int sys_umask(mode_t mask)
 int sys_setuid(uid_t uid)
 {
     if (suser())
-	current->uid = current->euid = current->suid = uid;
+        current->uid = current->euid = current->suid = uid;
     else if ((uid == current->uid) || (uid == current->suid))
-	current->euid = uid;
+        current->euid = uid;
     else
-	return -EPERM;
+        return -EPERM;
     return 0;
 }
 
 int sys_setsid(void)
 {
     if (current->session == current->pid)
-	return -EPERM;
+        return -EPERM;
     debug_tty("SETSID pgrp %P\n");
     current->session = current->pgrp = current->pid;
     current->tty = NULL;
@@ -146,14 +146,14 @@ int sys_setsid(void)
 int sys_times(struct tms *tbuf)
 {
     if (tbuf) {
-	int error = verify_area(VERIFY_WRITE, tbuf, sizeof *tbuf);
+        int error = verify_area(VERIFY_WRITE, tbuf, sizeof *tbuf);
 
-	if (error)
-	    return error;
-	put_user_long(current->utime, &tbuf->tms_utime);
-	put_user_long(current->stime, &tbuf->tms_stime);
-	put_user_long(current->cutime, &tbuf->tms_cutime);
-	put_user_long(current->cstime, &tbuf->tms_cstime);
+        if (error)
+            return error;
+        put_user_long(current->utime, &tbuf->tms_utime);
+        put_user_long(current->stime, &tbuf->tms_stime);
+        put_user_long(current->cutime, &tbuf->tms_cutime);
+        put_user_long(current->cstime, &tbuf->tms_cstime);
     }
     return jiffies;
 }
@@ -176,48 +176,48 @@ int sys_setpgid(pid_t pid, pid_t pgid)
     register struct task_struct *p;
 
     if (!pid)
-	pid = current->pid;
+        pid = current->pid;
 
     if (!pgid)
-	pgid = pid;
+        pgid = pid;
 
     if (pgid < 0)
-	return -EINVAL;
+        return -EINVAL;
 
     for_each_task(p) {
-	if (p->pid == pid && p->state != TASK_UNUSED) {
+        if (p->pid == pid && p->state != TASK_UNUSED) {
 
-	    if (p->p_pptr == current || p->p_opptr == current) {
+            if (p->p_pptr == current || p->p_opptr == current) {
 
-		if (p->session != current->session)
-		    return -EPERM;
+                if (p->session != current->session)
+                    return -EPERM;
 
-		if (p->did_exec)
-		    return -EACCES;
+                if (p->did_exec)
+                    return -EACCES;
 
-	    } else if (p != current)
-		return -ESRCH;
+            } else if (p != current)
+                return -ESRCH;
 
-	    if (p->leader)
-		return -EPERM;
+            if (p->leader)
+                return -EPERM;
 
-	    if (pgid != pid) {
-		struct task_struct *tmp;
+            if (pgid != pid) {
+                struct task_struct *tmp;
 
-		for_each_task(tmp) {
-		    if ((tmp->pgrp == pgid && tmp->state != TASK_UNUSED)
-			&& (tmp->session == current->session)) {
-			goto ok_pgid:
-		    }
-		}
-		return -EPERM;
-	    }
+                for_each_task(tmp) {
+                    if ((tmp->pgrp == pgid && tmp->state != TASK_UNUSED)
+                        && (tmp->session == current->session)) {
+                        goto ok_pgid:
+                    }
+                }
+                return -EPERM;
+            }
 
-	ok_pgid:
-	    p->pgrp = pgid;
+        ok_pgid:
+            p->pgrp = pgid;
 
-	    return 0;
-	}
+            return 0;
+        }
     }
     return -ESRCH;
 }
@@ -227,10 +227,10 @@ int sys_getpgid(pid_t pid)
     register struct task_struct *p;
 
     if (!pid)
-	return current->pgrp;
+        return current->pgrp;
     for_each_task(p)
-	if (p->pid == pid && p->state != TASK_UNUSED)
-	    return p->pgrp;
+        if (p->pid == pid && p->state != TASK_UNUSED)
+            return p->pgrp;
     return -ESRCH;
 }
 
@@ -244,10 +244,10 @@ int sys_getsid(pid_t pid)
     register struct task_struct *p;
 
     if (!pid)
-	return current->session;
+        return current->session;
     for_each_task(p)
-	if (p->pid == pid && p->state != TASK_UNUSED)
-	    return p->session;
+        if (p->pid == pid && p->state != TASK_UNUSED)
+            return p->session;
     return -ESRCH;
 
 }
@@ -266,14 +266,14 @@ int sys_getgroups(int gidsetsize, gid_t * grouplist)
     int i = 0;
 
     while ((pg[i] != NOGROUP) && (++i < NGROUPS))
-	continue;
+        continue;
 
     if (i && gidsetsize) {
-	if (i > gidsetsize) {
-	    return -EINVAL;
-	}
-	if (verified_memcpy_tofs(grouplist, pg, i * sizeof(gid_t)) != 0)
-	    return -EFAULT;
+        if (i > gidsetsize) {
+            return -EINVAL;
+        }
+        if (verified_memcpy_tofs(grouplist, pg, i * sizeof(gid_t)) != 0)
+            return -EFAULT;
 
     }
 
@@ -295,12 +295,12 @@ int sys_setgroups(int gidsetsize, gid_t * grouplist)
     lg = pg + gidsetsize;
 
     if (lg > pg) {
-	if (verified_memcpy_fromfs(pg, grouplist, ((char *)lg) - ((char *)pg)))
-	    return -EFAULT;
+        if (verified_memcpy_fromfs(pg, grouplist, ((char *)lg) - ((char *)pg)))
+            return -EFAULT;
     }
 
     if (gidsetsize < NGROUPS) {
-	*lg = NOGROUP;
+        *lg = NOGROUP;
     }
 
     return 0;
@@ -312,14 +312,14 @@ int in_group_p(gid_t grp)
     char *p;
 
     if (grp != (current->egid) {
-	pg = current->groups - 1;
-	p = (char *)(pg + NGROUPS);
+        pg = current->groups - 1;
+        p = (char *)(pg + NGROUPS);
 
-	do {
-	    if ((++pg > ((gid_t *) p)) || (*pg == NOGROUP)) {
-		return 0;
-	    }
-	} while (*pg != grp);
+        do {
+            if ((++pg > ((gid_t *) p)) || (*pg == NOGROUP)) {
+                return 0;
+            }
+        } while (*pg != grp);
     }
 
     return 1;

--- a/elks/kernel/sys2.c
+++ b/elks/kernel/sys2.c
@@ -17,47 +17,47 @@ static struct timer_list alarms[NR_ALARMS];
 
 static void alarm_callback(int data)
 {
-	struct task_struct *p = (struct task_struct *)data;
+    struct task_struct *p = (struct task_struct *)data;
 
-	debug("(%P)ALARM for pid %d\n", p->pid);
-	send_sig(SIGALRM, p, 1);
+    debug("(%P)ALARM for pid %d\n", p->pid);
+    send_sig(SIGALRM, p, 1);
 }
 
 static struct timer_list *find_alarm(struct task_struct *t)
 {
-	struct timer_list *ap;
+    struct timer_list *ap;
 
-	for (ap = alarms; ap < &alarms[NR_ALARMS]; ap++ ) {
-		if (ap->tl_data == (int)t)
-			return ap;
-	}
-	return NULL;
+    for (ap = alarms; ap < &alarms[NR_ALARMS]; ap++ ) {
+        if (ap->tl_data == (int)t)
+            return ap;
+    }
+    return NULL;
 }
 
 static int setalarm(unsigned long jiffs)
 {
-	struct timer_list *ap;
+    struct timer_list *ap;
 
-	debug("(%P)sys_alarm %d\n", secs);
-	ap = find_alarm(current);
-	if (jiffs == 0) {
-		if (ap) {
-			del_timer(ap);
-			ap->tl_data = 0;
-			return 0;
-		}
-	} else {
-		if (!ap && !(ap = find_alarm(NULL))) {
-			printk("No more alarms\n");
-			return 0;
-		}
-		del_timer(ap);
-		ap->tl_expires = jiffies + jiffs;
-		ap->tl_function = alarm_callback;
-		ap->tl_data = (int)current;	/* must delete timer on process exit*/
-		add_timer(ap);
-	}
-	return 0;
+    debug("(%P)sys_alarm %d\n", secs);
+    ap = find_alarm(current);
+    if (jiffs == 0) {
+        if (ap) {
+            del_timer(ap);
+            ap->tl_data = 0;
+            return 0;
+        }
+    } else {
+        if (!ap && !(ap = find_alarm(NULL))) {
+            printk("No more alarms\n");
+            return 0;
+        }
+        del_timer(ap);
+        ap->tl_expires = jiffies + jiffs;
+        ap->tl_function = alarm_callback;
+        ap->tl_data = (int)current; /* must delete timer on process exit*/
+        add_timer(ap);
+    }
+    return 0;
 }
 
 unsigned int sys_alarm(unsigned int secs)

--- a/elks/kernel/time.c
+++ b/elks/kernel/time.c
@@ -64,23 +64,23 @@ int sys_settimeofday(register struct timeval *tv, struct timezone *tz)
 
     /* only user running as root can set the time */
     if (current->euid != 0)
-	return -EPERM;
+        return -EPERM;
 
     /* verify we have valid addresses to read from */
     if (tv != NULL) {
-	if (verified_memcpy_fromfs(&tmp_tv, tv, sizeof(struct timeval)))
-	    return -EFAULT;
-	if (((unsigned long) tmp_tv.tv_usec) >= 1000000L)
-	    return -EINVAL;
+        if (verified_memcpy_fromfs(&tmp_tv, tv, sizeof(struct timeval)))
+            return -EFAULT;
+        if (((unsigned long) tmp_tv.tv_usec) >= 1000000L)
+            return -EINVAL;
     }
 
     if (tz != NULL) {
-	if (verified_memcpy_fromfs(&tmp_tz, tz, sizeof(struct timezone)))
-	    return -EFAULT;
-	if (((unsigned int)(tmp_tz.tz_dsttime - DST_NONE)) > (DST_AUSTALT - DST_NONE))
-	    return -EINVAL;
-	/* Setting the timezone is easy, just a straight copy */
-	xzone = tmp_tz;
+        if (verified_memcpy_fromfs(&tmp_tz, tz, sizeof(struct timezone)))
+            return -EFAULT;
+        if (((unsigned int)(tmp_tz.tz_dsttime - DST_NONE)) > (DST_AUSTALT - DST_NONE))
+            return -EINVAL;
+        /* Setting the timezone is easy, just a straight copy */
+        xzone = tmp_tz;
     }
 
     /* Setting time is a bit tricky, since we don't really keep the time in the xtime
@@ -90,9 +90,9 @@ int sys_settimeofday(register struct timeval *tv, struct timezone *tz)
      * current jiffies for later use as offset - ghaerr.
      */
     if (tv != NULL) {
-	xtime_jiffies = jiffies;
-	xtime.tv_sec = tmp_tv.tv_sec;
-	xtime.tv_usec = tmp_tv.tv_usec;
+        xtime_jiffies = jiffies;
+        xtime.tv_sec = tmp_tv.tv_sec;
+        xtime.tv_usec = tmp_tv.tv_usec;
     }
 
     /* success */
@@ -107,17 +107,17 @@ int sys_gettimeofday(register struct timeval *tv, struct timezone *tz)
 
     /* load the current time into the structures passed */
     if (tv != NULL) {
-	now = jiffies;
-	tmp_tv.tv_sec = xtime.tv_sec + (now - xtime_jiffies) / HZ;
-	tmp_tv.tv_usec = xtime.tv_usec + ((now - xtime_jiffies) % HZ) * (1000000L / HZ);
-	if (tmp_tv.tv_usec >= 10000000L)
-	    tmp_tv.tv_usec -= 10000000L;
-	if (verified_memcpy_tofs(tv, &tmp_tv, sizeof(struct timeval)))
-	    return -EFAULT;
+        now = jiffies;
+        tmp_tv.tv_sec = xtime.tv_sec + (now - xtime_jiffies) / HZ;
+        tmp_tv.tv_usec = xtime.tv_usec + ((now - xtime_jiffies) % HZ) * (1000000L / HZ);
+        if (tmp_tv.tv_usec >= 10000000L)
+            tmp_tv.tv_usec -= 10000000L;
+        if (verified_memcpy_tofs(tv, &tmp_tv, sizeof(struct timeval)))
+            return -EFAULT;
     }
     if (tz != NULL)
-	if (verified_memcpy_tofs(tz, &xzone, sizeof(struct timezone)))
-	    return -EFAULT;
+        if (verified_memcpy_tofs(tz, &xzone, sizeof(struct timezone)))
+            return -EFAULT;
 
     /* success */
     return 0;

--- a/elkscmd/lib/tiny_vfprintf.c
+++ b/elkscmd/lib/tiny_vfprintf.c
@@ -7,7 +7,7 @@
  *  printf, fprintf, sprintf
  *
  * Limitations:
- *	%s, %c, %d, %u, %x, %o, %ld, %lu, %lx, %lo only w/field width & precision
+ *      %s, %c, %d, %u, %x, %o, %ld, %lu, %lx, %lo only w/field width & precision
  *  Don't use with fopen (stdout, stderr only)
  *    Replaces stdout and stderr buffers with single buffer
  *
@@ -133,89 +133,89 @@ int vfprintf(FILE *op, const char *fmt, va_list ap)
    {
       if (*fmt == '%')
       {
-	 ljustf = 0;		/* left justify flag */
-	 dpoint = 0;		/* found decimal point */
-	 lval = 0;
-	 width = -1;		/* min field width */
-	 preci = -1;		/* max data width */
-	 pad = ' ';		/* justification padding char */
-	 radix = 10;		/* number base */
-	 ptmp = tmp;		/* pointer to area to print */
+         ljustf = 0;            /* left justify flag */
+         dpoint = 0;            /* found decimal point */
+         lval = 0;
+         width = -1;            /* min field width */
+         preci = -1;            /* max data width */
+         pad = ' ';             /* justification padding char */
+         radix = 10;            /* number base */
+         ptmp = tmp;            /* pointer to area to print */
        fmtnxt:
-	 i = 0;
-	 for(;;)
-	 {
-	    ++fmt;
-	    if(*fmt < '0' || *fmt > '9' ) break;
-	    i = (i * 10) + (*fmt - '0');
-	    if (dpoint)
-	       preci = i;
-	    else if (!i && (pad == ' '))
-	    {
-	       pad = '0';
-	       goto fmtnxt;
-	    }
-	    else
-	       width = i;
-	 }
+         i = 0;
+         for(;;)
+         {
+            ++fmt;
+            if(*fmt < '0' || *fmt > '9' ) break;
+            i = (i * 10) + (*fmt - '0');
+            if (dpoint)
+               preci = i;
+            else if (!i && (pad == ' '))
+            {
+               pad = '0';
+               goto fmtnxt;
+            }
+            else
+               width = i;
+         }
 
-	 switch (*fmt)
-	 {
-	 case '-':		/* left justification */
-	    ljustf = 1;
-	    goto fmtnxt;
+         switch (*fmt)
+         {
+         case '-':              /* left justification */
+            ljustf = 1;
+            goto fmtnxt;
 
-	 case '.':		/* secondary width field */
-	    dpoint = 1;
-	    goto fmtnxt;
+         case '.':              /* secondary width field */
+            dpoint = 1;
+            goto fmtnxt;
 
-	 case 'l':		/* long data */
-	    lval = 1;
-	 case 'h':      /* short data */
-	    goto fmtnxt;
+         case 'l':              /* long data */
+            lval = 1;
+         case 'h':      /* short data */
+            goto fmtnxt;
 
-	 case 'd':		/* Signed decimal */
-	    ptmp = ltostr((long) ((lval)
-			 ? va_arg(ap, long)
-			 : va_arg(ap, int)), 10);
-	    goto printit;
+         case 'd':              /* Signed decimal */
+            ptmp = ltostr((long) ((lval)
+                         ? va_arg(ap, long)
+                         : va_arg(ap, int)), 10);
+            goto printit;
 
-	 case 'o':		/* Unsigned octal */
-	    radix = 8;
-	    goto usproc;
+         case 'o':              /* Unsigned octal */
+            radix = 8;
+            goto usproc;
 
-	 case 'x':      /* Unsigned hexadecimal */
-	    radix = 16;
-	    /* fall thru */
+         case 'x':      /* Unsigned hexadecimal */
+            radix = 16;
+            /* fall thru */
 
-	 case 'u':		/* Unsigned decimal */
-	  usproc:
-	    ptmp = ultostr((unsigned long) ((lval)
-			? va_arg(ap, unsigned long)
-			: va_arg(ap, unsigned int)), radix);
-	    goto printit;
+         case 'u':              /* Unsigned decimal */
+          usproc:
+            ptmp = ultostr((unsigned long) ((lval)
+                        ? va_arg(ap, unsigned long)
+                        : va_arg(ap, unsigned int)), radix);
+            goto printit;
 
-	 case 'c':		/* Character */
-	    ptmp[0] = va_arg(ap, int);
-	    ptmp[1] = '\0';
-	    goto nopad;
+         case 'c':              /* Character */
+            ptmp[0] = va_arg(ap, int);
+            ptmp[1] = '\0';
+            goto nopad;
 
-	 case 's':		/* String */
-	    ptmp = va_arg(ap, char*);
-	  nopad:
-	  printit:
-	    cnt += prtfld(op, (unsigned char *)ptmp, ljustf, pad, width, preci);
-	    break;
+         case 's':              /* String */
+            ptmp = va_arg(ap, char*);
+          nopad:
+          printit:
+            cnt += prtfld(op, (unsigned char *)ptmp, ljustf, pad, width, preci);
+            break;
 
-	 default:		/* unknown character */
-	    goto charout;
-	 }
+         default:               /* unknown character */
+            goto charout;
+         }
       }
       else
       {
        charout:
-	 __fputc(*fmt, op);	/* normal char out */
-	 ++cnt;
+         __fputc(*fmt, op);     /* normal char out */
+         ++cnt;
       }
       ++fmt;
    }

--- a/elkscmd/sys_utils/meminfo.c
+++ b/elkscmd/sys_utils/meminfo.c
@@ -21,14 +21,14 @@
 #include <fcntl.h>
 #include <sys/ioctl.h>
 
-#define LINEARADDRESS(off, seg)		((off_t) (((off_t)seg << 4) + off))
+#define LINEARADDRESS(off, seg)     ((off_t) (((off_t)seg << 4) + off))
 
-int aflag;		/* show application memory*/
-int fflag;		/* show free memory*/
-int tflag;		/* show tty and driver memory*/
-int bflag;		/* show buffer memory*/
-int sflag;		/* show system memory*/
-int allflag;	/* show all memory*/
+int aflag;      /* show application memory*/
+int fflag;      /* show free memory*/
+int tflag;      /* show tty and driver memory*/
+int bflag;      /* show buffer memory*/
+int sflag;      /* show system memory*/
+int allflag;    /* show all memory*/
 
 unsigned int ds;
 unsigned int heap_all;
@@ -38,22 +38,22 @@ struct task_struct task_table;
 
 int memread(int fd, word_t off, word_t seg, void *buf, int size)
 {
-	if (lseek(fd, LINEARADDRESS(off, seg), SEEK_SET) == -1)
-		return 0;
+    if (lseek(fd, LINEARADDRESS(off, seg), SEEK_SET) == -1)
+        return 0;
 
-	if (read(fd, buf, size) != size)
-		return 0;
+    if (read(fd, buf, size) != size)
+        return 0;
 
-	return 1;
+    return 1;
 }
 
 word_t getword(int fd, word_t off, word_t seg)
 {
-	word_t word;
+    word_t word;
 
-	if (!memread(fd, off, seg, &word, sizeof(word)))
-		return 0;
-	return word;
+    if (!memread(fd, off, seg, &word, sizeof(word)))
+        return 0;
+    return word;
 }
 
 void process_name(int fd, unsigned int off, unsigned int seg)
@@ -94,117 +94,117 @@ struct task_struct *find_process(int fd, unsigned int seg)
 
 void dump_heap(int fd)
 {
-	word_t total_size = 0;
-	word_t total_free = 0;
-	long total_segsize = 0;
-	static char *heaptype[] =
+    word_t total_size = 0;
+    word_t total_free = 0;
+    long total_segsize = 0;
+    static char *heaptype[] =
         { "free", "MEM ", "DRVR", "TTY ", "TASK", "BUFH", "PIPE", "INOD", "FILE", "CACH"};
-	static char *segtype[] =
+    static char *segtype[] =
         { "free", "CSEG", "DSEG", "DDAT", "FDAT", "BUF ", "RDSK" };
 
-	printf("  HEAP   TYPE  SIZE    SEG   TYPE    SIZE  CNT  NAME\n");
+    printf("  HEAP   TYPE  SIZE    SEG   TYPE    SIZE  CNT  NAME\n");
 
-	word_t n = getword (fd, heap_all + offsetof(list_s, next), ds);
-	while (n != heap_all) {
-		word_t h = n - offsetof(heap_s, all);
-		word_t size = getword(fd, h + offsetof(heap_s, size), ds);
-		byte_t tag = getword(fd, h + offsetof(heap_s, tag), ds) & HEAP_TAG_TYPE;
-		word_t mem = h + sizeof(heap_s);
-		seg_t segbase;
-		segext_t segsize;
-		word_t segflags;
-		byte_t ref_count;
-		int free, used, tty, buffer, system;
-		struct task_struct *t;
+    word_t n = getword (fd, heap_all + offsetof(list_s, next), ds);
+    while (n != heap_all) {
+        word_t h = n - offsetof(heap_s, all);
+        word_t size = getword(fd, h + offsetof(heap_s, size), ds);
+        byte_t tag = getword(fd, h + offsetof(heap_s, tag), ds) & HEAP_TAG_TYPE;
+        word_t mem = h + sizeof(heap_s);
+        seg_t segbase;
+        segext_t segsize;
+        word_t segflags;
+        byte_t ref_count;
+        int free, used, tty, buffer, system;
+        struct task_struct *t;
 
-		if (tag == HEAP_TAG_SEG)
-			segflags = getword(fd, mem + offsetof(segment_s, flags), ds) & SEG_FLAG_TYPE;
-		else segflags = -1;
-		free = (tag == HEAP_TAG_FREE || segflags == SEG_FLAG_FREE);
-		used = ((tag == HEAP_TAG_SEG)
+        if (tag == HEAP_TAG_SEG)
+            segflags = getword(fd, mem + offsetof(segment_s, flags), ds) & SEG_FLAG_TYPE;
+        else segflags = -1;
+        free = (tag == HEAP_TAG_FREE || segflags == SEG_FLAG_FREE);
+        used = ((tag == HEAP_TAG_SEG)
             && (segflags == SEG_FLAG_CSEG || segflags == SEG_FLAG_DSEG ||
                 segflags == SEG_FLAG_DDAT || segflags == SEG_FLAG_FDAT));
-		tty = (tag == HEAP_TAG_TTY || tag == HEAP_TAG_DRVR);
-		buffer = (tag == HEAP_TAG_SEG && segflags == SEG_FLAG_EXTBUF)
+        tty = (tag == HEAP_TAG_TTY || tag == HEAP_TAG_DRVR);
+        buffer = (tag == HEAP_TAG_SEG && segflags == SEG_FLAG_EXTBUF)
             || tag == HEAP_TAG_BUFHEAD || tag == HEAP_TAG_CACHE || tag == HEAP_TAG_PIPE;
-		system = (tag == HEAP_TAG_TASK || tag == HEAP_TAG_INODE || tag == HEAP_TAG_FILE);
+        system = (tag == HEAP_TAG_TASK || tag == HEAP_TAG_INODE || tag == HEAP_TAG_FILE);
 
-		if (allflag ||
-		   (fflag && free) || (aflag && used) || (tflag && tty) || (bflag && buffer)
-				|| (sflag && system)) {
-			printf("  %4x   %s %5d", mem, heaptype[tag], size);
-			total_size += size + sizeof(heap_s);
-			if (tag == HEAP_TAG_FREE)
-				total_free += size;
+        if (allflag ||
+           (fflag && free) || (aflag && used) || (tflag && tty) || (bflag && buffer)
+                || (sflag && system)) {
+            printf("  %4x   %s %5d", mem, heaptype[tag], size);
+            total_size += size + sizeof(heap_s);
+            if (tag == HEAP_TAG_FREE)
+                total_free += size;
 
-			switch (tag) {
-			case HEAP_TAG_SEG:
-				segbase = getword(fd, mem + offsetof(segment_s, base), ds);
-				segsize = getword(fd, mem + offsetof(segment_s, size), ds);
-				ref_count = getword(fd, mem + offsetof(segment_s, ref_count), ds);
-				printf("   %4x   %s %7ld %4d  ",
+            switch (tag) {
+            case HEAP_TAG_SEG:
+                segbase = getword(fd, mem + offsetof(segment_s, base), ds);
+                segsize = getword(fd, mem + offsetof(segment_s, size), ds);
+                ref_count = getword(fd, mem + offsetof(segment_s, ref_count), ds);
+                printf("   %4x   %s %7ld %4d  ",
                     segbase, segtype[segflags], (long)segsize << 4, ref_count);
                 if (segflags == SEG_FLAG_CSEG || segflags == SEG_FLAG_DSEG) {
                     if ((t = find_process(fd, mem)) != NULL) {
-			            process_name(fd, t->t_begstack, t->t_regs.ss);
+                        process_name(fd, t->t_begstack, t->t_regs.ss);
                     }
                 }
 
-				total_segsize += (long)segsize << 4;
-				break;
-			}
-			printf("\n");
-		}
+                total_segsize += (long)segsize << 4;
+                break;
+            }
+            printf("\n");
+        }
 
-		/* next in heap*/
-		n = getword(fd, n + offsetof(list_s, next), ds);
-	}
+        /* next in heap*/
+        n = getword(fd, n + offsetof(list_s, next), ds);
+    }
 
-	printf("  Heap/free   %5u/%5u Total mem %7ld\n", total_size, total_free, total_segsize);
+    printf("  Heap/free   %5u/%5u Total mem %7ld\n", total_size, total_free, total_segsize);
 }
 
 void usage(void)
 {
-	printf("usage: meminfo [-a][-f][-t][-b]\n");
+    printf("usage: meminfo [-a][-f][-t][-b]\n");
 }
 
 int main(int argc, char **argv)
 {
-	int fd, c;
-	struct mem_usage mu;
+    int fd, c;
+    struct mem_usage mu;
 
-	if (argc < 2)
-		allflag = 1;
-	else while ((c = getopt(argc, argv, "aftbsh")) != -1) {
-		switch (c) {
-			case 'a':
-				aflag = 1;
-				break;
-			case 'f':
-				fflag = 1;
-				break;
-			case 't':
-				tflag = 1;
-				break;
-			case 'b':
-				bflag = 1;
-				break;
-			case 's':
-				sflag = 1;
-				break;
-			case 'h':
-				usage();
-				return 0;
-			default:
-				usage();
-				return 1;
-		}
-	}
+    if (argc < 2)
+        allflag = 1;
+    else while ((c = getopt(argc, argv, "aftbsh")) != -1) {
+        switch (c) {
+            case 'a':
+                aflag = 1;
+                break;
+            case 'f':
+                fflag = 1;
+                break;
+            case 't':
+                tflag = 1;
+                break;
+            case 'b':
+                bflag = 1;
+                break;
+            case 's':
+                sflag = 1;
+                break;
+            case 'h':
+                usage();
+                return 0;
+            default:
+                usage();
+                return 1;
+        }
+    }
 
-	if ((fd = open("/dev/kmem", O_RDONLY)) < 0) {
-		perror("meminfo");
-		return 1;
-	}
+    if ((fd = open("/dev/kmem", O_RDONLY)) < 0) {
+        perror("meminfo");
+        return 1;
+    }
     if (ioctl(fd, MEM_GETDS, &ds) ||
         ioctl(fd, MEM_GETHEAP, &heap_all) ||
         ioctl(fd, MEM_GETTASK, &taskoff) ||
@@ -215,13 +215,13 @@ int main(int argc, char **argv)
     if (!memread(fd, taskoff, ds, &task_table, sizeof(task_table))) {
         perror("taskinfo");
     }
-	dump_heap(fd);
+    dump_heap(fd);
 
-	if (!ioctl(fd, MEM_GETUSAGE, &mu)) {
-		/* note MEM_GETUSAGE amounts are floors, so total may display less by 1k than actual*/
-		printf("  Memory usage %4dKB total, %4dKB used, %4dKB free\n",
-			mu.used_memory + mu.free_memory, mu.used_memory, mu.free_memory);
-	}
+    if (!ioctl(fd, MEM_GETUSAGE, &mu)) {
+        /* note MEM_GETUSAGE amounts are floors, so total may display less by 1k than actual*/
+        printf("  Memory usage %4dKB total, %4dKB used, %4dKB free\n",
+            mu.used_memory + mu.free_memory, mu.used_memory, mu.free_memory);
+    }
 
-	return 0;
+    return 0;
 }

--- a/elkscmd/sys_utils/ps.c
+++ b/elkscmd/sys_utils/ps.c
@@ -33,97 +33,97 @@
 #include <paths.h>
 #include <libgen.h>
 
-#define LINEARADDRESS(off, seg)		((off_t) (((off_t)seg << 4) + off))
+#define LINEARADDRESS(off, seg)     ((off_t) (((off_t)seg << 4) + off))
 
 static int maxtasks;
 
 int memread(int fd, word_t off, word_t seg, void *buf, int size)
 {
-	if (lseek(fd, LINEARADDRESS(off, seg), SEEK_SET) == -1)
-		return 0;
+    if (lseek(fd, LINEARADDRESS(off, seg), SEEK_SET) == -1)
+        return 0;
 
-	if (read(fd, buf, size) != size)
-		return 0;
+    if (read(fd, buf, size) != size)
+        return 0;
 
-	return 1;
+    return 1;
 }
 
 word_t getword(int fd, word_t off, word_t seg)
 {
-	word_t word;
+    word_t word;
 
-	if (!memread(fd, off, seg, &word, sizeof(word)))
-		return 0;
-	return word;
+    if (!memread(fd, off, seg, &word, sizeof(word)))
+        return 0;
+    return word;
 }
 
 void process_name(int fd, unsigned int off, unsigned int seg)
 {
-	word_t argc, argv;
-	char buf[80];
+    word_t argc, argv;
+    char buf[80];
 
-	argc = getword(fd, off, seg);
+    argc = getword(fd, off, seg);
 
-	while (argc-- > 0) {
-		off += 2;
-		argv = getword(fd, off, seg);
-		if (!memread(fd, argv, seg, buf, sizeof(buf)))
-			return;
-		printf("%s ",buf);
-	}
+    while (argc-- > 0) {
+        off += 2;
+        argv = getword(fd, off, seg);
+        if (!memread(fd, argv, seg, buf, sizeof(buf)))
+            return;
+        printf("%s ",buf);
+    }
 }
 
 /* fast cached version of devname() */
 char *dev_name(unsigned int minor)
 {
-	struct dirent *d;
-	dev_t ttydev = MKDEV(TTY_MAJOR, minor);
-	static dev_t prevdev = -1;
-	static DIR *fp = NULL;
-	struct stat st;
-	static char path[MAXNAMLEN+6] = _PATH_DEVSL;    /* /dev/ */
+    struct dirent *d;
+    dev_t ttydev = MKDEV(TTY_MAJOR, minor);
+    static dev_t prevdev = -1;
+    static DIR *fp = NULL;
+    struct stat st;
+    static char path[MAXNAMLEN+6] = _PATH_DEVSL;    /* /dev/ */
 #define NAMEOFF     (sizeof(_PATH_DEVSL) - 1)
 
-	if (prevdev == ttydev) return path+NAMEOFF+3;
-	if (!fp) {
-		if (!(fp = opendir(_PATH_DEV)))
-			return "??";
-	} else rewinddir(fp);
+    if (prevdev == ttydev) return path+NAMEOFF+3;
+    if (!fp) {
+        if (!(fp = opendir(_PATH_DEV)))
+            return "??";
+    } else rewinddir(fp);
 
-	while ((d = readdir(fp)) != 0) {
-		if (d->d_name[0] == '.')
-			continue;
-		if (strncmp(d->d_name, "tty", 3))
-			continue;
-		strcpy(&path[NAMEOFF], d->d_name);
-		if (!stat(path, &st) && st.st_rdev == ttydev) {
-			prevdev = ttydev;
-			return path+NAMEOFF+3;
-		}
-	}
-	return "?";
+    while ((d = readdir(fp)) != 0) {
+        if (d->d_name[0] == '.')
+            continue;
+        if (strncmp(d->d_name, "tty", 3))
+            continue;
+        strcpy(&path[NAMEOFF], d->d_name);
+        if (!stat(path, &st) && st.st_rdev == ttydev) {
+            prevdev = ttydev;
+            return path+NAMEOFF+3;
+        }
+    }
+    return "?";
 }
 
 char *tty_name(int fd, unsigned int off, unsigned int seg)
 {
-	off_t addr = ((off_t)seg << 4) + off;
-	struct tty tty;
+    off_t addr = ((off_t)seg << 4) + off;
+    struct tty tty;
 
-	if (off == 0)
-		return "";
-	if (lseek(fd, addr, SEEK_SET) == -1) return "?";
+    if (off == 0)
+        return "";
+    if (lseek(fd, addr, SEEK_SET) == -1) return "?";
 
-	if (read(fd, &tty, sizeof(tty)) != sizeof(tty)) return "?";
+    if (read(fd, &tty, sizeof(tty)) != sizeof(tty)) return "?";
 
-	return dev_name(tty.minor);
+    return dev_name(tty.minor);
 }
 
 int main(int argc, char **argv)
 {
-	int c, fd;
-	unsigned int j, ds, off;
-	word_t cseg, dseg;
-	struct passwd * pwent;
+    int c, fd;
+    unsigned int j, ds, off;
+    word_t cseg, dseg;
+    struct passwd * pwent;
     int f_listall = 0;
     char *progname;
     int f_uptime;
@@ -147,26 +147,26 @@ int main(int argc, char **argv)
         }
     }
 
-	if ((fd = open("/dev/kmem", O_RDONLY)) < 0) {
-		printf("ps: no /dev/kmem\n");
-		return 1;
-	}
-	if (ioctl(fd, MEM_GETDS, &ds) < 0 ||
-		ioctl(fd, MEM_GETMAXTASKS, &maxtasks) < 0) {
-		printf("ps: ioctl mem_getds\n");
-		return 1;
-	}
+    if ((fd = open("/dev/kmem", O_RDONLY)) < 0) {
+        printf("ps: no /dev/kmem\n");
+        return 1;
+    }
+    if (ioctl(fd, MEM_GETDS, &ds) < 0 ||
+        ioctl(fd, MEM_GETMAXTASKS, &maxtasks) < 0) {
+        printf("ps: ioctl mem_getds\n");
+        return 1;
+    }
 
 #ifdef CONFIG_CPU_USAGE
     if (f_uptime) {
         jiff_t uptime;
         unsigned int upoff;
 
-	    if (ioctl(fd, MEM_GETUPTIME, &upoff) < 0 ||
+        if (ioctl(fd, MEM_GETUPTIME, &upoff) < 0 ||
                 !memread(fd, upoff, ds, &uptime, sizeof(uptime))) {
-		    printf("ps: ioctl mem_getuptime\n");
-		    return 1;
-	    }
+            printf("ps: ioctl mem_getuptime\n");
+            return 1;
+        }
 
         unsigned long n = uptime / HZ;
         int days = n / (24 * 3600L);
@@ -181,49 +181,49 @@ int main(int argc, char **argv)
     }
 #endif
 
-	if (ioctl(fd, MEM_GETTASK, &off) < 0) {
-		printf("ps: ioctl mem_gettask\n");
-		return 1;
-	}
+    if (ioctl(fd, MEM_GETTASK, &off) < 0) {
+        printf("ps: ioctl mem_gettask\n");
+        return 1;
+    }
 
-	printf("  PID   GRP  TTY USER STAT ");
+    printf("  PID   GRP  TTY USER STAT ");
 #ifdef CONFIG_CPU_USAGE
     printf("CPU");
 #endif
     printf(" ");
-	if (f_listall) printf("CSEG DSEG ");
-	printf(" HEAP  FREE   SIZE COMMAND\n");
-	for (j = 1; j < maxtasks; j++) {
-		if (!memread(fd, off + j*sizeof(struct task_struct), ds, &task_table, sizeof(task_table))) {
-			printf("ps: memread\n");
-			return 1;
-		}
+    if (f_listall) printf("CSEG DSEG ");
+    printf(" HEAP  FREE   SIZE COMMAND\n");
+    for (j = 1; j < maxtasks; j++) {
+        if (!memread(fd, off + j*sizeof(struct task_struct), ds, &task_table, sizeof(task_table))) {
+            printf("ps: memread\n");
+            return 1;
+        }
 
-		switch (task_table.state) {
-		case TASK_UNUSED:			continue;
-		case TASK_RUNNING:			c = 'R'; break;
-		case TASK_INTERRUPTIBLE:	c = 'S'; break;
-		case TASK_UNINTERRUPTIBLE:	c = 's'; break;
-		case TASK_STOPPED:			c = 'T'; break;
-		case TASK_ZOMBIE:			c = 'Z'; break;
-		case TASK_EXITING:			c = 'E'; break;
-		default:					c = '?'; break;
-		}
+        switch (task_table.state) {
+        case TASK_UNUSED:           continue;
+        case TASK_RUNNING:          c = 'R'; break;
+        case TASK_INTERRUPTIBLE:    c = 'S'; break;
+        case TASK_UNINTERRUPTIBLE:  c = 's'; break;
+        case TASK_STOPPED:          c = 'T'; break;
+        case TASK_ZOMBIE:           c = 'Z'; break;
+        case TASK_EXITING:          c = 'E'; break;
+        default:                    c = '?'; break;
+        }
 
-		if (task_table.kstack_magic != KSTACK_MAGIC) {
-			printf("Recompile ps, mismatched task structure\n");
-			return 1;
-		}
+        if (task_table.kstack_magic != KSTACK_MAGIC) {
+            printf("Recompile ps, mismatched task structure\n");
+            return 1;
+        }
 
-		pwent = getpwuid(task_table.uid);
+        pwent = getpwuid(task_table.uid);
 
-		/* pid grp tty user stat*/
-		printf("%5d %5d %4s %-8s%c ",
-				task_table.pid,
-				task_table.pgrp,
-				tty_name(fd, (unsigned int)task_table.tty, ds),
-				(pwent ? pwent->pw_name : "unknown"),
-				c);
+        /* pid grp tty user stat*/
+        printf("%5d %5d %4s %-8s%c ",
+                task_table.pid,
+                task_table.pgrp,
+                tty_name(fd, (unsigned int)task_table.tty, ds),
+                (pwent ? pwent->pw_name : "unknown"),
+                c);
 
 #ifdef CONFIG_CPU_USAGE
         {
@@ -232,34 +232,34 @@ int main(int argc, char **argv)
             printf("%3d", FIXED_INT(cpu_percent));
         }
 #endif
-		/* CSEG*/
-		cseg = (word_t)task_table.mm[SEG_CODE];
-		if (f_listall) printf(" %4x ",
+        /* CSEG*/
+        cseg = (word_t)task_table.mm[SEG_CODE];
+        if (f_listall) printf(" %4x ",
             cseg? getword(fd, (word_t)cseg+offsetof(struct segment, base), ds): 0);
 
-		/* DSEG*/
-		dseg = (word_t)task_table.mm[SEG_DATA];
-		if (f_listall) printf("%4x",
+        /* DSEG*/
+        dseg = (word_t)task_table.mm[SEG_DATA];
+        if (f_listall) printf("%4x",
             dseg? getword(fd, (word_t)dseg+offsetof(struct segment, base), ds): 0);
 
-		if (dseg) {
-			/* heap*/
-			printf(" %5u ", (word_t)(task_table.t_endbrk - task_table.t_enddata));
+        if (dseg) {
+            /* heap*/
+            printf(" %5u ", (word_t)(task_table.t_endbrk - task_table.t_enddata));
 
-			/* free*/
-			printf("%5u ", (word_t)(task_table.t_regs.sp - task_table.t_endbrk));
+            /* free*/
+            printf("%5u ", (word_t)(task_table.t_regs.sp - task_table.t_endbrk));
 
-			/* stack*/
-			//printf("%5u ", (word_t)(task_table.t_begstack - task_table.t_regs.sp));
+            /* stack*/
+            //printf("%5u ", (word_t)(task_table.t_begstack - task_table.t_regs.sp));
 
-			/* size*/
-			segext_t size = getword(fd, (word_t)cseg+offsetof(struct segment, size), ds)
-							+ getword(fd, (word_t)dseg+offsetof(struct segment, size), ds);
-			printf("%6ld ", (long)size << 4);
+            /* size*/
+            segext_t size = getword(fd, (word_t)cseg+offsetof(struct segment, size), ds)
+                            + getword(fd, (word_t)dseg+offsetof(struct segment, size), ds);
+            printf("%6ld ", (long)size << 4);
 
-			process_name(fd, task_table.t_begstack, task_table.t_regs.ss);
-		}
-		printf("\n");
-	}
-	return 0;
+            process_name(fd, task_table.t_begstack, task_table.t_regs.ss);
+        }
+        printf("\n");
+    }
+    return 0;
 }

--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -10,29 +10,29 @@
 #define SEEK_END 2
 #endif
 
-#define _IOFBF		0x00	/* full buffering */
-#define _IOLBF		0x01	/* line buffering */
-#define _IONBF		0x02	/* no buffering */
-#define __MODE_BUF	0x03	/* Modal buffering dependent on isatty */
+#define _IOFBF          0x00    /* full buffering */
+#define _IOLBF          0x01    /* line buffering */
+#define _IONBF          0x02    /* no buffering */
+#define __MODE_BUF      0x03    /* Modal buffering dependent on isatty */
 
-#define __MODE_FREEBUF	0x04	/* Buffer allocated with malloc, can free */
-#define __MODE_FREEFIL	0x08	/* FILE allocated with malloc, can free */
+#define __MODE_FREEBUF  0x04    /* Buffer allocated with malloc, can free */
+#define __MODE_FREEFIL  0x08    /* FILE allocated with malloc, can free */
 
-#define __MODE_READ	0x10	/* Opened in read only */
-#define __MODE_WRITE	0x20	/* Opened in write only */
-#define __MODE_RDWR	0x30	/* Opened in read/write */
+#define __MODE_READ     0x10    /* Opened in read only */
+#define __MODE_WRITE    0x20    /* Opened in write only */
+#define __MODE_RDWR     0x30    /* Opened in read/write */
 
-#define __MODE_READING	0x40	/* Buffer has pending read data */
-#define __MODE_WRITING	0x80	/* Buffer has pending write data */
+#define __MODE_READING  0x40    /* Buffer has pending read data */
+#define __MODE_WRITING  0x80    /* Buffer has pending write data */
 
-#define __MODE_EOF	0x100	/* EOF status */
-#define __MODE_ERR	0x200	/* Error status */
-#define __MODE_UNGOT	0x400	/* Buffer has been polluted by ungetc */
+#define __MODE_EOF      0x100   /* EOF status */
+#define __MODE_ERR      0x200   /* Error status */
+#define __MODE_UNGOT    0x400   /* Buffer has been polluted by ungetc */
 
 #ifdef __MSDOS__
-#define __MODE_IOTRAN	0x1000	/* MSDOS nl <-> cr,nl translation */
+#define __MODE_IOTRAN   0x1000  /* MSDOS nl <-> cr,nl translation */
 #else
-#define __MODE_IOTRAN	0
+#define __MODE_IOTRAN   0
 #endif
 
 /* when you add or change fields here, be sure to change the initialization
@@ -53,34 +53,34 @@ struct __stdio_file {
   struct __stdio_file * next;
 };
 
-#define EOF	(-1)
+#define EOF     (-1)
 #ifndef NULL
-#define NULL	((void*)0)
+#define NULL    ((void*)0)
 #endif
 
 typedef struct __stdio_file FILE;
 
-#define BUFSIZ	(1024)
+#define BUFSIZ  (1024)
 
 extern FILE stdin[1];
 extern FILE stdout[1];
 extern FILE stderr[1];
 
-#define putc(c, stream)	\
-    (((stream)->bufpos >= (stream)->bufwrite) ? fputc((c), (stream))	\
-                          : (unsigned char) (*(stream)->bufpos++ = (c))	)
+#define putc(c, stream) \
+    (((stream)->bufpos >= (stream)->bufwrite) ? fputc((c), (stream))    \
+                          : (unsigned char) (*(stream)->bufpos++ = (c)) )
 
-#define getc(stream)	\
-  (((stream)->bufpos >= (stream)->bufread) ? fgetc(stream):		\
+#define getc(stream)    \
+  (((stream)->bufpos >= (stream)->bufread) ? fgetc(stream):             \
     (*(stream)->bufpos++))
 
 #define putchar(c) putc((c), stdout)  
 #define getchar() getc(stdin)
 
-#define ferror(fp)	(((fp)->mode&__MODE_ERR) != 0)
-#define feof(fp)   	(((fp)->mode&__MODE_EOF) != 0)
-#define clearerr(fp)	((fp)->mode &= ~(__MODE_EOF|__MODE_ERR))
-#define fileno(fp)	((fp)->fd)
+#define ferror(fp)      (((fp)->mode&__MODE_ERR) != 0)
+#define feof(fp)        (((fp)->mode&__MODE_EOF) != 0)
+#define clearerr(fp)    ((fp)->mode &= ~(__MODE_EOF|__MODE_ERR))
+#define fileno(fp)      ((fp)->fd)
 
 /* declare functions; not like it makes much difference without ANSI */
 /* RDB: The return values _are_ important, especially if we ever use
@@ -103,9 +103,9 @@ int fflush(FILE*);
 char *fgets(char*, size_t, FILE*);
 
 ssize_t getdelim(char ** restrict lineptr, size_t * restrict n,
-		int delimiter, register FILE * restrict stream);
+                int delimiter, register FILE * restrict stream);
 ssize_t getline(char ** restrict lineptr, size_t * restrict n,
-		FILE * restrict stream);
+                FILE * restrict stream);
 
 FILE *fopen(const char*, const char*);
 FILE *fdopen(int, const char*);
@@ -125,7 +125,7 @@ int fseek(FILE *fp, long offset, int ref);
 long ftell(FILE *fp);
 void rewind(FILE *fp);
 int fwrite(const char *buf, int size, int nelm, FILE *fp);
-char * gets(char *str);	/* BAD function; DON'T use it! */
+char * gets(char *str); /* BAD function; DON'T use it! */
 
 int fscanf(FILE * fp, const char * fmt, ...);
 

--- a/libc/stdio/vfprintf.c
+++ b/libc/stdio/vfprintf.c
@@ -37,8 +37,8 @@
 #endif
 
 static int
-printfield(FILE *op, unsigned char *buf,
-	int ljustf, char sign, char pad, int width, int preci, int buffer_mode)
+printfield(FILE *op, unsigned char *buf, int ljustf, char sign, char pad, int width,
+    int preci, int buffer_mode)
 /*
  * Output the given field in the manner specified by the arguments. Return
  * the number of characters output.
@@ -54,10 +54,10 @@ printfield(FILE *op, unsigned char *buf,
    else if (sign)
       len++;
 
-   if ((preci != -1) && (len > preci))	/* limit max data width */
+   if ((preci != -1) && (len > preci))  /* limit max data width */
       len = preci;
 
-   if (width < len)		/* flexible field width or width overflow */
+   if (width < len)             /* flexible field width or width overflow */
       width = len;
 
    /*
@@ -69,28 +69,28 @@ printfield(FILE *op, unsigned char *buf,
 
    while (width || len)
    {
-      if (!ljustf && width)	/* left padding */
+      if (!ljustf && width)     /* left padding */
       {
-	 if (len && sign && (pad == '0'))
-	    goto showsign;
-	 ch = pad;
-	 --width;
+         if (len && sign && (pad == '0'))
+            goto showsign;
+         ch = pad;
+         --width;
       }
       else if (len)
       {
-	 if (sign)
-	 {
-	  showsign:ch = sign;	/* sign */
-	    sign = '\0';
-	 }
-	 else
-	    ch = *buf++;	/* main field */
-	 --len;
+         if (sign)
+         {
+          showsign:ch = sign;   /* sign */
+            sign = '\0';
+         }
+         else
+            ch = *buf++;        /* main field */
+         --len;
       }
       else
       {
-	 ch = pad;		/* right padding */
-	 --width;
+         ch = pad;              /* right padding */
+         --width;
       }
       putc(ch, op);
       if( ch == '\n' && buffer_mode == _IOLBF ) fflush(op);
@@ -119,161 +119,161 @@ vfprintf(FILE *op, const char *fmt, va_list ap)
       if (*fmt == '%')
       {
          if( buffer_mode == _IONBF ) fflush(op);
-	 ljustf = 0;		/* left justify flag */
-	 sign = '\0';		/* sign char & status */
-	 pad = ' ';		/* justification padding char */
-	 width = -1;		/* min field width */
-	 dpoint = 0;		/* found decimal point */
-	 preci = -1;		/* max data width */
-	 radix = 10;		/* number base */
-	 ptmp = tmp;		/* pointer to area to print */
-	 hash = 0;
-	 lval = (sizeof(int)==sizeof(long));	/* long value flag */
+         ljustf = 0;            /* left justify flag */
+         sign = '\0';           /* sign char & status */
+         pad = ' ';             /* justification padding char */
+         width = -1;            /* min field width */
+         dpoint = 0;            /* found decimal point */
+         preci = -1;            /* max data width */
+         radix = 10;            /* number base */
+         ptmp = tmp;            /* pointer to area to print */
+         hash = 0;
+         lval = (sizeof(int)==sizeof(long));    /* long value flag */
        fmtnxt:
-	 i = 0;
-	 for(;;)
-	 {
-	    ++fmt;
-	    if(*fmt < '0' || *fmt > '9' ) break;
-	    i = (i * 10) + (*fmt - '0');
-	    if (dpoint)
-	       preci = i;
-	    else if (!i && (pad == ' '))
-	    {
-	       pad = '0';
-	       goto fmtnxt;
-	    }
-	    else
-	       width = i;
-	 }
-
-	 switch (*fmt)
-	 {
-	 case '\0':		/* early EOS */
-	    --fmt;
-	    goto charout;
-
-	 case '-':		/* left justification */
-	    ljustf = 1;
-	    goto fmtnxt;
-
-	 case ' ':
-	 case '+':		/* leading sign flag */
-	    sign = *fmt;
-	    goto fmtnxt;
-
-	 case '*':		/* parameter width value */
-	    i = va_arg(ap, int);
-	    if (dpoint)
-	       preci = i;
-	    else {
-		if (i < 0) {
-		    width = -i;
-		    ljustf = 1;
-		} else width = i;
+         i = 0;
+         for(;;)
+         {
+            ++fmt;
+            if(*fmt < '0' || *fmt > '9' ) break;
+            i = (i * 10) + (*fmt - '0');
+            if (dpoint)
+               preci = i;
+            else if (!i && (pad == ' '))
+            {
+               pad = '0';
+               goto fmtnxt;
             }
-	    goto fmtnxt;
+            else
+               width = i;
+         }
 
-	 case '.':		/* secondary width field */
-	    dpoint = 1;
-	    goto fmtnxt;
+         switch (*fmt)
+         {
+         case '\0':             /* early EOS */
+            --fmt;
+            goto charout;
 
-	 case 'l':		/* long data */
-	    lval = 1;
-	    goto fmtnxt;
+         case '-':              /* left justification */
+            ljustf = 1;
+            goto fmtnxt;
 
-	 case 'h':		/* short data */
-	    lval = 0;
-	    goto fmtnxt;
+         case ' ':
+         case '+':              /* leading sign flag */
+            sign = *fmt;
+            goto fmtnxt;
 
-	 case 'd':		/* Signed decimal */
-	 case 'i':
-	    ptmp = ltostr((long) ((lval)
-			 ? va_arg(ap, long)
-			 : va_arg(ap, int)),
-		 10);
-	    goto printit;
+         case '*':              /* parameter width value */
+            i = va_arg(ap, int);
+            if (dpoint)
+               preci = i;
+            else {
+                if (i < 0) {
+                    width = -i;
+                    ljustf = 1;
+                } else width = i;
+            }
+            goto fmtnxt;
 
-	 case 'b':		/* Unsigned binary */
-	    radix = 2;
-	    goto usproc;
+         case '.':              /* secondary width field */
+            dpoint = 1;
+            goto fmtnxt;
 
-	 case 'o':		/* Unsigned octal */
-	    radix = 8;
-	    goto usproc;
+         case 'l':              /* long data */
+            lval = 1;
+            goto fmtnxt;
 
-	 case 'p':		/* Pointer */
-	    lval = (sizeof(char*) == sizeof(long));
-	    pad = '0';
-	    width = 4;
-	    preci = 8;
-	    /* fall thru */
+         case 'h':              /* short data */
+            lval = 0;
+            goto fmtnxt;
 
-	 case 'x':		/* Unsigned hexadecimal */
-	 case 'X':
-	    radix = 16;
-	    /* fall thru */
+         case 'd':              /* Signed decimal */
+         case 'i':
+            ptmp = ltostr((long) ((lval)
+                         ? va_arg(ap, long)
+                         : va_arg(ap, int)),
+                 10);
+            goto printit;
 
-	 case 'u':		/* Unsigned decimal */
-	 case 'k':		/* Pticks */
-	  usproc:
-	    l = lval? va_arg(ap, unsigned long) : (unsigned long)va_arg(ap, unsigned int);
-	    if (*fmt == 'k') {
-		if (_weakaddr(ptostr)) {
-		    (_weakfn(ptostr))(l, ptmp);
-		    preci = -1;
-		    goto printit;
-		}
-		/* if precision timing not linked in, display as unsigned */
-	    }
-	    ptmp = ultostr(l, radix);
-	    if( hash && radix == 8 ) { width = strlen(ptmp)+1; pad='0'; }
-	    goto printit;
+         case 'b':              /* Unsigned binary */
+            radix = 2;
+            goto usproc;
 
-	 case '#':
-	    hash=1;
-	    goto fmtnxt;
+         case 'o':              /* Unsigned octal */
+            radix = 8;
+            goto usproc;
 
-	 case 'c':		/* Character */
-	    ptmp[0] = va_arg(ap, int);
-	    ptmp[1] = '\0';
-	    goto nopad;
+         case 'p':              /* Pointer */
+            lval = (sizeof(char*) == sizeof(long));
+            pad = '0';
+            width = 4;
+            preci = 8;
+            /* fall thru */
 
-	 case 's':		/* String */
-	    ptmp = va_arg(ap, char*);
-	    if (!ptmp) ptmp = "(null)";
-	  nopad:
-	    sign = '\0';
-	    pad = ' ';
-	  printit:
-	    cnt += printfield(op, (unsigned char *)ptmp, ljustf,
-			   sign, pad, width, preci, buffer_mode);
-	    break;
+         case 'x':              /* Unsigned hexadecimal */
+         case 'X':
+            radix = 16;
+            /* fall thru */
+
+         case 'u':              /* Unsigned decimal */
+         case 'k':              /* Pticks */
+          usproc:
+            l = lval? va_arg(ap, unsigned long) : (unsigned long)va_arg(ap, unsigned int);
+            if (*fmt == 'k') {
+                if (_weakaddr(ptostr)) {
+                    (_weakfn(ptostr))(l, ptmp);
+                    preci = -1;
+                    goto printit;
+                }
+                /* if precision timing not linked in, display as unsigned */
+            }
+            ptmp = ultostr(l, radix);
+            if( hash && radix == 8 ) { width = strlen(ptmp)+1; pad='0'; }
+            goto printit;
+
+         case '#':
+            hash=1;
+            goto fmtnxt;
+
+         case 'c':              /* Character */
+            ptmp[0] = va_arg(ap, int);
+            ptmp[1] = '\0';
+            goto nopad;
+
+         case 's':              /* String */
+            ptmp = va_arg(ap, char*);
+            if (!ptmp) ptmp = "(null)";
+          nopad:
+            sign = '\0';
+            pad = ' ';
+          printit:
+            cnt += printfield(op, (unsigned char *)ptmp, ljustf,
+                           sign, pad, width, preci, buffer_mode);
+            break;
 
 #ifndef __HAS_NO_FLOATS__
-	 case 'e':		/* float */
-	 case 'f':
-	 case 'g':
-	 case 'E':
-	 case 'G':
-	    if (_weakaddr(dtostr))
-	    {
-	       (_weakfn(dtostr))(va_arg(ap, double), *fmt, preci, ptmp);
-	       preci = -1;
-	       goto printit;
-	    }
-	    /* FALLTHROUGH if no floating printf available */
+         case 'e':              /* float */
+         case 'f':
+         case 'g':
+         case 'E':
+         case 'G':
+            if (_weakaddr(dtostr))
+            {
+               (_weakfn(dtostr))(va_arg(ap, double), *fmt, preci, ptmp);
+               preci = -1;
+               goto printit;
+            }
+            /* FALLTHROUGH if no floating printf available */
 #endif
 
-	 default:		/* unknown character */
-	    goto charout;
-	 }
+         default:               /* unknown character */
+            goto charout;
+         }
       }
       else
       {
        charout:
-	 putc(*fmt, op);	/* normal char out */
-	 ++cnt;
+         putc(*fmt, op);        /* normal char out */
+         ++cnt;
          if( *fmt == '\n' && buffer_mode == _IOLBF ) fflush(op);
       }
       ++fmt;


### PR DESCRIPTION
The combinations of 4- and 8-character tabs, as well as fixed indention with spaces to 4- and 8-column positions, is out of control. This continues the retabbing of a number of kernel C and ASM source files, using fixed spaces to 4 columns for C, and fixed spaces to 8 columns for most ASM code.

Only reformatting, no functional changes. This needed to be done as some vfprintf/tiny_printf changes coming that need careful source diffs between them.