### PR TITLE
[tools] Add 'ecc' ELKS C86 compiler driver script

### DIFF
--- a/elks/tools/bin/ecc
+++ b/elks/tools/bin/ecc
@@ -1,0 +1,81 @@
+# ecc - ELKS cc compiler wrapper for C86 (8086-toolchain)
+#
+# This script runs cpp86, c86, nasm and ld86 on the input file.
+# The input file must be specified without its .c extension for now,
+# and the script must be run in the 8086-toolchain/ directory,
+# as it also builds the libc86.a C86 library.
+# This restriction will be removed shortly.
+#
+# Usage: to compile and link foo.c:
+#   cd 8086-toolchain
+#   ecc foo
+#
+# Before using, modify the full paths below to ELKS and C86:
+
+#####################################################################
+
+# Full path to ELKS and C86 installations
+export TOPDIR=/Users/greg/net/elks-gh
+export C86DIR=/Users/greg/net/8086-toolchain
+
+# OpenWatcom path, not yet necessary to have installed
+export WATCOM=/Users/greg/net/open-watcom-v2/rel
+
+#####################################################################
+
+set -e
+
+add_path () {
+    if [[ ":$PATH:" != *":$1:"* ]]; then
+        export PATH="$1:$PATH"
+    fi
+}
+
+# ia16-elf-gcc
+export MAKEFLAGS="$MAKEFLAGS"
+add_path "$TOPDIR/cross/bin"
+add_path "$TOPDIR/elks/tools/bin"
+
+# OpenWatcom
+#add_path "$WATCOM/binl"    # for Linux-32
+#add_path "$WATCOM/binl64"  # for Linux-64
+#add_path "$WATCOM/bino64"   # for macOS
+
+#echo PATH set to $PATH
+
+# C86
+add_path "$C86DIR/host-bin"
+
+INCLUDES="-I$TOPDIR/libc/include -I$TOPDIR/elks/include"
+DEFINES="-D__C86__ -Drestrict="
+C86FLAGS="-O -warn=4 -lang=c99 -align=yes -stackopt=minimum -peep=all -stackcheck=no"
+CPPFLAGS="$INCLUDES $DEFINES"
+CFLAGS="$C86FLAGS"
+ASFLAGS="-f as86"
+ARFLAGS="q"
+LDFLAGS="-0 -i"
+
+# preprocessor
+echo cpp86 $CPPFLAGS $1.c $1.i
+cpp86 $CPPFLAGS $1.c -o $1.i
+
+# C compiler
+echo c86 $CFLAGS $1.c $1.asm
+c86 $CFLAGS $1.i $1.asm
+
+# assembler
+echo nasm $ASFLAGS -l $1.lst -o $1.o $1.asm
+nasm $ASFLAGS -l $1.lst -o $1.o $1.asm
+objdump86 -s $1.o
+
+# create libc86.a
+nasm $ASFLAGS lib/c86lib.asm -o c86lib.o
+nasm $ASFLAGS lib/syscall.asm -o syscall.o
+rm -f libc86.a
+echo ar86 $ARFLAGS libc86.a c86lib.o syscall.o
+ar86 $ARFLAGS libc86.a c86lib.o syscall.o
+
+# link executable
+echo ld86 $LDFLAGS $1.o -o $1 -lc86
+ld86 $LDFLAGS $1.o -o $1 -lc86
+objdump86 -s $1


### PR DESCRIPTION
Adds easy-to-use `ecc` compiler driver for use with @rafael2k's 8086-toolchain which is being discussed in #2112 and requires the changes in https://github.com/rafael2k/8086-toolchain/pull/5.

The initial primary purpose of this script is to allow for quick test preprocessing, compilation, assembly and link of a single .c file to test the C86 toolchain without having to write a Makefile.

For instance, with a complete foo.c program in 8086-toolchain, the files foo.i, foo.asm, foo.o and foo will be created by:
```
cd 8086-toolchain
ecc foo
```
The ecc script lives in ELKS $TOPDIR/elks/tools/bin/ecc. It must first be edited to contain the top directories of the ELKS and C86 installation before it will work. This is documented in the script itself.

Also, currently the script requires running in the 8086-toolchain directory. This is because it assembles the lib86.a library from source each time. This will be automated in the 8086-toolchain master make shortly.