### PR TITLE
[watcom libc] Add routines required for JWasm port

### DIFF
--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -163,4 +163,8 @@ int vsscanf(char *sp, const char *fmt, va_list ap);
 FILE *popen(const char *, const char *);
 int pclose(FILE *);
 
+#ifdef __WATCOMC__
+int remove(const char *filename);
+#endif
+
 #endif /* __STDIO_H */

--- a/libc/include/string.h
+++ b/libc/include/string.h
@@ -51,6 +51,9 @@ char *strsep(char **, const char *);
 size_t strcspn(const char *, const char *);
 size_t strspn(const char *, const char *);
 
+char *strlwr(char *str);
+char *strupr(char *str);
+
 /* Linux silly hour */
 char *strfry(char *);
 

--- a/libc/string/Makefile
+++ b/libc/string/Makefile
@@ -31,6 +31,8 @@ OBJS = \
 	strspn.o \
 	strstr.o \
 	strtok.o \
+	strlwr.o \
+	strupr.o \
 	# end of list
 
 .PHONY: all

--- a/libc/string/strlwr.c
+++ b/libc/string/strlwr.c
@@ -1,0 +1,12 @@
+#include <string.h>
+#include <ctype.h>
+
+char *
+strlwr(char *str)
+{
+    unsigned char *p;
+
+    for (p = (unsigned char *)str; *p != '\0'; p++)
+        *p = tolower(*p);
+    return str;
+}

--- a/libc/string/strupr.c
+++ b/libc/string/strupr.c
@@ -1,0 +1,12 @@
+#include <string.h>
+#include <ctype.h>
+
+char *
+strupr(char *str)
+{
+    unsigned char *p;
+
+    for (p = (unsigned char *)str; *p != '\0'; p++)
+        *p = toupper(*p);
+    return str;
+}

--- a/libc/watcom/asm/i8ls086.asm
+++ b/libc/watcom/asm/i8ls086.asm
@@ -1,0 +1,65 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
+;*               DESCRIBE IT HERE!
+;*
+;*****************************************************************************
+
+
+;========================================================================
+;==     Name:           I8LS,U8LS                                      ==
+;==     Operation:      integer eight byte left shift                  ==
+;==     Inputs:         AX:BX:CX:DX integer M1                         ==
+;==                     SI          shift count                        ==
+;==     Outputs:        AX:BX:CX:DX result                             ==
+;========================================================================
+include mdef.inc
+include struct.inc
+
+        modstart        i8ls086
+
+        xdefp   __I8LS
+        xdefp   __U8LS
+
+        defp    __I8LS
+        defp    __U8LS
+        test    si,si                   ; shifting anything?
+        _if     ne                      ; if so then
+          _loop                         ; - top of loop
+            shl dx,1                    ; - - shift one bit
+            rcl cx,1                    ; - - ...
+            rcl bx,1                    ; - - ...
+            rcl ax,1                    ; - - ...
+            dec si                      ; - - decrement shift count
+          _until e                      ; - kick out if done
+        _endif                          ; endif
+        ret
+        endproc __U8LS
+        endproc __I8LS
+
+        endmod
+        end

--- a/libc/watcom/asm/pia.asm
+++ b/libc/watcom/asm/pia.asm
@@ -1,0 +1,77 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
+;*               DESCRIBE IT HERE!
+;*
+;*****************************************************************************
+
+
+;========================================================================
+;==     Name:           PIA,PIS                                        ==
+;==     Operation:      Pointer integer add and subtract               ==
+;==     Inputs:         DX:AX pointer                                  ==
+;==                     CX:BX long int                                 ==
+;==     Outputs:        DX:AX has DX:AX op CX:BX as  pointer           ==
+;==     Volatile:       DX:AX and CX:BX                                ==
+;==                                                                    ==
+;========================================================================
+include mdef.inc
+
+
+extrn  "C",_HShift      : byte
+
+        modstart        pia
+
+        xdefp   __PIA
+        xdefp   __PIS
+
+        defp    __PIS
+        neg     cx              ; negate the 32 bit integer
+        neg     bx              ; ...
+        sbb     cx,0            ; ...
+
+        defp    __PIA
+        add     ax,bx           ; add offsets
+        adc     cx,0            ; calculate overflow
+        mov     bx,cx           ; shuffle overflow info bx
+if (_MODEL and (_BIG_DATA or _HUGE_DATA)) and ((_MODEL and _DS_PEGGED) eq 0)
+        push    ds              ; need a segment register
+        mov     cx,seg _HShift  ; get the huge shift value
+        mov     ds,cx           ; ...
+        mov     cl,ds:_HShift   ; ...
+        pop     ds              ; restore register
+else
+        mov     cl,_HShift      ; get huge shift value
+endif
+        shl     bx,cl           ; adjust the overflow by huge shift value
+        add     dx,bx           ; and add into selector value
+        ret                     ; ...
+        endproc __PIA
+        endproc __PIS
+
+        endmod
+        end

--- a/libc/watcom/asm/u8rs086.asm
+++ b/libc/watcom/asm/u8rs086.asm
@@ -1,0 +1,62 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
+;*               DESCRIBE IT HERE!
+;*
+;*****************************************************************************
+
+
+;========================================================================
+;==     Name:           U8RS                                           ==
+;==     Operation:      integer eight byte right shift (unsigned)      ==
+;==     Inputs:         AX:BX:CX:DX integer M1                         ==
+;==                     SI          shift count                        ==
+;==     Outputs:        AX:BX:CX:DX result                             ==
+;========================================================================
+include mdef.inc
+include struct.inc
+
+        modstart        u8rs086
+
+        xdefp   __U8RS
+
+        defp    __U8RS
+        test    si,si                   ; shifting anything?
+        _if     ne                      ; if so then
+          _loop                         ; - top of loop
+            shr ax,1                    ; - - shift one bit
+            rcr bx,1                    ; - - ...
+            rcr cx,1                    ; - - ...
+            rcr dx,1                    ; - - ...
+            dec si                      ; - - decrement shift count
+          _until e                      ; - kick out if done
+        _endif                          ; endif
+        ret
+        endproc __U8RS
+
+        endmod
+        end

--- a/libc/watcom/syscall/remove.c
+++ b/libc/watcom/syscall/remove.c
@@ -1,0 +1,42 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  ELKS remove() implementation (identical to unlink()).
+*
+****************************************************************************/
+
+
+#include <unistd.h>
+#include "watcom/syselks.h"
+
+
+int remove( const char *filename )
+{
+    sys_setseg(filename);
+    syscall_res res = sys_call1( SYS_unlink, (unsigned)filename );
+    __syscall_return( int, res );
+}


### PR DESCRIPTION
Adds C library and system call routines required for possible JWasm port, discussed in #2103.

Adds U8RS, U8LS and PIA internal OWC routines to libc/watcom/asm.
Adds remove() system call; identical to unlink().
Adds strupr() and strlwr() libc routines.
