### PR TITLE
[setup] Add 80386+ CPU testing to cputest.S

### DIFF
--- a/elks/arch/i86/boot/cputype.S
+++ b/elks/arch/i86/boot/cputype.S
@@ -1,7 +1,6 @@
 // obsolete and inaccurate, but required for arch_cpu = 6 and 7 (286, 386+)
 // XT vs AT BIOS system capabilities (sys_caps) auto-detection by kernel
 //
-#define CONFIG_CPU_8086		/* required for this file only */
 
 /*
 ! Probe for the CPU
@@ -12,7 +11,6 @@
 getcpu:
 	mov	$SETUPSEG,%ax   // setup.S code segment
 	mov	%ax,%ds
-#ifndef CONFIG_ROMCODE
 	pushf                   // check for 8088/8086/V20/V30/80188/80186
 	xor	%ax,%ax
 	push	%ax
@@ -50,13 +48,11 @@ getcpu:
 	lea	p80386,%si
 	jmp	cpu_store
 
-not_32bit:                      // Unknown CPU
+not_32bit:			// Unknown CPU
 	mov	$255,%cl
 	lea	px86,%si
 	jmp	cpu_store
-#endif
 
-#if !defined(CONFIG_ROMCODE) || defined(CONFIG_CPU_8086)
 is8086:
 	mov	$0xff,%al
 	mov	$0x21,%cl	// 80188/86 uses only the five lower
@@ -96,18 +92,14 @@ isv30:
 isv20:	mov	$2,%cl
 	lea	pv20,%si
 	jmp     cpu_store
-#endif
-#if !defined (CONFIG_ROMCODE) || defined(CONFIG_CPU_80286)
+
 is80286:mov	$6,%cl
 	lea	p80286,%si
 //	jmp	cpu_store
-#endif
 
 cpu_store:
-	//
-	// Store the processor name and type
-	//
-	push	%cx
+#if UNUSED
+	push	%cx		// Store processor name
 	mov	$INITSEG,%ax
 	mov	%ax,%es
 	mov	$0x30,%di
@@ -124,12 +116,13 @@ con_cp1:
 	rep
 	movsb
 	pop	%cx
-	mov	$INITSEG,%ax
+#endif
+	mov	$INITSEG,%ax	// Store processor type
 	mov	%ax,%ds
 	mov	%cl,0x20
+	cli			// FIXME reset to cli; shouldn't have sti's above
 	ret
 
-#if !defined(CONFIG_ROMCODE) || defined(CONFIG_CPU_8086)
 /*
 !
 ! Determine the length of the prefetch queue. 8088/188/v20 has
@@ -189,24 +182,19 @@ queue_end:
 
 	or	%dx,%dx
 	ret
+
 //
 // The processor name must not be longer than 15 characters!
 //
-#if !defined(CONFIG_ROMCODE) || defined(CONFIG_CPU_8086)
 p8088:	.ascii "Intel 8088\0"
 p8086:	.ascii "Intel 8086\0"
 pv20:	.ascii "NEC V20\0"
 pv30:	.ascii "NEC V30\0"
 p80188:	.ascii "Intel 80188\0"
 p80186:	.ascii "Intel 80186\0"
-#endif
-#if !defined(CONFIG_ROMCODE) || defined(CONFIG_CPU_80286)
 p80286:	.ascii "Intel 80286\0"
 p80386:	.ascii "Intel 80386+\0"
-#endif
-#if !defined(CONFIG_ROMCODE)
 px86:   .ascii "Unknown x86\0"
-#endif
 //
 // Here is the CPU id stored
 //
@@ -214,7 +202,3 @@ v_id:	.byte 0,0,0,0
 v_id2:	.byte 0,0,0,0
 v_id3:	.byte 0,0,0,0
 	.byte 0
-
-#endif /* !defined(CONFIG_ROMCODE) || defined(CONFIG_CPU_8086)*/
-
-#undef CONFIG_CPU_8086

--- a/elks/arch/i86/boot/cputype.S
+++ b/elks/arch/i86/boot/cputype.S
@@ -1,6 +1,6 @@
 // obsolete and inaccurate, but required for arch_cpu = 6 and 7 (286, 386+)
 // XT vs AT BIOS system capabilities (sys_caps) auto-detection by kernel
-//
+// Note: enables, then disables interrupts when called
 
 /*
 ! Probe for the CPU
@@ -9,7 +9,7 @@
 !
 */
 getcpu:
-	mov	$SETUPSEG,%ax   // setup.S code segment
+	mov	$SETUPSEG,%ax   // setup code segment
 	mov	%ax,%ds
 	pushf                   // check for 8088/8086/V20/V30/80188/80186
 	xor	%ax,%ax
@@ -45,12 +45,12 @@ getcpu:
 	and	$0x70,%bh       // 32-bit CPU if we changed NT or IOPL
 	je	not_32bit
 	mov	$7,%cl          // 80386+
-	lea	p80386,%si
+	#lea	p80386,%si
 	jmp	cpu_store
 
 not_32bit:			// Unknown CPU
 	mov	$255,%cl
-	lea	px86,%si
+	#lea	px86,%si
 	jmp	cpu_store
 
 is8086:
@@ -63,38 +63,37 @@ is8086:
 	mov	$0xffff,%cx
 	nop
 	rep
-//	seg	es
 	lodsb
 	or	%cx,%cx
 	jz	isv30
 	call	queue
 	jz	is8088
 	mov	$1,%cl
-	lea	p8086,%si
+	#lea	p8086,%si
 	jmp	cpu_store
 is8088:	xor	%cl,%cl
-	lea	p8088,%si
+	#lea	p8088,%si
 	jmp	cpu_store
 is80186:call	queue
 	jz	is80188
 	mov	$5,%cl
-	lea	p80186,%si
+	#lea	p80186,%si
 	jmp	cpu_store
 is80188:mov	$4,%cl
-	lea	p80188,%si
+	#lea	p80188,%si
 	jmp	cpu_store
 isv30:	
 	call	queue
 	jz	isv20
 	mov	$3,%cl
-	lea	pv30,%si
+	#lea	pv30,%si
 	jmp	cpu_store
 isv20:	mov	$2,%cl
-	lea	pv20,%si
+	#lea	pv20,%si
 	jmp     cpu_store
 
 is80286:mov	$6,%cl
-	lea	p80286,%si
+	#lea	p80286,%si
 //	jmp	cpu_store
 
 cpu_store:
@@ -183,6 +182,7 @@ queue_end:
 	or	%dx,%dx
 	ret
 
+#if UNUSED
 //
 // The processor name must not be longer than 15 characters!
 //
@@ -202,3 +202,4 @@ v_id:	.byte 0,0,0,0
 v_id2:	.byte 0,0,0,0
 v_id3:	.byte 0,0,0,0
 	.byte 0
+#endif

--- a/elks/arch/i86/boot/cputype.S
+++ b/elks/arch/i86/boot/cputype.S
@@ -1,4 +1,4 @@
-// obsolote and inaccurate, but required for arch_cpu > 5
+// obsolete and inaccurate, but required for arch_cpu = 6 and 7 (286, 386+)
 // XT vs AT BIOS system capabilities (sys_caps) auto-detection by kernel
 //
 #define CONFIG_CPU_8086		/* required for this file only */
@@ -10,10 +10,10 @@
 !
 */
 getcpu:
-	mov	$SETUPSEG,%ax         /* Codesegment setup.S */
+	mov	$SETUPSEG,%ax   // setup.S code segment
 	mov	%ax,%ds
 #ifndef CONFIG_ROMCODE
-	pushf
+	pushf                   // check for 8088/8086/V20/V30/80188/80186
 	xor	%ax,%ax
 	push	%ax
 	popf
@@ -23,7 +23,7 @@ getcpu:
 	and	$0xf000,%ax
 	cmp	$0xf000,%ax
 	je	is8086
-	mov	$0x7000,%ax
+	mov	$0x7000,%ax     // check for 80286
 	pushf
 	push	%ax
 	popf
@@ -32,13 +32,28 @@ getcpu:
 	popf
 	and	$0x7000,%ax
 	je	is80286
-//
-// Default & unknown CPU
-//
-	mov	$0xff,%cl
+	pushf			// check for 32-bit CPU (80386+)
+	pushf
+	pop	%bx             // old FLAGS -> BX
+	mov	%bx,%ax
+	xor	$0x70,%ah       // try changing b14 (NT) or b13:b12 (IOPL)
+	push	%ax
+	popf
+	pushf
+	pop	%ax             // new FLAGS -> AX
+	popf
+	xor	%ah,%bh
+	xor	%ax,%ax
+	and	$0x70,%bh       // 32-bit CPU if we changed NT or IOPL
+	je	not_32bit
+	mov	$7,%cl          // 80386+
+	lea	p80386,%si
+	jmp	cpu_store
+
+not_32bit:                      // Unknown CPU
+	mov	$255,%cl
 	lea	px86,%si
 	jmp	cpu_store
-	nop
 #endif
 
 #if !defined(CONFIG_ROMCODE) || defined(CONFIG_CPU_8086)
@@ -178,26 +193,19 @@ queue_end:
 // The processor name must not be longer than 15 characters!
 //
 #if !defined(CONFIG_ROMCODE) || defined(CONFIG_CPU_8086)
-p8088:	.ascii "Intel 8088"
-	.byte 0
-p8086:	.ascii "Intel 8086"
-	.byte 0
-pv20:	.ascii "NEC V20"
-	.byte 0
-pv30:	.ascii "NEC V30"
-	.byte 0
-p80188:	.ascii "Intel 80188"
-	.byte 0
-p80186:	.ascii "Intel 80186"
-	.byte 0
+p8088:	.ascii "Intel 8088\0"
+p8086:	.ascii "Intel 8086\0"
+pv20:	.ascii "NEC V20\0"
+pv30:	.ascii "NEC V30\0"
+p80188:	.ascii "Intel 80188\0"
+p80186:	.ascii "Intel 80186\0"
 #endif
 #if !defined(CONFIG_ROMCODE) || defined(CONFIG_CPU_80286)
-p80286:	.ascii "Intel 80286"
-	.byte 0
+p80286:	.ascii "Intel 80286\0"
+p80386:	.ascii "Intel 80386+\0"
 #endif
 #if !defined(CONFIG_ROMCODE)
-px86:   .ascii "Unknown x86"
-	.byte 0
+px86:   .ascii "Unknown x86\0"
 #endif
 //
 // Here is the CPU id stored

--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -43,7 +43,7 @@
 !	10:	mono/color, video memory size, 2 bytes 
 !	14:	screen_lines, 1 byte
 !	15:	VGA present, 1 byte
-!	0x20:	cpu_type	byte Processor type UNUSED
+!	0x20:	cpu_type	byte Processor type
 !			0  = 8088
 !			1  = 8086
 !			2  = NEC V20

--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -52,10 +52,10 @@
 !			5  = 80186
 !			6  = 80286
 !			7  = 80386
-!			8  = 80486
-!			9  = Pentium
-!			10 = Pentium PRO
-!			255 = VM86 mode
+!			8  = 80486 UNUSED
+!			9  = Pentium UNUSED
+!			10 = Pentium PRO UNUSED
+!			255 = Unknown
 !	...
 !	0x2a:	mem_kbytes	word	size of base memory in kbytes
 !	0x30:	proc_name	byte[16] processor name string UNUSED

--- a/elks/arch/i86/kernel/system.c
+++ b/elks/arch/i86/kernel/system.c
@@ -71,7 +71,7 @@ unsigned int INITPROC setup_arch(void)
     byte_t arch_cpu = SETUP_CPU_TYPE;
     if (arch_cpu > 5)       /* 80286+ IBM PC/AT capabilities or Unknown CPU */
         sys_caps = CAP_ALL;
-    printk("arch %d sys_caps %02x\n", arch_cpu, sys_caps);
+    debug("arch %d sys_caps %02x\n", arch_cpu, sys_caps);
 #endif
 
     return endbss;                      /* used as start address in near heap init */

--- a/elks/arch/i86/kernel/system.c
+++ b/elks/arch/i86/kernel/system.c
@@ -69,7 +69,7 @@ unsigned int INITPROC setup_arch(void)
     sys_caps = SYS_CAPS;    /* custom system capabilities */
 #else
     byte_t arch_cpu = SETUP_CPU_TYPE;
-    if (arch_cpu > 5)       /* IBM PC/AT capabilities */
+    if (arch_cpu > 5)       /* 80286+ IBM PC/AT capabilities or Unknown CPU */
         sys_caps = CAP_ALL;
     printk("arch %d sys_caps %02x\n", arch_cpu, sys_caps);
 #endif

--- a/elks/arch/i86/kernel/system.c
+++ b/elks/arch/i86/kernel/system.c
@@ -71,7 +71,7 @@ unsigned int INITPROC setup_arch(void)
     byte_t arch_cpu = SETUP_CPU_TYPE;
     if (arch_cpu > 5)       /* IBM PC/AT capabilities */
         sys_caps = CAP_ALL;
-    debug("arch %d sys_caps %02x\n", arch_cpu, sys_caps);
+    printk("arch %d sys_caps %02x\n", arch_cpu, sys_caps);
 #endif
 
     return endbss;                      /* used as start address in near heap init */


### PR DESCRIPTION
Requested by @Mellvik in https://github.com/Mellvik/TLVC/pull/97#issuecomment-2447517406 as a means for a quick "fast system" check with which to disable floppy disk caching in the DF driver in the future.

Adds 32-bit CPU test from working XMS 32-bit CPU check to setup's cputest.S, which saves the processor type (arch_cpu) in SETUP_CPU_TYPE (`setupb(0x20)`). 

Note that arch_cpu isn't a global in a previous effort to remove specific CPU tests from the kernel. This means probably best to use `SETUP_CPU_TYPE == 7` for the presence of a 386 or later CPU. Note that unfortunately due to constant selection long ago, the use of `SETUP_CPU_TYPE >= 7` is a bad idea (and still used in setup_arch() for setting SYS_CAPS) because arch_cpu type of 255 is Unknown, which out to be zero, except that's the value for 8088.

This PR also fixes what looked like incorrect handling of CPU testing when CONFIG_ROMCODE is set, but is untested.

Also, it was discovered that cputest.S enabled interrupts after calling, which is prohibited during setup. This apparently can't be avoided for some CPU tests, but interrupts are disabled again at the end of the cputest routine, as the kernel is expected to be started with interrupts disabled for safety reasons.

Tested on QEMU but not real hardware.