### PR TITLE
[directfd] Add IODELAY floppy delay emulation to DF driver

### DIFF
--- a/elks/arch/i86/drivers/block/bios.c
+++ b/elks/arch/i86/drivers/block/bios.c
@@ -129,8 +129,9 @@ int BFPROC bios_disk_rw(unsigned cmd, unsigned num_sectors, unsigned drive,
         static unsigned lastcyl;
         unsigned ms = abs(cylinder - lastcyl) * 4 / 10;
         lastcyl = cylinder;
-        ms += 10 + num_sectors;        /* 1440k @300rpm = 100ms + ~10ms/sector + 4ms/tr */
-        if (drive == 1)
+        if (drive == 0)
+            ms += 10 + num_sectors;   /* 1440k @300rpm = 100ms + ~10ms/sector + 4ms/tr */
+        else
             ms += 8 + (num_sectors<<1); /* 360k @360rpm = 83ms + ~20ms/sector + 3ms/tr */
         unsigned long timeout = jiffies + ms*HZ/100;
         while (!time_after(jiffies, timeout)) continue;

--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -775,9 +775,8 @@ static void DFPROC setup_rw_floppy(void)
 {
     DEBUG("setup_rw-");
 #if IODELAY
-    int num_sectors = read_track?
-        floppy->sect + (read_track && (floppy->sect & 1) && !head)
-        : CURRENT->rq_nr_sectors;
+    int num_sectors = read_track? floppy->sect + (floppy->sect & 1 && !head);
+                                : CURRENT->rq_nr_sectors;
     DEBUG("[%ur%u]", current_drive, num_sectors);
     static unsigned lasttrack;
     unsigned ms = abs(track - lasttrack) * 4 / 10;


### PR DESCRIPTION
Allows comparison between DF and BIOS driver track cache code.

Currently, the BIOS driver is booting in 4.5s while DF is taking 6.1s. This is because the DF driver is still track-caching entire tracks, rather than caching from the requested start sector to end of track. Change coming, along with consideration of TLVC track cache changes in https://github.com/Mellvik/TLVC/pull/88.

Also fixes IODELAY calculation for drive 1 in BIOS driver.

It was also noted that setup_DMA() enabled interrupts before reseting the driver interrupt handler to rw_interrupt. This introduced a small race condition that likely never mattered, unless the DMA controller were to signal an interrupt immediately after being programmed (likely for an error).