### PR TITLE
[directfd] Add track cache debug code to directfd driver

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -679,7 +679,7 @@ static int BFPROC do_cache_read(struct drive_infot *drivep, sector_t start, char
     if (cmd == READ) {
         cache_tries++;
         if (cache_valid(drivep, start, buf, seg)) { /* try cache first*/
-            debug_cache2("CH %lu ", start>>1);
+            debug_cache2("CH %lu ", start >> 1);
             cache_hits++;
             return 1;
         }

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -106,6 +106,7 @@ static struct gendisk bioshd_gendisk = {
 
 static void BFPROC set_cache_invalid(void)
 {
+    if (cache_drive) debug_cache("INV%d ", cache_drive - drive_info);
     cache_drive = NULL;
 }
 
@@ -580,8 +581,8 @@ static int BFPROC do_readwrite(struct drive_infot *drivep, sector_t start, char 
             segment = (seg_t)seg;
             offset = (unsigned) buf;
         }
-        debug_bios("bioshd(%x): cmd %d CHS %d/%d/%d count %d\n",
-            drive, cmd, cylinder, head, sector, this_pass);
+        debug_cache("bioshd(%x): %s CHS %d/%d/%d count %d\n",
+            drive, cmd==WRITE? "WR": "RD", cylinder, head, sector, this_pass);
 
         bios_set_ddpt(drivep->sectors);
         error = bios_disk_rw(cmd == WRITE? BIOSHD_WRITE: BIOSHD_READ, this_pass,
@@ -622,8 +623,8 @@ static void BFPROC do_readtrack(struct drive_infot *drivep, sector_t start)
         num_sectors = DMASEGSZ / drivep->sector_size;
 
     do {
-        debug_cache("\nTR %lu(CHS %u,%u,%u-%u) ", start>>1, cylinder, head, sector,
-            sector+num_sectors-1);
+        debug_cache("\nTR%d %lu(CHS %u,%u,%u-%u) ", drive, start>>1, cylinder, head,
+            sector, sector+num_sectors-1);
         debug_bios("bioshd(%x): track read CHS %d/%d/%d count %d\n",
                 drive, cylinder, head, sector, num_sectors);
 

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -106,7 +106,7 @@ static struct gendisk bioshd_gendisk = {
 
 static void BFPROC set_cache_invalid(void)
 {
-    if (cache_drive) debug_cache("INV%d ", cache_drive - drive_info);
+    if (cache_drive) debug_cache2("INV%d ", cache_drive - drive_info);
     cache_drive = NULL;
 }
 
@@ -536,7 +536,7 @@ static void BFPROC get_chst(struct drive_infot *drivep, sector_t *start_sec,
         *start_sec -= save - *s;
     }
 #endif
-    if (extra) debug_cache("bioshd: lba %ld is CHS %d/%d/%d remaining sectors %d\n",
+    if (extra) debug_cache2("bioshd: lba %ld is CHS %d/%d/%d remaining sectors %d\n",
         start, *c, *h, *s, *t);
 }
 
@@ -581,8 +581,10 @@ static int BFPROC do_readwrite(struct drive_infot *drivep, sector_t start, char 
             segment = (seg_t)seg;
             offset = (unsigned) buf;
         }
-        debug_cache("bioshd(%x): %s CHS %d/%d/%d count %d\n",
-            drive, cmd==WRITE? "WR": "RD", cylinder, head, sector, this_pass);
+        debug_cache("%s%d CHS %d/%d/%d count %d\n",
+            cmd==WRITE? "WR": "RD", drive, cylinder, head, sector, this_pass);
+        debug_bios("bioshd(%x): cmd %d CHS %d/%d/%d count %d\n",
+            drive, cmd, cylinder, head, sector, this_pass);
 
         bios_set_ddpt(drivep->sectors);
         error = bios_disk_rw(cmd == WRITE? BIOSHD_WRITE: BIOSHD_READ, this_pass,
@@ -677,7 +679,7 @@ static int BFPROC do_cache_read(struct drive_infot *drivep, sector_t start, char
     if (cmd == READ) {
         cache_tries++;
         if (cache_valid(drivep, start, buf, seg)) { /* try cache first*/
-            debug_cache("CH %lu ", start>>1);
+            debug_cache2("CH %lu ", start>>1);
             cache_hits++;
             return 1;
         }

--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -1229,7 +1229,8 @@ static void DFPROC redo_fd_request(void)
          * number of sectors (full blocks). When head=1 we read the entire track
          * and ignore the first sector.
          */
-        DEBUG("bufrd chs %d/%d/%d\n", seek_track, head, sector);
+        DEBUG("cache CHS %d/%d/%d\n", seek_track, head, sector);
+        debug_cache2("CH %d ", start >> 1);
         char *buf_ptr = (char *) (sector << 9);
         if (command == FD_READ) {       /* requested data is in buffer */
             xms_fmemcpyw(req->rq_buffer, req->rq_seg, buf_ptr, DMASEG, BLOCK_SIZE/2);

--- a/elks/arch/i86/drivers/block/ll_rw_blk.c
+++ b/elks/arch/i86/drivers/block/ll_rw_blk.c
@@ -161,6 +161,14 @@ static void add_request(struct blk_dev_struct *dev, struct request *req)
         req->rq_next = tmp->rq_next;
         tmp->rq_next = req;
         set_irq();
+#if DEBUG_CACHE
+        if (debug_level) {
+            int n = 0;
+            for (tmp = dev->current_request; tmp->rq_next; tmp = tmp->rq_next)
+                n++;
+            if (n > 1) printk("REQS %d ", n);
+        }
+#endif
 #else
         panic("add_request");   /* non-empty request queue */
 #endif

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -501,7 +501,7 @@ struct buffer_head *getblk32(kdev_t dev, block32_t block)
     ebh = EBH(bh);
     ebh->b_dev = dev;
     ebh->b_blocknr = block;
-    debug_cache("BM %lu ", block);
+    debug_cache2("BM %lu ", block);
     goto return_it;
 
   found_it:
@@ -511,7 +511,8 @@ struct buffer_head *getblk32(kdev_t dev, block32_t block)
         CLR_COUNT(en_bh);
         en_bh->b_count = 0;     /* Release previously created buffer head */
     }
-    if (bh->b_data) debug_cache("L1 %lu ", block); else debug_cache("L2 %lu ", block);
+    if (bh->b_data) { debug_cache2("L1 %lu ", block); }
+               else { debug_cache2("L2 %lu ", block); }
     ebh = EBH(bh);
     INR_COUNT(ebh);
     wait_on_buffer(bh);

--- a/elks/include/linuxmt/debug.h
+++ b/elks/include/linuxmt/debug.h
@@ -16,7 +16,7 @@
 #define DEBUG_LEVEL     0               /* default startup debug level*/
 #define DEBUG_BIOS      0               /* BIOS driver*/
 #define DEBUG_BLK       0               /* block i/o*/
-#define DEBUG_CACHE     1               /* floppy track cache*/
+#define DEBUG_CACHE     0               /* floppy track cache*/
 #define DEBUG_ETH       0               /* ethernet*/
 #define DEBUG_FAT       0               /* FAT filesystem*/
 #define DEBUG_FILE      0               /* sys open and file i/o*/

--- a/elks/include/linuxmt/debug.h
+++ b/elks/include/linuxmt/debug.h
@@ -13,10 +13,10 @@
  * Kernel debug options, set =1 to turn on. Works across multiple files.
  */
 #define DEBUG_EVENT     1               /* generate debug events on CTRLN-CTRLP*/
-#define DEBUG_STARTDEF  0               /* default startup debug display*/
+#define DEBUG_LEVEL     0               /* default startup debug level*/
 #define DEBUG_BIOS      0               /* BIOS driver*/
 #define DEBUG_BLK       0               /* block i/o*/
-#define DEBUG_CACHE     0               /* floppy track cache*/
+#define DEBUG_CACHE     1               /* floppy track cache*/
 #define DEBUG_ETH       0               /* ethernet*/
 #define DEBUG_FAT       0               /* FAT filesystem*/
 #define DEBUG_FILE      0               /* sys open and file i/o*/
@@ -57,8 +57,10 @@ void debug_setcallback(int evnum, void (*cbfunc)()); /* callback on debug event*
 
 #if DEBUG_CACHE
 #define debug_cache     PRINTK
+#define debug_cache2    if (debug_level > 1) PRINTK
 #else
 #define debug_cache(...)
+#define debug_cache2(...)
 #endif
 
 #if DEBUG_ETH

--- a/elks/include/linuxmt/kernel.h
+++ b/elks/include/linuxmt/kernel.h
@@ -19,7 +19,7 @@
 
 extern char running_qemu;
 extern dev_t dev_console;
-extern int dprintk_on;
+extern int debug_level;
 
 extern void do_exit(int) noreturn;
 

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -491,10 +491,6 @@ static int INITPROC parse_options(void)
             root_mountflags &= ~MS_RDONLY;
             continue;
         }
-        if (!strcmp(line,"debug")) {
-            dprintk_on = 1;
-            continue;
-        }
         if (!strcmp(line,"strace")) {
             tracing |= TRACE_STRACE;
             continue;
@@ -518,6 +514,10 @@ static int INITPROC parse_options(void)
         }
         if (!strncmp(line,"3c0=",4)) {
             parse_nic(line+4, &netif_parms[ETH_EL3]);
+            continue;
+        }
+        if (!strncmp(line,"debug=", 6)) {
+            debug_level = (int)simple_strtol(line+6, 10);
             continue;
         }
         if (!strncmp(line,"buf=",4)) {

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -326,7 +326,7 @@ void panic(const char *error, ...)
     halt();
 }
 
-int dprintk_on = DEBUG_STARTDEF;        /* toggled by debug events*/
+int debug_level = DEBUG_LEVEL;      /* set with debug= or toggled by debug events */
 #if DEBUG_EVENT
 static void (*debug_cbfuncs[3])();  /* debug event callback function*/
 
@@ -338,8 +338,8 @@ void debug_setcallback(int evnum, void (*cbfunc)())
 
 void debug_event(int evnum)
 {
-    if (evnum == 2) {           /* CTRLP toggles dprintk*/
-        dprintk_on = !dprintk_on;
+    if (evnum == 2) {               /* CTRLP toggles debug */
+        debug_level = !debug_level;
         kill_all(SIGURG);
     }
     if (debug_cbfuncs[evnum])
@@ -350,7 +350,7 @@ void dprintk(const char *fmt, ...)
 {
     va_list p;
 
-    if (!dprintk_on)
+    if (!debug_level)
         return;
     va_start(p, fmt);
     vprintk(fmt, p);

--- a/elks/kernel/sysctl.c
+++ b/elks/kernel/sysctl.c
@@ -15,7 +15,7 @@ static int malloc_debug;
 static int net_debug;
 
 struct sysctl sysctl[] = {
-    { "kern.debug",         &dprintk_on         },  /* debug (^P) on/off */
+    { "kern.debug",         &debug_level        },  /* debug level (^P toggled) */
     { "kern.strace",        &tracing            },  /* strace=1, kstack=2 */
     { "kern.console",       (int *)&dev_console },  /* console */
     { "malloc.debug",       &malloc_debug       },

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -19,5 +19,5 @@
 #strace
 #FTRACE=1
 #net=ne0
-#debug
+#debug=1
 #console=ttyS0,19200 3


### PR DESCRIPTION
As discussed in https://github.com/Mellvik/TLVC/pull/88#issuecomment-2415726588, this tooling is show track cache performance when copying files between floppy drives.

Fixes num_sector calculation in DF driver resulting in previously incorrect calculation of emulated delay when IODELAY.
Adds drive number to TR/RD/WR debug display.
Displays request queue size when DEBUG_CACHE and queue length > 1.
Adds debug=N option to /bootopts allowing for multilevel debug display.
Adds debug_cache2 when debug=2 for CH/BM/L1/L2 track cache display.
Removes auto-probe message in DF driver when not actually probing.

During cache testing between drives, it was found that full track cache switching between drives is not causing any noticeable performance delays, contrary to what I had thought. What is happening is that during a file copy, the system track reads, quickly gaining access to contiguous file sectors, while buffer writes end up going into the kernel L2 system buffers, with no I/O scheduled at all. So no track cache switching to speak of. After the system buffers become full, sync_buffers() is called which schedules the write I/O. When the async DF driver is in use, this ends up initially quickly queuing 9 request headers, but which apparently are quickly dequeued, and multiple request headers aren't used again. Not sure why this is occurring yet.

Ultimately, both the BIOS and DF drivers are showing fairly good performance on both boot times and multi drive copies. A previous num_sector bug caused the IODELAY emulated delay to be incorrect for the DF driver, and we're now seeing boot times of 4.5 secs for BIOS and 5.0 secs for DF, very close. Both are half of what they used to be, so progress is looking good.


