### PR TITLE
[nx] Add CONFIG_ARCH_PC98 to ntetris.h to use same HEIGHT as VGA

### DIFF
--- a/elkscmd/nano-X/demos/ntetris.h
+++ b/elkscmd/nano-X/demos/ntetris.h
@@ -54,7 +54,7 @@
 #define TEXT_Y_POSITION 15
 #define TEXT2_Y_POSITION 30
 #define WELL_WIDTH 12
-#ifdef CONFIG_HW_VGA
+#if defined(CONFIG_HW_VGA) || defined(CONFIG_ARCH_PC98)
 #define WELL_HEIGHT 28
 #define WELL_VISIBLE_HEIGHT 24
 #else


### PR DESCRIPTION
Fix for
https://github.com/ghaerr/elks/issues/2041#issuecomment-2380848375

Thank you!