### PR TITLE
[cmds] Add env vars to /etc/sashrc, use HOSTNAME env var in getty not /etc/hostname

### DIFF
--- a/elkscmd/rootfs_template/etc/sashrc
+++ b/elkscmd/rootfs_template/etc/sashrc
@@ -1,4 +1,8 @@
 # init file for sash
+setenv TERM ansi
+setenv USER root
+setenv HOME /root
+setenv SHELL /bin/sash
 setenv TZ GMT0
 setenv HISTORY 30
 setenv HISTPAGE 20

--- a/elkscmd/sys_utils/getty.c
+++ b/elkscmd/sys_utils/getty.c
@@ -90,9 +90,8 @@ void consolemsg(const char *str, ...)
 }
 
 
-#ifndef SUPER_SMALL
-char	Host[256], *Date = 0, *Time = 0;
-
+#if UNUSED
+char	Host[256];
 void host(void) {
     char *ptr;
     int fp = open(_PATH_HOSTNAME,O_RDONLY), sz;
@@ -113,6 +112,10 @@ void host(void) {
     if (!*Host)
 	strcpy( Host, "LocalHost" );
 }
+#endif
+
+#ifndef SUPER_SMALL
+char	*Date, *Time;
 
 /*	Before  = "Sun Dec 25 12:34:56 7890"
  *	Columns = "0....:....1....:....2..."
@@ -296,7 +299,6 @@ int main(int argc, char **argv)
 	    write(1,Buffer,n);
 #else
 	when();
-	host();
 	*Buffer = '\0';
 	while (read(fd,Buffer,1) > 0) {
 	    ch = *Buffer;
@@ -359,7 +361,9 @@ int main(int argc, char **argv)
 			    state(Date);
 			    break;
 			case 'H':			/* Host */
-			    state(Host);
+                            if (!(ptr = getenv("HOSTNAME")))
+                                ptr = "LocalHost";
+                            state(ptr);
 			    break;
 			case 'L':			/* Line used */
 			    ptr = rindex(argv[1],'/');


### PR DESCRIPTION
Reduces startup time by not accessing non-existent /etc/hostname.

Allows setting init=/bin/sash and using editors by setting appropriate environ vars in /etc/sashrc.