### PR TITLE
[kernel,libc] Add _fmemfree system call and wrapper functions

### DIFF
--- a/elks/arch/i86/kernel/strace.h
+++ b/elks/arch/i86/kernel/strace.h
@@ -171,5 +171,6 @@ struct sc_info elks_table2[] = {
     ENTRY("connect",        packinfo(3, P_SSHORT, P_PDATA,   P_SSHORT )),
     ENTRY("setsockopt",     packinfo(5, P_SSHORT, P_SSHORT,  P_SSHORT )), /* +2 args*/
     ENTRY("getsocknam",     packinfo(4, P_SSHORT, P_DATA,    P_PUSHORT)), /* +1 arg*/
-    ENTRY("fmemalloc",      packinfo(2, P_USHORT, P_PUSHORT, P_NONE)   ),   // 206
+    ENTRY("fmemalloc",      packinfo(2, P_USHORT, P_PUSHORT, P_NONE)   ),
+    ENTRY("fmemfree",       packinfo(1, P_USHORT, P_NONE,    P_NONE)   ),   // 207
 };

--- a/elks/arch/i86/kernel/syscall.dat
+++ b/elks/arch/i86/kernel/syscall.dat
@@ -105,6 +105,7 @@ connect		+203	3	= CONFIG_SOCKET
 setsockopt	+204	5	= CONFIG_SOCKET
 getsocknam	+205	4	= CONFIG_SOCKET
 fmemalloc	+206	2	*
+fmemfree	+207	1	*
 #
 # Name			No	Args	Flag&comment
 #

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -294,6 +294,28 @@ int sys_fmemalloc(int paras, unsigned short *pseg)
 	return 0;
 }
 
+// free process allocated memory
+int sys_fmemfree(unsigned short segment)
+{
+	list_s *n;
+
+	for (n = _seg_all.next; n != &_seg_all; ) {
+		segment_s * seg = structof (n, segment_s, all);
+
+        if (seg->base == segment) {
+		    if (seg->pid == current->pid) {
+			    seg_free(seg);
+                return 0;
+            }
+            printk("sys_fmemfree: not owner %04x\n", segment);
+            return -EACCES;
+        }
+		n = seg->all.next;
+	}
+    printk("sys_fmemfree: segment not found %04x\n", segment);
+    return -EINVAL;
+}
+
 // free all program allocated segments for PID pid
 void seg_free_pid(pid_t pid)
 {

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -307,12 +307,12 @@ int sys_fmemfree(unsigned short segment)
 			    seg_free(seg);
                 return 0;
             }
-            printk("sys_fmemfree: not owner %04x\n", segment);
+            debug("sys_fmemfree: not owner %04x\n", segment);
             return -EACCES;
         }
 		n = seg->all.next;
 	}
-    printk("sys_fmemfree: segment not found %04x\n", segment);
+    debug("sys_fmemfree: segment not found %04x\n", segment);
     return -EINVAL;
 }
 

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -302,18 +302,18 @@ int sys_fmemfree(unsigned short segment)
 	for (n = _seg_all.next; n != &_seg_all; ) {
 		segment_s * seg = structof (n, segment_s, all);
 
-        if (seg->base == segment) {
-		    if (seg->pid == current->pid) {
-			    seg_free(seg);
-                return 0;
-            }
-            debug("sys_fmemfree: not owner %04x\n", segment);
-            return -EACCES;
-        }
+		if (seg->base == segment) {
+			if (seg->pid == current->pid) {
+				seg_free(seg);
+				return 0;
+			}
+			debug("sys_fmemfree: not owner %04x\n", segment);
+			return -EACCES;
+		}
 		n = seg->all.next;
 	}
-    debug("sys_fmemfree: segment not found %04x\n", segment);
-    return -EINVAL;
+	debug("sys_fmemfree: segment not found %04x\n", segment);
+	return -EINVAL;
 }
 
 // free all program allocated segments for PID pid

--- a/elkscmd/man/man2/fmemalloc.2
+++ b/elkscmd/man/man2/fmemalloc.2
@@ -5,6 +5,7 @@ _fmemalloc \- allocate far memory outside process
 .nf
 .ft B
 _fmemalloc(int \fIparas\fP, unsigned short *\fIpseg\fP)
+_fmemfree(unsigned short \fIseg\fP)
 .ft R
 .fi
 .SH DESCRIPTION
@@ -16,6 +17,10 @@ paragraphs of main memory
 from outside the process for use using a __far pointer within the application.
 The segment address of the memory is stored in the pointer
 .IR pseg .
+.PP
+.B _fmemfree
+frees the memory segment allocated by a previous
+.BR _fmemalloc .
 .SH "RETURN VALUE
 The value 0 is returned if no error occurs.  Otherwise,
 the call returns a negative error number.

--- a/elkscmd/man/man3/fmemalloc.3
+++ b/elkscmd/man/man3/fmemalloc.3
@@ -7,6 +7,7 @@ fmemalloc \- allocate far memory outside process
 #include <stdlib.h>
 
 void __far *fmemalloc(unsigned long \fIsize\fP)
+int fmemfree(void __far *\fIptr\fP)
 .ft R
 .fi
 .SH DESCRIPTION
@@ -19,7 +20,11 @@ within the application.
 The
 .IR size
 parameter will be rounded up to the next paragraph boundary.
-
+.PP
+.B fmemfree
+frees memory allocated by a prevous
+.BR fmemalloc .
+.PP
 Any allocated memory will be automatically freed on exit from the application.
 .SH "RETURN VALUE
 The value 0 is returned if no error occurs.  Otherwise,

--- a/libc/include/malloc.h
+++ b/libc/include/malloc.h
@@ -31,6 +31,8 @@ extern void __wcnear *(*__alloca_alloc)(size_t);
 
 /* alloc from main memory */
 void __far *fmemalloc(unsigned long size);
+int fmemfree(void __far *ptr);
 int _fmemalloc(int paras, unsigned short *pseg);
+int _fmemfree(unsigned short seg);
 
 #endif

--- a/libc/include/watcom/syselks.h
+++ b/libc/include/watcom/syselks.h
@@ -149,6 +149,7 @@ typedef int syscall_res;
 #define SYS_setsockopt          204
 #define SYS_getsocknam          205
 #define SYS_fmemalloc           206
+#define SYS_fmemfree            207
 
 
 #define _sys_exit(rc)       sys_call1n(SYS_exit, rc)

--- a/libc/malloc/Makefile
+++ b/libc/malloc/Makefile
@@ -27,6 +27,7 @@ OBJS = \
 	realloc.o \
 	sbrk.o \
 	fmemalloc.o \
+	fmemfree.o \
 
 .PHONY: all
 

--- a/libc/malloc/fmemfree.c
+++ b/libc/malloc/fmemfree.c
@@ -1,0 +1,7 @@
+#include <malloc.h>
+
+/* free from main memory */
+int fmemfree(void __far *ptr)
+{
+    return _fmemfree((unsigned short)((unsigned long)ptr >> 16));
+}

--- a/libc/watcom/syscall/crt0.c
+++ b/libc/watcom/syscall/crt0.c
@@ -45,6 +45,7 @@ char **__argv;
 char *__program_filename;
 char **environ;
 unsigned int __stacklow;
+unsigned char _HShift = 12;      /* huge pointer support required by pia.asm */
 
 static unsigned int _SP(void);
 #pragma aux _SP = __value [__sp]

--- a/libc/watcom/syscall/fmemfree.c
+++ b/libc/watcom/syscall/fmemfree.c
@@ -1,0 +1,14 @@
+/****************************************************************************
+*
+* Description:  ELKS _fmemfree() system call.
+*
+****************************************************************************/
+
+#include <malloc.h>
+#include "watcom/syselks.h"
+
+int _fmemfree( unsigned short __seg )
+{
+    syscall_res res = sys_call1( SYS_fmemfree, __seg);
+    __syscall_return( int, res );
+}


### PR DESCRIPTION
Adds the ability to free memory allocated by `fmemalloc`. This will likely be required for large/huge memory allocations for the JWasm port in #2103. Supports ELKS and OWC compilers/libraries.

Usage:
```
#include <stdlib.h>
...
    char __far *p = fmemalloc(0x10000L);  // allocate 64K of main memory
...
    fmemfree(p); // free 64k memory
```

Updates fmemalloc man pages in sections 2 and 3.
Also adds `_HShift` global for OWC huge pointer support, required in pia.asm.