### PR TITLE
[docs,build] Update build.sh to stop on error, update docs on mtools, flex, bison

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -3,12 +3,9 @@
 ## Prerequisites
 
 To build ELKS, you need a development environment on Linux or macOS or Windows with [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux), including:
-- flex
-- bison
-- texinfo
 - libncurses5-dev
-- mtools-4.0.23 (for MSDOS/FAT images)
 - compress (for compressed man pages; use `sudo apt-get install ncompress`)
+- texinfo
 
 ## Build steps
 
@@ -39,7 +36,6 @@ configuration, that folder is used to create either a floppy disk image
 (fd360, fd720, fd1200, fd1440, fd2880), a flat 32MB hard disk image (without MBR),
 or a ROM file image into the `image` folder. The image extension is '.img'
 and will be in either ELKS (MINIX) or MSDOS (FAT) filesystem format.
-Building FAT images requires the 'mtools-4.0.23' package to be installed.
 
 6- Before writing that image on the real medium, you can test it first on QEMU:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV USER=builder \
 WORKDIR /elks
 RUN apt-get update -qq \
  && apt-get install -y --no-install-recommends \
-  flex bison texinfo libncurses5-dev \
+  texinfo libncurses5-dev \
   bash make g++ git libelf-dev patch \
   xxd ca-certificates wget mtools \
  && rm -r /var/lib/apt/lists /var/cache/apt/archives \

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,7 @@
 
 # Arguments:
 #   - 'auto' : continuous integration context
+set -e
 
 SCRIPTDIR="$(dirname "$0")"
 

--- a/libc/misc/atoi.c
+++ b/libc/misc/atoi.c
@@ -1,5 +1,4 @@
 #include <stdlib.h>
-#include <ctype.h>
 
 int atoi(const char *s)
 {

--- a/libc/misc/atol.c
+++ b/libc/misc/atol.c
@@ -1,18 +1,17 @@
 #include <stdlib.h>
-#include <ctype.h>
 
 long atol(const char *s)
 {
-	long n = 0;
-	int neg = 0;
+    long n = 0;
+    int neg = 0;
 
-	while (*s == ' ' || *s == '\t')
-		s++;
-	switch (*s) {
-	case '-': neg = 1;
-	case '+': s++;
-	}
-	while ((unsigned) (*s - '0') <= 9u)
-		n = n * 10 + *s++ - '0';
-	return neg ? 0u - n : n;
+    while (*s == ' ' || *s == '\t')
+        s++;
+    switch (*s) {
+    case '-': neg = 1;
+    case '+': s++;
+    }
+    while ((unsigned) (*s - '0') <= 9u)
+        n = n * 10 + *s++ - '0';
+    return neg ? 0u - n : n;
 }


### PR DESCRIPTION
Enhance `./build.sh` to stop on error (discussed in https://github.com/ghaerr/elks/issues/2042).

Update documentation on mtools, flex, bison (not needed).

Cleans up atoi.c, atol.c.