### PR TITLE
[cmds] Replace ifdef __ia16__ with ifdef _M_I86

### DIFF
--- a/elks/arch/i86/drivers/char/crtc-6845.c
+++ b/elks/arch/i86/drivers/char/crtc-6845.c
@@ -79,12 +79,6 @@ void INITPROC crtc_init(int dev)
     }
 
     /* Clear vram */
-#if 0   //FIXME remove: return value never checked, useless code
-    for (i = 0; i < p->vseg_bytes; i += 2)
-        pokew(i, p->vseg_base, 0x5555);
-    for (i = 0; i < p->vseg_bytes; i += 2)
-        if (peekw(i, p->vseg_base) != 0x5555) return 1;
-#endif
     for (i = 0; i < p->vseg_bytes; i += 2)
         pokew(i, p->vseg_base, 0x07 << 8 | ' ');
 

--- a/elkscmd/basic/host.c
+++ b/elkscmd/basic/host.c
@@ -54,7 +54,7 @@ float adjust(float f) {
 // for float testing compatibility, use same FP formatting routines on host for now
 // floats have approx 7 sig figs, 15 for double
 
-#if __ia16__ || defined(__WATCOMC__)
+#ifdef _M_I86
 #include <sys/linksym.h>
 
 char *host_floatToStr(float f, char *buf) {
@@ -162,7 +162,7 @@ int host_breakPressed() {
     return intflag;
 }
 
-#if __ia16__
+#ifdef _M_I86
 /* replacement fread to fix fgets not returning ferror/errno properly on SIGINT*/
 size_t fread(void *buf, size_t size, size_t nelm, FILE *fp)
 {
@@ -371,7 +371,7 @@ int host_loadProgramFromFile(char *fileName) {
 }
 
 int host_peekb(int offset, int segment) {
-#if __ia16__
+#ifdef _M_I86
     unsigned char __far *peek;
     peek = _MK_FP(segment,offset);
     return (int) *peek;
@@ -381,7 +381,7 @@ int host_peekb(int offset, int segment) {
 }
 
 void host_pokeb(int offset, int segment, int value) {
-#if __ia16__
+#ifdef _M_I86
     unsigned char __far *poke;
     poke = _MK_FP(segment,offset);
     *poke = (unsigned char) value;

--- a/elkscmd/debug/dis.c
+++ b/elkscmd/debug/dis.c
@@ -15,7 +15,7 @@
 #include "debug/syms.h"
 #include "debug/instrument.h"
 #include "disasm.h"
-#if __ia16__
+#ifdef _M_I86
 #include <linuxmt/mem.h>
 #endif
 
@@ -174,7 +174,7 @@ int main(int ac, char **av)
         exit(1);
     }
 
-#if __ia16__
+#ifdef _M_I86
     if (f_ksyms) {
         fd = open("/dev/kmem", O_RDONLY);
         if (fd < 0

--- a/elkscmd/disk_utils/fdisk.c
+++ b/elkscmd/disk_utils/fdisk.c
@@ -15,7 +15,7 @@
 #include <string.h>
 #include <sys/ioctl.h>
 
-#ifdef __ia16__
+#ifdef _M_I86
 #include <arch/hdreg.h>
 #endif
 
@@ -439,7 +439,7 @@ int main(int argc, char **argv)
 	}
 
 	{
-#ifdef __ia16__
+#ifdef _M_I86
 	struct hd_geometry hdgeometry;
 	if (ioctl(pFd, HDIO_GETGEO, &hdgeometry)) {
 	    printf("Error reading geometry for %s\n", dev);

--- a/elkscmd/disk_utils/mkfat.c
+++ b/elkscmd/disk_utils/mkfat.c
@@ -22,7 +22,7 @@
 
 typedef unsigned char uint8;
 typedef unsigned short uint16;
-#ifdef __ia16__
+#ifdef _M_I86
 typedef unsigned long uint32;
 #else
 typedef unsigned int uint32;

--- a/elkscmd/ktcp/vjhc.c
+++ b/elkscmd/ktcp/vjhc.c
@@ -71,7 +71,7 @@ static int rcv_toss;
 static rcv_state_ut *rcv_state;
 static rcv_state_ut *rcv_last;
 
-#ifndef __ia16__
+#ifndef _M_I86
 /* Encode/decode ops - used to be macros, changed to functions
  * for reduced code size
  */

--- a/elkscmd/sys_utils/man.c
+++ b/elkscmd/sys_utils/man.c
@@ -35,7 +35,7 @@
 #include <limits.h>
 
 #include <paths.h>
-#ifdef __ia16__			/* ELKS */
+#ifdef _M_I86			/* ELKS */
 #define MORE			"more"
 #else					/* Host */
 #define MORE			"less -R"

--- a/elkscmd/tui/ttytetris.h
+++ b/elkscmd/tui/ttytetris.h
@@ -65,7 +65,7 @@
 #define EXP_FACT 2
 
 /* Frame dimension */
-#if __ia16__
+#ifdef _M_I86
 #define FRAMEW 23
 #define FRAMEH 20
 #else

--- a/libc/debug/syms.c
+++ b/libc/debug/syms.c
@@ -32,7 +32,7 @@ static unsigned char __far * noinstrument alloc_read(int fd, size_t size)
 {
     if (size == 0 || size > 32767)
         return NULL;
-#if __ia16__
+#ifdef _M_I86
     unsigned char __far *s;
     size_t n, t = 0;
     static unsigned char buf[512];  /* don't use application stack */

--- a/libc/stdio/vsnprintf.c
+++ b/libc/stdio/vsnprintf.c
@@ -18,14 +18,8 @@ vsnprintf(char *sp, size_t size, const char *fmt, va_list ap)
 
 	int rv;
 
-	char bogo[1];
-
 	if (size == 0)
-	{
-		sp = bogo;
-		size = 1;
-	}
-
+		return 0;
 	string->bufpos = (unsigned char *)sp;
 	string->bufwrite = string->bufend = (unsigned char *)(sp + size - 1);
 	rv = vfprintf(string, fmt, ap);

--- a/libc/time/strftime.c
+++ b/libc/time/strftime.c
@@ -245,7 +245,7 @@ _fmt(const char *format, const struct tm *t)
 					return(0);
 				continue;
 			case 'Z':
-#if defined(__ia16__) || defined(__WATCOMC__)
+#ifdef _M_I86
 				if (!getenv("TZ") || _add(getenv("TZ")))
 					return(0);
 #else


### PR DESCRIPTION
Both ia16-elf-gcc and Open Watcom predefine `_M_I86` which means real mode 8086 compatible; prepares for more portable applications code using either compiler.

Cleans up some if 0 code and needless vsnprintf.c code.