### PR TITLE
[cmds,kernel] Add meminfo -m option to display sorted main memory segments

### DIFF
--- a/elks/arch/i86/drivers/char/mem.c
+++ b/elks/arch/i86/drivers/char/mem.c
@@ -29,12 +29,12 @@
 #include <arch/io.h>
 #include <arch/segment.h>
 
-#define DEV_MEM_MINOR		1       /* unused */
-#define DEV_KMEM_MINOR		2
-#define DEV_NULL_MINOR		3
-#define DEV_PORT_MINOR		4
-#define DEV_ZERO_MINOR		5
-#define DEV_FULL_MINOR		6       /* unused */
+#define DEV_MEM_MINOR           1       /* unused */
+#define DEV_KMEM_MINOR          2
+#define DEV_NULL_MINOR          3
+#define DEV_PORT_MINOR          4
+#define DEV_ZERO_MINOR          5
+#define DEV_FULL_MINOR          6       /* unused */
 
 /*
  * generally useful code...
@@ -45,15 +45,15 @@ static int memory_lseek(struct inode *inode, struct file *filp, loff_t offset,
     debugmem("mem_lseek()\n");
     switch (origin) {
     case 1:
-	offset += filp->f_pos;
+        offset += filp->f_pos;
     case 0:
-	if (offset >= 0)
-	    break;
+        if (offset >= 0)
+            break;
     default:
-	return -EINVAL;
+        return -EINVAL;
     }
     if (offset != filp->f_pos) {
-	filp->f_pos = offset;
+        filp->f_pos = offset;
     }
     return 0;
 }
@@ -135,7 +135,7 @@ size_t port_read(struct inode *inode, struct file *filp, char *data, size_t len)
     return i;
 }
 #else
-#	define	port_read	NULL
+#       define  port_read       NULL
 #endif
 
 #if defined(CONFIG_CHAR_DEV_MEM_PORT_WRITE)
@@ -156,7 +156,7 @@ size_t port_write(struct inode *inode, struct file *filp, char *data, size_t len
     return i;
 }
 #else
-#	define	port_write	NULL
+#       define  port_write      NULL
 #endif
 
 #if UNUSED
@@ -228,98 +228,98 @@ int kmem_ioctl(struct inode *inode, struct file *file, int cmd, char *arg)
 
     switch (cmd) {
     case MEM_GETTASK:
-	retword = (unsigned short)task;
-	break;
+        retword = (unsigned short)task;
+        break;
     case MEM_GETMAXTASKS:
-	retword = max_tasks;
-	break;
+        retword = max_tasks;
+        break;
     case MEM_GETCS:
-	retword = kernel_cs;
-	break;
+        retword = kernel_cs;
+        break;
     case MEM_GETDS:
-	retword = kernel_ds;
-	break;
+        retword = kernel_ds;
+        break;
     case MEM_GETFARTEXT:
         retword = (unsigned)((long)buffer_init >> 16);
         break;
     case MEM_GETUSAGE:
-	mm_get_usage (&(mu.free_memory), &(mu.used_memory));
-	memcpy_tofs(arg, &mu, sizeof(struct mem_usage));
-	return 0;
+        mm_get_usage (&(mu.free_memory), &(mu.used_memory));
+        memcpy_tofs(arg, &mu, sizeof(struct mem_usage));
+        return 0;
     case MEM_GETHEAP:
-	retword = (unsigned short) &_heap_all;
-	break;
+        retword = (unsigned short) &_heap_all;
+        break;
     case MEM_GETJIFFADDR:
-	retword = (unsigned short) &jiffies;
+        retword = (unsigned short) &jiffies;
         break;
     case MEM_GETUPTIME:
 #ifdef CONFIG_CPU_USAGE
-	retword = (unsigned short) &uptime;
-	break;
+        retword = (unsigned short) &uptime;
+        break;
 #endif
     default:
-	return -EINVAL;
+        return -EINVAL;
     }
     put_user(retword, arg);
     return 0;
 }
 
 static struct file_operations null_fops = {
-    null_lseek,			/* lseek */
-    null_read,			/* read */
-    null_write,			/* write */
-    NULL,			/* readdir */
-    NULL,			/* select */
-    NULL,			/* ioctl */
-    NULL,			/* open */
-    NULL			/* release */
+    null_lseek,                 /* lseek */
+    null_read,                  /* read */
+    null_write,                 /* write */
+    NULL,                       /* readdir */
+    NULL,                       /* select */
+    NULL,                       /* ioctl */
+    NULL,                       /* open */
+    NULL                        /* release */
 };
 
 #if defined(CONFIG_CHAR_DEV_MEM_PORT_READ) || defined(CONFIG_CHAR_DEV_MEM_PORT_WRITE)
 static struct file_operations port_fops = {
-    port_lseek,			/* lseek */
-    port_read,			/* read */
-    port_write,			/* write */
-    NULL,			/* readdir */
-    NULL,			/* select */
-    NULL,			/* ioctl */
-    NULL,			/* open */
-    NULL			/* release */
+    port_lseek,                 /* lseek */
+    port_read,                  /* read */
+    port_write,                 /* write */
+    NULL,                       /* readdir */
+    NULL,                       /* select */
+    NULL,                       /* ioctl */
+    NULL,                       /* open */
+    NULL                        /* release */
 };
 #endif
 
 static struct file_operations zero_fops = {
-    memory_lseek,		/* lseek */
-    zero_read,			/* read */
-    null_write,			/* write */
-    NULL,			/* readdir */
-    NULL,			/* select */
-    NULL,			/* ioctl */
-    NULL,			/* open */
-    NULL			/* release */
+    memory_lseek,               /* lseek */
+    zero_read,                  /* read */
+    null_write,                 /* write */
+    NULL,                       /* readdir */
+    NULL,                       /* select */
+    NULL,                       /* ioctl */
+    NULL,                       /* open */
+    NULL                        /* release */
 };
 
 static struct file_operations kmem_fops = {
-    memory_lseek,		/* lseek */
-    kmem_read,			/* read */
-    kmem_write,			/* write */
-    NULL,			/* readdir */
-    NULL,			/* select */
-    kmem_ioctl,			/* ioctl */
-    NULL,			/* open */
-    NULL			/* release */
+    memory_lseek,               /* lseek */
+    kmem_read,                  /* read */
+    kmem_write,                 /* write */
+    NULL,                       /* readdir */
+    NULL,                       /* select */
+    kmem_ioctl,                 /* ioctl */
+    NULL,                       /* open */
+    NULL                        /* release */
 };
 
 #if UNUSED
 static struct file_operations full_fops = {
-    memory_lseek,		/* lseek */
-    full_read,			/* read */
-    full_write,			/* write */
-    NULL,			/* readdir */
-    NULL,			/* select */
-    NULL,			/* ioctl */
-    NULL,			/* open */
-    NULL			/* release */
+    memory_lseek,               /* lseek */
+    full_read,                  /* read */
+    full_write,                 /* write */
+    NULL,                       /* readdir */
+    NULL,                       /* select */
+    NULL,                       /* ioctl */
+    NULL,                       /* open */
+    NULL                        /* release */
 };
 #endif
 
@@ -329,38 +329,38 @@ static struct file_operations full_fops = {
 int memory_open(register struct inode *inode, struct file *filp)
 {
     static struct file_operations *mdev_fops[] = {
-	NULL,
-	&kmem_fops,	/* DEV_MEM_MINOR */
-	&kmem_fops,	/* DEV_KMEM_MINOR */
-	&null_fops,	/* DEV_NULL_MINOR */
+        NULL,
+        &kmem_fops,     /* DEV_MEM_MINOR */
+        &kmem_fops,     /* DEV_KMEM_MINOR */
+        &null_fops,     /* DEV_NULL_MINOR */
 #if defined(CONFIG_CHAR_DEV_MEM_PORT_READ) || defined(CONFIG_CHAR_DEV_MEM_PORT_WRITE)
-	&port_fops,	/* DEV_PORT_MINOR */
+        &port_fops,     /* DEV_PORT_MINOR */
 #else
         NULL,
 #endif
-	&zero_fops,	/* DEV_ZERO_MINOR */
+        &zero_fops,     /* DEV_ZERO_MINOR */
 #if UNUSED
-	&full_fops	/* DEV_FULL_MINOR */
+        &full_fops      /* DEV_FULL_MINOR */
 #endif
     };
     unsigned int minor;
 
     minor = MINOR(inode->i_rdev);
     if (minor > 5 || !mdev_fops[minor])
-	return -ENXIO;
+        return -ENXIO;
     filp->f_op = mdev_fops[minor];
     return 0;
 }
 
 static struct file_operations memory_fops = {
-    NULL,			/* lseek */
-    NULL,			/* read */
-    NULL,			/* write */
-    NULL,			/* readdir */
-    NULL,			/* select */
-    NULL,			/* ioctl */
-    memory_open,		/* open */
-    NULL			/* release */
+    NULL,                       /* lseek */
+    NULL,                       /* read */
+    NULL,                       /* write */
+    NULL,                       /* readdir */
+    NULL,                       /* select */
+    NULL,                       /* ioctl */
+    memory_open,                /* open */
+    NULL                        /* release */
 };
 
 void INITPROC mem_dev_init(void)

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -36,10 +36,8 @@ static segment_s * seg_split (segment_s * s1, segext_t size0)
 
 		// TODO: use pool_alloc
 		segment_s * s2 = (segment_s *) heap_alloc (sizeof (segment_s), HEAP_TAG_SEG);
-		if (!s2) {
-			printk ("seg:cannot split:heap full\n");
-			return 0;
-		}
+		if (!s2)
+			return 0;   // heap_alloc gives heap full message
 
 		s2->base = s1->base + size0;
 		s2->size = size2;
@@ -323,7 +321,7 @@ void INITPROC seg_add(seg_t start, seg_t end)
 		seg->ref_count = 0;
 		seg->pid = 0;
 
-		list_insert_before (&_seg_all, &(seg->all));  // add tail
+		list_insert_before (&_seg_all, &(seg->all));    // add tail
 		list_insert_before (&_seg_free, &(seg->free));  // add tail
 	}
 }

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -22,7 +22,7 @@
 // and to ease the 286 protected mode
 // whenever that mode comes back one day
 
-static list_s _seg_all;
+list_s _seg_all;
 static list_s _seg_free;
 
 

--- a/elks/include/linuxmt/mem.h
+++ b/elks/include/linuxmt/mem.h
@@ -1,20 +1,21 @@
 #ifndef __LINUXMT_MEM_H
 #define __LINUXMT_MEM_H
 
-#define MEM_GETTEXTSIZ	2
-#define MEM_GETUSAGE	3
-#define MEM_GETTASK	4
-#define MEM_GETDS	5
-#define MEM_GETCS	6
-#define MEM_GETHEAP	7
-#define MEM_GETUPTIME	8
+#define MEM_GETTEXTSIZ  2
+#define MEM_GETUSAGE    3
+#define MEM_GETTASK     4
+#define MEM_GETDS       5
+#define MEM_GETCS       6
+#define MEM_GETHEAP     7
+#define MEM_GETUPTIME   8
 #define MEM_GETFARTEXT  9
 #define MEM_GETMAXTASKS 10
 #define MEM_GETJIFFADDR 11
+#define MEM_GETSEGALL   12
 
 struct mem_usage {
-	unsigned int free_memory;
-	unsigned int used_memory;
+    unsigned int free_memory;
+    unsigned int used_memory;
 };
 
 #endif

--- a/elks/include/linuxmt/mm.h
+++ b/elks/include/linuxmt/mm.h
@@ -56,12 +56,12 @@ int fs_memcmp(const void *,const void *,size_t);
 
 segment_s * seg_alloc (segext_t, word_t);
 void seg_free (segment_s *);
-
 segment_s * seg_get (segment_s *);
 void seg_put (segment_s *);
 segment_s * seg_dup (segment_s *);
-
 void seg_free_pid(pid_t pid);
+
+extern list_s _seg_all;
 
 void mm_get_usage (unsigned int * free, unsigned int * used);
 

--- a/elkscmd/man/man1/meminfo.1
+++ b/elkscmd/man/man1/meminfo.1
@@ -4,15 +4,21 @@ meminfo \- list system memory usage
 .SH SYNOPSIS
 .B meminfo
 .RB [ \-a ]
+.RB [ \-m ]
 .RB [ \-f ]
 .RB [ \-t ]
 .RB [ \-b ]
+.RB [ \-s ]
+.RB [ \-h ]
 .br
 .SS OPTIONS
-Defaults to showing all memory.
+Defaults to showing all memory (equivalent to -aftbs).
 .TP 5
 .B -a
-Show application memory
+Show memory in use by applications
+.TP 5
+.B -m
+Show main memory sorted by segment
 .TP 5
 .B -f
 Show free memory
@@ -24,7 +30,10 @@ Show tty and driver memory
 Show system buffer and pipe memory
 .TP 5
 .B -s
-Show system task, inode and file memory.
+Show system task, inode and file memory
+.TP 5
+.B -h
+Show help
 .SH DESCRIPTION
 .B meminfo
 traverses the kernel local heap and displays a line for each in-use or free entry. 

--- a/elkscmd/sys_utils/meminfo.c
+++ b/elkscmd/sys_utils/meminfo.c
@@ -191,7 +191,7 @@ void dump_heap(int fd)
 
 void usage(void)
 {
-    printf("usage: meminfo [-maftbsh]\n");
+    printf("usage: meminfo [-amftbsh]\n");
 }
 
 int main(int argc, char **argv)
@@ -201,10 +201,13 @@ int main(int argc, char **argv)
 
     if (argc < 2)
         allflag = 1;
-    else while ((c = getopt(argc, argv, "aftbsmh")) != -1) {
+    else while ((c = getopt(argc, argv, "amftbsh")) != -1) {
         switch (c) {
             case 'a':
                 aflag = 1;
+                break;
+            case 'm':
+                mflag = 1;
                 break;
             case 'f':
                 fflag = 1;
@@ -217,9 +220,6 @@ int main(int argc, char **argv)
                 break;
             case 's':
                 sflag = 1;
-                break;
-            case 'm':
-                mflag = 1;
                 break;
             case 'h':
                 usage();

--- a/elkscmd/sys_utils/meminfo.c
+++ b/elkscmd/sys_utils/meminfo.c
@@ -28,10 +28,12 @@ int fflag;      /* show free memory*/
 int tflag;      /* show tty and driver memory*/
 int bflag;      /* show buffer memory*/
 int sflag;      /* show system memory*/
+int mflag;      /* show main memory*/
 int allflag;    /* show all memory*/
 
 unsigned int ds;
 unsigned int heap_all;
+unsigned int seg_all;
 unsigned int taskoff;
 int maxtasks;
 struct task_struct task_table;
@@ -92,15 +94,55 @@ struct task_struct *find_process(int fd, unsigned int seg)
     return NULL;
 }
 
+static long total_segsize = 0;
+static char *segtype[] =
+    { "free", "CSEG", "DSEG", "DDAT", "FDAT", "BUF ", "RDSK" };
+
+void display_seg(int fd, word_t mem)
+{
+    seg_t segbase = getword(fd, mem + offsetof(segment_s, base), ds);
+    segext_t segsize = getword(fd, mem + offsetof(segment_s, size), ds);
+    word_t segflags = getword(fd, mem + offsetof(segment_s, flags), ds) & SEG_FLAG_TYPE;
+    byte_t ref_count = getword(fd, mem + offsetof(segment_s, ref_count), ds);
+    struct task_struct *t;
+
+    printf("   %4x   %s %7ld %4d  ",
+        segbase, segtype[segflags], (long)segsize << 4, ref_count);
+    if (segflags == SEG_FLAG_CSEG || segflags == SEG_FLAG_DSEG) {
+        if ((t = find_process(fd, mem)) != NULL) {
+            process_name(fd, t->t_begstack, t->t_regs.ss);
+        }
+    }
+
+    total_segsize += (long)segsize << 4;
+}
+
+void dump_segs(int fd)
+{
+    word_t n, mem;
+    seg_t segbase, oldbase = 0;
+
+    printf("    SEG   TYPE    SIZE  CNT  NAME\n");
+    n = getword (fd, seg_all + offsetof(list_s, next), ds);
+    while (n != seg_all) {
+        mem = n - offsetof(segment_s, all);
+        segbase = getword(fd, mem + offsetof(segment_s, base), ds);
+        if (segbase < oldbase) printf("\n");
+        oldbase = segbase;
+        display_seg(fd, mem);
+        printf("\n");
+
+        /* next in list */
+        n = getword(fd, n + offsetof(list_s, next), ds);
+    }
+}
+
 void dump_heap(int fd)
 {
     word_t total_size = 0;
     word_t total_free = 0;
-    long total_segsize = 0;
     static char *heaptype[] =
         { "free", "MEM ", "DRVR", "TTY ", "TASK", "BUFH", "PIPE", "INOD", "FILE", "CACH"};
-    static char *segtype[] =
-        { "free", "CSEG", "DSEG", "DDAT", "FDAT", "BUF ", "RDSK" };
 
     printf("  HEAP   TYPE  SIZE    SEG   TYPE    SIZE  CNT  NAME\n");
 
@@ -110,18 +152,14 @@ void dump_heap(int fd)
         word_t size = getword(fd, h + offsetof(heap_s, size), ds);
         byte_t tag = getword(fd, h + offsetof(heap_s, tag), ds) & HEAP_TAG_TYPE;
         word_t mem = h + sizeof(heap_s);
-        seg_t segbase;
-        segext_t segsize;
         word_t segflags;
-        byte_t ref_count;
-        int free, used, tty, buffer, system;
-        struct task_struct *t;
+        int free, app, tty, buffer, system;
 
         if (tag == HEAP_TAG_SEG)
             segflags = getword(fd, mem + offsetof(segment_s, flags), ds) & SEG_FLAG_TYPE;
         else segflags = -1;
         free = (tag == HEAP_TAG_FREE || segflags == SEG_FLAG_FREE);
-        used = ((tag == HEAP_TAG_SEG)
+        app = ((tag == HEAP_TAG_SEG)
             && (segflags == SEG_FLAG_CSEG || segflags == SEG_FLAG_DSEG ||
                 segflags == SEG_FLAG_DDAT || segflags == SEG_FLAG_FDAT));
         tty = (tag == HEAP_TAG_TTY || tag == HEAP_TAG_DRVR);
@@ -129,9 +167,8 @@ void dump_heap(int fd)
             || tag == HEAP_TAG_BUFHEAD || tag == HEAP_TAG_CACHE || tag == HEAP_TAG_PIPE;
         system = (tag == HEAP_TAG_TASK || tag == HEAP_TAG_INODE || tag == HEAP_TAG_FILE);
 
-        if (allflag ||
-           (fflag && free) || (aflag && used) || (tflag && tty) || (bflag && buffer)
-                || (sflag && system)) {
+        if (allflag || (fflag && free) || (aflag && app) || (tflag && tty)
+                    || (bflag && buffer) || (sflag && system)) {
             printf("  %4x   %s %5d", mem, heaptype[tag], size);
             total_size += size + sizeof(heap_s);
             if (tag == HEAP_TAG_FREE)
@@ -139,18 +176,7 @@ void dump_heap(int fd)
 
             switch (tag) {
             case HEAP_TAG_SEG:
-                segbase = getword(fd, mem + offsetof(segment_s, base), ds);
-                segsize = getword(fd, mem + offsetof(segment_s, size), ds);
-                ref_count = getword(fd, mem + offsetof(segment_s, ref_count), ds);
-                printf("   %4x   %s %7ld %4d  ",
-                    segbase, segtype[segflags], (long)segsize << 4, ref_count);
-                if (segflags == SEG_FLAG_CSEG || segflags == SEG_FLAG_DSEG) {
-                    if ((t = find_process(fd, mem)) != NULL) {
-                        process_name(fd, t->t_begstack, t->t_regs.ss);
-                    }
-                }
-
-                total_segsize += (long)segsize << 4;
+                display_seg(fd, mem);
                 break;
             }
             printf("\n");
@@ -165,7 +191,7 @@ void dump_heap(int fd)
 
 void usage(void)
 {
-    printf("usage: meminfo [-a][-f][-t][-b]\n");
+    printf("usage: meminfo [-maftbsh]\n");
 }
 
 int main(int argc, char **argv)
@@ -175,7 +201,7 @@ int main(int argc, char **argv)
 
     if (argc < 2)
         allflag = 1;
-    else while ((c = getopt(argc, argv, "aftbsh")) != -1) {
+    else while ((c = getopt(argc, argv, "aftbsmh")) != -1) {
         switch (c) {
             case 'a':
                 aflag = 1;
@@ -192,6 +218,9 @@ int main(int argc, char **argv)
             case 's':
                 sflag = 1;
                 break;
+            case 'm':
+                mflag = 1;
+                break;
             case 'h':
                 usage();
                 return 0;
@@ -207,15 +236,18 @@ int main(int argc, char **argv)
     }
     if (ioctl(fd, MEM_GETDS, &ds) ||
         ioctl(fd, MEM_GETHEAP, &heap_all) ||
+        ioctl(fd, MEM_GETSEGALL, &seg_all) ||
         ioctl(fd, MEM_GETTASK, &taskoff) ||
         ioctl(fd, MEM_GETMAXTASKS, &maxtasks)) {
           perror("meminfo");
-        return 1;
+          return 1;
     }
     if (!memread(fd, taskoff, ds, &task_table, sizeof(task_table))) {
         perror("taskinfo");
     }
-    dump_heap(fd);
+    if (mflag)
+        dump_segs(fd);
+    else dump_heap(fd);
 
     if (!ioctl(fd, MEM_GETUSAGE, &mu)) {
         /* note MEM_GETUSAGE amounts are floors, so total may display less by 1k than actual*/


### PR DESCRIPTION
Adds `meminfo -m` to display all main memory usage sorted by segment address. 

This option allows for easier-to-visualize main memory usage by address, for looking at how much main memory is used by applications and the sizes of the blocks beside each segment. It can also be used for system tuning when adjusting /bootopts parameters for seeing the memory blocks used by or available to applications, buffers and UMB.

The internal memory list is subsorted based on `seg_add` at boot, so there may an address which appears out of order, which is the case for the INITPROC used-once segment released at the end of kernel initialization (see below for screenshot). 

Also cleaned up mem.c considerably, reducing code size.

Here's `meminfo -m` running with UMB with two sorted segment lists; the last two lines are the freed INITPROC segment, now being occupied by /bin/init code followed by some free space:
<img width="788" alt="meminfo -m" src="https://github.com/user-attachments/assets/676b77c9-100a-4469-8760-278c9fb23813">
