### PR TITLE
[libc] Minimize differences between vfprintf.c and tiny_printf.c

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,13 +6,13 @@ on:
       - '**'
       - '!.github/workflows/cross.yml'
       - '!.github/workflows/ow-libc.yml'
-      - '!tools/**'
- pull_request:
-   paths:
+      - '!tools/*'
+  pull_request:
+    paths:
      - '**'
      - '!.github/workflows/cross.yml'
      - '!.github/workflows/ow-libc.yml'
-     - '!tools/**'
+     - '!tools/*'
 
 jobs:
   build:


### PR DESCRIPTION
In preparation for upcoming speed/size enhancements to libc printf and family.

Also (finally) fixes main.yml file - the number of indentation spaces matter!!