### PR TITLE
[build] Cleanup Makefiles, add RM, remove Make.rules

### DIFF
--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -1,6 +1,6 @@
 ########################################################################
 #                                                                      #
-# Standard rulesets for use when compiling and installing this system. #
+# Standard rulesets for use when compiling the ELKS kernel.            #
 #                                                                      #
 ########################################################################
 

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -88,7 +88,7 @@ sys_utils/kill                  :sysutil        :360c :720k
 sys_utils/ps            :sash   :sysutil        :360k           :128k       :nocomp
 sys_utils/ps :::uptime          :sysutil                        :128k   :1440k
 sys_utils/makeboot              :sysutil        :360k
-sys_utils/man                   :sysutil                :1200k
+sys_utils/man                   :sysutil
 sys_utils/meminfo       :sash   :sysutil        :360k           :128k
 sys_utils/mouse                 :sysutil                 :1200c     :1440k
 sys_utils/passwd                :sysutil                :1200k

--- a/elkscmd/Make.rules
+++ b/elkscmd/Make.rules
@@ -1,3 +1,0 @@
-# Commands common rules
-
-.PHONY: all clean install

--- a/elkscmd/Makefile
+++ b/elkscmd/Makefile
@@ -6,7 +6,7 @@
 
 BASEDIR = .
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
 #
@@ -46,8 +46,6 @@ SUBDIRS =       \
 ###############################################################################
 #
 # Compile everything.
-
-include $(BASEDIR)/Make.rules
 
 all:
 	@if [ ! -e $(TOPDIR)/include/autoconf.h ]; \

--- a/elkscmd/Makefile-rules
+++ b/elkscmd/Makefile-rules
@@ -96,13 +96,15 @@ TINYPRINTF=$(ELKSCMD_DIR)/lib/tiny_vfprintf.o
 #
 # Standard compilation rules.
 
+.PHONY: all clean install
+
 .S.s:
 	$(CC) -E -traditional $(INCLUDES) $(CCDEFS) -o $*.s $<
 
 .S.o:
 	$(CC) -E -traditional $(INCLUDES) $(CCDEFS) -o $*.tmp $<
 	$(AS) $(ASFLAGS) -o $*.o $*.tmp
-	rm -f $*.tmp
+	$(RM) $*.tmp
 
 .s.o:
 	$(AS) $(ASFLAGS) -o $*.o $<

--- a/elkscmd/Makefile-rules
+++ b/elkscmd/Makefile-rules
@@ -1,28 +1,11 @@
-# ***** IMPORTANT NOTE *****
-#
-# This file has been revised to remove the requirement that the elkscmd
-# and elks trees are located under /usr/src on the developer's system.
-# This requires that the variable BASEDIR be defined in every Makefile
-# that includes this header file, prior to including it, and the value
-# given to BASEDIR is required to be the relative path from the directory
-# containing that Makefile to the directory containing this file.
-#
-# In addition, if there are any local definitions that need including in
-# the CFLAGS value, those should be assigned to LOCALFLAGS before including
-# this file.
-#
-# So as to ensure this, it is recommended that the following three lines
-# be used as the first three lines of each Makefile including this file:
-#
-#	BASEDIR = ...
-#
-#	LOCALFLAGS = ...
-#
-#	include $(BASEDIR)/Make.defs
-#
-# This ensures that the correct value is assigned by using it to include
-# this file.
-#
+##############################################################################
+#                                                                            #
+# Standard rulesets for use when compiling ELKS applications.                #
+#                                                                            #
+# This file should be included in every Makefile below elkscmd/ via e.g.:    #
+#   BASEDIR=..                                                               #
+#   include $(BASEDIR)/Makefile-rules                                        #
+#                                                                            #
 ##############################################################################
 
 ifndef TOPDIR
@@ -41,11 +24,6 @@ ELKS_DIR=$(TOPDIR)/elks
 ELKSCMD_DIR=$(TOPDIR)/elkscmd
 
 INCLUDES=-I$(TOPDIR)/include -I$(TOPDIR)/libc/include -I$(ELKS_DIR)/include
-
-# temporarily turn off typical non-K&R warnings for now
-WARNINGS = -Wno-implicit-int
-# temporarily turn off suggesting parenthesis around assignment used as truth value
-WARNINGS += -Wno-parentheses
 
 ##############################################################################
 #
@@ -76,6 +54,11 @@ ifeq ($(CONFIG_APPS_FTRACE), y)
     CLBASE += -fno-omit-frame-pointer -fno-optimize-sibling-calls
     CLBASE += -finstrument-functions-simple -maout-symtab
 endif
+
+# temporarily turn off typical non-K&R warnings for now
+WARNINGS = -Wno-implicit-int
+# temporarily turn off suggesting parenthesis around assignment used as truth value
+WARNINGS += -Wno-parentheses
 
 CC=ia16-elf-gcc
 AS=ia16-elf-as

--- a/elkscmd/advent/Makefile
+++ b/elkscmd/advent/Makefile
@@ -1,12 +1,8 @@
 BASEDIR=..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
 
 CFLAGS += -DELKS=1
 #CFLAGS += -Wno-parentheses
@@ -43,4 +39,4 @@ install: $(PRGS)
 	$(INSTALL) advent.db $(DESTDIR)/lib
 
 clean:
-	rm -f $(PRGS) $(HOSTPRGS) *.o *.map
+	$(RM) $(PRGS) $(HOSTPRGS) *.o *.map

--- a/elkscmd/ash/Makefile
+++ b/elkscmd/ash/Makefile
@@ -5,16 +5,12 @@
 
 BASEDIR = ..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
+
+###############################################################################
 
 LOCALFLAGS = -DSHELL -I. -D_MINIX -D_POSIX_SOURCE -Dlint
 LOCALFLAGS += -Wno-implicit-int
-
-###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
@@ -57,7 +53,7 @@ install: ash
 	$(INSTALL) ash $(DESTDIR)/bin/sh
 
 clean:
-	rm -f core ash $(CLEANFILES)
+	$(RM) ash $(CLEANFILES)
 
 parser.o: token.def
 

--- a/elkscmd/basic/Makefile
+++ b/elkscmd/basic/Makefile
@@ -1,12 +1,8 @@
 BASEDIR=..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
 
 CFLAGS += -Wno-maybe-uninitialized
 
@@ -55,4 +51,4 @@ install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 clean:
-	rm -f $(PRGS) $(HOSTPRGS) *.o *.map
+	$(RM) $(PRGS) $(HOSTPRGS) *.o *.map

--- a/elkscmd/bc/Makefile
+++ b/elkscmd/bc/Makefile
@@ -2,13 +2,9 @@
 #
 # A makefile for bc.  This is part of the bc/sbc distribution.
 #
-# $Id$
-###############################################################################
-#
-# Include standard packaging commands.
 
 BASEDIR 	= ..
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
 #
@@ -52,7 +48,7 @@ math.h: libmath.b
 	$(MAKE) -$(MAKEFLAGS) fbc
 	elksemu ./fbc -c libmath.b </dev/null >math.h
 	./fix_math.h
-	rm -f ./fbc
+	$(RM) ./fbc
 
 fbc: $(OFILES) bc.o
 	echo \"\" > math.h
@@ -64,7 +60,7 @@ install: bc fbc
 #	$(INSTALL) fbc $(DESTDIR)/bin
 
 clean:
-	rm -f *.o *.bak core math.h bc fbc sbc bc.c sbc.c scan.c y.tab.h
+	$(RM) *.o *.bak math.h bc fbc sbc bc.c sbc.c scan.c y.tab.h
 
 scan.c: scan.l
 	$(LEX) scan.l

--- a/elkscmd/busyelks/makefile
+++ b/elkscmd/busyelks/makefile
@@ -1,6 +1,5 @@
 BASEDIR	= ..
-include $(BASEDIR)/Make.defs
-include $(BASEDIR)/Make.rules
+include $(BASEDIR)/Makefile-rules
 
 # Install destination
 DESTDIR=$(TOPDIR)/target

--- a/elkscmd/cron/Makefile
+++ b/elkscmd/cron/Makefile
@@ -1,18 +1,12 @@
-##################################################################################
-
 # Makefile for cron
 
 BASEDIR=..
 
-include $(BASEDIR)/Make.defs
-
-LOCALFLAGS = -Wno-implicit-int -Wno-return-type $(OPTIONS)
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
 
-include $(BASEDIR)/Make.rules
+LOCALFLAGS = -Wno-implicit-int -Wno-return-type $(OPTIONS)
 
 ###############################################################################
 
@@ -31,7 +25,7 @@ crontab: crontab.o $(common)
 	$(CC) $(CFLAGS) -maout-heap=14336 -o $@ crontab.o $(common)
 
 clean:
-	rm -f $(progs) *.o
+	$(RM) $(progs) *.o
 	
 install: cron
 	$(INSTALL) cron $(DESTDIR)/bin/cron

--- a/elkscmd/debug/Makefile
+++ b/elkscmd/debug/Makefile
@@ -1,16 +1,8 @@
 BASEDIR=..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
-
-###############################################################################
-
-PRGS = testsym disasm nm opcodes
 
 # disable tail call optimization for better stack traces
 CFLAGS += -fno-optimize-sibling-calls
@@ -23,6 +15,10 @@ LDFLAGS += -maout-symtab
 
 # added after CFLAGS for non-instrumented .c files in this directory
 #NOINSTFLAGS = -fno-instrument-functions -fno-instrument-functions-simple
+
+###############################################################################
+
+PRGS = testsym disasm nm opcodes
 
 HOSTPRGS = nm86 hostdisasm
 HOSTCFLAGS += -I. -I$(TOPDIR)/elks/include
@@ -68,4 +64,4 @@ install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 clean:
-	rm -f $(PRGS) $(HOSTPRGS) *.o *.map system.sym
+	$(RM) $(PRGS) $(HOSTPRGS) *.o *.map system.sym

--- a/elkscmd/disk_utils/Makefile
+++ b/elkscmd/disk_utils/Makefile
@@ -1,12 +1,8 @@
 BASEDIR=..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
@@ -39,4 +35,4 @@ ramdisk: ramdisk.o
 	$(LD) $(LDFLAGS) -o ramdisk ramdisk.o $(LDLIBS)
 
 clean:
-	rm -f *.o $(PRGS)
+	$(RM) *.o $(PRGS)

--- a/elkscmd/elvis/Makefile
+++ b/elkscmd/elvis/Makefile
@@ -1,10 +1,10 @@
 # combined Makefile for ELVIS - a clone of `vi`
 #
-###############################################################################
 
 BASEDIR = ..
+include $(BASEDIR)/Makefile-rules
 
-include $(BASEDIR)/Make.defs
+###############################################################################
 
 LOCALFLAGS=-DM_SYSV -DCRUNCH -DNO_MKEXRC -DNO_CURSORSHAPE -DNO_CHARATTR \
 	-DNO_SHOWMODE -DNO_MODELINE -DNO_OPTCOLS -DNO_DIGRAPH -DNO_ABBR \
@@ -377,7 +377,7 @@ inst.os9: $(DUMMY)
 
 ##############################################################################
 clean: $(DUMMY)
-	$(RM) *.o $(DOC)*.1 elvis?.uue elvis?.sh core elvis ctags ref virec refont
+	$(RM) *.o $(DOC)*.1 elvis?.uue elvis?.sh elvis ctags ref virec refont
 
 
 clobber: clean

--- a/elkscmd/file_utils/Makefile
+++ b/elkscmd/file_utils/Makefile
@@ -1,12 +1,8 @@
 BASEDIR=..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
@@ -87,4 +83,4 @@ install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 clean:
-	rm -f $(PRGS) *.o
+	$(RM) $(PRGS) *.o

--- a/elkscmd/fsck_dos/Makefile
+++ b/elkscmd/fsck_dos/Makefile
@@ -1,18 +1,14 @@
 BASEDIR=..
 
-include $(BASEDIR)/Make.defs
-
-###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
 
 LOCALCFLAGS = -Dlint -DELKS=1
 # remove next line when FAT32 supported
 LOCALCFLAGS += -Wno-shift-count-overflow
+
+###############################################################################
 
 PRGS = fsck-dos
 
@@ -40,4 +36,4 @@ fsck-dos: main.o boot.o check.o dir.o fat.o
 	$(LD) $(LDFLAGS) -maout-heap=0xffff -o $@ $^ $(LDLIBS)
 
 clean:
-	rm -f *.o $(PRGS)
+	$(RM) *.o $(PRGS)

--- a/elkscmd/inet/Makefile
+++ b/elkscmd/inet/Makefile
@@ -1,12 +1,8 @@
 BASEDIR=..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
 
 ###############################################################################
 

--- a/elkscmd/inet/ftp/Makefile
+++ b/elkscmd/inet/ftp/Makefile
@@ -2,13 +2,9 @@
 
 BASEDIR=../..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
@@ -28,5 +24,5 @@ install: ftpd ftp
 	$(INSTALL) $(BINS)  $(DESTDIR)/bin
 
 clean:
-	rm -f $(BINS) $(OBJS)
+	$(RM) $(BINS) $(OBJS)
 

--- a/elkscmd/inet/httpd/Makefile
+++ b/elkscmd/inet/httpd/Makefile
@@ -1,19 +1,15 @@
 BASEDIR=../..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
 
-include $(BASEDIR)/Make.rules
+LOCALFLAGS=-I$(ELKSCMD_DIR)
+LDFLAGS += -maout-heap=1024 -maout-stack=1024
 
 ###############################################################################
 
 PRG=httpd
-
-LOCALFLAGS=-I$(ELKSCMD_DIR)
-LDFLAGS += -maout-heap=1024 -maout-stack=1024
 
 all: $(PRG)
 
@@ -26,4 +22,4 @@ install: $(PRG)
 	$(INSTALL) sample_index.html $(DESTDIR)/var/www/index.html
 
 clean:
-	rm -f *.o $(PRG)
+	$(RM) *.o $(PRG)

--- a/elkscmd/inet/nettools/Makefile
+++ b/elkscmd/inet/nettools/Makefile
@@ -1,18 +1,14 @@
 BASEDIR=../..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
 
-include $(BASEDIR)/Make.rules
+LOCALFLAGS=-I$(ELKSCMD_DIR)
 
 ###############################################################################
 
 PRGS=netstat nslookup arp
-
-LOCALFLAGS=-I$(ELKSCMD_DIR)
 
 all: $(PRGS)
 
@@ -30,4 +26,4 @@ arp: arp.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) arp.o $(TINYPRINTF) -o arp $(LDLIBS)
 
 clean:
-	rm -f core *.o $(PRGS)
+	$(RM) *.o $(PRGS)

--- a/elkscmd/inet/telnet/Makefile
+++ b/elkscmd/inet/telnet/Makefile
@@ -2,13 +2,9 @@
 
 BASEDIR=../..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
@@ -24,4 +20,4 @@ install: telnet
 	$(INSTALL) telnet $(DESTDIR)/bin
 
 clean:
-	rm -f $(OBJS) telnet
+	$(RM) $(OBJS) telnet

--- a/elkscmd/inet/telnetd/Makefile
+++ b/elkscmd/inet/telnetd/Makefile
@@ -2,13 +2,9 @@
 
 BASEDIR=../..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
@@ -25,5 +21,5 @@ install: telnetd
 	$(INSTALL) telnetd $(DESTDIR)/bin
 
 clean:
-	rm -f $(OBJS) telnetd
+	$(RM) $(OBJS) telnetd
 

--- a/elkscmd/inet/tinyirc/Makefile
+++ b/elkscmd/inet/tinyirc/Makefile
@@ -2,13 +2,7 @@
 
 BASEDIR=../..
 
-include $(BASEDIR)/Make.defs
-
-###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
 
@@ -16,6 +10,8 @@ include $(BASEDIR)/Make.rules
 # chat.freenode.net=
 SERVER = 162.213.39.42
 PORT = 8000
+
+###############################################################################
 
 all: tinyirc
 
@@ -31,4 +27,4 @@ install: tinyirc
 	$(INSTALL) tinyirc $(DESTDIR)/bin
 
 clean:
-	rm -f *.o tinyirc
+	$(RM) *.o tinyirc

--- a/elkscmd/inet/urlget/Makefile
+++ b/elkscmd/inet/urlget/Makefile
@@ -2,13 +2,9 @@
 
 BASEDIR=../..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
@@ -24,5 +20,5 @@ install: urlget
 	$(INSTALL) urlget $(DESTDIR)/bin
 
 clean:
-	rm -f urlget *.o
+	$(RM) urlget *.o
 

--- a/elkscmd/ktcp/Makefile
+++ b/elkscmd/ktcp/Makefile
@@ -1,15 +1,18 @@
 # Makefile for ktcp
 BASEDIR=..
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
+
+##############################################################################
 
 SHELL		= /bin/sh
+
+##############################################################################
 
 CFILES		= ktcp.c slip.c ip.c icmp.c tcp.c tcp_cb.c tcp_output.c \
 		  timer.c tcpdev.c netconf.c vjhc.c deveth.c arp.c hexdump.c
 
 OBJS		= $(CFILES:.c=.o)
 
-##############################################################################
 
 all:	ktcp
 
@@ -20,11 +23,7 @@ install: ktcp
 	$(INSTALL) ktcp $(DESTDIR)/bin
 
 clean: 
-	rm -f *~ *.o ktcp core 
+	$(RM) *.o ktcp
 
 dep:
 	makedepend $(CFILES)
-
-#######
-# EOF #
-#######

--- a/elkscmd/levee/Makefile
+++ b/elkscmd/levee/Makefile
@@ -2,17 +2,13 @@
 
 BASEDIR=..
 
-include $(BASEDIR)/Make.defs
-
-###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
 
 LOCALFLAGS=-DSIZE=16000L
+
+###############################################################################
 
 OBJS = blockio.o display.o editcor.o exec.o find.o \
     unixcall.o globals.o insert.o main.o misc.o \
@@ -27,7 +23,7 @@ install: lev
 	$(INSTALL) lev $(DESTDIR)/bin/vi
 
 clean:
-	rm -f *.o lev
+	$(RM) *.o lev
 
 # Dependencies
 

--- a/elkscmd/lib/Makefile
+++ b/elkscmd/lib/Makefile
@@ -1,12 +1,8 @@
 BASEDIR=..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
@@ -19,4 +15,4 @@ CFLAGS += -fno-instrument-functions -fno-instrument-functions-simple
 all: $(OBJS)
 
 clean:
-	rm -f *.o
+	$(RM) *.o

--- a/elkscmd/minix1/Makefile
+++ b/elkscmd/minix1/Makefile
@@ -1,16 +1,12 @@
 BASEDIR=..
 
-include $(BASEDIR)/Make.defs
-
-###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
 
 LOCALFLAGS=-D_POSIX_SOURCE
+
+###############################################################################
 
 PRGS = banner decomp16 fgrep grep proto sum uniq wc cksum cut du
 
@@ -54,4 +50,4 @@ install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 clean:
-	rm -f $(PRGS) *.o
+	$(RM) $(PRGS) *.o

--- a/elkscmd/minix2/Makefile
+++ b/elkscmd/minix2/Makefile
@@ -1,14 +1,10 @@
 BASEDIR=..
 
-LOCALFLAGS=-D_POSIX_SOURCE
-
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
 
-include $(BASEDIR)/Make.rules
+LOCALFLAGS=-D_POSIX_SOURCE
 
 ###############################################################################
 
@@ -47,4 +43,4 @@ install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 clean:
-	rm -f core *.o $(PRGS)
+	$(RM) *.o $(PRGS)

--- a/elkscmd/minix3/Makefile
+++ b/elkscmd/minix3/Makefile
@@ -1,22 +1,16 @@
 BASEDIR=..
 
-LOCALFLAGS=
-
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
 
-include $(BASEDIR)/Make.rules
+LOCALFLAGS=
 
 ###############################################################################
 
 PRGS = file head sed sort tail tee cal diff find mail
 
-#
-# Rules
-#
+all: $(PRGS)
 
 cal: cal.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -o cal cal.o $(TINYPRINTF) $(LDLIBS)
@@ -51,14 +45,8 @@ tee: tee.o
 mail: mail.o
 	$(LD) $(LDFLAGS) -o mail mail.o $(LDLIBS)
 
-
-include $(BASEDIR)/Make.rules
-
-all: $(PRGS)
-
-
 install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 clean:
-	rm -f core *.o $(PRGS)
+	$(RM) *.o $(PRGS)

--- a/elkscmd/misc_utils/Makefile
+++ b/elkscmd/misc_utils/Makefile
@@ -1,12 +1,8 @@
 BASEDIR=..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
@@ -71,4 +67,4 @@ install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 clean:
-	rm -f $(PRGS) $(HOSTPRGS) *~ *.o
+	$(RM) $(PRGS) $(HOSTPRGS) *~ *.o

--- a/elkscmd/nano-X/Makefile
+++ b/elkscmd/nano-X/Makefile
@@ -4,7 +4,7 @@
 #
 
 BASEDIR = ..
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 LOCALFLAGS = -DELKS=1 -DUNIX=1 -DDEBUG=1 -I.
 MATHLIB =
@@ -143,9 +143,9 @@ install: $(NANOXDEMOS)
 	$(INSTALL) demos/nxworld.map $(DESTDIR)/lib/nxworld.map
 
 clean:
-	rm -f *.o *.a nano-X core
-	rm -f drivers/*.o
-	rm -f bin/*
-	rm -f nanox/*.o
-	rm -f engine/*.o
-	rm -f demos/*.o
+	$(RM) *.o *.a nano-X
+	$(RM) drivers/*.o
+	$(RM) bin/*
+	$(RM) nanox/*.o
+	$(RM) engine/*.o
+	$(RM) demos/*.o

--- a/elkscmd/nano-X/demos/Makefile
+++ b/elkscmd/nano-X/demos/Makefile
@@ -10,7 +10,7 @@ install:	$(PROGS)
 	cd $(BINDIR); strip $(PROGS); chmod 755 $(PROGS)
 
 clean:
-	rm -f $(PROGS) *.o core
+	$(RM) $(PROGS) *.o
 
 demo:	demo.c
 	$(CC) $(CFLAGS) -o demo demo.c $(LDFLAGS)

--- a/elkscmd/nano/Makefile
+++ b/elkscmd/nano/Makefile
@@ -1,12 +1,8 @@
 BASEDIR=..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
 
 ###############################################################################
 

--- a/elkscmd/nano/ncurses-5.2/ncurses/Makefile
+++ b/elkscmd/nano/ncurses-5.2/ncurses/Makefile
@@ -80,7 +80,7 @@ LN_S		= ln -s
 #CFLAGS		= -O3 
 #RANLIB		= ranlib
 
-include ../../Make.defs
+include ../../Makefile-rules
 CFLAGS += -fno-inline
 
 INCDIR		= $(srcdir)/../include

--- a/elkscmd/romprg/Makefile
+++ b/elkscmd/romprg/Makefile
@@ -1,12 +1,8 @@
 BASEDIR=..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
 
 CFLAGS += -Wno-maybe-uninitialized
 
@@ -33,7 +29,7 @@ install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 clean:
-	rm -f $(PRGS) $(HOSTPRGS) *.o *.map
+	$(RM) $(PRGS) $(HOSTPRGS) *.o *.map
 
 
 

--- a/elkscmd/sash/Makefile
+++ b/elkscmd/sash/Makefile
@@ -2,15 +2,11 @@
 
 BASEDIR=..
 
-include $(BASEDIR)/Make.defs
-
-LOCALFLAGS = -Wno-implicit-int
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
 
-include $(BASEDIR)/Make.rules
+LOCALFLAGS = -Wno-implicit-int
 
 ###############################################################################
 
@@ -23,7 +19,7 @@ sash:	$(OBJS)
 	$(LD) $(LDFLAGS) -o sash $(OBJS) $(LDLIBS)
 
 clean:
-	rm -f core sash $(OBJS)
+	$(RM) sash $(OBJS)
 
 install: sash
 ifdef CONFIG_APP_ASH

--- a/elkscmd/screen/Makefile
+++ b/elkscmd/screen/Makefile
@@ -24,7 +24,9 @@
 
 BASEDIR=..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
+
+###############################################################################
 
 OPTIONS	= -DELKS # -DUSEBCOPY # -DLOADAV -DSUNLOADAV -DGETTTYENT -DUSEBCOPY
 
@@ -36,13 +38,6 @@ LOCALFLAGS = -Wno-implicit-int \
 		$(OPTIONS)
 		
 LOCALFLAGS += -maout-heap=0x7000
-
-
-###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
@@ -58,7 +53,7 @@ ansi.o: ansi.c screen.h
 	$(CC) $(CFLAGS) -c ansi.c
 
 clean:
-	rm -f screen *.o core *~
+	$(RM) screen *.o
 
 install: screen
 	$(INSTALL) screen $(DESTDIR)/bin/screen

--- a/elkscmd/sh_utils/Makefile
+++ b/elkscmd/sh_utils/Makefile
@@ -1,12 +1,8 @@
 BASEDIR=..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
@@ -80,4 +76,4 @@ install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 clean:
-	rm -f *.o $(PRGS)
+	$(RM) *.o $(PRGS)

--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -1,12 +1,8 @@
 BASEDIR=..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
@@ -137,4 +133,4 @@ install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 clean:
-	rm -f *.o core $(PRGS) $(HOSTPRGS)
+	$(RM) *.o $(PRGS) $(HOSTPRGS)

--- a/elkscmd/test/Makefile
+++ b/elkscmd/test/Makefile
@@ -1,4 +1,6 @@
-.PHONY: all clean
+BASEDIR=..
+
+include $(BASEDIR)/Makefile-rules
 
 SUBDIRS =  \
 	libc   \

--- a/elkscmd/test/cgatext/makefile
+++ b/elkscmd/test/cgatext/makefile
@@ -1,7 +1,6 @@
 ELKS	= ../..
 BASEDIR	= ../
-include $(BASEDIR)/Make.defs
-include $(BASEDIR)/Make.rules
+include $(BASEDIR)/Makefile-rules
 
 # Install destination
 DESTDIR		= $(TOPDIR)/target

--- a/elkscmd/test/echo/Makefile
+++ b/elkscmd/test/echo/Makefile
@@ -1,12 +1,8 @@
 BASEDIR=../..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
@@ -24,4 +20,4 @@ install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 clean:
-	rm -f *.o $(PRGS)
+	$(RM) *.o $(PRGS)

--- a/elkscmd/test/libc/Makefile
+++ b/elkscmd/test/libc/Makefile
@@ -2,7 +2,7 @@
 
 BASEDIR=../..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 PGM = test_libc
 
@@ -22,8 +22,6 @@ SRCS = \
 
 OBJS = $(SRCS:.c=.o)
 
-include $(BASEDIR)/Make.rules
-
 all: $(PGM)
 
 $(PGM): $(OBJS)
@@ -33,4 +31,4 @@ install: $(PGM)
 	$(INSTALL) $(PGM) $(DESTDIR)/bin
 
 clean:
-	rm -f $(OBJS) $(PGM)
+	$(RM) $(OBJS) $(PGM)

--- a/elkscmd/test/other/Makefile
+++ b/elkscmd/test/other/Makefile
@@ -1,12 +1,8 @@
 BASEDIR=../..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
 
 KERNEL_LIBS = $(TOPDIR)/elks/arch/i86/lib/lib86.a
 
@@ -53,4 +49,4 @@ install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 clean:
-	rm -f $(PRGS) *.o
+	$(RM) $(PRGS) *.o

--- a/elkscmd/tui/Makefile
+++ b/elkscmd/tui/Makefile
@@ -1,12 +1,10 @@
 BASEDIR=..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
 
-include $(BASEDIR)/Make.rules
+CFLAGS += -DELKS=1
 
 ###############################################################################
 
@@ -14,7 +12,6 @@ PRGS = fm matrix cons ttyinfo sl ttyclock ttypong ttytetris
 
 #PRGS_HOST =
 
-CFLAGS += -DELKS=1
 TUILIB = tty.o runes.o unikey.o
 
 all: $(PRGS) $(PRGS_HOST)
@@ -47,4 +44,4 @@ install: $(PRGS)
 	$(INSTALL) $(PRGS) $(DESTDIR)/bin
 
 clean:
-	rm -f $(PRGS) $(PRGS_HOST) *~ *.o
+	$(RM) $(PRGS) $(PRGS_HOST) *.o

--- a/elkscmd/tui/unikey.c
+++ b/elkscmd/tui/unikey.c
@@ -295,7 +295,7 @@ int stream_to_rune(unsigned int ch)
  *     "\e\001"          ESC CTRL-ALFA
  *     "\eOP"            PF1
  *     "\000"            NUL
- *     "\e]rm -rf /\e\\" OSC
+ *     "\e]ls -lR /\e\\" OSC
  *     "\302\233A"       UP
  *     "\300\200"        NUL
  *

--- a/elkscmd/unused/byacc/Makefile
+++ b/elkscmd/unused/byacc/Makefile
@@ -2,21 +2,17 @@
 
 BASEDIR = ..
     
-include ../Make.defs
+include $(BASEDIR)/Make.defs
 
 ###############################################################################
-#
-# Include standard packaging commands.
 
-include $(BASEDIR)/Make.rules
+LOCALFLAGS    = -DNDEBUG -D_POSIX_SOURCE
 
 ###############################################################################
 
 BINDIR	      = /bin
 
 HDRS	      = defs.h
-
-LOCALFLAGS    = -DNDEBUG -D_POSIX_SOURCE
 
 LIBS	      =
 
@@ -63,7 +59,7 @@ install: $(PROGRAM)
 	$(INSTALL) $(PROGRAM) $(DESTDIR)/bin
 
 clean:
-	rm -f $(OBJS) $(PROGRAM) core
+	$(RM) $(OBJS) $(PROGRAM)
 
 #depend:;	@mkmf -f $(MAKEFILE) PROGRAM=$(PROGRAM) DEST=$(DEST)
 #

--- a/elkscmd/unused/m4/Makefile
+++ b/elkscmd/unused/m4/Makefile
@@ -2,15 +2,11 @@
 
 BASEDIR = ..
 
-include $(BASEDIR)/Make.defs
-
-LOCALFLAGS =
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
 
-include $(BASEDIR)/Make.rules
+LOCALFLAGS =
 
 ###############################################################################
 
@@ -34,5 +30,5 @@ test: m4
 	diff -u test_host_m4.txt test_elks_m4.txt
 
 clean:
-	rm -f core m4 $(CLEANFILES)
+	$(RM) m4 $(CLEANFILES)
 

--- a/elkscmd/unused/mtools/Makefile
+++ b/elkscmd/unused/mtools/Makefile
@@ -4,15 +4,11 @@
 
 BASEDIR = ..
 
-include $(BASEDIR)/Make.defs
-
-LOCALFLAGS =
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
 
-include $(BASEDIR)/Make.rules
+LOCALFLAGS =
 
 ###############################################################################
 
@@ -67,7 +63,7 @@ install-man:
 	done
 
 clean:
-	rm -f $(PROGS) *.o
+	$(RM) $(PROGS) *.o
 
 lint:
 	$(LINT) mdir.c getfat.c init.c search.c match.c convdate.c subdir.c \

--- a/elkscmd/unused/prems/Makefile
+++ b/elkscmd/unused/prems/Makefile
@@ -1,12 +1,8 @@
 BASEDIR=..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
 
 ###############################################################################
 

--- a/elkscmd/unused/prems/prem/Makefile
+++ b/elkscmd/unused/prems/prem/Makefile
@@ -1,6 +1,5 @@
 BASEDIR = ../..
-include $(BASEDIR)/Make.defs
-include $(BASEDIR)/Make.rules
+include $(BASEDIR)/Makefile-rules
 
 LOCALFLAGS=-I.
 

--- a/elkscmd/unused/prems/pres/Makefile
+++ b/elkscmd/unused/prems/pres/Makefile
@@ -1,6 +1,5 @@
 BASEDIR = ../..
-include $(BASEDIR)/Make.defs
-include $(BASEDIR)/Make.rules
+include $(BASEDIR)/Makefile-rules
 
 LOCALFLAGS= -I. -I../prem
 

--- a/elkscmd/unused/xvi/Makefile
+++ b/elkscmd/unused/xvi/Makefile
@@ -1,12 +1,8 @@
 BASEDIR=..
 
-include $(BASEDIR)/Make.defs
+include $(BASEDIR)/Makefile-rules
 
 ###############################################################################
-#
-# Include standard packaging commands.
-
-include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
@@ -19,4 +15,4 @@ install: xvi
 	$(INSTALL) xvi $(DESTDIR)/bin
 
 clean:
-	rm -f core xvi *.o
+	$(RM) xvi *.o

--- a/image/Make.rules
+++ b/image/Make.rules
@@ -1,3 +1,0 @@
-# Images common rules
-
-.PHONY: all clean install


### PR DESCRIPTION
Renames elkscmd/Make.defs to elkscmd/Makefile-rules to match elks/Makefile-rules naming.

Moves single line .PHONY from Make.rules to Makefile-rules, removes Make.rules.

Adds $(RM) for rm -f from #2020 to elkscmd/*/Makefiles.

Removes `man` from 1440k disk; only added when man pages present.

