### PR TITLE
[libc] Add thousands grouping to printf

### DIFF
--- a/elkscmd/file_utils/cat.c
+++ b/elkscmd/file_utils/cat.c
@@ -15,7 +15,8 @@ static char readbuf[BUFSIZ];    /* use disk block size for stack limit and effic
 #if TEST
 void test(void)
 {
-    printf("#04X: '%#04X'\n", 0x2ab);
+    printf("   p: '%p'\n", 0x18AF);
+    printf("  lp: '%lp'\n", 0x02d018AFL);
     printf("04X: '%04X'\n", 0x2ab);
     printf("04x: '%04x'\n", 0x2ab);
     printf(" 4x: '%4x'\n", 0x2ab);
@@ -25,7 +26,7 @@ void test(void)
     printf(" 5d: '%5d'\n", -20);
     printf("+5d: '%5d'\n", -20);
     printf("+5d: '%5d'\n", 20);
-    printf(" ld: '%ld'\n", -123456789L);
+    printf(",ld: '%,ld'\n", -123456789L);
     printf(" lx: '%lx'\n", 0x87654321L);
     printf(" lo: '%lo'\n", 0xFFFFFFFFL);
     printf("  s: '%s'\n", "thisisatest");


### PR DESCRIPTION
Adds the ability to display large numbers using comma-based thousands separator, e.g. `%,lu` to display up to 4 billion and more easily read it. Also supports ' and _ instead of , by specifying the same. This code could be used to enhance `df` or mount displays showing filesystem sizes with more readability.

Eliminated some unused code in vfprintf, `#` hash flag specifier previously only used for octal display.

Added documentation on supported format types and flag specifiers at top of libc/stdio/vfprintf.c.

Temporarily using test code in cat.c, to be removed shortly.