### PR TITLE
[libc,cmds] Add arena numbers to meminfo -m, prohibit fprintf to fputs conversions

### DIFF
--- a/bootblocks/boot_minix.c
+++ b/bootblocks/boot_minix.c
@@ -122,7 +122,7 @@ static int strcmp (const char * s, const char * d)
 
 static void load_super ()
 {
-	disk_read (2, 1, sb_block, seg_data ());
+	disk_read (2, 1, sb_block, seg_data ());    /* cheat and read only first sector */
 
 	/*
 	if (sb_data->s_log_zone_size) {

--- a/elkscmd/Makefile-rules
+++ b/elkscmd/Makefile-rules
@@ -48,7 +48,7 @@ HOSTCFLAGS = -O3
 
 CLBASE =  -mcmodel=small -melks-libc -mtune=i8086 -Wall -Os
 CLBASE += -mno-segment-relocation-stuff
-CLBASE += -fno-inline -fno-builtin-printf
+CLBASE += -fno-inline -fno-builtin-printf -fno-builtin-fprintf
 #CLBASE += -mregparmcall
 ifeq ($(CONFIG_APPS_FTRACE), y)
     CLBASE += -fno-omit-frame-pointer -fno-optimize-sibling-calls

--- a/elkscmd/sys_utils/meminfo.c
+++ b/elkscmd/sys_utils/meminfo.c
@@ -31,6 +31,7 @@ int sflag;      /* show system memory*/
 int mflag;      /* show main memory*/
 int allflag;    /* show all memory*/
 
+int fd;
 unsigned int ds;
 unsigned int heap_all;
 unsigned int seg_all;
@@ -38,7 +39,7 @@ unsigned int taskoff;
 int maxtasks;
 struct task_struct task_table;
 
-int memread(int fd, word_t off, word_t seg, void *buf, int size)
+int memread(word_t off, word_t seg, void *buf, int size)
 {
     if (lseek(fd, LINEARADDRESS(off, seg), SEEK_SET) == -1)
         return 0;
@@ -49,39 +50,39 @@ int memread(int fd, word_t off, word_t seg, void *buf, int size)
     return 1;
 }
 
-word_t getword(int fd, word_t off, word_t seg)
+word_t getword(word_t off, word_t seg)
 {
     word_t word;
 
-    if (!memread(fd, off, seg, &word, sizeof(word)))
+    if (!memread(off, seg, &word, sizeof(word)))
         return 0;
     return word;
 }
 
-void process_name(int fd, unsigned int off, unsigned int seg)
+void process_name(unsigned int off, unsigned int seg)
 {
     word_t argc, argv;
     char buf[80];
 
-    argc = getword(fd, off, seg);
+    argc = getword(off, seg);
 
     while (argc-- > 0) {
         off += 2;
-        argv = getword(fd, off, seg);
-        if (!memread(fd, argv, seg, buf, sizeof(buf)))
+        argv = getword(off, seg);
+        if (!memread(argv, seg, buf, sizeof(buf)))
             return;
         printf("%s ",buf);
         break;      /* display only executable name for now */
     }
 }
 
-struct task_struct *find_process(int fd, unsigned int seg)
+struct task_struct *find_process(unsigned int seg)
 {
     int i;
     int off = taskoff;
 
     for (i = 0; i < maxtasks; i++) {
-        if (!memread(fd, off, ds, &task_table, sizeof(task_table))) {
+        if (!memread(off, ds, &task_table, sizeof(task_table))) {
             perror("taskinfo");
             exit(1);
         }
@@ -98,65 +99,68 @@ static long total_segsize = 0;
 static char *segtype[] =
     { "free", "CSEG", "DSEG", "DDAT", "FDAT", "BUF ", "RDSK" };
 
-void display_seg(int fd, word_t mem)
+void display_seg(word_t mem)
 {
-    seg_t segbase = getword(fd, mem + offsetof(segment_s, base), ds);
-    segext_t segsize = getword(fd, mem + offsetof(segment_s, size), ds);
-    word_t segflags = getword(fd, mem + offsetof(segment_s, flags), ds) & SEG_FLAG_TYPE;
-    byte_t ref_count = getword(fd, mem + offsetof(segment_s, ref_count), ds);
+    seg_t segbase = getword(mem + offsetof(segment_s, base), ds);
+    segext_t segsize = getword(mem + offsetof(segment_s, size), ds);
+    word_t segflags = getword(mem + offsetof(segment_s, flags), ds) & SEG_FLAG_TYPE;
+    byte_t ref_count = getword(mem + offsetof(segment_s, ref_count), ds);
     struct task_struct *t;
 
     printf("   %04x   %s %7ld %4d  ",
         segbase, segtype[segflags], (long)segsize << 4, ref_count);
     if (segflags == SEG_FLAG_CSEG || segflags == SEG_FLAG_DSEG) {
-        if ((t = find_process(fd, mem)) != NULL) {
-            process_name(fd, t->t_begstack, t->t_regs.ss);
+        if ((t = find_process(mem)) != NULL) {
+            process_name(t->t_begstack, t->t_regs.ss);
         }
     }
 
     total_segsize += (long)segsize << 4;
 }
 
-void dump_segs(int fd)
+void dump_segs(void)
 {
-    word_t n, mem;
+    word_t n, mem, arena = 2;
     seg_t segbase, oldbase = 0;
 
     printf("    SEG   TYPE    SIZE  CNT  NAME\n");
-    n = getword (fd, seg_all + offsetof(list_s, next), ds);
+    n = getword (seg_all + offsetof(list_s, next), ds);
     while (n != seg_all) {
         mem = n - offsetof(segment_s, all);
-        segbase = getword(fd, mem + offsetof(segment_s, base), ds);
-        if (segbase < oldbase) printf("\n");
+        segbase = getword(mem + offsetof(segment_s, base), ds);
+        if (segbase < oldbase)
+            printf("[Arena %d]\n", arena++);
         oldbase = segbase;
-        display_seg(fd, mem);
+        display_seg(mem);
         printf("\n");
 
         /* next in list */
-        n = getword(fd, n + offsetof(list_s, next), ds);
+        n = getword(n + offsetof(list_s, next), ds);
     }
 }
 
-void dump_heap(int fd)
+void dump_heap(void)
 {
     word_t total_size = 0;
     word_t total_free = 0;
     static char *heaptype[] =
         { "free", "MEM ", "DRVR", "TTY ", "TASK", "BUFH", "PIPE", "INOD", "FILE", "CACH"};
 
-    printf("  HEAP   TYPE  SIZE    SEG   TYPE    SIZE  CNT  NAME\n");
+    /* split into two to save floppy space; linker will combine 2nd with above printf */
+    printf("  HEAP   TYPE  SIZE");
+    printf("    SEG   TYPE    SIZE  CNT  NAME\n");
 
-    word_t n = getword (fd, heap_all + offsetof(list_s, next), ds);
+    word_t n = getword (heap_all + offsetof(list_s, next), ds);
     while (n != heap_all) {
         word_t h = n - offsetof(heap_s, all);
-        word_t size = getword(fd, h + offsetof(heap_s, size), ds);
-        byte_t tag = getword(fd, h + offsetof(heap_s, tag), ds) & HEAP_TAG_TYPE;
+        word_t size = getword(h + offsetof(heap_s, size), ds);
+        byte_t tag = getword(h + offsetof(heap_s, tag), ds) & HEAP_TAG_TYPE;
         word_t mem = h + sizeof(heap_s);
         word_t segflags;
         int free, app, tty, buffer, system;
 
         if (tag == HEAP_TAG_SEG)
-            segflags = getword(fd, mem + offsetof(segment_s, flags), ds) & SEG_FLAG_TYPE;
+            segflags = getword(mem + offsetof(segment_s, flags), ds) & SEG_FLAG_TYPE;
         else segflags = -1;
         free = (tag == HEAP_TAG_FREE || segflags == SEG_FLAG_FREE);
         app = ((tag == HEAP_TAG_SEG)
@@ -176,14 +180,14 @@ void dump_heap(int fd)
 
             switch (tag) {
             case HEAP_TAG_SEG:
-                display_seg(fd, mem);
+                display_seg(mem);
                 break;
             }
             printf("\n");
         }
 
         /* next in heap*/
-        n = getword(fd, n + offsetof(list_s, next), ds);
+        n = getword(n + offsetof(list_s, next), ds);
     }
 
     printf("  Heap/free   %5u/%5u Total mem %7ld\n", total_size, total_free, total_segsize);
@@ -196,7 +200,7 @@ void usage(void)
 
 int main(int argc, char **argv)
 {
-    int fd, c;
+    int c;
     struct mem_usage mu;
 
     if (argc < 2)
@@ -242,12 +246,12 @@ int main(int argc, char **argv)
           perror("meminfo");
           return 1;
     }
-    if (!memread(fd, taskoff, ds, &task_table, sizeof(task_table))) {
+    if (!memread(taskoff, ds, &task_table, sizeof(task_table))) {
         perror("taskinfo");
     }
     if (mflag)
-        dump_segs(fd);
-    else dump_heap(fd);
+        dump_segs();
+    else dump_heap();
 
     if (!ioctl(fd, MEM_GETUSAGE, &mu)) {
         /* note MEM_GETUSAGE amounts are floors, so total may display less by 1k than actual*/

--- a/elkscmd/tui/.gitignore
+++ b/elkscmd/tui/.gitignore
@@ -1,9 +1,10 @@
 *.o
-fm
-matrix
 cons
-ttyinfo
+fm
+invaders
+matrix
 sl
 ttyclock
-ttytetris
+ttyinfo
 ttypong
+ttytetris


### PR DESCRIPTION
While cleaning up `meminfo -m` blank lines and adding arena numbers instead (see screenshot) it was noticed that `meminfo` was ~30 bytes over 4K. Trying to save those bytes involved another couple of changes; sharing some strings, and using `fd` as a global, rather than being passed around to most all the internal functions. Discussed with @Mellvik in https://github.com/Mellvik/TLVC/pull/105#issuecomment-2486575615. Sorry about all the new changes to reduce size, just after you ported the previous version, with all its changes!!


It was also noticed that while the `-fno-builtin-printf` option had already been added, prohibiting GCC compilation conversion of printf to fputs, this did not apply to fprintf being converted to fputs! After reading everywhere for a solution to no avail, I guessed at `-fno-builtin-fprintf` which was accepted. Recompiling all applications resulted in saving 4K floppy space, apparently from not dragging in the extra fputs code into a number of applications. 

Here's `meminfo -m` without blank lines:
<img width="832" alt="Screen Shot 2024-11-19 at 11 28 02 AM" src="https://github.com/user-attachments/assets/53ccdc76-cb09-4e71-91b9-caa447f03bd6">
