### PR TITLE
[cmds] Fix off-by-one bug in getty @T command

### DIFF
--- a/elkscmd/sys_utils/getty.c
+++ b/elkscmd/sys_utils/getty.c
@@ -138,7 +138,7 @@ void when(void) {
 
 	Result[2]  = Result[6]	 = '-';
 
-	for (n=20; n>12; n--)
+	for (n=20; n>11; n--)
 	    Result[n] = Result[n-1];
 
 	Result[11] = Result[20] = '\0';


### PR DESCRIPTION
The `@T` command, when placed in /etc/issue, displays the current system time. The shuffling of the date string in `when()` had an off-by-one error, which meant that instead of showing `17:42:00`, it showed `77:42:00`