### PR TITLE
[libc] Fix fdopen bug introduced in #1923

### DIFF
--- a/libc/stdio/__fopen.c
+++ b/libc/stdio/__fopen.c
@@ -74,11 +74,6 @@ __fopen(const char * fname, int fd, FILE * fp, const char * mode)
       break;
    }
 
-   if (!fname) {
-        errno = EINVAL;
-        return 0;
-   }
-
    /* Allocate the (FILE) before we do anything irreversable */
    if (fp == 0)
    {
@@ -88,7 +83,8 @@ __fopen(const char * fname, int fd, FILE * fp, const char * mode)
    }
 
    /* Open the file itself */
-   fd = open(fname, open_mode, 0666);
+   if (fname)
+       fd = open(fname, open_mode, 0666);
    if (fd < 0)			/* Grrrr */
    {
       if (nfp)

--- a/libc/stdio/fopen.c
+++ b/libc/stdio/fopen.c
@@ -1,6 +1,11 @@
 #include <stdio.h>
+#include <errno.h>
 
 FILE * fopen (const char * file, const char * mode)
 {
-	return __fopen(file, -1, (FILE*)0, mode);
+    if (file == NULL) {
+        errno = EINVAL;
+        return 0;
+    }
+    return __fopen(file, -1, (FILE *)0, mode);
 }


### PR DESCRIPTION
Refactors incorrect bugfix originally introduced in #1923. This had the effect that the `man` command stopped working, which uses `popen` which calls `fdopen` with a NULL filename.