### PR TITLE
[kernel,libc] Fix precision timer get_ptime

### DIFF
--- a/elks/arch/i86/lib/prectimer.c
+++ b/elks/arch/i86/lib/prectimer.c
@@ -2,6 +2,9 @@
  * Precision timer routines for IBM PC and compatibles
  * 2 Aug 2024 Greg Haerr
  *
+ * This file is identical in elks/arch/i86/kernel/lib/prectimer.c (kernel)
+ * and libc/debug/prectimer.c (user mode).
+ *
  * Use 8254 PIT to measure elapsed time in pticks = 0.8381 usecs.
  */
 
@@ -109,14 +112,22 @@ unsigned long get_ptime(void)
 
     count = lo | hi;
     pticks = lastcount - count;
+    lastcount = count;
+#if 1
+    if ((int)pticks < 0) {          /* wrapped, jiffies is higher */
+        pticks += MAX_PTICK;        /* = MAX_PTICK - count + lastcount */
+        jdiff--;                    /* adjust jiffies for wrap, won't ever be negative */
+    }
+    if (jdiff < 4286)               /* < ~42.86s */
+        return jdiff * (unsigned long)MAX_PTICK + pticks;
+#else /* incorrect (old) version - to be removed */
     if ((int)pticks < 0)            /* wrapped */
         pticks += MAX_PTICK;        /* = MAX_PTICK - count + lastcount */
-    lastcount = count;
-
     if (jdiff < 2)                  /* < 10ms: 1..11931 */
         return pticks;
     if (jdiff < 4286)               /* < ~42.86s */
         return (jdiff - 1) * (unsigned long)MAX_PTICK + pticks;
+#endif
     return 0;                       /* overflow displays 0s */
 }
 

--- a/libc/debug/prectimer.c
+++ b/libc/debug/prectimer.c
@@ -2,6 +2,9 @@
  * Precision timer routines for IBM PC and compatibles
  * 2 Aug 2024 Greg Haerr
  *
+ * This file is identical in elks/arch/i86/kernel/lib/prectimer.c (kernel)
+ * and libc/debug/prectimer.c (user mode).
+ *
  * Use 8254 PIT to measure elapsed time in pticks = 0.8381 usecs.
  */
 
@@ -109,14 +112,22 @@ unsigned long get_ptime(void)
 
     count = lo | hi;
     pticks = lastcount - count;
+    lastcount = count;
+#if 1
+    if ((int)pticks < 0) {          /* wrapped, jiffies is higher */
+        pticks += MAX_PTICK;        /* = MAX_PTICK - count + lastcount */
+        jdiff--;                    /* adjust jiffies for wrap, won't ever be negative */
+    }
+    if (jdiff < 4286)               /* < ~42.86s */
+        return jdiff * (unsigned long)MAX_PTICK + pticks;
+#else /* incorrect (old) version - to be removed */
     if ((int)pticks < 0)            /* wrapped */
         pticks += MAX_PTICK;        /* = MAX_PTICK - count + lastcount */
-    lastcount = count;
-
     if (jdiff < 2)                  /* < 10ms: 1..11931 */
         return pticks;
     if (jdiff < 4286)               /* < ~42.86s */
         return (jdiff - 1) * (unsigned long)MAX_PTICK + pticks;
+#endif
     return 0;                       /* overflow displays 0s */
 }
 


### PR DESCRIPTION
Following @Mellvik's fantastic job at testing, using and now identifying a major bug in the precision timer `get_ptime` routine in https://github.com/Mellvik/TLVC/pull/97, this PR fixes it.

The original precision timing calculation was found to be up to 10ms inaccurate possibly 50% of the time - whenever the PIT countdown timer decreased to a value less than its original value *and* wrapped across zero (i.e. a hardware timer interrupt).

The original routine should have been unit tested, instead of "eyeballing" its output using QEMU. The current fix has been unit tested using the following, as well as re-eyeballed under QEMU:
```
#include <stdio.h>

#define MAX_PTICK   11932U     /* PIT reload value for 10ms (100 HZ) */

#define HIGH        11900U
#define LOW         11800U

unsigned testpt(unsigned lastcount, unsigned count, unsigned jdiff)
{
    unsigned pticks;

    printf("lastcount %u, count %u, jdiff %u ", lastcount, count, jdiff);
    pticks = lastcount - count;

#if 1
    if ((int)pticks < 0) {          /* wrapped */
        pticks += MAX_PTICK;        /* = MAX_PTICK - count + lastcount */
        jdiff--;                    /* won't ever be negative */
    }
    if (jdiff < 4286)               /* < ~42.86s */
        return jdiff * (unsigned long)MAX_PTICK + pticks;
#else
    if ((int)pticks < 0)            /* wrapped */
        pticks += MAX_PTICK;        /* = MAX_PTICK - count + lastcount */
    if (jdiff < 2)                  /* < 10ms: 1..11931 */
        return pticks;
    if (jdiff < 4286)               /* < ~42.86s */
        return (jdiff - 1) * (unsigned long)MAX_PTICK + pticks;
#endif
    return 0;
}

int main(int ac, char **av)
{
    printf("= %u\n", testpt(HIGH, LOW, 0));
    //printf("= %u\n", testpt(LOW, HIGH, 0));   /* not possible */
    printf("= %u\n", testpt(HIGH, LOW, 1));
    printf("= %u\n", testpt(LOW, HIGH, 1));
    printf("= %u\n", testpt(HIGH, LOW, 2));
    printf("= %u\n", testpt(LOW, HIGH, 2));
}
```
For now, all code has `#if 1` including both the new/fixed and original code, for possible comparison purposes. This will be removed after having been verified on real hardware.

Thank you @Mellvik for your excellent debugging work on this, well done!!!!