### PR TITLE
[kernel] Replace atoi in ANSI console with very fast version

### DIFF
--- a/elks/arch/i86/drivers/char/Makefile
+++ b/elks/arch/i86/drivers/char/Makefile
@@ -117,9 +117,11 @@ chr_drv.a: $(OBJS)
 KeyMaps/keymaps.h:
 	$(MAKE) -C KeyMaps keymaps.h
 
-dircon.o: console.c
+console-direct.o: console.c
 
-bioscon.o: console.c
+console-direct-pc98.o: console.c
+
+console-bios.o: console.c
 
 #########################################################################
 # Standard commands.

--- a/elks/arch/i86/drivers/char/console.c
+++ b/elks/arch/i86/drivers/char/console.c
@@ -60,14 +60,14 @@ static int parm2(register unsigned char *buf)
     return parm1(buf);
 }
 
-static void itoaQueue(int i)
+static void itoaQueue(unsigned int i)
 {
    unsigned char a[6];
    unsigned char *b = a + sizeof(a) - 1;
 
    *b = 0;
    do {
-      *--b = '0' + (i % 10);
+      *--b = (i % 10) + '0';
       i /= 10;
    } while (i);
    while (*b)

--- a/elks/lib/string.c
+++ b/elks/lib/string.c
@@ -58,9 +58,14 @@ long simple_strtol(const char *s, int base)
 	return (neg == '-') ? -result: result;
 }
 
-int atoi(const char *number)
+/* no leading space or -/+ handling, needs to be fast */
+int atoi(const char *s)
 {
-	return (int)simple_strtol(number, 10);
+    int n = 0;
+
+    while ((unsigned) (*s - '0') <= 9u)
+        n = n * 10 + *s++ - '0';
+    return n;
 }
 
 #ifndef __HAVE_ARCH_STRCPY


### PR DESCRIPTION
Previous implementation of kernel `atoi` using `simple_strtol` was very slow for ANSI escape sequence parsing.

Rebuilds console-xxx.c when console.c changes.