### PR TITLE
[directfd] Disable track/cylinder cache on 32-bit CPUs

### DIFF
--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -51,7 +51,7 @@
 !			4  = 80188
 !			5  = 80186
 !			6  = 80286
-!			7  = 80386
+!			7  = 32-bit CPU (80386+)
 !			8  = 80486 UNUSED
 !			9  = Pentium UNUSED
 !			10 = Pentium PRO UNUSED

--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -1203,7 +1203,8 @@ static void DFPROC redo_fd_request(void)
     startsector = sector;
     numsectors = req->rq_nr_sectors;
 #ifdef CONFIG_TRACK_CACHE
-    use_cache = (command == FD_READ) && (req->rq_errors < 4);
+    use_cache = (command == FD_READ) && (req->rq_errors < 4)
+        && (SETUP_CPU_TYPE != 7 || running_qemu);    /* disable cache on 32-bit systems */
     if (use_cache) {
         /* full track caching only if cache large enough */
         if (CACHE_FULL_TRACK && floppy->sect < CACHE_SIZE)


### PR DESCRIPTION
Disables track and cylinder caching in the DF driver for best performance, from discussions in https://github.com/Mellvik/TLVC/pull/88.

When running QEMU caching is not disabled, since QEMU always emulates a 32-bit CPU. This makes testing the DF cache much easier on QEMU. This should not be an issue, since performance testing, even using IODELAY, remains less than realistic with QEMU.

This PR completes the long set of enhancements to the DF driver regarding cache and performance enhancements. 