### PR TITLE
[boot] Fix mfs duplicate mknod/mkdir, default boot optimziations on

### DIFF
--- a/elks/tools/mfs/dir.c
+++ b/elks/tools/mfs/dir.c
@@ -242,6 +242,7 @@ int domkdir(struct minix_fs_dat *fs,char *newdir, int mode) {
   int dinode;
   int ninode = make_node(fs,newdir,mode|S_IFDIR,dogetuid(),dogetgid(), 0,
   			NOW,NOW,NOW,&dinode);
+  if (ninode == 0) return 0;    /* already exists, must remove to recreate */
   dname_add(fs,ninode,".",ninode);
   dname_add(fs,ninode,"..",dinode);
   if (VERSION_2(fs)) {

--- a/elks/tools/mfs/iname.c
+++ b/elks/tools/mfs/iname.c
@@ -140,8 +140,8 @@ void dname_rem(struct minix_fs_dat *fs,int dinode,const char *name) {
 
   i =  ilookup_name(fs,dinode,name,&nblk,&off);
   if (i == -1) return;
-  i = (VERSION_2(fs) ? INODE2(fs,dinode)->i_size : INODE(fs,dinode)->i_size)
-	- dentsz;
+  i = (VERSION_2(fs) ?
+        INODE2(fs,dinode)->i_size : INODE(fs,dinode)->i_size) - dentsz;
 
   if (i == (nblk * BLOCK_SIZE + off)) {
     /* Need to shorten directory file */
@@ -181,7 +181,17 @@ int make_node(struct minix_fs_dat *fs,char *fpath, int mode,
   char *fname = strrchr(fpath,'/');
   int dinode,ninode;
 
-  if (find_inode(fs,fpath) != -1) printf("%s: already exists\n",fpath);
+  ninode = find_inode(fs,fpath);
+  /*
+   * Allow already existing inode/dir for boot image optimization using
+   * initial addfs followed by genfs -a or duplicate mknods in Make.devices.
+   * This change won't work for non-duplicate mknod or symlinks, but allows
+   * duplicate mkdirs.
+   */
+  if (ninode != -1) {
+    fprintf(stderr, "mfs: %s already exists, no change made\n", fpath);
+    return 0;
+  }
   if (fname) {
     *fname++ = 0;
   } else {

--- a/elks/tools/mfs/main.c
+++ b/elks/tools/mfs/main.c
@@ -40,6 +40,7 @@
  *	use ELKS defaults of -1 -n14 -i360 -s1440 for mkfs/genfs
  *	add genfs -k option to not copy 0 length (hidden) files starting with .
  *	add addfs option to add files/dirs specified in file from directory
+ *  allow existing inode/dir in make_node for boot optimization of mknod and mkdir
  *
  * Bug fixes by ghaerr:
  * fix mkfs -1, -n overwriting -i, -n14

--- a/elks/tools/mfs/writer.c
+++ b/elks/tools/mfs/writer.c
@@ -89,6 +89,7 @@ void writedata(struct minix_fs_dat *fs,u8 *blk,u32 cnt,int inode) {
 void dosymlink(struct minix_fs_dat *fs,char *source,char *lnkpath) {
   int len = strlen(source);
   int inode = make_node(fs,lnkpath,0777|S_IFLNK,0,0,len,NOW,NOW,NOW,NULL);
+  if (inode == 0) return;   /* already exists, must remove to recreate */
   writedata(fs,(unsigned char *)source,len,inode);
 }
 

--- a/elkscmd/sys_utils/getty.c
+++ b/elkscmd/sys_utils/getty.c
@@ -49,7 +49,7 @@
 #include <linuxmt/mem.h>
 
 #define PARSE_ETC_ISSUE 0       /* set =1 to process /etc/issue @ sequences */
-#define BOOT_TIMER      0       /* set =1 to display system startup time */
+#define BOOT_TIMER      1       /* set =1 to display system startup time */
 #define DEBUG           0       /* set =1 for debug messages */
 #define CONSOLE _PATH_CONSOLE   /* debug messages go here */
 

--- a/image/Make.devices
+++ b/image/Make.devices
@@ -15,11 +15,11 @@ devices:
 
 ##############################################################################
 # Create frequently accessed /dev files first
-#	$(MKDEV) /dev/console	c 4 254 1 1 0600
-#	$(MKDEV) /dev/tty1      c 4 0
-#	$(MKDEV) /dev/ttyS0     c 4 64
-#	$(MKDEV) /dev/fd0       b 3 32
-#	$(MKDEV) /dev/fd1       b 3 40
+	$(MKDEV) /dev/console	c 4 254 1 1 0600
+	$(MKDEV) /dev/tty1      c 4 0
+	$(MKDEV) /dev/ttyS0     c 4 64
+	$(MKDEV) /dev/fd0       b 3 32
+	$(MKDEV) /dev/fd1       b 3 40
 
 ##############################################################################
 # Create memory devices.

--- a/image/Make.image
+++ b/image/Make.image
@@ -77,15 +77,15 @@ endif
 
 minixfs:
 	rm -f $(TARGET_FILE)
-#	mfs $(VERBOSE) $(TARGET_FILE) mkfs $(MINIX_MKFSOPTS)
-#	mfs -v $(VERBOSE) $(TARGET_FILE) addfs Image.all $(DESTDIR)
+	mfs $(VERBOSE) $(TARGET_FILE) mkfs $(MINIX_MKFSOPTS)
+	mfs -v $(TARGET_FILE) addfs Image.all $(DESTDIR)
 #	rm -f Filelist
 #	for f in $$(cd $(DESTDIR); find * -name '*'); do \
 #		echo $$f >> FileList; \
 #	done
-#	mfs -v $(VERBOSE) $(TARGET_FILE) addfs Filelist $(DESTDIR)
-#	mfs $(VERBOSE) $(TARGET_FILE) genfs -a $(MINIX_MKFSOPTS) $(DESTDIR)
-	mfs $(VERBOSE) $(TARGET_FILE) genfs $(MINIX_MKFSOPTS) $(DESTDIR)
+#	mfs $(VERBOSE) $(TARGET_FILE) addfs Filelist $(DESTDIR)
+	mfs $(VERBOSE) $(TARGET_FILE) genfs -a $(MINIX_MKFSOPTS) $(DESTDIR)
+#	mfs $(VERBOSE) $(TARGET_FILE) genfs $(MINIX_MKFSOPTS) $(DESTDIR)
 ifdef CONFIG_IMG_DEV
 	# command to make char/block devices in image (no sudo required)
 	$(MAKE) -f Make.devices "MKDEV=mfs $(TARGET_FILE) mknod"


### PR DESCRIPTION
Turns back on boot optimizations that halve boot time. Fixes small mfs problem creating duplicate inodes.

The improvements result from identifying all files and directories accessed at boot using DEBUG_CACHE, and adding those files to Image.all for early placement in the floppy boot image.

By default for the time being, the elapsed time since boot is now displayed at the login prompt, so users can accurately see their boot time when manipulating Image.all without recompilation.

To be tested on real hardware. 