### PR TITLE
[cmds] Fix sys and makeboot to copy /bootopts and updated required files

### DIFF
--- a/elkscmd/rootfs_template/bin/sys
+++ b/elkscmd/rootfs_template/bin/sys
@@ -1,19 +1,17 @@
 # sys - create bootable system
-#
-#set -x
 
 usage()
 {
-	echo "Usage: sys [-3][-M][-F] /dev/{fd0,fd1,hda1,hda2,etc}"
+	echo "Usage: sys [-3][-M][-F] /dev/{fd0,fd1,hda1,hda2}"
 	echo "	-3  Build minimal (360k) system"
 	echo "	-M  add MBR to target device"
-	echo "	-F  required for flat non-MBR /dev/hd[a-d]"
+	echo "	-F  create flat non-MBR /dev/hd[a-d]"
 	exit 1
 }
 
 create_dev_dir()
 {
-	echo "Creating /dev entries..."
+	echo "Create /dev"
 	mkdir $MNT/dev
 	mknod $MNT/dev/hda	b 3 0
 	mknod $MNT/dev/hda1	b 3 1
@@ -41,7 +39,6 @@ create_dev_dir()
 	mknod $MNT/dev/tty	c 4 255
 	chmod 0666 $MNT/dev/tty
 	if test "$small" = "1"; then return; fi
-
 	mknod $MNT/dev/hdb	b 3 8
 	mknod $MNT/dev/hdb1	b 3 9
 	mknod $MNT/dev/hdb2	b 3 10
@@ -66,7 +63,6 @@ create_dev_dir()
 
 create_directories()
 {
-	echo "Creating directories"
 	mkdir $MNT/bin
 	mkdir $MNT/etc
 	mkdir $MNT/mnt
@@ -76,11 +72,14 @@ create_directories()
 
 copy_bin_files()
 {
-	echo "Copying files from /bin..."
+	echo "Copy /bin"
 	if test "$small" = "1"; then
 	cp /bin/sh	$MNT/bin
+	cp /bin/cat	$MNT/bin
+	cp /bin/clock	$MNT/bin
 	cp /bin/chmod	$MNT/bin
 	cp /bin/cp	$MNT/bin
+	cp /bin/date	$MNT/bin
 	cp /bin/df	$MNT/bin
 	cp /bin/echo	$MNT/bin
 	cp /bin/fdisk	$MNT/bin
@@ -99,11 +98,12 @@ copy_bin_files()
 	cp /bin/printenv $MNT/bin
 	cp /bin/ps	$MNT/bin
 	cp /bin/pwd	$MNT/bin
-	cp /bin/reboot	$MNT/bin
+	cp /bin/shutdown $MNT/bin
 	cp /bin/rm	$MNT/bin
 	cp /bin/sync	$MNT/bin
 	cp /bin/sys	$MNT/bin
 	cp /bin/umount	$MNT/bin
+	cp /bin/uname	$MNT/bin
 	else
 	cp -fR /bin $MNT/bin
 	fi
@@ -111,7 +111,7 @@ copy_bin_files()
 
 copy_etc_files()
 {
-	echo "Copy files from /etc..."
+	echo "Copy /etc"
 	cp /etc/*	$MNT/etc
 }
 
@@ -134,11 +134,8 @@ mount $1 $MNT
 
 # if MINIX, create /dev entries
 if test "$FSTYPE" = "1"; then create_dev_dir; fi
-
 create_directories
-
 copy_bin_files
-
 copy_etc_files
 
 sync

--- a/elkscmd/sys_utils/makeboot.c
+++ b/elkscmd/sys_utils/makeboot.c
@@ -37,7 +37,7 @@
 #define MOUNTDIR	"/tmp/mnt"
 
 #define SYSFILE1	"/linux"		/* copied for MINIX and FAT*/
-#define SYSFILE2	"/bootopts"		/* copied for MINIX only */
+#define SYSFILE2	"/bootopts"		/* copied for MINIX and FAT */
 #define DEVDIR		"/dev"			/* created for FAT only */
 
 /* BIOS driver numbers must match bioshd.c*/
@@ -458,13 +458,12 @@ usage:
 			fprintf(stderr, "Error copying %s\n", SYSFILE1);
 			goto errout;
 		}
+		if (!copyfile(SYSFILE2, MOUNTDIR SYSFILE2, 1))
+			fprintf(stderr, "Not copying %s file\n", SYSFILE2);
 
 		if (fstype == FST_MSDOS) {
 			if (mkdir(MOUNTDIR DEVDIR, 0777) < 0)
 				fprintf(stderr, "/dev directory may already exist on target\n");
-		} else {
-			if (!copyfile(SYSFILE2, MOUNTDIR SYSFILE2, 1))
-				fprintf(stderr, "Not copying %s file\n", SYSFILE2);
 		}
 	
 		if (umount(targetdevice) < 0)


### PR DESCRIPTION
Fixes the initial problem reported by @tyama501 in #2062. `makeboot` now creates /bootopts at the same time that /linux is copied, if it is present. Some other important programs /bin are also now included in the `sys -3` (minimal 360k sys) command.

Took some effort to keep the size of bin/sys within 3K for efficiency.

Tested on MINIX and FAT 360k filesystems on QEMU. 

Haven't looked into @toncho11's reported problem of using `sys` to an HD FAT partition yet (coming).