### PR TITLE
[boot] Fix bad MBR partition generated by setboot

### DIFF
--- a/elks/tools/setboot/setboot.c
+++ b/elks/tools/setboot/setboot.c
@@ -78,17 +78,19 @@ static void writePartition(unsigned char *buf)
 	p->sector = 1;				/* next cylinder after MBR, standard*/
 	p->cyl = 0;
 	p->start_sect = NumTracks;	/* zero-relative start sector here*/
+	nr_sects -= SecPerTrk;
 #else
 	p->head = 0;
 	p->sector = 2;				/* next sector after MBR, non-standard*/
 	p->cyl = 0;
 	p->start_sect = 1;			/* zero-relative start sector here*/
+	nr_sects -= 1;
 #endif
 	StartSector = p->start_sect;
 	p->sys_ind = 0x80;			/* ELKS, Old Minix*/
 	p->end_head = NumHeads;
-	p->end_sector = SecPerTrk | ((NumTracks >> 2) & 0xc0);
-	p->end_cyl = NumTracks & 0xff;
+	p->end_sector = SecPerTrk | (((NumTracks-1) >> 2) & 0xc0);
+	p->end_cyl = (NumTracks-1) & 0xff;
 	p->start_sect_hi = 0;
 	p->nr_sects = nr_sects & 0xffff;
 	p->nr_sects_hi = nr_sects >> 16;

--- a/elkscmd/disk_utils/fdisk.c
+++ b/elkscmd/disk_utils/fdisk.c
@@ -164,8 +164,8 @@ void add_part(void)
     oset = MBR + PARTITION_START + ((part - 1) * 16);
 
     printf("Total cylinders: %d\n", geometry.cylinders);
-    for (scyl = geometry.cylinders + 1; scyl < 0 || scyl > geometry.cylinders;) {
-        printf("First cylinder (%d-%d): ", 0, geometry.cylinders);
+    for (scyl = geometry.cylinders; scyl < 0 || scyl > geometry.cylinders-1;) {
+        printf("First cylinder (%d-%d): ", 0, geometry.cylinders-1);
         fflush(stdout);
         fgets(buf, 31, stdin);
         scyl = atoi(buf);
@@ -185,8 +185,8 @@ void add_part(void)
     p.cyl       = (scyl & 0xff);
     p.sys_ind   = PARTITION_TYPE;
 
-    for (ecyl = geometry.cylinders + 1; ecyl < scyl || ecyl > geometry.cylinders;) {
-        printf("Ending cylinder (%d-%d): ", 0, geometry.cylinders);
+    for (ecyl = geometry.cylinders; ecyl < scyl || ecyl > geometry.cylinders-1;) {
+        printf("Ending cylinder (%d-%d): ", 0, geometry.cylinders-1);
         fflush(stdout);
         fgets(buf, 31, stdin);
         ecyl = atoi(buf);

--- a/image/Makefile
+++ b/image/Makefile
@@ -202,11 +202,11 @@ hd32-fat:
 	rm Config
 
 # MBR images
-hd32mbr-minix:
+hd32mbr-minix: hd32-minix
 	dd if=/dev/zero bs=512 count=63 | cat - hd32-minix.img > hd32mbr-minix.img
 	setboot hd32mbr-minix.img -P63,16,63 -Sm $(HD_MBR_BOOT)
 
-hd32mbr-fat:
+hd32mbr-fat: hd32-fat
 	dd if=/dev/zero bs=512 count=63 | cat - hd32-fat.img > hd32mbr-fat.img
 	setboot hd32mbr-fat.img -P63,16,63 -Sf $(HD_MBR_BOOT)
 


### PR DESCRIPTION
Corrects improper end cylinder number and partition size for hd32mbr-minix.img and hd32mbr-fat.img images. This resulted in an extra cylinder being used for the partition as well as calculating the partition size incorrectly, which would result in writing off the end of the partition, a major bug.

Also fixes `fdisk` to accept only the correct start and end cylinder numbers, courtesy of @Mellvik's fix https://github.com/Mellvik/TLVC/pull/93.

Here's the corrected setboot (and fdisk) output for the HD32 images with CHS 63/16/63. Note the correct 32MB disk size is 63441 sectors (instead of the previous 63504):
<img width="832" alt="hd32mbr fdisk" src="https://github.com/user-attachments/assets/a8701765-0c2c-40fe-9946-90dbef0ec6e7">
