### PR TITLE
[libc] Cleanup errno.h and reduce size of etc/perror file

### DIFF
--- a/elks/arch/i86/drivers/block/ssd-sd.c
+++ b/elks/arch/i86/drivers/block/ssd-sd.c
@@ -172,7 +172,7 @@ static int sd_cmd_go_idle(void) {
  * Gets the SD version following the advised algorithm
  * on the phyisical layer specification of the SD alliance.
  * 
- * returns: 1 for SDv1, 2 for SDv2 and SDHC, -ENAVAIL when
+ * returns: 1 for SDv1, 2 for SDv2 and SDHC, -ENODATA when
  * the card can't be used (out of spec).
  */
 static int sd_check_version(void) {
@@ -197,7 +197,7 @@ static int sd_check_version(void) {
     if ((cmd8_voltage != 0x01)
         || (cmd8_check_pattern != 0xaa)) {
         /* card shouldn't be used */
-        return -ENAVAIL;
+        return -ENODATA;
     }
 
     return 2;
@@ -271,7 +271,7 @@ static int sd_set_block_length(uint16_t n) {
  * 
  * token: expected data-start token.
  * 
- * returns: 0 if found, -ENAVAIL if another token was found,
+ * returns: 0 if found, -ENODATA if another token was found,
  * -ETIMEDOUT if it times out waiting.
  */
 static int sd_wait_for_token(uint8_t token) {
@@ -285,7 +285,7 @@ static int sd_wait_for_token(uint8_t token) {
         } else if (rx == 0xff) {
             continue;
         } else {
-            return -ENAVAIL;
+            return -ENODATA;
         }
     } while (--counter);
 
@@ -298,7 +298,7 @@ static int sd_wait_for_token(uint8_t token) {
  * *csd: pointer to the CSD buffer. Must be 16 bytes.
  * 
  * returns: 0 on succes, -EIO if SEND_CSD is not supported,
- * -ENAVAIL if data token wasn't found, -ETIMEDOUT if it
+ * -ENODATA if data token wasn't found, -ETIMEDOUT if it
  * times out waiting for the data token.
  */
 static int sd_read_csd(char * csd) {

--- a/elks/include/linuxmt/errno.h
+++ b/elks/include/linuxmt/errno.h
@@ -6,8 +6,6 @@
  * combined into a single file.
  */
 
-/*****************************************************************************/
-
 /* These were in Linux's include/asm/errno.h file.
  */
 
@@ -22,6 +20,7 @@
 #define EBADF            9      /* Bad file number */
 #define ECHILD          10      /* No child processes */
 #define EAGAIN          11      /* Try again */
+#define EWOULDBLOCK     EAGAIN  /* Operation would block */
 #define ENOMEM          12      /* Out of memory */
 #define EACCES          13      /* Permission denied */
 #define EFAULT          14      /* Bad address */
@@ -35,8 +34,8 @@
 #define EINVAL          22      /* Invalid argument */
 #define ENFILE          23      /* File table overflow */
 #define EMFILE          24      /* Too many open files */
-#define ENOTTY          25      /* Not a typewriter */
-#define ETXTBSY         26      /* Text file busy */
+#define ENOTTY          25      /* Not a typewriter */  //linenoise
+#define ETXTBSY         26      /* Text file busy */    //ash
 #define EFBIG           27      /* File too large */
 #define ENOSPC          28      /* No space left on device */
 #define ESPIPE          29      /* Illegal seek */
@@ -45,15 +44,38 @@
 #define EPIPE           32      /* Broken pipe */
 #define EDOM            33      /* Math argument out of domain of func */
 #define ERANGE          34      /* Math result not representable */
+#if UNUSED
 #define EDEADLK         35      /* Resource deadlock would occur */
-#define ENAMETOOLONG    36      /* File name too long */
 #define ENOLCK          37      /* No record locks available */
+#endif
+#define ENAMETOOLONG    36      /* File name too long */
+
 #define ENOSYS          38      /* Function not implemented */
 #define ENOTEMPTY       39      /* Directory not empty */
 #define ELOOP           40      /* Too many symbolic links encountered */
 
-#define EWOULDBLOCK     EAGAIN  /* Operation would block */
+/* these are used, pulled out of the below unused list */
+#define ENOSR           63      /* Out of streams resources */
+#define ENOTSOCK        88      /* Socket operation on non-socket */
+#define EADDRINUSE      98      /* Address already in use */
+#define ENETDOWN        100     /* Network is down */
+#define ENETUNREACH     101     /* Network is unreachable */
+#define ENOBUFS         105     /* No buffer space available */ //regex
+#define EISCONN         106     /* Transport endpoint is already connected */
+#define ETIMEDOUT       110     /* Connection timed out */
+#define ECONNREFUSED    111     /* Connection refused */
+#define EHOSTUNREACH    113     /* Host not reachable */
+#define EINPROGRESS     115     /* Operation now in progress */
+#define ENONAMESERVER   125     /* Nameserver not found */
+#define ENONAME         126     /* Name not found */
+#define EBADQUERY       127     /* Bad query format */
+#define EQUERYREFUSED   128     /* Query refused */
+#define ESERVERERR      129     /* Server error */
+#define ERESTARTSYS     512     /* Restart system call*/
 
+#if UNUSED
+/* when any of these added in, add string to etc/perror as well */
+#define EWOULDBLOCK     41      /* Operation would block */
 #define ENOMSG          42      /* No message of desired type */
 #define EIDRM           43      /* Identifier removed */
 #define ECHRNG          44      /* Channel number out of range */
@@ -70,14 +92,12 @@
 #define ENOANO          55      /* No anode */
 #define EBADRQC         56      /* Invalid request code */
 #define EBADSLT         57      /* Invalid slot */
-
-#define EDEADLOCK       EDEADLK
-
+#define EDEADLOCK       58      /* File locking deadlock error */
 #define EBFONT          59      /* Bad font file format */
 #define ENOSTR          60      /* Device not a stream */
 #define ENODATA         61      /* No data available */
 #define ETIME           62      /* Timer expired */
-#define ENOSR           63      /* Out of streams resources */
+
 #define ENONET          64      /* Machine is not on the network */
 #define ENOPKG          65      /* Package not installed */
 #define EREMOTE         66      /* Object is remote */
@@ -102,7 +122,7 @@
 #define ERESTART        85      /* Interrupted system call should be restarted */
 #define ESTRPIPE        86      /* Streams pipe error */
 #define EUSERS          87      /* Too many users */
-#define ENOTSOCK        88      /* Socket operation on non-socket */
+
 #define EDESTADDRREQ    89      /* Destination address required */
 #define EMSGSIZE        90      /* Message too long */
 #define EPROTOTYPE      91      /* Protocol wrong type for socket */
@@ -112,24 +132,21 @@
 #define EOPNOTSUPP      95      /* Operation not supported on transport endpoint */
 #define EPFNOSUPPORT    96      /* Protocol family not supported */
 #define EAFNOSUPPORT    97      /* Address family not supported by protocol */
-#define EADDRINUSE      98      /* Address already in use */
+
 #define EADDRNOTAVAIL   99      /* Cannot assign requested address */
-#define ENETDOWN        100     /* Network is down */
-#define ENETUNREACH     101     /* Network is unreachable */
+
 #define ENETRESET       102     /* Network dropped connection because of reset */
 #define ECONNABORTED    103     /* Software caused connection abort */
 #define ECONNRESET      104     /* Connection reset by peer */
-#define ENOBUFS         105     /* No buffer space available */
-#define EISCONN         106     /* Transport endpoint is already connected */
+
 #define ENOTCONN        107     /* Transport endpoint is not connected */
 #define ESHUTDOWN       108     /* Cannot send after transport endpoint shutdown */
 #define ETOOMANYREFS    109     /* Too many references: cannot splice */
-#define ETIMEDOUT       110     /* Connection timed out */
-#define ECONNREFUSED    111     /* Connection refused */
+
 #define EHOSTDOWN       112     /* Host is down */
-#define EHOSTUNREACH    113     /* Host not reachable */
+
 #define EALREADY        114     /* Operation already in progress */
-#define EINPROGRESS     115     /* Operation now in progress */
+
 #define ESTALE          116     /* Stale NFS file handle */
 #define EUCLEAN         117     /* Structure needs cleaning */
 #define ENOTNAM         118     /* Not a XENIX named type file */
@@ -139,37 +156,16 @@
 #define EDQUOT          122     /* Quota exceeded */
 #define ENOMEDIUM       123     /* No medium found */
 #define EMEDIUMTYPE     124     /* Wrong medium type */
-#define ENONAMESERVER   125     /* Nameserver not found */
-#define ENONAME         126     /* Name not found */
-#define EBADQUERY       127     /* Bad query format */
-#define EQUERYREFUSED   128     /* Query refused */
-#define ESERVERERR      129     /* Server error */
 
-/* added here for userland ktcp compile */
-#define ERESTARTSYS     512     /* Restart system call*/
-
-/*****************************************************************************/
-
-/* These are comedy ones inserted for fun, and are never used.
- */
-
+/* These are comedy ones inserted for fun, and are never used.  */
 #define EEEEEEEEEEEEK   510     /* cat /dev/mouse */
 #define EIEIO           511     /* Old McDonald is on the rampage */
 
-/*****************************************************************************/
-
-/* These were in Linux's include/linux/errno.h file.
- */
-
-#ifdef __KERNEL__
-
-/* Should never be seen by user programs */
-
+/* Should never be seen by user programs (including 512) */
 #define ERESTARTNOINTR  513     /* Restart without interrupts */
 #define ENOIOCTLCMD     515     /* No ioctl command */
 
 /* Defined for the NFSv3 protocol */
-
 #define EBADHANDLE      521     /* Illegal NFS file handle */
 #define ENOTSYNC        522     /* Update synchronization mismatch */
 #define EBADCOOKIE      523     /* Cookie is stale */
@@ -179,8 +175,6 @@
 #define EBADTYPE        527     /* Type not supported by server */
 #define EJUKEBOX        528     /* Request initiated, but will timeout */
 
-#endif
-
-/*****************************************************************************/
+#endif /* UNUSED */
 
 #endif

--- a/elks/include/linuxmt/errno.h
+++ b/elks/include/linuxmt/errno.h
@@ -11,150 +11,150 @@
 /* These were in Linux's include/asm/errno.h file.
  */
 
-#define	EPERM		 1	/* Operation not permitted */
-#define	ENOENT		 2	/* No such file or directory */
-#define	ESRCH		 3	/* No such process */
-#define	EINTR		 4	/* Interrupted system call */
-#define	EIO		 5	/* I/O error */
-#define	ENXIO		 6	/* No such device or address */
-#define	E2BIG		 7	/* Arg list too long */
-#define	ENOEXEC		 8	/* Exec format error */
-#define	EBADF		 9	/* Bad file number */
-#define	ECHILD		10	/* No child processes */
-#define	EAGAIN		11	/* Try again */
-#define	ENOMEM		12	/* Out of memory */
-#define	EACCES		13	/* Permission denied */
-#define	EFAULT		14	/* Bad address */
-#define	ENOTBLK		15	/* Block device required */
-#define	EBUSY		16	/* Device or resource busy */
-#define	EEXIST		17	/* File exists */
-#define	EXDEV		18	/* Cross-device link */
-#define	ENODEV		19	/* No such device */
-#define	ENOTDIR		20	/* Not a directory */
-#define	EISDIR		21	/* Is a directory */
-#define	EINVAL		22	/* Invalid argument */
-#define	ENFILE		23	/* File table overflow */
-#define	EMFILE		24	/* Too many open files */
-#define	ENOTTY		25	/* Not a typewriter */
-#define	ETXTBSY		26	/* Text file busy */
-#define	EFBIG		27	/* File too large */
-#define	ENOSPC		28	/* No space left on device */
-#define	ESPIPE		29	/* Illegal seek */
-#define	EROFS		30	/* Read-only file system */
-#define	EMLINK		31	/* Too many links */
-#define	EPIPE		32	/* Broken pipe */
-#define	EDOM		33	/* Math argument out of domain of func */
-#define	ERANGE		34	/* Math result not representable */
-#define	EDEADLK		35	/* Resource deadlock would occur */
-#define	ENAMETOOLONG	36	/* File name too long */
-#define	ENOLCK		37	/* No record locks available */
-#define	ENOSYS		38	/* Function not implemented */
-#define	ENOTEMPTY	39	/* Directory not empty */
-#define	ELOOP		40	/* Too many symbolic links encountered */
+#define EPERM            1      /* Operation not permitted */
+#define ENOENT           2      /* No such file or directory */
+#define ESRCH            3      /* No such process */
+#define EINTR            4      /* Interrupted system call */
+#define EIO              5      /* I/O error */
+#define ENXIO            6      /* No such device or address */
+#define E2BIG            7      /* Arg list too long */
+#define ENOEXEC          8      /* Exec format error */
+#define EBADF            9      /* Bad file number */
+#define ECHILD          10      /* No child processes */
+#define EAGAIN          11      /* Try again */
+#define ENOMEM          12      /* Out of memory */
+#define EACCES          13      /* Permission denied */
+#define EFAULT          14      /* Bad address */
+#define ENOTBLK         15      /* Block device required */
+#define EBUSY           16      /* Device or resource busy */
+#define EEXIST          17      /* File exists */
+#define EXDEV           18      /* Cross-device link */
+#define ENODEV          19      /* No such device */
+#define ENOTDIR         20      /* Not a directory */
+#define EISDIR          21      /* Is a directory */
+#define EINVAL          22      /* Invalid argument */
+#define ENFILE          23      /* File table overflow */
+#define EMFILE          24      /* Too many open files */
+#define ENOTTY          25      /* Not a typewriter */
+#define ETXTBSY         26      /* Text file busy */
+#define EFBIG           27      /* File too large */
+#define ENOSPC          28      /* No space left on device */
+#define ESPIPE          29      /* Illegal seek */
+#define EROFS           30      /* Read-only file system */
+#define EMLINK          31      /* Too many links */
+#define EPIPE           32      /* Broken pipe */
+#define EDOM            33      /* Math argument out of domain of func */
+#define ERANGE          34      /* Math result not representable */
+#define EDEADLK         35      /* Resource deadlock would occur */
+#define ENAMETOOLONG    36      /* File name too long */
+#define ENOLCK          37      /* No record locks available */
+#define ENOSYS          38      /* Function not implemented */
+#define ENOTEMPTY       39      /* Directory not empty */
+#define ELOOP           40      /* Too many symbolic links encountered */
 
-#define	EWOULDBLOCK	EAGAIN	/* Operation would block */
+#define EWOULDBLOCK     EAGAIN  /* Operation would block */
 
-#define	ENOMSG		42	/* No message of desired type */
-#define	EIDRM		43	/* Identifier removed */
-#define	ECHRNG		44	/* Channel number out of range */
-#define	EL2NSYNC	45	/* Level 2 not synchronized */
-#define	EL3HLT		46	/* Level 3 halted */
-#define	EL3RST		47	/* Level 3 reset */
-#define	ELNRNG		48	/* Link number out of range */
-#define	EUNATCH		49	/* Protocol driver not attached */
-#define	ENOCSI		50	/* No CSI structure available */
-#define	EL2HLT		51	/* Level 2 halted */
-#define	EBADE		52	/* Invalid exchange */
-#define	EBADR		53	/* Invalid request descriptor */
-#define	EXFULL		54	/* Exchange full */
-#define	ENOANO		55	/* No anode */
-#define	EBADRQC		56	/* Invalid request code */
-#define	EBADSLT		57	/* Invalid slot */
+#define ENOMSG          42      /* No message of desired type */
+#define EIDRM           43      /* Identifier removed */
+#define ECHRNG          44      /* Channel number out of range */
+#define EL2NSYNC        45      /* Level 2 not synchronized */
+#define EL3HLT          46      /* Level 3 halted */
+#define EL3RST          47      /* Level 3 reset */
+#define ELNRNG          48      /* Link number out of range */
+#define EUNATCH         49      /* Protocol driver not attached */
+#define ENOCSI          50      /* No CSI structure available */
+#define EL2HLT          51      /* Level 2 halted */
+#define EBADE           52      /* Invalid exchange */
+#define EBADR           53      /* Invalid request descriptor */
+#define EXFULL          54      /* Exchange full */
+#define ENOANO          55      /* No anode */
+#define EBADRQC         56      /* Invalid request code */
+#define EBADSLT         57      /* Invalid slot */
 
-#define	EDEADLOCK	EDEADLK
+#define EDEADLOCK       EDEADLK
 
-#define	EBFONT		59	/* Bad font file format */
-#define	ENOSTR		60	/* Device not a stream */
-#define	ENODATA		61	/* No data available */
-#define	ETIME		62	/* Timer expired */
-#define	ENOSR		63	/* Out of streams resources */
-#define	ENONET		64	/* Machine is not on the network */
-#define	ENOPKG		65	/* Package not installed */
-#define	EREMOTE		66	/* Object is remote */
-#define	ENOLINK		67	/* Link has been severed */
-#define	EADV		68	/* Advertise error */
-#define	ESRMNT		69	/* Srmount error */
-#define	ECOMM		70	/* Communication error on send */
-#define	EPROTO		71	/* Protocol error */
-#define	EMULTIHOP	72	/* Multihop attempted */
-#define	EDOTDOT		73	/* RFS specific error */
-#define	EBADMSG		74	/* Not a data message */
-#define	EOVERFLOW	75	/* Value too large for defined data type */
-#define	ENOTUNIQ	76	/* Name not unique on network */
-#define	EBADFD		77	/* File descriptor in bad state */
-#define	EREMCHG		78	/* Remote address changed */
-#define	ELIBACC		79	/* Can not access a needed shared library */
-#define	ELIBBAD		80	/* Accessing a corrupted shared library */
-#define	ELIBSCN		81	/* .lib section in a.out corrupted */
-#define	ELIBMAX		82	/* Attempting to link in too many shared libraries */
-#define	ELIBEXEC	83	/* Cannot exec a shared library directly */
-#define	EILSEQ		84	/* Illegal byte sequence */
-#define	ERESTART	85	/* Interrupted system call should be restarted */
-#define	ESTRPIPE	86	/* Streams pipe error */
-#define	EUSERS		87	/* Too many users */
-#define	ENOTSOCK	88	/* Socket operation on non-socket */
-#define	EDESTADDRREQ	89	/* Destination address required */
-#define	EMSGSIZE	90	/* Message too long */
-#define	EPROTOTYPE	91	/* Protocol wrong type for socket */
-#define	ENOPROTOOPT	92	/* Protocol not available */
-#define	EPROTONOSUPPORT	93	/* Protocol not supported */
-#define	ESOCKTNOSUPPORT	94	/* Socket type not supported */
-#define	EOPNOTSUPP	95	/* Operation not supported on transport endpoint */
-#define	EPFNOSUPPORT	96	/* Protocol family not supported */
-#define	EAFNOSUPPORT	97	/* Address family not supported by protocol */
-#define	EADDRINUSE	98	/* Address already in use */
-#define	EADDRNOTAVAIL	99	/* Cannot assign requested address */
-#define	ENETDOWN	100	/* Network is down */
-#define	ENETUNREACH	101	/* Network is unreachable */
-#define	ENETRESET	102	/* Network dropped connection because of reset */
-#define	ECONNABORTED	103	/* Software caused connection abort */
-#define	ECONNRESET	104	/* Connection reset by peer */
-#define	ENOBUFS		105	/* No buffer space available */
-#define	EISCONN		106	/* Transport endpoint is already connected */
-#define	ENOTCONN	107	/* Transport endpoint is not connected */
-#define	ESHUTDOWN	108	/* Cannot send after transport endpoint shutdown */
-#define	ETOOMANYREFS	109	/* Too many references: cannot splice */
-#define	ETIMEDOUT	110	/* Connection timed out */
-#define	ECONNREFUSED	111	/* Connection refused */
-#define	EHOSTDOWN	112	/* Host is down */
-#define	EHOSTUNREACH	113	/* Host not reachable */
-#define	EALREADY	114	/* Operation already in progress */
-#define	EINPROGRESS	115	/* Operation now in progress */
-#define	ESTALE		116	/* Stale NFS file handle */
-#define	EUCLEAN		117	/* Structure needs cleaning */
-#define	ENOTNAM		118	/* Not a XENIX named type file */
-#define	ENAVAIL		119	/* No XENIX semaphores available */
-#define	EISNAM		120	/* Is a named type file */
-#define	EREMOTEIO	121	/* Remote I/O error */
-#define	EDQUOT		122	/* Quota exceeded */
-#define	ENOMEDIUM	123	/* No medium found */
-#define	EMEDIUMTYPE	124	/* Wrong medium type */
-#define ENONAMESERVER	125	/* Nameserver not found */
-#define ENONAME		126	/* Name not found */
-#define EBADQUERY	127	/* Bad query format */
-#define EQUERYREFUSED	128	/* Query refused */
-#define ESERVERERR	129	/* Server error */
+#define EBFONT          59      /* Bad font file format */
+#define ENOSTR          60      /* Device not a stream */
+#define ENODATA         61      /* No data available */
+#define ETIME           62      /* Timer expired */
+#define ENOSR           63      /* Out of streams resources */
+#define ENONET          64      /* Machine is not on the network */
+#define ENOPKG          65      /* Package not installed */
+#define EREMOTE         66      /* Object is remote */
+#define ENOLINK         67      /* Link has been severed */
+#define EADV            68      /* Advertise error */
+#define ESRMNT          69      /* Srmount error */
+#define ECOMM           70      /* Communication error on send */
+#define EPROTO          71      /* Protocol error */
+#define EMULTIHOP       72      /* Multihop attempted */
+#define EDOTDOT         73      /* RFS specific error */
+#define EBADMSG         74      /* Not a data message */
+#define EOVERFLOW       75      /* Value too large for defined data type */
+#define ENOTUNIQ        76      /* Name not unique on network */
+#define EBADFD          77      /* File descriptor in bad state */
+#define EREMCHG         78      /* Remote address changed */
+#define ELIBACC         79      /* Can not access a needed shared library */
+#define ELIBBAD         80      /* Accessing a corrupted shared library */
+#define ELIBSCN         81      /* .lib section in a.out corrupted */
+#define ELIBMAX         82      /* Attempting to link in too many shared libraries */
+#define ELIBEXEC        83      /* Cannot exec a shared library directly */
+#define EILSEQ          84      /* Illegal byte sequence */
+#define ERESTART        85      /* Interrupted system call should be restarted */
+#define ESTRPIPE        86      /* Streams pipe error */
+#define EUSERS          87      /* Too many users */
+#define ENOTSOCK        88      /* Socket operation on non-socket */
+#define EDESTADDRREQ    89      /* Destination address required */
+#define EMSGSIZE        90      /* Message too long */
+#define EPROTOTYPE      91      /* Protocol wrong type for socket */
+#define ENOPROTOOPT     92      /* Protocol not available */
+#define EPROTONOSUPPORT 93      /* Protocol not supported */
+#define ESOCKTNOSUPPORT 94      /* Socket type not supported */
+#define EOPNOTSUPP      95      /* Operation not supported on transport endpoint */
+#define EPFNOSUPPORT    96      /* Protocol family not supported */
+#define EAFNOSUPPORT    97      /* Address family not supported by protocol */
+#define EADDRINUSE      98      /* Address already in use */
+#define EADDRNOTAVAIL   99      /* Cannot assign requested address */
+#define ENETDOWN        100     /* Network is down */
+#define ENETUNREACH     101     /* Network is unreachable */
+#define ENETRESET       102     /* Network dropped connection because of reset */
+#define ECONNABORTED    103     /* Software caused connection abort */
+#define ECONNRESET      104     /* Connection reset by peer */
+#define ENOBUFS         105     /* No buffer space available */
+#define EISCONN         106     /* Transport endpoint is already connected */
+#define ENOTCONN        107     /* Transport endpoint is not connected */
+#define ESHUTDOWN       108     /* Cannot send after transport endpoint shutdown */
+#define ETOOMANYREFS    109     /* Too many references: cannot splice */
+#define ETIMEDOUT       110     /* Connection timed out */
+#define ECONNREFUSED    111     /* Connection refused */
+#define EHOSTDOWN       112     /* Host is down */
+#define EHOSTUNREACH    113     /* Host not reachable */
+#define EALREADY        114     /* Operation already in progress */
+#define EINPROGRESS     115     /* Operation now in progress */
+#define ESTALE          116     /* Stale NFS file handle */
+#define EUCLEAN         117     /* Structure needs cleaning */
+#define ENOTNAM         118     /* Not a XENIX named type file */
+#define ENAVAIL         119     /* No XENIX semaphores available */
+#define EISNAM          120     /* Is a named type file */
+#define EREMOTEIO       121     /* Remote I/O error */
+#define EDQUOT          122     /* Quota exceeded */
+#define ENOMEDIUM       123     /* No medium found */
+#define EMEDIUMTYPE     124     /* Wrong medium type */
+#define ENONAMESERVER   125     /* Nameserver not found */
+#define ENONAME         126     /* Name not found */
+#define EBADQUERY       127     /* Bad query format */
+#define EQUERYREFUSED   128     /* Query refused */
+#define ESERVERERR      129     /* Server error */
 
 /* added here for userland ktcp compile */
-#define ERESTARTSYS	512	/* Restart system call*/
+#define ERESTARTSYS     512     /* Restart system call*/
 
 /*****************************************************************************/
 
 /* These are comedy ones inserted for fun, and are never used.
  */
 
-#define EEEEEEEEEEEEK	510	/* cat /dev/mouse */
-#define EIEIO		511	/* Old McDonald is on the rampage */
+#define EEEEEEEEEEEEK   510     /* cat /dev/mouse */
+#define EIEIO           511     /* Old McDonald is on the rampage */
 
 /*****************************************************************************/
 
@@ -165,19 +165,19 @@
 
 /* Should never be seen by user programs */
 
-#define ERESTARTNOINTR	513	/* Restart without interrupts */
-#define ENOIOCTLCMD	515	/* No ioctl command */
+#define ERESTARTNOINTR  513     /* Restart without interrupts */
+#define ENOIOCTLCMD     515     /* No ioctl command */
 
 /* Defined for the NFSv3 protocol */
 
-#define EBADHANDLE	521	/* Illegal NFS file handle */
-#define ENOTSYNC	522	/* Update synchronization mismatch */
-#define EBADCOOKIE	523	/* Cookie is stale */
-#define ENOTSUPP	524	/* Operation is not supported */
-#define ETOOSMALL	525	/* Buffer or request is too small */
-#define ESERVERFAULT	526	/* An untranslatable error occurred */
-#define EBADTYPE	527	/* Type not supported by server */
-#define EJUKEBOX	528	/* Request initiated, but will timeout */
+#define EBADHANDLE      521     /* Illegal NFS file handle */
+#define ENOTSYNC        522     /* Update synchronization mismatch */
+#define EBADCOOKIE      523     /* Cookie is stale */
+#define ENOTSUPP        524     /* Operation is not supported */
+#define ETOOSMALL       525     /* Buffer or request is too small */
+#define ESERVERFAULT    526     /* An untranslatable error occurred */
+#define EBADTYPE        527     /* Type not supported by server */
+#define EJUKEBOX        528     /* Request initiated, but will timeout */
 
 #endif
 

--- a/elks/include/linuxmt/errno.h
+++ b/elks/include/linuxmt/errno.h
@@ -55,6 +55,7 @@
 #define ELOOP           40      /* Too many symbolic links encountered */
 
 /* these are used, pulled out of the below unused list */
+#define ENODATA         61      /* No data available */
 #define ENOSR           63      /* Out of streams resources */
 #define ENOTSOCK        88      /* Socket operation on non-socket */
 #define EADDRINUSE      98      /* Address already in use */
@@ -95,7 +96,7 @@
 #define EDEADLOCK       58      /* File locking deadlock error */
 #define EBFONT          59      /* Bad font file format */
 #define ENOSTR          60      /* Device not a stream */
-#define ENODATA         61      /* No data available */
+
 #define ETIME           62      /* Timer expired */
 
 #define ENONET          64      /* Machine is not on the network */

--- a/elkscmd/file_utils/mknod.c
+++ b/elkscmd/file_utils/mknod.c
@@ -1,13 +1,9 @@
 #include <unistd.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <errno.h>
-#include <stdlib.h>
+#include <linuxmt/kdev_t.h>
 #include "futils.h"
-
-#ifndef makedev
-#define makedev(maj, min)  (((maj) << 8) | (min))
-#endif
 
 int main(int argc, char **argv)
 {
@@ -32,12 +28,13 @@ int main(int argc, char **argv)
 		major = atoi(argv[3]);
 		minor = atoi(argv[4]);
 		
-		if (errno != ERANGE)
-			if (mknod (argv[1], newmode | filetype, makedev(major, minor))) {
+		if (major > 0 && minor > 0) {
+			if (mknod (argv[1], newmode | filetype, MKDEV(major, minor))) {
 				errstr(argv[1]);
 				errmsg(": cannot make device\n");
 				return 1;
 			}
+		}
 	} else if ((argc == 3) && (argv[2][0] == 'p')) {
 		if (mknod (argv[1],newmode | S_IFIFO, 0)) {
 			errstr(argv[1]);

--- a/elkscmd/rootfs_template/etc/perror
+++ b/elkscmd/rootfs_template/etc/perror
@@ -32,96 +32,21 @@
 32 Broken pipe 
 33 Math argument out of domain of func 
 34 Math result not representable 
-35 Resource deadlock would occur 
 36 File name too long 
-37 No record locks available 
 38 Function not implemented 
 39 Directory not empty 
 40 Too many symbolic links encountered 
-41 Operation would block 
-42 No message of desired type 
-43 Identifier removed 
-44 Channel number out of range 
-45 Level 2 not synchronized 
-46 Level 3 halted 
-47 Level 3 reset 
-48 Link number out of range 
-49 Protocol driver not attached 
-50 No CSI structure available 
-51 Level 2 halted 
-52 Invalid exchange 
-53 Invalid request descriptor 
-54 Exchange full 
-55 No anode 
-56 Invalid request code 
-57 Invalid slot 
-58 File locking deadlock error 
-59 Bad font file format 
-60 Device not a stream 
-61 No data available 
-62 Timer expired 
 63 Out of streams resources 
-64 Machine is not on the network 
-65 Package not installed 
-66 Object is remote 
-67 Link has been severed 
-68 Advertise error 
-69 Srmount error 
-70 Communication error on send 
-71 Protocol error 
-72 Multihop attempted 
-73 RFS specific error 
-74 Not a data message 
-75 Value too large for defined data type 
-76 Name not unique on network 
-77 File descriptor in bad state 
-78 Remote address changed 
-79 Can not access a needed shared library 
-80 Accessing a corrupted shared library 
-81 .lib section in a.out corrupted 
-82 Attempting to link in too many shared libraries 
-83 Cannot exec a shared library directly 
-84 Illegal byte sequence 
-85 Interrupted system call should be restarted 
-86 Streams pipe error 
-87 Too many users 
 88 Socket operation on non-socket 
-89 Destination address required 
-90 Message too long 
-91 Protocol wrong type for socket 
-92 Protocol not available 
-93 Protocol not supported 
-94 Socket type not supported 
-95 Operation not supported on transport endpoint 
-96 Protocol family not supported 
-97 Address family not supported by protocol 
 98 Address already in use 
-99 Cannot assign requested address 
 100 Network is down 
 101 Network is unreachable 
-102 Network dropped connection because of reset 
-103 Software caused connection abort 
-104 Connection reset by peer 
 105 No buffer space available 
 106 Transport endpoint is already connected 
-107 Transport endpoint is not connected 
-108 Cannot send after transport endpoint shutdown 
-109 Too many references: cannot splice 
 110 Connection timed out 
 111 Connection refused 
-112 Host is down 
 113 Host not reachable 
-114 Operation already in progress 
 115 Operation now in progress 
-116 Stale NFS file handle 
-117 Structure needs cleaning 
-118 Not a XENIX named type file 
-119 No XENIX semaphores available 
-120 Is a named type file 
-121 Remote I/O error 
-122 Quota exceeded 
-123 No medium found 
-124 Wrong medium type 
 125 Nameserver not found 
 126 Name not found 
 127 Bad query format 

--- a/elkscmd/rootfs_template/etc/perror
+++ b/elkscmd/rootfs_template/etc/perror
@@ -36,6 +36,7 @@
 38 Function not implemented 
 39 Directory not empty 
 40 Too many symbolic links encountered 
+61 No data available 
 63 Out of streams resources 
 88 Socket operation on non-socket 
 98 Address already in use 

--- a/libc/error/perror
+++ b/libc/error/perror
@@ -1,0 +1,129 @@
+1 Operation not permitted 
+2 No such file or directory 
+3 No such process 
+4 Interrupted system call 
+5 I/O error 
+6 No such device or address 
+7 Arg list too long 
+8 Exec format error (install ash for shell scripts) 
+9 Bad file number 
+10 No child processes 
+11 Try again 
+12 Out of memory 
+13 Permission denied 
+14 Bad address 
+15 Block device required 
+16 Device or resource busy 
+17 File exists 
+18 Cross-device link 
+19 No such device 
+20 Not a directory 
+21 Is a directory 
+22 Invalid argument 
+23 File table overflow 
+24 Too many open files 
+25 Not a typewriter 
+26 Text file busy 
+27 File too large 
+28 No space left on device 
+29 Illegal seek 
+30 Read-only file system 
+31 Too many links 
+32 Broken pipe 
+33 Math argument out of domain of func 
+34 Math result not representable 
+35 Resource deadlock would occur 
+36 File name too long 
+37 No record locks available 
+38 Function not implemented 
+39 Directory not empty 
+40 Too many symbolic links encountered 
+41 Operation would block 
+42 No message of desired type 
+43 Identifier removed 
+44 Channel number out of range 
+45 Level 2 not synchronized 
+46 Level 3 halted 
+47 Level 3 reset 
+48 Link number out of range 
+49 Protocol driver not attached 
+50 No CSI structure available 
+51 Level 2 halted 
+52 Invalid exchange 
+53 Invalid request descriptor 
+54 Exchange full 
+55 No anode 
+56 Invalid request code 
+57 Invalid slot 
+58 File locking deadlock error 
+59 Bad font file format 
+60 Device not a stream 
+61 No data available 
+62 Timer expired 
+63 Out of streams resources 
+64 Machine is not on the network 
+65 Package not installed 
+66 Object is remote 
+67 Link has been severed 
+68 Advertise error 
+69 Srmount error 
+70 Communication error on send 
+71 Protocol error 
+72 Multihop attempted 
+73 RFS specific error 
+74 Not a data message 
+75 Value too large for defined data type 
+76 Name not unique on network 
+77 File descriptor in bad state 
+78 Remote address changed 
+79 Can not access a needed shared library 
+80 Accessing a corrupted shared library 
+81 .lib section in a.out corrupted 
+82 Attempting to link in too many shared libraries 
+83 Cannot exec a shared library directly 
+84 Illegal byte sequence 
+85 Interrupted system call should be restarted 
+86 Streams pipe error 
+87 Too many users 
+88 Socket operation on non-socket 
+89 Destination address required 
+90 Message too long 
+91 Protocol wrong type for socket 
+92 Protocol not available 
+93 Protocol not supported 
+94 Socket type not supported 
+95 Operation not supported on transport endpoint 
+96 Protocol family not supported 
+97 Address family not supported by protocol 
+98 Address already in use 
+99 Cannot assign requested address 
+100 Network is down 
+101 Network is unreachable 
+102 Network dropped connection because of reset 
+103 Software caused connection abort 
+104 Connection reset by peer 
+105 No buffer space available 
+106 Transport endpoint is already connected 
+107 Transport endpoint is not connected 
+108 Cannot send after transport endpoint shutdown 
+109 Too many references: cannot splice 
+110 Connection timed out 
+111 Connection refused 
+112 Host is down 
+113 Host not reachable 
+114 Operation already in progress 
+115 Operation now in progress 
+116 Stale NFS file handle 
+117 Structure needs cleaning 
+118 Not a XENIX named type file 
+119 No XENIX semaphores available 
+120 Is a named type file 
+121 Remote I/O error 
+122 Quota exceeded 
+123 No medium found 
+124 Wrong medium type 
+125 Nameserver not found 
+126 Name not found 
+127 Bad query format 
+128 Query refused 
+129 Server error 

--- a/libc/include/errno.h
+++ b/libc/include/errno.h
@@ -6,48 +6,4 @@
 
 extern int errno;
 
-#if 0
-// From asm-generic/errno-base.h
-#define EPERM    1  // Operation not permitted
-#define ENOENT   2	// No such file or directory
-#define EINTR    4  // Interrupted system call
-#define EIO      5	// I/O error
-#define	ENXIO    6  // No such device or address
-#define E2BIG    7  // Argument list too long
-#define ENOEXEC  8  // Exec format error
-#define EAGAIN  11  // Try again
-#define ENOMEM  12  // Out of memory
-#define EACCES  13  // Permission denied
-#define EBUSY   16  // Device or resource busy
-#define EEXIST  17  // File exists
-#define EXDEV   18  // Cross-device link
-#define ENOTDIR 20  // Not a directory
-#define EISDIR  21  // Is a directory
-#define EINVAL  22  // Invalid argument
-#define ENFILE  23  // File table overflow
-#define EMFILE  24  // Too many open files
-#define ENOTTY  25  // Not a typewriter
-#define ETXTBSY 26  // Text file busy
-#define ENOSPC  28	// No space left on device
-#define EROFS   30  // Read-only file system
-#define ERANGE  34  // Math result not representable
-
-/*
-#define	ESRCH		 3	// No such process
-#define	EBADF		 9	// Bad file number
-#define	ECHILD		10	// No child processes
-#define	EFAULT		14	// Bad address
-#define	ENOTBLK		15	// Block device required
-#define	ENODEV		19	// No such device
-#define	EFBIG		27	// File too large
-#define	ESPIPE		29	// Illegal seek
-#define	EMLINK		31	// Too many links
-#define	EPIPE		32	// Broken pipe
-#define	EDOM		33	// Math argument out of domain of func
-*/
-
-#define ENOSYS  38  // Function not implemented
-
-#endif /* #if 0*/
-
 #endif


### PR DESCRIPTION
Used a script to determine all program and kernel usage of errno.h. Then retabbed and refactored errno.h and reduced size of /etc/perror (used by `perror`) to save 2k on all distribution floppies.