### PR TITLE
[c86] Allow C86 to compile using most all ELKS libc header files

### DIFF
--- a/elks/include/arch/cdefs.h
+++ b/elks/include/arch/cdefs.h
@@ -41,5 +41,19 @@
 #define __wcnear        __near
 #endif
 
+#ifdef __C86__
+#define __HAS_NO_FLOATS__
+#define __far
+#define noreturn
+#define stdcall
+#define restrict
+#define printfesque(n)
+#define noinstrument
+#define CONSTRUCTOR(fn,pri) void fn(void)
+#define DESTRUCTOR(fn,pri)  void fn(void)
+#define __attribute__(n)
+#define __wcfar
+#define __wcnear
+#endif
 
 #endif

--- a/elks/include/linuxmt/errno.h
+++ b/elks/include/linuxmt/errno.h
@@ -34,8 +34,8 @@
 #define EINVAL          22      /* Invalid argument */
 #define ENFILE          23      /* File table overflow */
 #define EMFILE          24      /* Too many open files */
-#define ENOTTY          25      /* Not a typewriter */  //linenoise
-#define ETXTBSY         26      /* Text file busy */    //ash
+#define ENOTTY          25      /* Not a typewriter */  /*linenoise*/
+#define ETXTBSY         26      /* Text file busy */    /*ash*/
 #define EFBIG           27      /* File too large */
 #define ENOSPC          28      /* No space left on device */
 #define ESPIPE          29      /* Illegal seek */
@@ -61,7 +61,7 @@
 #define EADDRINUSE      98      /* Address already in use */
 #define ENETDOWN        100     /* Network is down */
 #define ENETUNREACH     101     /* Network is unreachable */
-#define ENOBUFS         105     /* No buffer space available */ //regex
+#define ENOBUFS         105     /* No buffer space available */ /*regex*/
 #define EISCONN         106     /* Transport endpoint is already connected */
 #define ETIMEDOUT       110     /* Connection timed out */
 #define ECONNREFUSED    111     /* Connection refused */

--- a/elks/include/linuxmt/signal.h
+++ b/elks/include/linuxmt/signal.h
@@ -187,7 +187,8 @@ typedef stdcall __far void (*__kern_sighandler_t)(int);
 #pragma GCC diagnostic pop
 #endif
 
-#ifdef __WATCOMC__
+#if defined(__WATCOMC__) || defined(__C86__)
+/* FIXME broken for C86 w/o stdcall and __far */
 typedef void stdcall (__far *__kern_sighandler_t)(int);
 #endif
 

--- a/elks/tools/bin/ecc
+++ b/elks/tools/bin/ecc
@@ -46,14 +46,14 @@ add_path "$TOPDIR/elks/tools/bin"
 # C86
 add_path "$C86DIR/host-bin"
 
-INCLUDES="-I$TOPDIR/libc/include -I$TOPDIR/elks/include -I$C86DIR/lib"
+INCLUDES="-I$TOPDIR/libc/include -I$TOPDIR/elks/include -I$C86DIR/libc/include"
 DEFINES="-D__C86__ -D__STDC__"
 C86FLAGS="-O -warn=4 -lang=c99 -align=yes -stackopt=minimum -peep=all -stackcheck=no"
 CPPFLAGS="$INCLUDES $DEFINES"
 CFLAGS="$C86FLAGS"
 ASFLAGS="-f as86"
 ARFLAGS="q"
-LDFLAGS="-0 -i"
+LDFLAGS="-0 -i -L$C86DIR/libc"
 
 # preprocessor
 echo cpp86 $CPPFLAGS $1.c $1.i
@@ -67,13 +67,6 @@ c86 $CFLAGS $1.i $1.asm
 echo nasm $ASFLAGS -l $1.lst -o $1.o $1.asm
 nasm $ASFLAGS -l $1.lst -o $1.o $1.asm
 objdump86 -s $1.o
-
-# create libc86.a
-nasm $ASFLAGS lib/c86lib.asm -o c86lib.o
-nasm $ASFLAGS lib/syscall.asm -o syscall.o
-rm -f libc86.a
-echo ar86 $ARFLAGS libc86.a c86lib.o syscall.o
-ar86 $ARFLAGS libc86.a c86lib.o syscall.o
 
 # link executable
 echo ld86 $LDFLAGS $1.o -o $1 -lc86

--- a/elks/tools/bin/ecc
+++ b/elks/tools/bin/ecc
@@ -46,8 +46,8 @@ add_path "$TOPDIR/elks/tools/bin"
 # C86
 add_path "$C86DIR/host-bin"
 
-INCLUDES="-I$TOPDIR/libc/include -I$TOPDIR/elks/include"
-DEFINES="-D__C86__ -Drestrict="
+INCLUDES="-I$TOPDIR/libc/include -I$TOPDIR/elks/include -I$C86DIR/lib"
+DEFINES="-D__C86__ -D__STDC__"
 C86FLAGS="-O -warn=4 -lang=c99 -align=yes -stackopt=minimum -peep=all -stackcheck=no"
 CPPFLAGS="$INCLUDES $DEFINES"
 CFLAGS="$C86FLAGS"


### PR DESCRIPTION
With the recent enhancements made to the [C86 toolchain](https://github.com/rafael2k/8086-toolchain) and the [ELKS C86 compiler driver](https://github.com/ghaerr/elks/pull/2119) `ecc`, most all the ELKS C library header files are now acceptable input to C86, making a major step forward in moving down the path with the next step of beginning to compile the ELKS C library and bringing a toolchain to ELKS.

> which header should I include to use the system calls implemented in the syscall.asm currently in 8086-toolchat repo?

You can now use the standard C headers to access system calls with the 8086 toolchain. I have currently tested the following include files which are accepted:
```
#include <stdio.h>
#include <stdlib.h>
#include <unistd.h>
#include <fcntl.h>
#include <ctype.h>
#include <assert.h>
#include <errno.h>
#include <signal.h>
#include <termios.h>
#include <time.h>
#include <sys/ioctl.h>
#include <sys/stat.h>
```