### PR TITLE
[directfd] Add cache to end of cylinder option

### DIFF
--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -99,7 +99,7 @@
 
 /* Don't touch these, unless you really know what you are doing. */
 #define DEF_INITSEG     0x0100  /* initial Image load address by boot code */
-#define DEF_SYSSEG      0x1300  /* address setup then copies kernel to, then REL_SYSSEG */
+#define DEF_SYSSEG      0x1400  /* address setup then copies kernel to, then REL_SYSSEG */
 #define DEF_SETUPSEG    DEF_INITSEG + 0x20
 #define DEF_SYSMAX      0x2F00  /* maximum system size (=.text+.fartext+.data) */
 

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -123,12 +123,12 @@
 
 #if defined(CONFIG_BLK_DEV_BFD) || defined(CONFIG_BLK_DEV_BHD) || defined(CONFIG_BLK_FD)
 #ifdef CONFIG_TRACK_CACHE           /* floppy track buffer in low mem */
-#   define TRACKSEGSZ      0x2400   /* SECTOR_SIZE * 18 (9216) */
+#   define TRACKSEGSZ   0x2400      /* SECTOR_SIZE * 18 (9216) */
 #else
 #  ifdef CONFIG_BLK_FD
-#  define TRACKSEGSZ      0x0400    /* DF driver requires DMASEG internal to TRACKSEG */
+#  define TRACKSEGSZ    0x0400      /* DF driver requires DMASEG internal to TRACKSEG */
 #  else
-#  define TRACKSEGSZ      0         /* no TRACKSEG buffer */
+#  define TRACKSEGSZ    0           /* no TRACKSEG buffer */
 #  endif
 #endif
 #define TRACKSEG        (DMASEG+(DMASEGSZ>>4))


### PR DESCRIPTION
Adds CACHE_CYLINDER option to direct FD driver to cache until end of cylinder instead of end of track. Additional CACHE_CYLINDER_MAX define sets maximum sector count of cylinder cache (currently 12 = 6K).

DF driver now supports full track, track split block, full cylinder and partial (fixed size until end of cylinder) caching, as well supporting floppies of any sector count. Most of these options are likely to be used only for performance testing the floppy I/O subsystem.

Next step will be automatic disabling of cache for 386+ systems.

Discussed in https://github.com/Mellvik/TLVC/pull/88#issuecomment-2462624378 and tested on QEMU.



