### PR TITLE
[kernel] Fix mount ignoring passed device on ROM/ROMFS systems

### DIFF
--- a/elks/fs/romfs/romfs.c
+++ b/elks/fs/romfs/romfs.c
@@ -10,6 +10,7 @@
 #include <linuxmt/mm.h>
 #include <linuxmt/string.h>
 #include <linuxmt/debug.h>
+#include <linuxmt/devnum.h>
 #include <arch/segment.h>
 
 
@@ -320,6 +321,8 @@ static struct super_block * romfs_read_super (struct super_block * s, void * dat
 	struct romfs_super_mem rsm;
 	struct inode * i;
 
+    if (s->s_dev != DEV_ROM)
+        return NULL;
 	while (1) {
 		lock_super (s);
 

--- a/emu86.sh
+++ b/emu86.sh
@@ -16,7 +16,7 @@
 exec emu86 -w 0xe0000 -f image/rom-8088.bin -w 0x80000 -f image/romfs-8088.bin ${1+"$@"}
 
 # just built ROM version using 'make'
-#exec emu86 -w 0xe0000 -f elks/arch/i86/boot/Image -w 0x80000 -f image/romfs.bin ${1+"$@"}
+#exec emu86 -w 0xe0000 -f elks/arch/i86/boot/Image -w 0x80000 -f image/romfs.bin -I image/fd1440.img ${1+"$@"}
 
 # For ELKS Full ROM Configuration:
 # ELKS must be configured minimally with 'cp emu86-rom-full.config .config'


### PR DESCRIPTION
Discovered this working on buildimages.sh.

`mount` must be passed the -t flag on CONFIG_ROMCODE systems to specify the mounted filesystem format.