### PR TITLE
[libc,kernel] Rewrite ptostr for speed, add thousands separator to printk

### DIFF
--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -52,7 +52,7 @@ static void INITPROC print_minor_name(register struct gendisk *hd, unsigned int 
     printk("%s%c", hd->major_name, 'a' + (unsigned char)(minor >> hd->minor_shift));
     if ((part = (unsigned) (minor & ((1 << hd->minor_shift) - 1))))
         printk("%d", part);
-    printk(":(%lu,%lu) ", hdp->start_sect, hdp->nr_sects);
+    printk(":(%,lu;%,lu) ", hdp->start_sect, hdp->nr_sects);
 }
 
 static void INITPROC add_partition(struct gendisk *hd, unsigned int minor,

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -168,7 +168,7 @@ static struct super_block *msdos_read_super(struct super_block *s, char *data,
 	sb->previous_cluster = 0;
 	unmap_brelse(bh);
 
-printk("FAT: me=%x,csz=%d,#f=%d,floc=%d,fsz=%d,rloc=%d,#d=%d,dloc=%d,#s=%lu,ts=%lu\n",
+printk("FAT: me=%x,csz=%d,#f=%d,floc=%d,fsz=%d,rloc=%d,#d=%d,dloc=%d,#s=%,lu,ts=%,lu\n",
 	b->media, sb->cluster_size, sb->fats, sb->fat_start,
 	sb->fat_length, sb->dir_start, sb->dir_entries,
 	sb->data_start, total_sectors, b->total_sect);
@@ -183,7 +183,7 @@ printk("FAT: me=%x,csz=%d,#f=%d,floc=%d,fsz=%d,rloc=%d,#d=%d,dloc=%d,#s=%lu,ts=%
 	 * Disk free space will be shown incorrectly between ELKS and MSDOS in this case.
 	 */
 	if (sb->clusters > max_clusters) {
-	    printk("FAT: #clus=%ld > max=%ld, limiting free space\n",
+	    printk("FAT: #clus=%,ld > max=%,ld, limiting free space\n",
 		    sb->clusters, max_clusters);
 	    sb->clusters = max_clusters;
 	}

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -126,7 +126,7 @@ void start_kernel(void)
     printk(" 5d: '%5d'\n", -20);
     printk("+5d: '%5d'\n", -20);
     printk("+5d: '%5d'\n", 20);
-    printk(" ld: '%ld'\n", -123456789L);
+    printk(",ld: '%,ld'\n", -123456789L);
     printk(" lx: '%lx'\n", 0x87654321L);
     printk(" lo: '%lo'\n", 0xFFFFFFFFL);
     printk("  s: '%s'\n", "thisisatest");

--- a/elkscmd/file_utils/cat.c
+++ b/elkscmd/file_utils/cat.c
@@ -7,7 +7,6 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
-#include <stdlib.h>
 
 static char readbuf[BUFSIZ];    /* use disk block size for stack limit and efficiency*/
 

--- a/libc/misc/ptostr.c
+++ b/libc/misc/ptostr.c
@@ -2,58 +2,52 @@
  * Convert precision timing pticks (=0.838us) to string for printf %k format.
  * This routine is normally weak linked into vfprintf by a get_ptime reference.
  */
+#include <stdlib.h>
 
-static char dec_string[] = "0123456789 ";
-
-void ptostr(unsigned long v, char *buf)
+void ptostr(unsigned long v, char *outbuf)
 {
-    int c, vch, i;
-    int Msecs, Decimal, Zero, width;
-    unsigned long dvr;
+    unsigned int c;
+    char *p;
+    int n, Decimal, Suffix = 0;
+    char buf[12];
 
-    i = 10;
-    dvr = 1000000000L;
-    width = Zero = 0;
-    Msecs = 0;
-    /* display 1/1193182s get_time*() pticks in range 0.838usec through 42.85sec */
-    Decimal = 3;
-    if (v > 51130563UL)             /* = 2^32 / 84 high max range = ~42.85s */
-        v = 0;                      /* ... displays 0us */
-    if (v > 5125259UL) {            /* = 2^32 / 838 */
-        v = v * 84UL;
+    /* display 1/1193182s get_ptick() pticks in range 0.838usec through 42.85sec */
+    if (v > 5125259UL) {            /* = 2^32 / 838  = ~4.3s */
+        if (v > 51130563UL)         /* = 2^32 / 84 high max range = ~42.85s */
+            v = 0;                  /* ... displays 0us */
+        v *= 84;
         Decimal = 2;                /* display xx.xx secs */
-    } else
-        v = v * 838UL;              /* convert to nanosecs w/o 32-bit overflow */
-    if (v > 1000000000UL) {         /* display x.xxx secs */
-        v /= 1000000UL;             /* divide using _udivsi3 for speed */
-    } else if (v > 1000000UL) {
-        v /= 1000UL;                /* display xx.xxx msecs */
-        Msecs = 1;
     } else {
-        Msecs = 2;                  /* display xx.xxx usecs */
+        v *= 838;                   /* convert to nanosecs w/o 32-bit overflow */
+        Decimal = 3;                /* display xx.xxx */
     }
+    while (v > 1000000L) {          /* quick divides for readability */
+        c = 1000;
+        v = __divmod(v, &c);
+        Suffix++;
+    }
+    if (Suffix == 0)      Suffix = ('s' << 8) | 'u';
+    else if (Suffix == 1) Suffix = ('s' << 8) | 'm';
+    else                  Suffix = 's';
 
-    vch = 0;
+    p = buf + sizeof(buf) - 1;
+    *p = '\0';
     do {
-        c = (int)(v / dvr);
-        v %= dvr;
-        dvr /= 10U;
-        if (c || (i <= width) || (i < 2)) {
-            if (i > width)
-                width = i;
-            if (!Zero && !c && (i > 1))
-                c = 10;
-            else
-                Zero = 1;
-            if (vch)
-                *buf++ = vch;
-            vch = *(dec_string + c);
-            if (i == Decimal) *buf++ = '.';
-        }
-    } while (--i);
-    *buf++ = vch;
-    if (Msecs)
-        *buf++ = (Msecs == 1? 'm': 'u');
-    *buf++ = 's';
-    *buf = '\0';
+        c = 10;
+        v = __divmod(v, &c);        /* remainder returned in c */
+        *--p = '0' + c;
+    } while (v != 0);
+
+    n = buf + sizeof(buf) - 1 - p;  /* string length */
+    while (*p) {
+        if (n == Decimal)
+            *outbuf++ = '.';
+        --n;
+        *outbuf++ = *p++;
+    }
+    while (Suffix) {
+        *outbuf++ = Suffix & 255;
+        Suffix >>= 8;
+    }
+    *outbuf = '\0';
 }

--- a/libc/stdio/vfprintf.c
+++ b/libc/stdio/vfprintf.c
@@ -278,12 +278,10 @@ vfprintf(FILE *op, const char *fmt, va_list ap)
                     i = 0;
                 }
             }
-#if 0
-            if (hash && radix == 8) {
-                width = strlen(p) + 1;
-                pad = '0';
-            }
-#endif
+            //if (hash && radix == 8) {
+                //width = strlen(p) + 1;
+                //pad = '0';
+            //}
             goto printit;
 
          case 'c':              /* Character */


### PR DESCRIPTION
Rewrites `ptostr` precision timer routine to be much faster, using __divmod routine.
Same for kernel %k precision timing output: rewritten for speed to using __divmod.

Adds `%ld`, `%lu` thousands grouping to kernel printk (like recently added libc printf).

Enhances some kernel output to use thousands grouping commas for large numbers.