### PR TITLE
[libc] Create debug version of malloc, fix near->far malloc conversion bug

### DIFF
--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -272,9 +272,11 @@ int sys_sbrk(int increment, segoff_t *pbrk)
     segoff_t brk = current->t_endbrk;   /* always return start of old break*/
     int err;
 
-    if (increment)
-        dprintk("(%P)SBRK %d, curbreak %u, SP %u\n",
-            increment, current->t_endbrk, current->t_regs.sp);
+    if (increment) {
+        dprintk("(%P)SBRK %d\n", increment);
+        /*dprintk("(%P)SBRK %d, curbreak %u, SP %u\n",
+            increment, current->t_endbrk, current->t_regs.sp);*/
+    }
     err = verify_area(VERIFY_WRITE, pbrk, sizeof(*pbrk));
     if (err)
         return err;
@@ -296,8 +298,11 @@ int sys_fmemalloc(int paras, unsigned short *pseg)
     if (err)
         return err;
     seg = seg_alloc((segext_t)paras, SEG_FLAG_FDAT);
-    if (!seg)
+    if (!seg) {
+        dprintk("(%P)FMEMALLOC %ld FAIL\n", (unsigned long)paras << 4);
         return -ENOMEM;
+    }
+    dprintk("(%P)FMEMALLOC %ld\n", (unsigned long)paras << 4);
     seg->pid = current->pid;
     put_user(seg->base, pseg);
     return 0;

--- a/libc/malloc/Makefile
+++ b/libc/malloc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/libc/$(COMPILER).inc
 CFLAGS	+= -DMCHUNK=16
 #CFLAGS	+= -DMINALLOC
 #CFLAGS	+= -DLAZY_FREE
-#CFLAGS	+= -DVERBOSE
+CFLAGS	+= -DVERBOSE=1
 #CFLAGS	+= -DL_alloca
 
 # use V7 malloc for heap integrity checking
@@ -25,6 +25,7 @@ OBJS = \
 	free.o \
 	malloc.o \
 	noise.o \
+	dprintf.o \
 	realloc.o \
 	sbrk.o \
 	fmemalloc.o \

--- a/libc/malloc/__mini_malloc.c
+++ b/libc/malloc/__mini_malloc.c
@@ -9,7 +9,7 @@ __mini_malloc(size_t size)
 {
 	mem __wcnear *ptr;
 
-#if 0
+#if 0       /* not required and slow, initial break always even */
 	size_t sz;
 	/* First time round this _might_ be odd, But we won't do that! */
 	sz = (size_t)sbrk(0);
@@ -28,11 +28,11 @@ __mini_malloc(size_t size)
 
 	size /= sizeof(mem);
 	ptr = (mem __wcnear *) sbrk(size * sizeof(mem));
-	/*if((uintptr_t)ptr == (intptr_t)-1)*/  /* this is better only when not __wcnear */
-    if ((int)ptr == -1)
+	if ((int)ptr == -1) {
+		debug("SBRK FAIL", 0);
 		return 0;
-
+	}
 	m_size(ptr) = size;
-	__noise("CREATE", ptr);
+	debug("SBRK", ptr);
 	return ptr + 1;
 }

--- a/libc/malloc/_malloc.h
+++ b/libc/malloc/_malloc.h
@@ -10,10 +10,19 @@ typedef union mem_cell
    char __wcnear *depth;		/* For the alloca hack */
 } mem;
 
-#ifdef VERBOSE
 void __noise(char *y, mem __wcnear *x);
+int __dprintf(const char *fmt, ...);
+extern int __debug_level;
+
+#if !VERBOSE
+#define dprintf(...)
+#define debug(str,ptr)
+#elif VERBOSE == 1
+#define dprintf             __dprintf
+#define debug(str,ptr)
 #else
-#define __noise(y,x)
+#define dprintf(...)
+#define debug(str,ptr)      __noise(str,ptr)
 #endif
 
 #define m_deep(p)  ((p) [0].depth)	/* For alloca */

--- a/libc/malloc/dprintf.c
+++ b/libc/malloc/dprintf.c
@@ -1,0 +1,41 @@
+#if VERBOSE
+#include <stdarg.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int __debug_level = 1;
+
+/*
+ * Very tiny printf to stderr.
+ * Supports:
+ *  %u  unsigned int
+ */
+int __dprintf(const char *fmt, ...)
+{
+    unsigned int n = 0;
+    char *p;
+    va_list va;
+    char b[128];
+
+    if (__debug_level == 0)
+        return 0;
+    va_start(va, fmt);
+    for (; *fmt; fmt++) {
+        if (*fmt == '%') {
+            switch (*++fmt) {
+            case 'u':
+                p = uitoa(va_arg(va, unsigned int));
+                while (*p && n < sizeof(b))
+                    b[n++] = *p++;
+                break;
+            }
+            continue;
+        } else {
+            if (n < sizeof(b))
+                b[n++] = *fmt;
+        }
+    }
+    va_end(va);
+    return write(2, b, n);
+}
+#endif

--- a/libc/malloc/free.c
+++ b/libc/malloc/free.c
@@ -18,7 +18,7 @@ free(void * ptr)
 #endif
 	top = (mem __wcnear *) sbrk(0);
 	if (chk + m_size(chk) == top) {
-		__noise("FREE brk", chk);
+		debug("BRK (releasing top chunk)", chk);
 		brk(top - m_size(chk));
 		/*
 		 * Adding this code allow free to release blocks in any order; they
@@ -49,6 +49,6 @@ free(void * ptr)
 		m_next(chk) = (union mem_cell __wcnear *)__freed_list;
 		__freed_list = chk;
 #endif
-		__noise("ADD LIST", chk);
+		debug("ADD LIST", chk);
 	}
 }

--- a/libc/malloc/noise.c
+++ b/libc/malloc/noise.c
@@ -1,4 +1,4 @@
-#if defined(VERBOSE)
+#if VERBOSE
 #include <errno.h>
 #include <string.h>
 #include <unistd.h>
@@ -17,23 +17,17 @@ phex(unsigned int val)
 }
 
 void
-__noise(char *y, mem __wcnear *x)
+__noise(char *str, mem __wcnear *ptr)
 {
     int saved_errno = errno;
     write(2, "Malloc ", 7);
-    phex((int)x);
-    write(2, " sz ", 4);
-    if (x)
-        phex((unsigned int)m_size(x));
-    else
-        phex(0);
+    phex(ptr? (unsigned int)m_size(ptr): 0);
+    write(2, " ptr ", 5);
+    phex((int)ptr);
     write(2, " nxt ", 5);
-    if (x)
-        phex((unsigned int)m_next(x));
-    else
-        phex(0);
-    write(2, " is ", 4);
-    write(2, y, strlen(y));
+    phex(ptr? (unsigned int)m_next(ptr): 0);
+    write(2, " ", 1);
+    write(2, str, strlen(str));
     write(2, "\n", 1);
     errno = saved_errno;
 }


### PR DESCRIPTION
Fixes bug in malloc that returned non-zero DS:0 on failure, rather than 0:0 (NULL) in large model. Discussed in https://github.com/rafael2k/8086-toolchain/pull/19.

Adds debugging display to malloc and fmemalloc. When 'debug=1` is set in /bootopts, the sizes in bytes of malloc and fmemalloc will be displayed along with the process id, for easier tracking of near and far memory allocations used by the under-development 8086-toolchain. When malloc or fmemalloc fails, that will also be displayed to let the developer know the application is out of memory.

For instance, when running LD86, the following is displayed.
```
    ./ld86 -0 -i test.o libc86.a -o test
(15)SBRK 148
(15)SBRK 32
(15)SBRK 32
(15)BRK 10120
(15)SBRK 32
(15)SBRK 68
(16)SBRK 150
MALLOC 3074
(16)SBRK 3076
MALLOC 1026
(16)SBRK 1028
MALLOC 1026
(16)SBRK 1028
MALLOC 2050
(16)SBRK 2052
MALLOC 1026
(16)SBRK 1028
(16)FMEMALLOC 57344
```

The MALLOC value is the requested allocation (+2 for internal tracking), and the SBRK value is the data segment heap expansion value (+ another 2 for heap tracking). 

This allows for much better visibility on which tools ask for near vs far memory and how much is requested. Currently, no attempt is made to determine remaining free space or summing the allocations and frees to determine working set storage requirements.

@rafael2k: I haven't tested this on your last couple of days enhancements, as I'm in the middle of some C86 enhancements. Thus, my versions don't have the bug fixes you've run into regarding memrealloc and others. However, this PR does fix the problem of malloc returning DS:0 rather than NULL (0:), so the NULLPTR defines should not be necessary anymore, although it won't hurt to leave them in.

When you have time, please test this with your latest build (requires OWC libc rebuild and updated kernel, of course). I'm interested to hear what you think with regards to the memory allocations being used with the latest toolchain fixes.