### PR TITLE
[kernel] Fix BIOS track read retry errors under QEMU

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -58,7 +58,6 @@
 #define DEBUG_PROBE     0       /* =1 to display more floppy probing information */
 #define FORCE_PROBE     0       /* =1 to force floppy probing */
 #define FULL_TRACK      0       /* =1 to read full tracks when track caching */
-//#define IODELAY       5       /* times 10ms, emulated delay for floppy on QEMU */
 #define MAX_ERRS        5       /* maximum sector read/write error retries */
 
 #define MAJOR_NR        BIOSHD_MAJOR


### PR DESCRIPTION
Fixes #1119.

While this fix has been coded using `RESET_DISK_CHG` for some time in bios.c, a test for running QEMU now makes the fix permanent, with no further `bioshd(0) track read retry` errors being displayed on the console.

Discussed recently in https://github.com/Mellvik/TLVC/pull/88#issuecomment-2386895898, this issue has been previously tested by @Mellvik on real hardware and was found to be a QEMU BIOS issue only. On QEMU, a BIOS disk reset is required when changing I/O (single or multi-sector) between floppy drives, for reasons unknown. This fix will allow for upcoming performance testing on QEMU without being concerned about track or sector I/O retries by automatically performing the required BIOS disk reset when needed.

The `IODELAY` option in bios.c is now enhanced to simulate realistic 1440k and 360k drive delays under QEMU (default OFF). A 1440k drive is assumed to be spinning at 300rpm (200ms/revolution) and 360k at 360rpm (167ms/revolution). A half-revolution delay plus additional time for the number of sectors read/written (~10ms/sector for 1440k and ~20ms for 360k) is performed, simulating average-case real hardware. Soon, this will be compared with the `jiffies` calculations @Mellvik is performing on real hardware in https://github.com/Mellvik/TLVC/pull/88 for comparison and subsequent development of faster-booting disk images.

@Mellvik, feel free to comment on whether my floppy timings make sense for the two drives being simulated.