### PR TITLE
[kernel,libc] Add %#k alt option to precision timer displays

### DIFF
--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -20,6 +20,7 @@
  *              %D      device name as %04x
  *              %P      process ID
  *              %k      pticks (0.838usec intervals auto displayed as us, ms or s)
+ *              %#k     pticks truncated at decimal point
  *
  *      All except %% can be followed by a width specifier 1 -> 31 only
  *      and the h/l length specifiers also work where appropriate.

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -172,8 +172,9 @@ static void numout(unsigned long v, int width, unsigned int base, int type,
         kputchar('-');
     while (*p) {
         if (n-- == Decimal) {               /* only for %k pticks */
-            if (alt) break;
-            else kputchar('.');
+            if (alt)
+                break;
+            kputchar('.');
         }
         kputchar(*p++);
     }

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -154,8 +154,8 @@ static void numout(unsigned long v, int width, unsigned int base, int type,
             *--p = '0' + c;
         if (!v)
             break;
-        if (alt == ',' && ++i == 3) {
-            *--p = ',';
+        if ((alt == ',' || alt == '\'') && ++i == 3) {
+            *--p = alt;
             i = 0;
         }
     }
@@ -171,8 +171,10 @@ static void numout(unsigned long v, int width, unsigned int base, int type,
     if (Sign)
         kputchar('-');
     while (*p) {
-        if (n-- == Decimal)                 /* only for %k pticks */
-            kputchar('.');
+        if (n-- == Decimal) {               /* only for %k pticks */
+            if (alt) break;
+            else kputchar('.');
+        }
         kputchar(*p++);
     }
     while (Suffix) {
@@ -199,7 +201,7 @@ static void vprintk(const char *fmt, va_list p)
             }
 
             ptrfmt = alt = width = 0;
-            if (c == '#' || c == ',') {
+            if (c == '#' || c == ',' || c == '\'') {
                 alt = c;
                 c = *fmt++;
             }

--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -143,7 +143,7 @@ void dtostr(double val, int style, int preci, char *buf);
 /* use this macro to link in libc %e,%f,%g printf/sprintf support into user program */
 #define __STDIO_PRINT_FLOATS    __LINK_SYMBOL(dtostr)
 #endif
-void ptostr(unsigned long pticks, char *buf);
+void ptostr(unsigned long pticks, int alt, char *buf);
 
 #define stdio_pending(fp) ((fp)->bufread>(fp)->bufpos)
 

--- a/libc/misc/ptostr.c
+++ b/libc/misc/ptostr.c
@@ -4,7 +4,7 @@
  */
 #include <stdlib.h>
 
-void ptostr(unsigned long v, char *outbuf)
+void ptostr(unsigned long v, int alt, char *outbuf)
 {
     unsigned int c;
     char *p;
@@ -40,8 +40,11 @@ void ptostr(unsigned long v, char *outbuf)
 
     n = buf + sizeof(buf) - 1 - p;  /* string length */
     while (*p) {
-        if (n == Decimal)
+        if (n == Decimal) {
+            if (alt)
+                break;
             *outbuf++ = '.';
+        }
         --n;
         *outbuf++ = *p++;
     }

--- a/libc/stdio/vfprintf.c
+++ b/libc/stdio/vfprintf.c
@@ -130,7 +130,7 @@ vfprintf(FILE *op, const char *fmt, va_list ap)
    unsigned long v;
    int buffer_mode;
    char *p;
-   //char hash;
+   int hash;
    char buf[64];
 
    /* turn off putc calling fputc every time for non or line buffered */
@@ -140,7 +140,7 @@ vfprintf(FILE *op, const char *fmt, va_list ap)
    while (*fmt) {
       if (*fmt == '%') {
          ljustf = 0;            /* left justify flag */
-         //hash = 0;            /* alternate output */
+         hash = 0;              /* alternate output */
          quot = 0;              /* thousands grouping */
          dpoint = 0;            /* found decimal point */
          sign = '\0';           /* sign char & status */
@@ -183,9 +183,9 @@ vfprintf(FILE *op, const char *fmt, va_list ap)
             quot = *fmt;
             goto fmtnxt;
 
-         //case '#':
-            //hash = 1;
-            //goto fmtnxt;
+         case '#':
+            hash = 1;
+            goto fmtnxt;
 
          case '\0':             /* early EOS */
             continue;
@@ -249,7 +249,7 @@ vfprintf(FILE *op, const char *fmt, va_list ap)
             v = lval? va_arg(ap, unsigned long) : (unsigned long)va_arg(ap, unsigned int);
             if (*fmt == 'k') {
                 if (_weakaddr(ptostr)) {
-                    (_weakfn(ptostr))(v, p);
+                    (_weakfn(ptostr))(v, hash, p);
                     preci = -1;
                     goto printit;
                 }

--- a/libc/stdio/vfprintf.c
+++ b/libc/stdio/vfprintf.c
@@ -12,6 +12,7 @@
  *              %x/%X   hexadecimal with lower/upper case letters
  *              %p      pointer - same as %04x
  *              %k      pticks (0.838usec intervals auto displayed as us, ms or s)
+ *              %#k     pticks truncated at decimal point
  *              %efgEG  optional floating point formatting using dtostr
  *          The following flags preceding the format type are supported:
  *              0       fill with leading zeros


### PR DESCRIPTION
Alternate format display for precision timing output truncates output at the decimal point for easy readability.
Added to libc printf and kernel printk.

Requested by @Mellvik in https://github.com/Mellvik/TLVC/pull/97#issuecomment-2435715555.

Also adds alternative %'d thousands grouping to printk (along with existing %,). Both exist in libc.