### PR TITLE
[libc] Use __divmod in ltoa, ultoa, ltostr, ultostr and dd

### DIFF
--- a/elkscmd/file_utils/cat.c
+++ b/elkscmd/file_utils/cat.c
@@ -11,30 +11,6 @@
 
 static char readbuf[BUFSIZ];    /* use disk block size for stack limit and efficiency*/
 
-#define TEST    0
-#if TEST
-void test(void)
-{
-    printf("   p: '%p'\n", 0x18AF);
-    printf("  lp: '%lp'\n", 0x02d018AFL);
-    printf("04X: '%04X'\n", 0x2ab);
-    printf("04x: '%04x'\n", 0x2ab);
-    printf(" 4x: '%4x'\n", 0x2ab);
-    printf("04d: '%04d'\n", 0x200);
-    printf(" 4d: '%4d'\n", 0x200);
-    printf("05d: '%05d'\n", -20);
-    printf(" 5d: '%5d'\n", -20);
-    printf("+5d: '%5d'\n", -20);
-    printf("+5d: '%5d'\n", 20);
-    printf(",ld: '%,ld'\n", -123456789L);
-    printf(" lx: '%lx'\n", 0x87654321L);
-    printf(" lo: '%lo'\n", 0xFFFFFFFFL);
-    printf("  s: '%s'\n", "thisisatest");
-    printf(" 6s: '%6s'\n", "thisisatest");
-    printf("20s: '%20s'\n", "thisisatest");
-}
-#endif
-
 static int copyfd(int fd)
 {
 	int n;
@@ -50,10 +26,6 @@ int main(int argc, char **argv)
 {
 	int i, fd;
 
-#if TEST
-    test();
-    exit(0);
-#endif
 	if (argc <= 1) {
 		if (copyfd(STDIN_FILENO)) {
 			perror("stdin");

--- a/elkscmd/file_utils/dd.c
+++ b/elkscmd/file_utils/dd.c
@@ -88,9 +88,18 @@ char *ultoa_r(char *buf, unsigned long i)
     char *b = buf + 34 - 1;
 
     *b = '\0';
+#ifdef _M_I86
+    do {
+        unsigned int c;
+        c = 10;
+        i = __divmod(i, &c);
+        *--b = '0' + c;
+    } while (i);
+#else
     do {
         *--b = '0' + (i % 10);
     } while ((i /= 10) != 0);
+#endif
     return b;
 }
 static void eprintf(const char *s, ...)

--- a/elkscmd/lib/tiny_vfprintf.c
+++ b/elkscmd/lib/tiny_vfprintf.c
@@ -15,10 +15,10 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <string.h>
-#include <arch/divmod.h>
 
 static unsigned char bufout[80];
 

--- a/elkscmd/test/other/test_float.c
+++ b/elkscmd/test/other/test_float.c
@@ -271,5 +271,30 @@ int main(int argc, char **argv) {
     printf("%s\n", ultostr(-0x7fffffff, 10));
     printf("%s\n", ultostr(0x80000000, 10));
     printf("%s\n", ultostr(0xffffffff, 10));
+
+    printf("-25     %s\n", itoa(-25));
+    printf("32767   %s\n", uitoa(32767));
+    printf(" 100000  %s\n", ultoa(100000L));
+    printf("-100000 %s\n", ltoa(-100000L));
+    printf(" 300000  %s\n", ultostr(300000L, 10));
+    printf("-300000 %s\n", ltostr(-300000L, 10));
+    printf("   p: '%p'\n", 0x18AF);
+    printf("  lp: '%lp'\n", 0x02d018AFL);
+    printf("04X: '%04X'\n", 0x2ab);
+    printf("04x: '%04x'\n", 0x2ab);
+    printf(" 4x: '%4x'\n", 0x2ab);
+    printf("04d: '%04d'\n", 0x200);
+    printf(" 4d: '%4d'\n", 0x200);
+    printf("05d: '%05d'\n", -20);
+    printf(" 5d: '%5d'\n", -20);
+    printf("+5d: '%5d'\n", -20);
+    printf("+5d: '%5d'\n", 20);
+    printf(",ld: '%,ld'\n", -123456789L);
+    printf(" lx: '%lx'\n", 0x87654321L);
+    printf(" lo: '%lo'\n", 0xFFFFFFFFL);
+    printf("  s: '%s'\n", "thisisatest");
+    printf(" 6s: '%6s'\n", "thisisatest");
+    printf("20s: '%20s'\n", "thisisatest");
+
 	return 0;
 }

--- a/libc/include/stdlib.h
+++ b/libc/include/stdlib.h
@@ -5,6 +5,7 @@
 #include <features.h>
 #include <sys/types.h>
 #include <malloc.h>
+#include <arch/divmod.h>
 
 /* Don't overwrite user definitions of NULL */
 #ifndef NULL

--- a/libc/misc/ltoa.c
+++ b/libc/misc/ltoa.c
@@ -9,9 +9,18 @@ char *ltoa(long val)
    unsigned long u = (val < 0)? 0u - val: val;
 
    *b = '\0';
+#ifdef _M_I86
+    do {
+        unsigned int c;
+        c = 10;
+        u = __divmod(u, &c);
+        *--b = '0' + c;
+    } while (u);
+#else
    do {
       *--b = '0' + (u % 10);
    } while ((u /= 10) != 0);
+#endif
    if (val < 0)
       *--b = '-';
    return b;

--- a/libc/misc/ultoa.c
+++ b/libc/misc/ultoa.c
@@ -8,8 +8,17 @@ char *ultoa(unsigned long i)
     char *b = buf + sizeof(buf) - 1;
 
     *b = '\0';
+#ifdef _M_I86
+    do {
+        unsigned int c;
+        c = 10;
+        i = __divmod(i, &c);
+        *--b = '0' + c;
+    } while (i);
+#else
     do {
         *--b = '0' + (i % 10);
     } while ((i /= 10) != 0);
+#endif
     return b;
 }

--- a/libc/misc/ultostr.c
+++ b/libc/misc/ultostr.c
@@ -9,11 +9,18 @@ char *ultostr(unsigned long val, int radix)
 
   *p = '\0';
   do {
-      int c = val % radix;
+#ifdef _M_I86
+      unsigned int c;
+      c = radix;
+      val = __divmod(val, &c);
+#else
+      unsigned int c = val % radix;
+      val = val / radix;
+#endif
       if (c > 9)
         *--p = 'a' - 10 + c;
       else
         *--p = '0' + c;
-  } while ((val /= radix) != 0);
+  } while (val);
   return p;
 }

--- a/libc/stdio/vfprintf.c
+++ b/libc/stdio/vfprintf.c
@@ -42,9 +42,9 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <fcntl.h>
 #include <string.h>
-#include <arch/divmod.h>
 
 #ifndef __HAS_NO_FLOATS__
 #include <sys/weaken.h>
@@ -260,7 +260,7 @@ vfprintf(FILE *op, const char *fmt, va_list ap)
             p = buf + sizeof(buf) - 1;
             *p = '\0';
             for (i = 0;;) {
-#if 1
+#ifdef _M_I86
                 c = radix;
                 v = __divmod(v, &c);    /* remainder returned in c */
 #else


### PR DESCRIPTION
This is the final PR in the series, using the much faster __divmod routine for number to string conversion in the C library. 

Executables using these library functions are now ~60 bytes smaller than when __udivsi3/__umodsi3 were used.

Test code has been moved to elkscmd/test/other/test_float.c, where some of these routines were already being tested.