### PR TITLE
[boot] Expand /bootopts to 1023 bytes

### DIFF
--- a/bootblocks/boot_minix.c
+++ b/bootblocks/boot_minix.c
@@ -22,6 +22,7 @@
 static byte_t sb_block [BLOCK_SIZE];  // super block block buffer
 #define sb_data	((struct super_block *)sb_block)
 
+static char linux[] = "/linux";
 static int i_now;
 static int i_boot;
 static int loadaddr;
@@ -82,10 +83,10 @@ void load_prog ()
 	load_file ();
 
 	for (int d = 0; d < BLOCK_SIZE /*(int)i_data->i_size*/; d += DIRENT_SIZE) {
-		if (!strcmp ((char *)(d_dir + 2 + d), "linux")) {
+		if (!strcmp ((char *)(d_dir + 2 + d), linux+1)) {
 			i_boot = i_now = (*(int *)(d_dir + d)) - 1;
 			if (i_boot == -1) continue;
-			puts ("/linux");
+			puts (linux);
 			loadaddr = LOADSEG << 4;
 			load_file();
 			continue;
@@ -121,7 +122,7 @@ static int strcmp (const char * s, const char * d)
 
 static void load_super ()
 {
-	disk_read (2, 2, sb_block, seg_data ());
+	disk_read (2, 1, sb_block, seg_data ());
 
 	/*
 	if (sb_data->s_log_zone_size) {

--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -946,7 +946,10 @@ putc:	push %ax
 
 #ifdef CONFIG_BOOTOPTS
 //
-// load /bootopts for FAT filesystem boot
+// load /bootopts file for FAT filesystem boot
+//      If size > 512 bytes, both sectors must be contiguous.
+//      This is currently guaranteed by using a 1K /bootopts in
+//      distribution images, as later edits will remain contiguous.
 //
 // Uses previous boot sector's BPB contents for disk geometry
 // and previous boot sector's buffer which still holds root directory sector.
@@ -990,20 +993,19 @@ bootopts:
 	xor	%bp,%bp
 
 	mov	root_dev,%al	// Physical Device Address
-	mov	$0xD6,%ah		// Read Data
-	mov	$512,%bx
-	test	$0x10,%al		// Check Floppy Disk or Hard Disk
+	mov	$0xD6,%ah	// Read Data
+	mov	$1024,%bx	// 1K bytes
+	test	$0x10,%al	// Check Floppy Disk or Hard Disk
 	jz	pc98_int1b
 #ifdef CONFIG_IMG_FD1232
-	mov	$1024,%bx
-	mov	$0x03,%ch		// 1024 Bytes per sector
-	inc	%dl				// sector number for PC_98 Floppy Disk
+	mov	$0x03,%ch	// 1024 Bytes per sector
+	inc	%dl		// sector number for PC_98 Floppy Disk
 #else
-	mov	$0x02,%ch		// 512 Bytes per sector
-	inc	%dl				// sector number for PC_98 Floppy Disk
+	mov	$0x02,%ch	// 512 Bytes per sector
+	inc	%dl		// sector number for PC_98 Floppy Disk
 #endif
 pc98_int1b:
-	int	$0x1B			// BIOS disk interrupt
+	int	$0x1B		// BIOS disk interrupt
 	pop	%bp
 #else
 	mov	$INITSEG,%ax
@@ -1013,7 +1015,7 @@ pc98_int1b:
 	mov	$DEF_OPTSEG,%ax	// ES:BX = DEF_OPTSEG:0
 	mov	%ax,%es
 	xor	%bx,%bx
-	mov	$0x0201,%ax	// BIOS read disk, 1 sector
+	mov	$0x0202,%ax	// BIOS read disk, 2 sectors
 	int	$0x13		// BIOS disk interrupt
 #endif
 

--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -7,10 +7,9 @@
 ! both setup.s and system has been loaded by the bootblock.
 !
 ! This code asks the bios for memory/disk/other parameters, and
-! puts them in a "safe" place: INITSEG:0-INITSEG:01FF, ie where the
-! boot-block used to be. It is then up to the protected mode
-! system to read them from there before the area is overwritten
-! for buffer-blocks.
+! puts them in a "safe" place: REL_INITSEG:0-REL_INITSEG:01FF, ie where
+! the boot-block used to be. It is then up to the kernel to read them
+! from there before the area is released to the main memory allocator.
 !
 ! Move PS/2 aux init code to psaux.c
 ! (troyer@saifr00.cfsat.Honeywell.COM) 03Oct92
@@ -36,7 +35,7 @@
 !
 ! index
 !	...
-!	4:	display page
+!	4:	display page, 1 byte UNUSED
 !	6:	video mode, 1 byte
 !	7:	screen_cols, 1 byte
 !	8:	video data, 2 bytes
@@ -899,7 +898,6 @@ novga:	mov	%al,14		// CGA 25 rows
 
 	mov	$0x0f,%ah
 	int	$0x10
-	mov	%bx,4		// bh = display page
 	mov	%ax,6		// al = video mode, ah = window width
 
 	call	getcpu		// implemented in cputype.S

--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -946,8 +946,8 @@ putc:	push %ax
 //
 // load /bootopts file for FAT filesystem boot
 //      If size > 512 bytes, both sectors must be contiguous.
-//      This is currently guaranteed by using a 1K /bootopts in
-//      distribution images, as later edits will remain contiguous.
+//      This is currently guaranteed by providing a 1K /bootopts in
+//      distribution images, so later edits will remain contiguous.
 //
 // Uses previous boot sector's BPB contents for disk geometry
 // and previous boot sector's buffer which still holds root directory sector.

--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -1204,7 +1204,7 @@ static void DFPROC redo_fd_request(void)
     numsectors = req->rq_nr_sectors;
 #ifdef CONFIG_TRACK_CACHE
     use_cache = (command == FD_READ) && (req->rq_errors < 4)
-        && (SETUP_CPU_TYPE != 7 || running_qemu);    /* disable cache on 32-bit systems */
+        && (arch_cpu != 7 || running_qemu);     /* disable cache on 32-bit systems */
     if (use_cache) {
         /* full track caching only if cache large enough */
         if (CACHE_FULL_TRACK && floppy->sect < CACHE_SIZE)
@@ -1453,7 +1453,7 @@ static int DFPROC get_fdc_version(void)
     }
     switch (reply_buffer[0]) {
     case 0x80:
-        if (SETUP_CPU_TYPE > 5) {       /* 80286 CPU PC/AT or better */
+        if (arch_cpu > 5) {     /* 80286 CPU PC/AT or better */
             type = FDC_TYPE_8272PC_AT;
             name = "8272A (PC/AT)";
         } else {

--- a/elks/arch/i86/kernel/system.c
+++ b/elks/arch/i86/kernel/system.c
@@ -15,6 +15,7 @@
 seg_t membase, memend;  /* start and end segment of available main memory */
 unsigned int heapsize;  /* max size of kernel near heap */
 byte_t sys_caps;        /* system capabilities bits */
+unsigned char arch_cpu; /* CPU type from cputype.S */
 
 unsigned int INITPROC setup_arch(void)
 {
@@ -65,10 +66,10 @@ unsigned int INITPROC setup_arch(void)
     }
 #endif
 
+    arch_cpu = SETUP_CPU_TYPE;
 #ifdef SYS_CAPS
     sys_caps = SYS_CAPS;    /* custom system capabilities */
 #else
-    byte_t arch_cpu = SETUP_CPU_TYPE;
     if (arch_cpu > 5)       /* 80286+ IBM PC/AT capabilities or Unknown CPU */
         sys_caps = CAP_ALL;
     debug("arch %d sys_caps %02x\n", arch_cpu, sys_caps);

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -15,8 +15,8 @@
 
 /*
  * SETUP_ defines are initialzied by setup.S and queried only during kernel init.
- * The REL_INITSEG segment is released at end of kernel init. For later use the
- * value must be copied, as afterwards setupb/setupw will return incorrect data.
+ * The REL_INITSEG segment is released at end of kernel init. If used later any
+ * values must be copied, as afterwards setupb/setupw will return incorrect data.
  * These defines are overridden for ROM based systems w/o setup code.
  * See setup.S for setupb/setupw offsets.
  */

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -137,30 +137,33 @@
 #define DMASEGEND       DMASEG      /* no DMASEG buffer */
 #endif
 
+/* Define segment locations of low memory, must not overlap */
+
 #ifdef CONFIG_ROMCODE
 #define DMASEG          0x80        /* start of floppy sector buffer */
 #define KERNEL_DATA     DMASEGEND   /* kernel data segment */
 #define SETUP_DATA      CONFIG_ROM_SETUP_DATA
-#endif
 
-#if (defined(CONFIG_ARCH_IBMPC) || defined(CONFIG_ARCH_8018X)) && !defined(CONFIG_ROMCODE)
-/* Define segment locations of low memory, must not overlap */
-#define OPTSEGSZ        0x200       /* max size of /bootopts file (512 bytes max) */
-#define DEF_OPTSEG      0x50        /* 0x200 bytes boot options at lowest usable ram */
-#define REL_INITSEG     0x70        /* 0x200 bytes setup data */
-#define DMASEG          0x90        /* start of floppy sector buffer */
+#else /* !CONFIG_ROMCODE */
+
+#ifdef CONFIG_ARCH_IBMPC
+#define OPTSEGSZ        0x400       /* max size of /bootopts file (1024 bytes max) */
+#define DEF_OPTSEG      0x50        /* 0x400 bytes boot options at lowest usable ram */
+#define REL_INITSEG     0x90        /* 0x200 bytes setup data */
+#define DMASEG          0xB0        /* start of floppy sector buffer */
 #define REL_SYSSEG      DMASEGEND   /* kernel code segment */
 #define SETUP_DATA      REL_INITSEG
 #endif
 
-#if defined(CONFIG_ARCH_PC98) && !defined(CONFIG_ROMCODE)
-/* Define segment locations of low memory, must not overlap */
-#define OPTSEGSZ        0x200       /* max size of /bootopts file (512 bytes max) */
-#define DEF_OPTSEG      0x60        /* 0x200 bytes boot options at lowest usable ram */
-#define REL_INITSEG     0x80        /* 0x200 bytes setup data */
-#define DMASEG          0xA0        /* start of floppy sector buffer */
+#ifdef CONFIG_ARCH_PC98
+#define OPTSEGSZ        0x400       /* max size of /bootopts file (1024 bytes max) */
+#define DEF_OPTSEG      0x60        /* 0x400 bytes boot options at lowest usable ram */
+#define REL_INITSEG     0xA0        /* 0x200 bytes setup data */
+#define DMASEG          0xC0        /* start of floppy sector buffer */
 #define REL_SYSSEG      DMASEGEND   /* kernel code segment */
 #define SETUP_DATA      REL_INITSEG
 #endif
+
+#endif /* !CONFIG_ROMCODE */
 
 #endif

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -13,14 +13,16 @@
 #define CONFIG_MSDOS_PARTITION  1               /* support DOS HD partitions */
 #define CONFIG_FS_DEV           1               /* support FAT /dev folder */
 
+/*
+ * SETUP_ defines are initialzied by setup.S and queried only during kernel init.
+ * The REL_INITSEG segment is released at end of kernel init. For later use the
+ * value must be copied, as afterwards setupb/setupw will return incorrect data.
+ * These defines are overridden for ROM based systems w/o setup code.
+ * See setup.S for setupb/setupw offsets.
+ */
+
 #ifdef CONFIG_ARCH_IBMPC
 #define MAX_SERIAL              4               /* max number of serial tty devices*/
-
-/*
- * Setup data - normally queried by startup setup.S code, but can
- * be overridden for embedded systems with less overhead.
- * See setup.S for more details.
- */
 #define SETUP_VID_COLS          setupb(7)       /* BIOS video # columns */
 #define SETUP_VID_LINES         setupb(14)      /* BIOS video # lines */
 #define SETUP_CPU_TYPE          setupb(0x20)    /* processor type */

--- a/elks/include/linuxmt/kernel.h
+++ b/elks/include/linuxmt/kernel.h
@@ -18,6 +18,7 @@
 #define structof(p,t,m) ((t *) ((char *) (p) - offsetof (t,m)))
 
 extern char running_qemu;
+extern unsigned char arch_cpu;
 extern dev_t dev_console;
 extern int debug_level;
 

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -113,7 +113,7 @@ void start_kernel(void)
     setsp(&task->t_regs.ax);    /* change to idle task stack */
     kernel_init();              /* continue init running on idle task stack */
 
-    /* fork and setup procedure init_task() to run as task #1 */
+    /* fork and setup procedure init_task() to run as task #1 on reschedule */
     kfork_proc(init_task);
     wake_up_process(&task[1]);
 
@@ -126,7 +126,7 @@ void start_kernel(void)
 #ifdef CONFIG_TIMER_INT0F
         int0F();        /* simulate timer interrupt hooked on IRQ 7 */
 #else
-        idle_halt();    /* halt until interrupt to save poer */
+        idle_halt();    /* halt until interrupt to save power */
 #endif
     }
 }
@@ -619,16 +619,16 @@ static void INITPROC finalize_options(void)
 
     /* convert argv array to stack array for sys_execv*/
     args--;
-    argv_init[0] = (char *)args;        /* 0 = argc*/
+    argv_init[0] = (char *)args;            /* 0 = argc*/
     char *q = (char *)&argv_init[args+2+envs+1];
-    for (i=1; i<=args; i++) {           /* 1..argc = av*/
+    for (i=1; i<=args; i++) {               /* 1..argc = av*/
         char *p = argv_init[i];
         char *savq = q;
         while ((*q++ = *p++) != 0)
             ;
         argv_init[i] = (char *)(savq - (char *)argv_init);
     }
-    /*argv_init[args+1] = NULL;*/       /* argc+1 = 0*/
+    /*argv_init[args+1] = NULL;*/           /* argc+1 = 0*/
 #if ENV
     if (envs) {
         for (i=0; i<envs; i++) {

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -211,7 +211,7 @@ static void INITPROC kernel_init(void)
 static void INITPROC kernel_banner(seg_t init, seg_t extra)
 {
 #ifdef CONFIG_ARCH_IBMPC
-    printk("PC/%cT class cpu %d, ", (sys_caps & CAP_PC_AT) ? 'A' : 'X', SETUP_CPU_TYPE);
+    printk("PC/%cT class cpu %d, ", (sys_caps & CAP_PC_AT) ? 'A' : 'X', arch_cpu);
 #endif
 
 #ifdef CONFIG_ARCH_PC98
@@ -267,7 +267,16 @@ static void INITPROC do_init_task(void)
         sys_dup(num);       /* open stderr*/
     //}
 
+
 #ifdef CONFIG_BOOTOPTS
+    /* Release kernel data associated with /bootopts parsing */
+    heap_add(options, OPTSEGSZ);
+
+    /* Release /bootopts load segment (DEF_OPTSEG) and setup.S data segment (REL_INITSEG).
+     * Must not use SETUP_xxx setupw/setupb after this.
+     */
+    seg_add(DEF_OPTSEG, DMASEG);
+
     /* pass argc/argv/env array to init_command */
 
     /* unset special sys_wait4() processing if pid 1 not /bin/init*/

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -46,6 +46,7 @@ int tracing;
 int nr_ext_bufs, nr_xms_bufs, nr_map_bufs;
 char running_qemu;
 static int boot_console;
+static segext_t umbtotal;
 static char bininit[] = "/bin/init";
 static char binshell[] = "/bin/sh";
 #ifdef CONFIG_SYS_NO_BININIT
@@ -75,7 +76,6 @@ static struct {
         seg_t base;
         segext_t len;
     } umbseg[MAX_UMB], *nextumb;
-    segext_t umbtotal;
     unsigned char options[OPTSEGSZ];
 #if ENV
     char *envp_init[MAX_INIT_ENVS];
@@ -164,7 +164,7 @@ static void INITPROC early_kernel_init(void)
         if (p->base) {
             debug("umb segment from %x to %x\n", p->base, p->base + p->len);
             seg_add(p->base, p->base + p->len);
-            opts.umbtotal += p->len;
+            umbtotal += p->len;
         }
     }
 #endif
@@ -243,7 +243,7 @@ static void INITPROC kernel_banner(seg_t init, seg_t extra)
 #endif
     printk("data %x end %x top %x %u+%u+%uK free\n",
            kernel_ds, membase, memend, (int) ((memend - membase) >> 6),
-           extra >> 6, opts.umbtotal >> 6);
+           extra >> 6, umbtotal >> 6);
 }
 
 static void INITPROC try_exec_process(const char *path)

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -440,8 +440,8 @@ static int INITPROC parse_options(void)
     fmemcpyb(options, kernel_ds, 0, DEF_OPTSEG, sizeof(options));
 
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
-    /* check file starts with ## and max len 511 bytes*/
-    if (*(unsigned short *)options != 0x2323 || options[OPTSEGSZ-1])
+    /* check file starts with ##, one or two sectors, max 1023 bytes */
+    if (*(unsigned short *)options != 0x2323 || (options[511] && options[OPTSEGSZ-1]))
         return 0;
 
     next = line;

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,4 +1,4 @@
-## max 511 bytes
+## ELKS /bootopts boot options file, max 1023 bytes
 #TZ=MDT6
 #LOCALIP=10.0.2.16
 #HOSTNAME=elks16
@@ -11,7 +11,7 @@
 #task=16 buf=64 cache=8 file=64 inode=96 heap=44000 # std
 #task=6 buf=8 cache=4 file=20 inode=24 heap=15000 n # min w/no rc.sys
 #sync=30
-#init=/bin/init 3 n	# muser serial no rc.sys
+#init=/bin/init 3 n	# multiuser serial no rc.sys
 #init=/bin/sash
 #root=df0
 #root=hda1 ro


### PR DESCRIPTION
Requested by @Mellvik some time ago.

This PR adds the ability to use a larger /bootopts file for system configuration, on both MINIX and FAT filesystems. This will allow for more text, explanations or multiple scenarios to be saved. The current only caveat is that when /bootopts is larger than 512 bytes, both disk sectors must be contiguous. This should normally not be a problem since /bootopts is now distributed as a file > 512 bytes using contiguous sectors, and editing or rewriting the file will keep the same sector numbers on FAT. MINIX uses 1K blocks so this is not an issue.

The larger /bootopts file was already almost working, as MINIX already reads two 512-byte disk sectors per block. While looking deeper into the implementation, some subtle bugs were found and fixed, noted below. In addition, several related features were added at the same time, including the release of all the low memory and kernel data segment memory used for /bootopts buffers back to main memory and the kernel heap respectively.

Features added:
- /bootopts can now work with double its previous size, up to 1023 bytes.
- The 1024 byte DEF_OPTSEG as well as 512 byte REL_INITSEG (setup.S data segment) are released for main memory use after /bootopts processing.
- MINIX boot now only reads a single sector for the superblock instead of two.
- Six new bytes (total 8) are now available in the MINIX boot sector, allowing for some future expansion. Was 2 available.

Bugs fixed:
- On PC-98 1232k floppies which use a 1K sector, the /bootopts actually overwrote REL_INITSEG during startup. This didn't seem to be a problem with the random initialization, as setup.S reinitialized most SETUP_ variables on startup. If REL_INITSEG hadn't directly followed DEF_OPTSEG, this would have been a system crash.
- Same problem for MINIX, the boot loader was reading a 1K block the whole time into a 512-byte DEF_OPTSEG buffer.

Caveats:
- /bootopts must be contiguous sectors on FAT filesystems. This shouldn't be a problem since its shipped contiguous.
- SETUP_xxx defines can only be used during kernel initialization, as REL_INITSEG is released. Setup variables needing to be accessed during normal kernel operation must be copied during kernel init.

@Mellvik: Interestingly, all this work started as the result of playing with a [cool macOS hex editor](https://hexfiend.com). I tried it out and happened to be looking at the hex dump image/fd1440.img and immediately noticed two "linux" strings in the boot_minix.o second boot sector payload. I figured the boot sector code size could be decreased, and that started the process of noticing exactly how /bootopts was being loaded, and the overwrite occurring at REL_INITSEG... The attention was still focused on the config.h DMASEG and REL_SYSSEG areas and down the rabbit hole I went :)

I highly recommend Hex Fiend, if you set the column width to 32, filesystem layouts become very apparent while scrolling through floppy disk images. Seeing filesystem layouts visually really helps see what is going on.
