### PR TITLE
[boot] Decrease boot time from 10 to 5 seconds

### DIFF
--- a/elks/arch/i86/drivers/block/bios.c
+++ b/elks/arch/i86/drivers/block/bios.c
@@ -18,7 +18,7 @@
 #include "bioshd.h"
 
 #define RESET_DISK_CHG  1       /* =1 to reset BIOS on drive change fixes QEMU retry */
-#define IODELAY         0       /* emulate delay for floppy on QEMU */
+#define IODELAY         1       /* emulate delay for floppy on QEMU */
 
 #define abs(v)          (((int)(v) >= 0)? (v): -(v))
 /*

--- a/elks/arch/i86/drivers/block/bios.c
+++ b/elks/arch/i86/drivers/block/bios.c
@@ -18,7 +18,7 @@
 #include "bioshd.h"
 
 #define RESET_DISK_CHG  1       /* =1 to reset BIOS on drive change fixes QEMU retry */
-#define IODELAY         1       /* emulate delay for floppy on QEMU */
+#define IODELAY         0       /* emulate delay for floppy on QEMU */
 
 #define abs(v)          (((int)(v) >= 0)? (v): -(v))
 /*

--- a/elks/include/linuxmt/trace.h
+++ b/elks/include/linuxmt/trace.h
@@ -45,7 +45,7 @@
  * TRACK_SPLIT_BLK  - read extra sector on track split block (set in bioshd.c)
  * SPLIT_BLK        - read extra sector on single split block (set in bioshd.c)
  * FULL_TRACK       - read full track on cache refill (set in bioshd.c)
- * SHOW_STARTUP     - show startup time on boot (set in getty.c)
+ * BOOT_TIMER       - show startup time on boot (set in getty.c)
  */
 
 /* internal flags for kernel */

--- a/elkscmd/sys_utils/getty.c
+++ b/elkscmd/sys_utils/getty.c
@@ -19,15 +19,15 @@
  * Support for \? and @? codes has been added in, supporting the following
  * codes:
  *
- *	\@ = @			@@ = @
- *	\\ = \			@B = Baud Rate.
- *	\0 = ^@ 		@D = Date in dd-mmm-yyy format.
- *	\b = ^H 		@H = System hostname.
- *	\f = ^L 		@L = Line identifier.
- *	\n = ^J 		@S = System Identifier.
- *	\r = ^M 		@T = 24 hour time in HH:MM:SS format.
- *	\s = Space		@U = Users connected.
- *	\t = 8-column tab	@V = Kernel version.
+ *      \@ = @                  @@ = @
+ *      \\ = \                  @B = Baud Rate.
+ *      \0 = ^@                 @D = Date in dd-mmm-yyy format.
+ *      \b = ^H                 @H = System hostname.
+ *      \f = ^L                 @L = Line identifier.
+ *      \n = ^J                 @S = System Identifier.
+ *      \r = ^M                 @T = 24 hour time in HH:MM:SS format.
+ *      \s = Space              @U = Users connected.
+ *      \t = 8-column tab       @V = Kernel version.
  *
  * Note that @U is not yet implemented, and @V returns a fixed string
  * from the compile-time kernel rather than querying the current kernel.
@@ -49,79 +49,78 @@
 #include <linuxmt/mem.h>
 
 #define PARSE_ETC_ISSUE 0       /* set =1 to process /etc/issue @ sequences */
-#define BOOT_TIMER  	1       /* set =1 to display system startup time */
+#define BOOT_TIMER      0       /* set =1 to display system startup time */
 #define DEBUG           0       /* set =1 for debug messages */
-#define CONSOLE	_PATH_CONSOLE   /* debug messages go here */
+#define CONSOLE _PATH_CONSOLE   /* debug messages go here */
 
 #if DEBUG
-#define debug		consolemsg
+#define debug           consolemsg
 #else
 #define debug(...)
 #endif
 
 #define _MK_FP(seg,off) ((void __far *)((((unsigned long)(seg)) << 16) | ((unsigned int)(off))))
 
-char *	progname;
-char	Buffer[64];
-int	ch, col;
+char *  progname;
+char    Buffer[64];
+int     ch, col;
 
 void consolemsg(const char *str, ...)
 {
-	static int consolefd = -1;
-	char buf[80];
+    static int consolefd = -1;
+    char buf[80];
 
-	if (consolefd < 0)
-		consolefd = open(CONSOLE, O_RDWR);
+    if (consolefd < 0)
+        consolefd = open(CONSOLE, O_RDWR);
 
-	va_list args;
-	va_start(args, str);
-	sprintf(buf, "%s: ", progname);
-	write(consolefd, buf, strlen(buf));
-	vsprintf(buf, str, args);
-	write(consolefd, buf, strlen(buf));
-	va_end(args);
+    va_list args;
+    va_start(args, str);
+    sprintf(buf, "%s: ", progname);
+    write(consolefd, buf, strlen(buf));
+    vsprintf(buf, str, args);
+    write(consolefd, buf, strlen(buf));
+    va_end(args);
 }
 
 #if PARSE_ETC_ISSUE
-char	*Date, *Time;
+char    *Date, *Time;
 
-/*	Before  = "Sun Dec 25 12:34:56 7890"
- *	Columns = "0....:....1....:....2..."
- *	After   = "25-Dec-7890 12:34:56 "
+/* Before  = "Sun Dec 25 12:34:56 7890"
+ * Columns = "0....:....1....:....2..."
+ * After   = "25-Dec-7890 12:34:56 "
  */
-
 void when(void) {
     char *Result;
     time_t now;
     int n;
 
     if (!Date) {
-	now = time(0);
-	Result = ctime(&now);
+        now = time(0);
+        Result = ctime(&now);
 
-	Result[0]  = Result[8];
-	Result[1]  = Result[9];
+        Result[0]  = Result[8];
+        Result[1]  = Result[9];
 
-	Result[3]  = Result[4];
-	Result[4]  = Result[5];
-	Result[5]  = Result[6];
+        Result[3]  = Result[4];
+        Result[4]  = Result[5];
+        Result[5]  = Result[6];
 
-	Result[7]  = Result[20];
-	Result[8]  = Result[21];
-	Result[9]  = Result[22];
-	Result[10] = Result[23];
+        Result[7]  = Result[20];
+        Result[8]  = Result[21];
+        Result[9]  = Result[22];
+        Result[10] = Result[23];
 
-	Result[2]  = Result[6]	 = '-';
+        Result[2]  = Result[6]   = '-';
 
-	for (n=20; n>11; n--)
-	    Result[n] = Result[n-1];
+        for (n=20; n>11; n--)
+            Result[n] = Result[n-1];
 
-	Result[11] = Result[20] = '\0';
+        Result[11] = Result[20] = '\0';
 
-	Date = Result;
-	if (*Date < '1')
-	    Date++;
-	Time = Result + 12;
+        Date = Result;
+        if (*Date < '1')
+            Date++;
+        Time = Result + 12;
     }
 }
 #endif
@@ -130,7 +129,7 @@ static void put(unsigned char ch)
 {
     col++;
     if (ch == '\r' || ch == '\n')
-	col = 0;
+        col = 0;
     write(STDOUT_FILENO, &ch, 1);
 }
 
@@ -141,32 +140,32 @@ static void state(char *s)
 
 static speed_t convert_baudrate(speed_t baudrate)
 {
-	switch (baudrate) {
-	case 50: return B50;
-	case 75: return B75;
-	case 110: return B110;
-	case 134: return B134;
-	case 150: return B150;
-	case 200: return B200;
-	case 300: return B300;
-	case 600: return B600;
-	case 1200: return B1200;
-	case 1800: return B1800;
-	case 2400: return B2400;
-	case 4800: return B4800;
-	case 9600: return B9600;
-	case 19200: return B19200;
-	case 38400: return B38400;
-	case 57600: return B57600;
-	case 115200: return B115200;
-	case 230400: return B230400;
-	}
-	return 0;
+        switch (baudrate) {
+        case 50: return B50;
+        case 75: return B75;
+        case 110: return B110;
+        case 134: return B134;
+        case 150: return B150;
+        case 200: return B200;
+        case 300: return B300;
+        case 600: return B600;
+        case 1200: return B1200;
+        case 1800: return B1800;
+        case 2400: return B2400;
+        case 4800: return B4800;
+        case 9600: return B9600;
+        case 19200: return B19200;
+        case 38400: return B38400;
+        case 57600: return B57600;
+        case 115200: return B115200;
+        case 230400: return B230400;
+        }
+        return 0;
 }
 
 void show_startup(void)
 {
-#if SHOW_STARTUP
+#if BOOT_TIMER
     int fd;
     unsigned offset, kds;
     unsigned short __far *pjiffies;  /* only access low order jiffies word */
@@ -188,35 +187,35 @@ int main(int argc, char **argv)
     struct termios termios;
 
     progname = argv[0];
-    signal(SIGTSTP, SIG_IGN);		/* ignore ^Z stop signal*/
+    signal(SIGTSTP, SIG_IGN);           /* ignore ^Z stop signal*/
 
     if (argc < 2 || argc > 3) {
-	consolemsg("Usage: %s device [baudrate]\n", argv[0]);
-	exit(3);
+        consolemsg("Usage: %s device [baudrate]\n", argv[0]);
+        exit(3);
     }
 
     if (argc == 2)
-	debug("startup args '%s'\n", argv[1]);
+        debug("startup args '%s'\n", argv[1]);
     else if (argc == 3) {
-	baud = atol(argv[2]);
-	debug("startup args '%s' %ld\n", argv[1], baud);
+        baud = atol(argv[2]);
+        debug("startup args '%s' %ld\n", argv[1], baud);
     }
 
     /* allow execution outside of init*/
     if (getppid() != 1) {
-	int tty = open(argv[1], O_RDWR);
-	if (tty < 0) {
-		consolemsg("cannot open terminal %s\n", argv[1]);
-		exit(4);
-	}
+        int tty = open(argv[1], O_RDWR);
+        if (tty < 0) {
+                consolemsg("cannot open terminal %s\n", argv[1]);
+                exit(4);
+        }
 
-	debug("redirecting stdio to %s\n", argv[1]);
-	close(0); close(1); close(2); /* close inherited stdio */
-	if (dup2(tty, 0) != 0 || dup2(tty, 1) != 1 || dup2(tty, 2) != 2) {
-		consolemsg("cannot redirect stdio (error %d)\n", errno);
-		exit(5);
-	}
-	close(tty);
+        debug("redirecting stdio to %s\n", argv[1]);
+        close(0); close(1); close(2); /* close inherited stdio */
+        if (dup2(tty, 0) != 0 || dup2(tty, 1) != 1 || dup2(tty, 2) != 2) {
+                consolemsg("cannot redirect stdio (error %d)\n", errno);
+                exit(5);
+        }
+        close(tty);
     }
 
     /* setup tty termios state*/
@@ -227,15 +226,15 @@ int main(int argc, char **argv)
         termios.c_lflag &= ~(IEXTEN | ECHOK | NOFLSH | ECHONL);
         termios.c_iflag |= BRKINT | ICRNL;
         termios.c_iflag &= ~(IGNBRK | IGNPAR | PARMRK | INPCK | ISTRIP | INLCR | IGNCR
-		| IXON | IXOFF | IXANY);
+                | IXON | IXOFF | IXANY);
         termios.c_oflag |= OPOST | ONLCR;
         termios.c_oflag &= ~XTABS;
         if (baud)
             termios.c_cflag = baud;
         termios.c_cflag &= ~PARENB;
         termios.c_cflag |= CS8 | CREAD | HUPCL;
-        termios.c_cflag |= CLOCAL;			/* ignore modem control lines*/
-        //termios.c_cflag |= CRTSCTS;		/* hw flow control*/
+        termios.c_cflag |= CLOCAL;                      /* ignore modem control lines*/
+        //termios.c_cflag |= CRTSCTS;           /* hw flow control*/
         termios.c_cc[VMIN] = 1;
         termios.c_cc[VTIME] = 0;
         tcsetattr(STDIN_FILENO, TCSAFLUSH, &termios);
@@ -243,135 +242,135 @@ int main(int argc, char **argv)
 
     fd = open(_PATH_ISSUE, O_RDONLY);
     if (fd >= 0) {
-	put('\n');
+        put('\n');
 #if !PARSE_ETC_ISSUE
-	while ((n=read(fd,Buffer,sizeof(Buffer))) > 0)
-	    write(1,Buffer,n);
+        while ((n=read(fd,Buffer,sizeof(Buffer))) > 0)
+            write(1,Buffer,n);
 #else
-	char *ptr;
-	when();
-	*Buffer = '\0';
-	while (read(fd,Buffer,1) > 0) {
-	    ch = *Buffer;
-	    if (ch == '\\' || ch == '@') {
-		Buffer[1] = ch;
-		read(fd,Buffer+1,1);
-	    }
-	    switch (ch) {
-		case '\n':
-		    put(ch);
-		    break;
-		case '\\':
-		    ch = Buffer[1];
-		    switch(ch) {
-			case '0':			/* NUL */
-			    ch = 0;
-			case '\\':
-			case '@':
-			    put(ch);
-			    break;
-			case 'b':			/* BS Backspace */
-			    put(8);
-			    break;
-			case 'f':			/* FF Formfeed */
-			    put(12);
-			    break;
-			case 'n':			/* LF Linefeed */
-			    put(10);
-			    break;
-			case 's':			/* SP Space */
-			    put(32);
-			    break;
-			case 't':			/* HT Tab */
-			    do {
-				put(' ');
-			    } while (col & 7);
-			    break;
-			case 'r':			/* CR Return */
-			    ch=13;
-			default:			/* Anything else */
-			    put('\\');
-			    put(ch);
-			    break;
-		    }
-		    break;
-		case '@':
-		    ch = Buffer[1];
-		    switch(ch) {
-			case '@':
-			    put(ch);
-			    break;
-			case 'B':			/* Baud Rate */
-			    if (argc > 2) {
-				state(argv[2]);
-				state(" Baud");
-			    } else
-				state("Terminal");
-			    break;
-			case 'D':			/* Date */
-			    state(Date);
-			    break;
-			case 'H':			/* Host */
-			    if (!(ptr = getenv("HOSTNAME")))
-				ptr = "LocalHost";
-			    state(ptr);
-			    break;
-			case 'L':			/* Line used */
-			    ptr = rindex(argv[1],'/');
-			    if (ptr == NULL)
-				ptr = argv[1];
-			    state(ptr);
-			    break;
-			case 'S':			/* System */
-			    state("ELKS");
-			    break;
-			case 'T':			/* Time */
-			    state(Time);
-			    break;
-			case 'V':			/* Version */
-			    state(ELKS_VERSION);
-			    break;
-			default:
-			    put('@');
-			    put(ch);
-			    break;
-		    }
-		    break;
-		default:
-		    put(ch);
-		    break;
-	    }
-	    *Buffer = '\0';
-	}
+        char *ptr;
+        when();
+        *Buffer = '\0';
+        while (read(fd,Buffer,1) > 0) {
+            ch = *Buffer;
+            if (ch == '\\' || ch == '@') {
+                Buffer[1] = ch;
+                read(fd,Buffer+1,1);
+            }
+            switch (ch) {
+                case '\n':
+                    put(ch);
+                    break;
+                case '\\':
+                    ch = Buffer[1];
+                    switch(ch) {
+                        case '0':                       /* NUL */
+                            ch = 0;
+                        case '\\':
+                        case '@':
+                            put(ch);
+                            break;
+                        case 'b':                       /* BS Backspace */
+                            put(8);
+                            break;
+                        case 'f':                       /* FF Formfeed */
+                            put(12);
+                            break;
+                        case 'n':                       /* LF Linefeed */
+                            put(10);
+                            break;
+                        case 's':                       /* SP Space */
+                            put(32);
+                            break;
+                        case 't':                       /* HT Tab */
+                            do {
+                                put(' ');
+                            } while (col & 7);
+                            break;
+                        case 'r':                       /* CR Return */
+                            ch=13;
+                        default:                        /* Anything else */
+                            put('\\');
+                            put(ch);
+                            break;
+                    }
+                    break;
+                case '@':
+                    ch = Buffer[1];
+                    switch(ch) {
+                        case '@':
+                            put(ch);
+                            break;
+                        case 'B':                       /* Baud Rate */
+                            if (argc > 2) {
+                                state(argv[2]);
+                                state(" Baud");
+                            } else
+                                state("Terminal");
+                            break;
+                        case 'D':                       /* Date */
+                            state(Date);
+                            break;
+                        case 'H':                       /* Host */
+                            if (!(ptr = getenv("HOSTNAME")))
+                                ptr = "LocalHost";
+                            state(ptr);
+                            break;
+                        case 'L':                       /* Line used */
+                            ptr = rindex(argv[1],'/');
+                            if (ptr == NULL)
+                                ptr = argv[1];
+                            state(ptr);
+                            break;
+                        case 'S':                       /* System */
+                            state("ELKS");
+                            break;
+                        case 'T':                       /* Time */
+                            state(Time);
+                            break;
+                        case 'V':                       /* Version */
+                            state(ELKS_VERSION);
+                            break;
+                        default:
+                            put('@');
+                            put(ch);
+                            break;
+                    }
+                    break;
+                default:
+                    put(ch);
+                    break;
+            }
+            *Buffer = '\0';
+        }
 #endif
-	close(fd);
+        close(fd);
     }
 
     show_startup();
     for (;;) {
-	state("login: ");
-	errno = 0;
-	n=read(STDIN_FILENO,Buffer,sizeof(Buffer)-1);
-	if (n < 1) {
-	    debug("read fail on stdin, errno %d\n", errno);
-	    if (errno == EINTR)
-		continue;
-	    exit(1);
-	}
-	Buffer[n] = '\0';
-	while (n > 0)
-	    if (Buffer[--n] < ' ')
-		Buffer[n] = '\0';
-	if (*Buffer) {
-	    char *nargv[3];
+        state("login: ");
+        errno = 0;
+        n=read(STDIN_FILENO,Buffer,sizeof(Buffer)-1);
+        if (n < 1) {
+            debug("read fail on stdin, errno %d\n", errno);
+            if (errno == EINTR)
+                continue;
+            exit(1);
+        }
+        Buffer[n] = '\0';
+        while (n > 0)
+            if (Buffer[--n] < ' ')
+                Buffer[n] = '\0';
+        if (*Buffer) {
+            char *nargv[3];
 
-	    debug("calling login: %s\n", Buffer);
-	    nargv[0] = _PATH_LOGIN;
-	    nargv[1] = Buffer;
-	    nargv[2] = NULL;
-	    execv(nargv[0], nargv);
-	    debug("execv fail\n");
-	    exit(2);
-	}
+            debug("calling login: %s\n", Buffer);
+            nargv[0] = _PATH_LOGIN;
+            nargv[1] = Buffer;
+            nargv[2] = NULL;
+            execv(nargv[0], nargv);
+            debug("execv fail\n");
+            exit(2);
+        }
     }
 }

--- a/image/Make.devices
+++ b/image/Make.devices
@@ -13,9 +13,13 @@
 
 devices:
 
-#	$(MKDEV) /dev/console	c 4 254 1 1 0600
-#	$(MKDEV) /dev/tty1	c 4 0
-#	$(MKDEV) /dev/ttyS0     c 4 64
+##############################################################################
+# Create frequently accessed /dev files first
+	$(MKDEV) /dev/console	c 4 254 1 1 0600
+	$(MKDEV) /dev/tty1      c 4 0
+	$(MKDEV) /dev/ttyS0     c 4 64
+	$(MKDEV) /dev/fd0       b 3 32
+	$(MKDEV) /dev/fd1       b 3 40
 
 ##############################################################################
 # Create memory devices.
@@ -92,6 +96,7 @@ devices:
 	$(MKDEV) /dev/tty3	c 4 2
 	$(MKDEV) /dev/tty4	c 4 3
 
+##############################################################################
 # Pseudo-TTY slave devices.
 
 	$(MKDEV) /dev/ttyp0 c 4 8
@@ -101,7 +106,7 @@ devices:
 
 # /dev/tty is minor 255, /dev/console minor 254
 
-	$(MKDEV) /dev/tty		c 4 255 1 1 0666
+	$(MKDEV) /dev/tty       c 4 255 1 1 0666
 	$(MKDEV) /dev/console	c 4 254 1 1 0600
 
 # Serial ports, as detected by the ROM BIOS.
@@ -113,12 +118,6 @@ devices:
 
 	$(MKDEV) /dev/lp	c 6 0
 #	$(MKDEV) /dev/lp	c 6 0 4
-#	$MKSET  0 3  $(MKDEV) /dev/lp c 6
-
-##############################################################################
-# UDD user device driver, experimental
-
-#	$(MKDEV) /dev/udd c 7 0
 
 ##############################################################################
 # TCPDEV, used by ktcp

--- a/image/Make.image
+++ b/image/Make.image
@@ -78,7 +78,7 @@ endif
 minixfs:
 	rm -f $(TARGET_FILE)
 	mfs $(VERBOSE) $(TARGET_FILE) mkfs $(MINIX_MKFSOPTS)
-#	mfs -v $(VERBOSE) $(TARGET_FILE) addfs Image.all $(DESTDIR)
+	mfs -v $(VERBOSE) $(TARGET_FILE) addfs Image.all $(DESTDIR)
 #	rm -f Filelist
 #	for f in $$(cd $(DESTDIR); find * -name '*'); do \
 #		echo $$f >> FileList; \


### PR DESCRIPTION
On QEMU emulating floppy disk delays, boot time for MINIX images is halved from 10 to 5 seconds.

Adds `image/Image.all` as first directories and files to all MINIX images.
Creates frequently-accessed /dev entries first for less directory searching.
Decrease size of /bin/getty by turning off @-sequence processing by default.
Renames SHOW_STARTUP option to BOOT_TIMER in getty.c.
Cleanup and retab getty.c source.

