### PR TITLE
[libc] Get --ftrace option working on all commands

### DIFF
--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -71,7 +71,7 @@ int sys_execve(const char *filename, char *sptr, size_t slen)
     word_t magic;
 
     /* Open the image */
-    debug_file("EXEC(%P): '%t' env %d\n", filename, slen);
+    dprintk("EXEC(%P): '%t' env %d\n", filename, slen);
 
     retval = open_namei(filename, 0, 0, &inode, NULL);
     debug("EXEC: open returned %d\n", -retval);

--- a/elks/include/linuxmt/debug.h
+++ b/elks/include/linuxmt/debug.h
@@ -13,7 +13,7 @@
  * Kernel debug options, set =1 to turn on. Works across multiple files.
  */
 #define DEBUG_EVENT     1               /* generate debug events on CTRLN-CTRLP*/
-#define DEBUG_STARTDEF  1               /* default startup debug display*/
+#define DEBUG_STARTDEF  0               /* default startup debug display*/
 #define DEBUG_BIOS      0               /* BIOS driver*/
 #define DEBUG_BLK       0               /* block i/o*/
 #define DEBUG_ETH       0               /* ethernet*/

--- a/elkscmd/Make.defs
+++ b/elkscmd/Make.defs
@@ -68,20 +68,24 @@ HOSTCFLAGS = -O3
 #
 # Compiler variables for programs cross-compiled for ELKS.
 
-CC=ia16-elf-gcc
-CFLBASE=-fno-inline -melks-libc -mcmodel=small -mno-segment-relocation-stuff -mtune=i8086 -Wall -Os
+CLBASE =  -mcmodel=small -melks-libc -mtune=i8086 -Wall -Os
+CLBASE += -mno-segment-relocation-stuff
+CLBASE += -fno-inline -fno-builtin-printf
+#CLBASE += -mregparmcall
 ifeq ($(CONFIG_APPS_FTRACE), y)
-  CFLBASE += -fno-optimize-sibling-calls -fno-omit-frame-pointer
-  CFLBASE += -finstrument-functions-simple -maout-symtab
+    CLBASE += -fno-omit-frame-pointer -fno-optimize-sibling-calls
+    CLBASE += -finstrument-functions-simple -maout-symtab
 endif
-#CFLBASE += -mregparmcall
-LD=ia16-elf-gcc
-LDFLAGS=$(CFLBASE)
-CHECK=gcc -c -o .null.o -Wall -pedantic
-AS=ia16-elf-as
-ASFLAGS=-mtune=i8086 --32-segelf
 
-CFLAGS=$(CFLBASE) $(WARNINGS) $(LOCALFLAGS) $(INCLUDES) -D__ELKS__ -DELKS_VERSION=\"$(ELKS_VSN)\"
+CC=ia16-elf-gcc
+AS=ia16-elf-as
+LD=ia16-elf-gcc
+
+CFLAGS =  $(CLBASE) $(WARNINGS) $(LOCALFLAGS) $(INCLUDES)
+CFLAGS += -D__ELKS__ -DELKS_VERSION=\"$(ELKS_VSN)\"
+ASFLAGS = -mtune=i8086 --32-segelf
+LDFLAGS = $(CLBASE)
+
 
 ###############################################################################
 #

--- a/elkscmd/Make.install
+++ b/elkscmd/Make.install
@@ -165,7 +165,9 @@ endif
 ifdef CONFIG_APPS_2880K
 	# below TAGS relies on :ash rule following :defsash rule in Applications
 	TAGS = :*|
+ifndef CONFIG_APPS_FTRACE
 	CONFIG_APP_MAN_PAGES=y
+endif
 endif
 
 #

--- a/elkscmd/ash/Makefile
+++ b/elkscmd/ash/Makefile
@@ -29,6 +29,8 @@ OBJS=	builtins.o cd.o dirent.o error.o eval.o exec.o expand.o input.o \
 	output.o var.o init.o \
 	linenoise_elks.o autocomplete.o
 
+#OBJS += v7malloc.o
+
 # builtins must be manually added
 OBJS += bltin/echo.o
 OBJS += bltin/expr.o bltin/regexp.o bltin/operators.o

--- a/elkscmd/file_utils/rm.c
+++ b/elkscmd/file_utils/rm.c
@@ -12,16 +12,16 @@ int errcode;
 
 int usage(void)
 {
-	fprintf(stderr, "usage: rm [-rfi] file [...]\n");
-	return 1;
+        fprintf(stderr, "usage: rm [-rfi] file [...]\n");
+        return 1;
 }
 
 int yes(void) {
         int i, b;
 
-        i = b = getchar();
+        i = b = fgetc(stdin);
         while(b != '\n' && b != EOF)
-                b = getchar();
+                b = fgetc(stdin);
         return(i == 'y');
 }
 
@@ -35,7 +35,7 @@ int dotname(char *s) {
                 else if(s[1] == '\0')
                         return(1);
         }
-	return(0);
+        return(0);
 }
 
 void rm(char *arg, int level)
@@ -105,15 +105,15 @@ void rm(char *arg, int level)
                 fprintf(stderr, "rm: %s not removed\n", arg);
                 errcode++;
         }
-	return;
+        return;
 }
 
 int main(int argc, char **argv)
 {
-	char *arg;
+        char *arg;
 
-	if (argc < 2)
-		return usage();
+        if (argc < 2)
+                return usage();
 
         while(argc>1 && argv[1][0]=='-') {
                 arg = *++argv;

--- a/elkscmd/lib/tiny_vfprintf.c
+++ b/elkscmd/lib/tiny_vfprintf.c
@@ -4,12 +4,12 @@
  * Reduces executable size when linked with app for programs requiring
  *  output to terminal only (stdout, stderr) and no file I/O.
  * Automatically usable with:
- *  printf, fprintf, sprintf
+ *  printf, fprintf, sprintf, fputc, fflush
  *
  * Limitations:
  *      %s, %c, %d, %u, %x, %o, %ld, %lu, %lx, %lo only w/field width & precision
  *  Don't use with fopen (stdout, stderr only)
- *    Replaces stdout and stderr buffers with single buffer
+ *  Always line buffered
  *
  * Mar 2020 Greg Haerr
  */
@@ -21,56 +21,59 @@
 #include <string.h>
 
 static unsigned char bufout[80];
+static unsigned char buferr[80];
 
 FILE  stdout[1] =
 {
    {
     bufout,
     bufout,
-    bufout,
+    bufout + sizeof(bufout),    /* putc is full buffered */
     bufout,
     bufout + sizeof(bufout),
     1,
-    _IOFBF | __MODE_WRITE | __MODE_IOTRAN
+    _IOLBF | __MODE_WRITE | __MODE_IOTRAN
    }
 };
 
 FILE  stderr[1] =
 {
    {
-    bufout,
-    bufout,
-    bufout,
-    bufout,
-    bufout + sizeof(bufout),
+    buferr,
+    buferr,
+    buferr + sizeof(buferr),    /* putc is full buffered */
+    buferr,
+    buferr + sizeof(buferr),
     2,
-    _IOFBF | __MODE_WRITE | __MODE_IOTRAN
+    _IOLBF | __MODE_WRITE | __MODE_IOTRAN
    }
 };
 
-static void __fflush(FILE *fp)
+int fflush(FILE *fp)
 {
    int len;
 
-   /* Return if this is a fake FILE from sprintf */
-   if (fp->fd < 0)
-      return;
+   if (fp->fd < 0)              /* Return if this is a fake FILE from sprintf */
+      return EOF;
 
    len = fp->bufpos - fp->bufstart;
    if (len)
       write(fp->fd, fp->bufstart, len);
 
-   fp->bufwrite = fp->bufpos = fp->bufstart;
+   fp->bufpos = fp->bufstart;
+   return 0;
 }
 
-static void __fputc(int ch, FILE *fp)
+int fputc(int ch, FILE *fp)
 {
    if (fp->bufpos >= fp->bufend)
-     __fflush(fp);
+     fflush(fp);
 
    *(fp->bufpos++) = ch;
 
-   fp->bufwrite = fp->bufend;
+   if (ch == '\n')              /* fputc is always line buffered */
+     fflush(fp);
+    return ch;
 }
 
 /*
@@ -130,7 +133,7 @@ __fmt(FILE *op, unsigned char *buf, int ljustf, int width, int preci, char pad, 
          ch = pad;              /* right padding */
          --width;
       }
-      __fputc(ch, op);
+      fputc(ch, op);
    }
 
    return cnt;
@@ -241,11 +244,10 @@ vfprintf(FILE *op, const char *fmt, va_list ap)
          }
       } else {
        charout:
-         __fputc(*fmt, op);     /* normal char out */
+         fputc(*fmt, op);     /* normal char out */
          ++cnt;
       }
       ++fmt;
    }
-   __fflush(op);
    return cnt;
 }

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -12,10 +12,11 @@
 #task=6 buf=8 cache=4 file=20 inode=24 heap=15000 n # min w/no rc.sys
 #sync=30
 #init=/bin/init 3 n	# muser serial no rc.sys
-#init=/bin/sash		# singleuser sh
+#init=/bin/sash
 #root=df0
 #root=hda1 ro
 #kstack
 #strace
-#debug net=ne0
+#net=ne0
+#debug FTRACE=1
 #console=ttyS0,19200 3

--- a/libc/debug/syms.c
+++ b/libc/debug/syms.c
@@ -35,7 +35,8 @@ static unsigned char __far * noinstrument alloc_read(int fd, size_t size)
 #if __ia16__
     unsigned char __far *s;
     size_t n, t = 0;
-    unsigned char buf[512];
+    static unsigned char buf[512];  /* don't use application stack */
+
     if (!(s = fmemalloc(size)))
         return NULL;
     do {


### PR DESCRIPTION
Setting CONFIG_APPS_FTRACE=y now builds all applications, including the shell, with a full symbol table, allowing for symbolic function tracing during execution. Setting FTRACE=1 in /bootopts will turn on function tracing for all apps, or any app can be started with `--ftrace` as the first argument and it will display it execution to /dev/console.

While some of this was already present, it is now debugged. Turns out that /bin/sh actually has function nesting depth of over 100 and was overflowing the stack.

The stripped-down "tiny_printf.c" had to be slightly reworked for this to work, and it was then found that GCC was replacing some calls to printf with calls to puts or fputs, which complicated matters and unknowingly increased code size. The `-fno-builtin-printf` was added to stop that.

The `debug` option in /bootopts now turns on some basic debugging, showing which files are being exec'd, which is helpful when running a system ftrace. If you really want to see what's going on, set CONFIG_TRACE=y and `strace` in /bootopts, along with FTRACE=1. This will trace all system calls and all function calls for every program. Set `console=/dev/ttyS0` also in /bootopts and widen the terminal emulator window to 200 columns for best clarity.

When CONFIG_APPS_FTRACE=y, the disk image is so large that 2880k floppy or HD must be selected also, and man pages aren't added so there's enough space.

