### PR TITLE
[boot] Turn off mfs optimization 

### DIFF
--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -774,7 +774,7 @@ static void DFPROC setup_rw_floppy(void)
 {
     DEBUG("setup_rw-");
 #if IODELAY
-    int num_sectors = read_track? floppy->sect + (floppy->sect & 1 && !head);
+    int num_sectors = read_track? floppy->sect + (floppy->sect & 1 && !head)
                                 : CURRENT->rq_nr_sectors;
     DEBUG("[%ur%u]", current_drive, num_sectors);
     static unsigned lasttrack;

--- a/image/Make.image
+++ b/image/Make.image
@@ -78,7 +78,7 @@ endif
 minixfs:
 	rm -f $(TARGET_FILE)
 	mfs $(VERBOSE) $(TARGET_FILE) mkfs $(MINIX_MKFSOPTS)
-	mfs -v $(VERBOSE) $(TARGET_FILE) addfs Image.all $(DESTDIR)
+#	mfs -v $(VERBOSE) $(TARGET_FILE) addfs Image.all $(DESTDIR)
 #	rm -f Filelist
 #	for f in $$(cd $(DESTDIR); find * -name '*'); do \
 #		echo $$f >> FileList; \


### PR DESCRIPTION
Turns off mfs optimization due to lack of testing, in preparation for v0.8.1 release.

Fixes typo in directfd.c w/IODELAY set.