### PR TITLE
[libc] Properly handle max malloc (=32764 bytes) in v7malloc

### DIFF
--- a/elkscmd/test/libc/malloc.c
+++ b/elkscmd/test/libc/malloc.c
@@ -15,18 +15,14 @@ TEST_CASE(malloc_malloc_free) {
         free(p);
     }
 
-    /* TODO:BUG: causes hang at 100% CPU */
-#if 0
     errno = 0;
-    p = malloc((size_t) - 1);
+    p = malloc((size_t)-1);
     if (p == NULL) {
         EXPECT_EQ(errno, ENOMEM);
     } else {
         EXPECT_EQ(errno, 0);
-        memset(p, 0xff, (size_t) - 1);
         free(p);
     }
-#endif
 
     /* strange sizes are fine; memory is writable and free-able */
     for (int i = 1; i < 1024; i += 123) {


### PR DESCRIPTION
More v7malloc fixes paying proper attention to signed vs unsigned compares, 16-bit multiply overflow and address wrapping, all used within the allocation routine. This version properly handles the maximum allocation possible given it's`sbrk` implementation and 16-bit int, which is `malloc(32764)`.

Compiling with `-Wextra` also produced more warnings which are now fixed.

V7malloc is currently not used within any applications except `fm`, where it was required due to our current malloc fragmenting the heap. I am considering replacing the libc malloc with v7malloc. There is considerable difference in heap usage and fragmentation between malloc and realloc between the two implementations. Actual allocation speed performance is considered as less important than better heap management for our smaller address space.