### PR TITLE
[kernel] Fix incorrect BSS clearing when BSS size is zero

### DIFF
--- a/elks/fs/exec.c
+++ b/elks/fs/exec.c
@@ -488,7 +488,8 @@ static int execve_aout(struct inode *inode, struct file *filp, char *sptr, size_
     /* From this point, exec() will surely succeed */
 
     /* clear bss */
-    fmemsetb((char *)(size_t)mh.dseg + base_data, seg_data->base, 0, (size_t)mh.bseg);
+    if ((size_t)mh.bseg)
+        fmemsetb((char *)(size_t)mh.dseg + base_data, seg_data->base, 0, (size_t)mh.bseg);
 
     /* set data/stack limits and copy argc/argv */
     currentp->t_enddata = (size_t)mh.dseg + (size_t)mh.bseg + base_data;

--- a/elks/tools/objtools/objdump86.c
+++ b/elks/tools/objtools/objdump86.c
@@ -830,8 +830,7 @@ static char * byteord[] = { "LITTLE_ENDIAN", "(2143)","(3412)","BIG_ENDIAN" };
    if( h_flgs & 0x80 ) printf(" A_TOVLY");
    printf("\n");
 
-   if( header[5] )
-      printf("a_entry  = 0x%08lx\n", header[5]);
+   printf("a_entry  = 0x%08lx\n", header[5]);
    printf("a_total  = 0x%08lx\n", header[6]);
    if( header[7] )
       printf("a_syms   = 0x%08lx\n", header[7]);


### PR DESCRIPTION
The kernel never checked executables for zero-sized BSS, which was found during development of the native 8086-toolchain in https://github.com/rafael2k/8086-toolchain/pull/13.

Also enhances objdump86 to display executable entry point.