### PR TITLE
[cmds] Fix compiler warnings based on added -Wextra flag

### DIFF
--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -194,7 +194,7 @@ CFLAGS += -Wno-missing-prototypes
 CFLAGS += -Wno-empty-body
 #CFLAGS += -Wstrict-prototypes
 #CFLAGS += -Wconversion
-#CFLAGS += -Wextra
+CFLAGS += -Wextra -Wtype-limits
 
 LD      = ia16-elf-ld.gold
 LDFLAGS = $(CPU_LD) -s

--- a/elkscmd/Makefile-rules
+++ b/elkscmd/Makefile-rules
@@ -65,6 +65,7 @@ AS=ia16-elf-as
 LD=ia16-elf-gcc
 
 CFLAGS =  $(CLBASE) $(WARNINGS) $(LOCALFLAGS) $(INCLUDES)
+CFLAGS += -Wextra -Wtype-limits -Wno-unused-parameter -Wno-sign-compare -Wno-empty-body
 CFLAGS += -D__ELKS__ -DELKS_VERSION=\"$(ELKS_VSN)\"
 ASFLAGS = -mtune=i8086 --32-segelf
 LDFLAGS = $(CLBASE)

--- a/elkscmd/ash/exec.c
+++ b/elkscmd/ash/exec.c
@@ -543,7 +543,7 @@ int
 find_builtin(name)
 	register char *name;
 	{
-	const register struct builtincmd *bp;
+	register const struct builtincmd *bp;
 
 	for (bp = builtincmd ; bp->name ; bp++) {
 		if (*bp->name == *name && equal(bp->name, name))

--- a/elkscmd/ash/linenoise_elks.c
+++ b/elkscmd/ash/linenoise_elks.c
@@ -934,7 +934,7 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
         if (c == TAB && completionCallback != NULL) {
             c = completeLine(&l);
             /* Return on errors */
-            if (c < 0) return l.len;
+            if (c == (unsigned char)-1) return l.len;
             /* Read next character when 0 */
             if (c == 0) continue;
         }

--- a/elkscmd/ash/trap.c
+++ b/elkscmd/ash/trap.c
@@ -39,6 +39,7 @@ static char sccsid[] = "@(#)trap.c	5.2 (Berkeley) 4/12/91";
 #endif /* not lint */
 
 #include <unistd.h>
+#include <stdlib.h>
 #include "shell.h"
 #include "main.h"
 #include "nodes.h"	/* for other headers */

--- a/elkscmd/inet/ftp/ftpd.c
+++ b/elkscmd/inet/ftp/ftpd.c
@@ -597,7 +597,6 @@ int main(int argc, char **argv) {
 	int listenfd, ret;
 	unsigned int myport = FTP_PORT;
 	struct sockaddr_in servaddr, myaddr;
-	char *cp;
 
 	if (argc > 2) {	/* FIXME - improve parameter checking */
 		usage();
@@ -618,6 +617,7 @@ int main(int argc, char **argv) {
 			myport = atoi(argv[0]);
 	}
 #if 0 /* FIXME temporarily remove as ftpd hangs on start with QEMU=1 */
+	char *cp;
 	if ((cp = getenv("QEMU")) != NULL) {
 		qemu = atoi(cp);
 		//printf("QEMU set to %d\n", qemu);

--- a/elkscmd/lib/tiny_vfprintf.c
+++ b/elkscmd/lib/tiny_vfprintf.c
@@ -33,7 +33,9 @@ FILE  stdout[1] =
     bufout,
     bufout + sizeof(bufout),
     1,
-    _IOLBF | __MODE_WRITE | __MODE_IOTRAN
+    _IOLBF | __MODE_WRITE | __MODE_IOTRAN,
+    { 0,0,0,0,0,0,0,0 },
+    0
    }
 };
 
@@ -46,7 +48,9 @@ FILE  stderr[1] =
     buferr,
     buferr + sizeof(buferr),
     2,
-    _IOLBF | __MODE_WRITE | __MODE_IOTRAN
+    _IOLBF | __MODE_WRITE | __MODE_IOTRAN,
+    { 0,0,0,0,0,0,0,0 },
+    0
    }
 };
 

--- a/elkscmd/minix2/lp.c
+++ b/elkscmd/minix2/lp.c
@@ -42,7 +42,7 @@ lp(char *file)
     if (pid < 0)
         fatal("can't fork");
 
-    if (waitpid(pid, &status, 0) < 0)
+    if (waitpid(pid, &status, 0) == -1)
         fatal("wait");
 
     if (status != 0)

--- a/elkscmd/misc_utils/tar.c
+++ b/elkscmd/misc_utils/tar.c
@@ -213,7 +213,7 @@ char	*arg;
 
 	fseek(tfile, 0L, SEEK_SET);
 	for (;;) {
-		if ((seekp = lookup(arg)) < 0)
+		if ((seekp = lookup(arg)) == -1L)
 			return(1);
 		fseek(tfile, seekp, 0);
 		fscanf(tfile, "%s %lo", name, &mtime);

--- a/elkscmd/sys_utils/init.c
+++ b/elkscmd/sys_utils/init.c
@@ -141,7 +141,9 @@ FILE  stdin[1] =
     bufin,
     bufin + sizeof(bufin),
     0,
-    _IOFBF | __MODE_READ | __MODE_IOTRAN
+    _IOFBF | __MODE_READ | __MODE_IOTRAN,
+    { 0,0,0,0,0,0,0,0 },
+    0
    }
 };
 
@@ -155,7 +157,9 @@ FILE  stdout[1] =
     bufout,
     bufout + sizeof(bufout),
     1,
-    _IOFBF | __MODE_WRITE | __MODE_IOTRAN
+    _IOFBF | __MODE_WRITE | __MODE_IOTRAN,
+    { 0,0,0,0,0,0,0,0 },
+    0
    }
 };
 
@@ -169,7 +173,9 @@ FILE  stderr[1] =
     buferr,
     buferr + sizeof(buferr),
     2,
-    _IONBF | __MODE_WRITE | __MODE_IOTRAN
+    _IONBF | __MODE_WRITE | __MODE_IOTRAN,
+    { 0,0,0,0,0,0,0,0 },
+    0
    }
 };
 

--- a/elkscmd/tui/fm.h
+++ b/elkscmd/tui/fm.h
@@ -85,53 +85,53 @@ struct key {
 };
 
 struct key bindings[] = {
-	{ 'Z',            SEL_QUIT },
+	{ 'Z',            SEL_QUIT, 0,0 },
 
-	{ kBackSpace,     SEL_BACK },       /* exit directory */
-	{ kDel,           SEL_BACK },
-	{ kLeftArrow,     SEL_BACK },
-	{ CONTROL('H'),   SEL_BACK },
+	{ kBackSpace,     SEL_BACK, 0,0 },       /* exit directory */
+	{ kDel,           SEL_BACK, 0,0 },
+	{ kLeftArrow,     SEL_BACK, 0,0 },
+	{ CONTROL('H'),   SEL_BACK, 0,0 },
 
-	{ '\r',           SEL_GOIN },       /* enter directory or display file */
-	{ kRightArrow,    SEL_GOIN },
-	{ kMouseLeftDoubleClick,SEL_GOIN },
+	{ '\r',           SEL_GOIN, 0,0 },       /* enter directory or display file */
+	{ kRightArrow,    SEL_GOIN, 0,0 },
+	{ kMouseLeftDoubleClick,SEL_GOIN, 0,0 },
 
-	{ kDownArrow,     SEL_NEXT },       /* next entry */
-	{ kMouseWheelDown,SEL_NEXT },
-	{ CONTROL('N'),   SEL_NEXT },
+	{ kDownArrow,     SEL_NEXT, 0,0 },       /* next entry */
+	{ kMouseWheelDown,SEL_NEXT, 0,0 },
+	{ CONTROL('N'),   SEL_NEXT, 0,0 },
 
-	{ kUpArrow,       SEL_PREV },       /* previous entry */
-	{ CONTROL('P'),   SEL_PREV },
-	{ kMouseWheelUp,  SEL_PREV },
+	{ kUpArrow,       SEL_PREV, 0,0 },       /* previous entry */
+	{ CONTROL('P'),   SEL_PREV, 0,0 },
+	{ kMouseWheelUp,  SEL_PREV, 0,0 },
 
-	{ kPageDown,      SEL_PGDN },       /* more next entries */
-	{ CONTROL('D'),   SEL_PGDN },
+	{ kPageDown,      SEL_PGDN, 0,0 },       /* more next entries */
+	{ CONTROL('D'),   SEL_PGDN, 0,0 },
 
-	{ kPageUp,        SEL_PGUP },       /* more previous entries */
-	{ CONTROL('U'),   SEL_PGUP },
+	{ kPageUp,        SEL_PGUP, 0,0 },       /* more previous entries */
+	{ CONTROL('U'),   SEL_PGUP, 0,0 },
 
-	{ kHome,          SEL_HOME },       /* first entry */
-	{ '^',            SEL_HOME },
-	{ 'H',            SEL_HOME },
+	{ kHome,          SEL_HOME, 0,0 },       /* first entry */
+	{ '^',            SEL_HOME, 0,0 },
+	{ 'H',            SEL_HOME, 0,0 },
 
-	{ kEnd,           SEL_END },        /* last entry */
-	{ '$',            SEL_END },
-	{ 'B',            SEL_END },
+	{ kEnd,           SEL_END, 0,0 },        /* last entry */
+	{ '$',            SEL_END, 0,0 },
+	{ 'B',            SEL_END, 0,0 },
 
-	{ '/',            SEL_FLTR },       /* file filter */
+	{ '/',            SEL_FLTR, 0,0 },       /* file filter */
 
-	{ 'C',            SEL_CD },         /* Change dir */
-	{ '~',            SEL_CDHOME },     /* Change to home dir */
+	{ 'C',            SEL_CD, 0,0 },         /* Change dir */
+	{ '~',            SEL_CDHOME, 0,0 },     /* Change to home dir */
 
-	{ '.',            SEL_TOGGLEDOT },  /* Tottle hide .dot files */
-	{ 'D',            SEL_DSORT },      /* Toggle sort by directory first */
-	{ 'S',            SEL_SSIZE },      /* Toggle sort by size */
-	{ 'T',            SEL_MTIME },      /* Toggle sort by time */
-	{ 'I',            SEL_ICASE },      /* Toggle case sensitivity */
-	{ 'V',            SEL_VERS },       /* Toggle sort by version number */
+	{ '.',            SEL_TOGGLEDOT, 0,0 },  /* Tottle hide .dot files */
+	{ 'D',            SEL_DSORT, 0,0 },      /* Toggle sort by directory first */
+	{ 'S',            SEL_SSIZE, 0,0 },      /* Toggle sort by size */
+	{ 'T',            SEL_MTIME, 0,0 },      /* Toggle sort by time */
+	{ 'I',            SEL_ICASE, 0,0 },      /* Toggle case sensitivity */
+	{ 'V',            SEL_VERS, 0,0 },       /* Toggle sort by version number */
 
-	{ CONTROL('L'),   SEL_REDRAW },
-	{ '?',            SEL_HELP },
+	{ CONTROL('L'),   SEL_REDRAW, 0,0 },
+	{ '?',            SEL_HELP, 0,0 },
 
 	{ '!',            SEL_RUN, "sh",                            Noargs },
 	{ 'E',            SEL_RUN, "vi",                            Curname },

--- a/libc/ia16.inc
+++ b/libc/ia16.inc
@@ -19,6 +19,8 @@ AR=ia16-elf-ar
 LD=ia16-elf-ld
 
 CFLAGS=$(ARCH) $(INCLUDES) $(CDEFS) -Wall -Os $(MULTILIB)
+CFLAGS+=-Wextra -Wtype-limits -Wno-unused-parameter -Wno-sign-compare
+CFLAGS+=$(MULTILIB)
 ASFLAGS=--32-segelf -mtune=i8086
 LDFLAGS=-mtune=i8086
 # Used in subdirs to quickly create a library archive without a symbol index

--- a/libc/malloc/v7malloc.c
+++ b/libc/malloc/v7malloc.c
@@ -86,7 +86,9 @@ static FILE  dbgout[1] =
     bufdbg,
     bufdbg + sizeof(bufdbg),
     -1,
-    _IONBF | __MODE_WRITE | __MODE_IOTRAN
+    _IONBF | __MODE_WRITE | __MODE_IOTRAN,
+    { 0,0,0,0,0,0,0,0 },
+    0
    }
 };
 #else

--- a/libc/math/Makefile
+++ b/libc/math/Makefile
@@ -5,7 +5,7 @@ LIB ?= out.a
 
 include $(TOPDIR)/libc/$(COMPILER).inc
 
-CFLAGS += -I$(TOPDIR)/libc/math -D__BSD_VISIBLE
+CFLAGS += -I$(TOPDIR)/libc/math -D__BSD_VISIBLE -Wno-type-limits
 
 DOUBLE = \
 	s_floor.o \

--- a/libc/stdio/sprintf.c
+++ b/libc/stdio/sprintf.c
@@ -12,7 +12,10 @@ sprintf(char *sp, const char *fmt, ...)
      0,
      (unsigned char *)(unsigned)-1,
      -1,
-     _IOFBF | __MODE_WRITE}
+     _IOFBF | __MODE_WRITE,
+     { 0,0,0,0,0,0,0,0 },
+     0
+    }
   };
 
   va_list ptr;

--- a/libc/stdio/sscanf.c
+++ b/libc/stdio/sscanf.c
@@ -12,7 +12,9 @@ sscanf(const char *str, const char *format, ...)
 			0,
 			(unsigned char *)(unsigned)-1,
 			-1,
-			_IOFBF | __MODE_READ
+			_IOFBF | __MODE_READ,
+			{ 0,0,0,0,0,0,0,0 },
+			0
 		}
 	};
 

--- a/libc/stdio/stderr.c
+++ b/libc/stdio/stderr.c
@@ -13,6 +13,8 @@ FILE  stderr[1] =
     buferr,
     buferr + sizeof(buferr),
     2,
-    _IONBF | __MODE_WRITE | __MODE_IOTRAN
+    _IONBF | __MODE_WRITE | __MODE_IOTRAN,
+    { 0,0,0,0,0,0,0,0 },
+    0
    }
 };

--- a/libc/stdio/stdin.c
+++ b/libc/stdio/stdin.c
@@ -11,6 +11,8 @@ FILE  stdin[1] =
     bufin,
     bufin + sizeof(bufin),
     0,
-    _IOFBF | __MODE_READ | __MODE_IOTRAN
+    _IOFBF | __MODE_READ | __MODE_IOTRAN,
+    { 0,0,0,0,0,0,0,0 },
+    0
    }
 };

--- a/libc/stdio/stdout.c
+++ b/libc/stdio/stdout.c
@@ -12,9 +12,11 @@ FILE  stdout[1] =
     bufout + sizeof(bufout),
     1,
 #ifdef __WATCOMC__
-    _IOLBF | __MODE_WRITE | __MODE_IOTRAN   /* FIXME flush on exit to fix */
+    _IOLBF | __MODE_WRITE | __MODE_IOTRAN,  /* FIXME flush on exit to fix */
 #else
-    _IOFBF | __MODE_WRITE | __MODE_IOTRAN
+    _IOFBF | __MODE_WRITE | __MODE_IOTRAN,
 #endif
+    { 0,0,0,0,0,0,0,0 },
+    0
    }
 };

--- a/libc/stdio/vsnprintf.c
+++ b/libc/stdio/vsnprintf.c
@@ -12,7 +12,9 @@ vsnprintf(char *sp, size_t size, const char *fmt, va_list ap)
 			0,
 			(unsigned char *)(unsigned)-1,
 			-1,
-		 _IOFBF | __MODE_WRITE
+			_IOFBF | __MODE_WRITE,
+			{ 0,0,0,0,0,0,0,0 },
+			0
 		 }
 	};
 

--- a/libc/stdio/vsprintf.c
+++ b/libc/stdio/vsprintf.c
@@ -12,7 +12,9 @@ vsprintf(char *sp, const char *fmt, va_list ap)
 			0,
 			(unsigned char *)(unsigned)-1,
 			-1,
-		 _IOFBF | __MODE_WRITE
+			_IOFBF | __MODE_WRITE,
+			{ 0,0,0,0,0,0,0,0 },
+			0
 		 }
 	};
 


### PR DESCRIPTION
Generally straightforward changes based on the easier-to-fix issues illuminated by adding -Wextra and -Wtype-limits to the kernel, elkscmd/ and libc/ compilations. There'll be a few more warnings showing up compiling the applications in elkscmds/ until more time is available to figure out or test exactly might be incorrect.

Initially, -Wsign-compare was turned on, but signed vs unsigned comparisons can be quite tricky so only a few instances were obviously correctable. The rest will have to wait, and the warning turned off since there are a bit too many of them.

Overall, some of the warnings flagged some pretty bad, mostly error, handling in some applications. A big red flag is comparing any unsigned integer (or typedef'd type) to < 0, which is always false. Many of the kernel read/write functions return size_t, which is unsigned, so comparing their success with < 0 doesn't work. I suspect this is because of the K&R old days, when those same functions returned int and people were able to use < 0 for error checking.

The math library has a couple problems with overflow/underflow comparing to +50000/-50000 which overflows 'int'. Since I can't yet figure a way to test, those warnings have been turned off for the time being.