### PR TITLE
[kernel,libc] Rewrite kernel brk/sbrk and stack_check, fix C library malloc

### DIFF
--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -43,27 +43,27 @@ int run_init_process_sptr(const char *cmd, char *sptr, int slen)
 }
 
 /*
- * We only need to do this as long as we support old format binaries
- * that grow stack and heap towards each other
+ * Check that SP is within proper range, called before every syscall.
  */
 void stack_check(void)
 {
-    segoff_t end = current->t_endbrk;
+    segoff_t sp = current->t_regs.sp;
+    segoff_t brk = current->t_endbrk;
+    segoff_t stacklow = current->t_begstack - current->t_minstack;
 
-    {
-        /* optional: check stack over min stack*/
-        if (current->t_regs.sp < current->t_begstack - current->t_minstack) {
-          if (current->t_minstack)     /* display if protected stack*/
-            printk("(%P)STACK OUTSIDE PROTECTED LIMIT by %u\n",
-                current->t_begstack - current->t_minstack - current->t_regs.sp);
-        }
-
-        /* check stack overflow heap*/
-        if (current->t_regs.sp > end)
-            return;
+    if (sp < brk) {
+        printk("(%P)STACK OVERFLOW by %u\n", brk - sp);
+        printk("curbreak %u, SP %u\n", current->t_endbrk, current->t_regs.sp);
+        do_exit(SIGSEGV);
     }
-    printk("(%P)STACK OVERFLOW by %u\n", end - current->t_regs.sp);
-    do_exit(SIGSEGV);
+    if (sp < stacklow) {
+        /* notification only, allow process to continue */
+        printk("(%P)STACK USING %u UNUSED HEAP\n", stacklow - sp);
+    }
+    if (sp > current->t_begstack) {
+        printk("(%P)STACK UNDERFLOW\n");
+        do_exit(SIGSEGV);
+    }
 }
 
 /*

--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -50,13 +50,6 @@ void stack_check(void)
 {
     segoff_t end = current->t_endbrk;
 
-#ifdef CONFIG_EXEC_LOW_STACK
-    if (current->t_begstack <= current->t_enddata) {  /* stack below heap?*/
-        if (current->t_regs.sp < end)
-            return;
-        end = 0;
-    } else
-#endif
     {
         /* optional: check stack over min stack*/
         if (current->t_regs.sp < current->t_begstack - current->t_minstack) {

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -249,10 +249,6 @@ int sys_brk(segoff_t newbrk)
             return -ENOMEM;
         }
     }
-#ifdef CONFIG_EXEC_LOW_STACK
-    if (newbrk > current->t_endseg)
-        return -ENOMEM;
-#endif
     current->t_endbrk = newbrk;
 
     return 0;

--- a/libc/malloc/Makefile
+++ b/libc/malloc/Makefile
@@ -4,12 +4,13 @@ COMPILER ?= ia16
 LIB ?= out.a
 
 include $(TOPDIR)/libc/$(COMPILER).inc
-#CFLAGS	+= -DL_alloca
-#CFLAGS	+= -DLAZY_FREE
-# MCHUNK is word not byte min allocation size
-CFLAGS	+= -DMCHUNK=512
+# allocations smaller than MCHUNK words (not bytes) are rounded up,
+# larger requests are allocated from heap as is.
+CFLAGS	+= -DMCHUNK=16
 #CFLAGS	+= -DMINALLOC
+#CFLAGS	+= -DLAZY_FREE
 #CFLAGS	+= -DVERBOSE
+#CFLAGS	+= -DL_alloca
 
 # use V7 malloc for heap integrity checking
 #OBJS = v7malloc.o calloc.o sbrk.o brk.o

--- a/libc/malloc/__mini_malloc.c
+++ b/libc/malloc/__mini_malloc.c
@@ -8,12 +8,16 @@ void __wcnear *
 __mini_malloc(size_t size)
 {
 	mem __wcnear *ptr;
-	size_t sz;
 
+#if 0
+	size_t sz;
 	/* First time round this _might_ be odd, But we won't do that! */
 	sz = (size_t)sbrk(0);
 	if(sz & (sizeof(mem) - 1))
 		sbrk(4 - (sz & (sizeof(mem) - 1)));
+#endif
+
+	size += sizeof(mem) * 2 - 1;	/* Round up and leave space for size field */
 
 	/* Minor oops here, sbrk has a signed argument */
 	if((int)size <= 0 || size > (((unsigned)-1) >> 1) - sizeof(mem) * 3)
@@ -22,9 +26,7 @@ __mini_malloc(size_t size)
 		return 0;
 	}
 
-	size += sizeof(mem) * 2 - 1;	/* Round up and leave space for size field */
 	size /= sizeof(mem);
-
 	ptr = (mem __wcnear *) sbrk(size * sizeof(mem));
 	/*if((uintptr_t)ptr == (intptr_t)-1)*/  /* this is better only when not __wcnear */
     if ((int)ptr == -1)

--- a/libc/malloc/malloc.c
+++ b/libc/malloc/malloc.c
@@ -265,10 +265,13 @@ malloc(size_t size)
       {
 #ifdef MCHUNK
          unsigned int alloc;
-         alloc = sizeof(mem) * (MCHUNK * ((sz + MCHUNK - 1) / MCHUNK) - 1);
+         if (sz < MCHUNK)
+                alloc = sizeof(mem) * (MCHUNK * ((sz + MCHUNK - 1) / MCHUNK) - 1);
+         else alloc = sz * sizeof(mem);
 	 ptr = __mini_malloc(alloc);
 	 if (ptr)
 	    __insert_chunk(ptr - 1);
+#if MCHUNK >= 256
 	 else		/* Oooo, near end of RAM */
 	 {
 	    unsigned int needed = alloc;
@@ -283,6 +286,7 @@ malloc(size_t size)
 	       else     alloc/=2;
 	    }
 	 }
+#endif
 	 ptr = __search_chunk(sz);
 	 if (ptr == 0)
 #endif


### PR DESCRIPTION
Rewrites sys_brk, sys_sbrk and stack_check with better error checking and new messages for heap and stack problems. 

Also fixes a somewhat major problem with C library malloc which caused an extra 1024 bytes to be allocated from the heap for any allocation request >= 1024, which effectively doubled the size of the heap necessary to fulfill the request! 

The C library malloc routine now allocates all requests less than 32 bytes as 32 bytes from the heap for later subdivision, but all larger requests without chunking up to a large (previously 1024 byte) chunk size. In addition, when memory is low, malloc doesn't retry three times which produced multiple failure messages, usually right before a stack overflow message. That has been fixed for the most part, except for when an application uses large stack buffers without stack checking turned on (more coming on that in next steps).

Removes unused CONFIG_EXEC_LOW_STACK option from loader.

These changes were you used to test the 8086 toolchain and resulted in PR https://github.com/rafael2k/8086-toolchain/pull/17.

Now, when applications run out of heap or stack, or the stack pointer moves into the unused heap area, more informative messages are produced by the kernel, to let the developer know what is going on. 

Following are the changed error messages:

When the stack usage grows outside (below) its normally reserved and protected area into the heap, the following messages are produced:

"STACK USING 1131 UNUSED HEAP" when the stack isn't large enough and unused heap area is used, or
"STACK OVERFLOW" when the stack grew into an inuse area of the heap. In this case the process is also terminated.

When a request is made by malloc to get more memory from the heap, and that fails, the message

"SBRK 1024 FAIL, OUT OF HEAP SPACE" is displayed, and malloc returns NULL.

If the stack has already grown into the unused heap, but a malloc allocation request wants some of that heap area, the message 

"SBRK %d FAIL, WOULD OVERWRITE STACK" is displayed.

This may all sound complicated, but in the end more information is displayed, and when the messages are displayed, it gives better information as to whether the program's heap or stack should be increased. This was definitely needed for our upcoming C86 toolchain, as some tools require maximum heap or stack space.

To see detailed SBRK/BRK allocation information on the console, set `debug=1` in /bootopts.

