### PR TITLE
[libc] Fixes to v7malloc.c for OpenWatcom

### DIFF
--- a/libc/malloc/dprintf.c
+++ b/libc/malloc/dprintf.c
@@ -4,17 +4,41 @@
 #include <paths.h>
 #include <fcntl.h>
 
+static char *uitostr(unsigned int val, int radix, int width)
+{
+    static char buf[6];
+    char *p = buf + sizeof(buf) - 1;
+    unsigned int c;
+
+    *p = '\0';
+    do {
+        c = val % radix;
+        val = val / radix;
+        if (c > 9)
+            *--p = 'a' - 10 + c;
+        else
+            *--p = '0' + c;
+    } while (val);
+    c = (radix == 16)? '0': ' ';
+    while (buf + sizeof(buf) - 1 - p < width)
+        *--p = c;
+    return p;
+}
+
 /*
  * Very tiny printf to console.
  * Supports:
- *  %u  unsigned int
- *  %p  unsigned int (displays as unsigned int!)
- *  %d  int (positive numbers only)
- *  %s  char *
+ *  %{0-9}  width
+ *  %u      unsigned decimal
+ *  %d      decimal (positive numbers only)
+ *  %p      zero-fill hexadecimal width 4
+ *  %x      hexadecimal
+ *  %s      string
  */
 int __dprintf(const char *fmt, ...)
 {
     unsigned int n;
+    int radix, width;
     char *p;
     va_list va;
     char b[80];
@@ -25,14 +49,26 @@ int __dprintf(const char *fmt, ...)
     va_start(va, fmt);
     for (n = 0; *fmt; fmt++) {
         if (*fmt == '%') {
-            switch (*++fmt) {
+            ++fmt;
+            width = 0;
+            while (*fmt >= '0' && *fmt <= '9') {
+                width = width * 10 + *fmt - '0';
+                fmt++;
+            }
+            switch (*fmt) {
             case 's':
                 p = va_arg(va, char *);
                 goto outstr;
-            case 'p':   /* displays as unsigned int! */
+            case 'p':
+                width = 4;
+            case 'x':
+                radix = 16;
+                goto convert;
             case 'd':
             case 'u':
-                p = uitoa(va_arg(va, unsigned int));
+                radix = 10;
+        convert:
+                p = uitostr(va_arg(va, unsigned int), radix, width);
         outstr:
                 while (*p && n < sizeof(b))
                     b[n++] = *p++;

--- a/libc/malloc/v7malloc.c
+++ b/libc/malloc/v7malloc.c
@@ -113,7 +113,7 @@ malloc(size_t nbytes)
     ASSERT(allocp>=allocs && allocp<=alloct);
     ASSERT(malloc_check_heap());
 allocp = (union store __wcnear *)allocs;    /* experimental */
-    //debug("search start %p ", (unsigned)allocp);
+    //debug("search start %04x ", (unsigned)allocp);
     for(p=allocp; ; ) {
         for(temp=0; ; ) {
             if(!testbusy(p->ptr)) {
@@ -184,7 +184,7 @@ found:
         allocp->ptr = p->ptr;
     }
     p->ptr = setbusy(allocp);
-    debug("= %p\n", (unsigned)p);
+    debug("= %04x\n", (unsigned)p);
     malloc_show_heap();
     return((void *)(p+1));
 }
@@ -198,7 +198,7 @@ free(void *ptr)
 
     if (p == NULL)
         return;
-    debug("(%d)  free(%d) = %p\n", getpid(), (unsigned)(p[-1].ptr - p) << 1, p-1);
+    debug("(%d)  free(%d) = %04x\n", getpid(), (unsigned)(p[-1].ptr - p) << 1, p-1);
     ASSERT(p>clearbusy(allocs[1].ptr)&&p<=alloct);
     ASSERT(malloc_check_heap());
     allocp = --p;
@@ -223,7 +223,7 @@ realloc(void *ptr, size_t nbytes)
 
     if (p == 0)
         return malloc(nbytes);
-    debug("(%d)realloc(%p,%u) ", getpid(), (unsigned)(p-1), nbytes);
+    debug("(%d)realloc(%04x,%u) ", getpid(), (unsigned)(p-1), nbytes);
 
     ASSERT(testbusy(p[-1].ptr));
     if(testbusy(p[-1].ptr))
@@ -244,10 +244,10 @@ realloc(void *ptr, size_t nbytes)
 
     /* restore old data for special case of malloc link overwrite*/
     if(q<p && q+nw>=p) {
-        debug("allocx patch %p,%p,%d ", (unsigned)q, (unsigned)p, nw);
+        debug("allocx patch %04x,%04x,%d ", (unsigned)q, (unsigned)p, nw);
         (q+(q+nw-p))->ptr = allocx;
     }
-    debug("= %p\n", (unsigned)q);
+    debug("= %04x\n", (unsigned)q);
     return((void *)q);
 }
 
@@ -268,7 +268,8 @@ malloc_check_heap(void)
         if(p==allocp)
             x++;
     }
-    if (p != alloct) debug("%p %p %p\n", (unsigned)p, (unsigned)alloct, (unsigned)p->ptr);
+    if (p != alloct) debug("%04x %04x %04x\n",
+        (unsigned)p, (unsigned)alloct, (unsigned)p->ptr);
     ASSERT(p==alloct);
     return((x==1)|(p==allocp));
 }
@@ -286,7 +287,7 @@ malloc_show_heap(void)
     malloc_check_heap();
     for(p = (union store __wcnear *)&allocs[0]; clearbusy(p->ptr) > p; p=clearbusy(p->ptr)) {
         size = (clearbusy(p->ptr) - clearbusy(p)) * sizeof(union store);
-        debug2("%2d: %p %4u", n, (unsigned)p, size);
+        debug2("%2d: %04x %4u", n, (unsigned)p, size);
         if (!testbusy(p->ptr)) {
             debug2(" (free)");
             free += size;
@@ -299,7 +300,7 @@ malloc_show_heap(void)
         debug2("\n");
     }
     alloc += 2;
-    debug2("%2d: %p %4u (top) ", n, (unsigned)alloct, 2);
+    debug2("%2d: %04x %4u (top) ", n, (unsigned)alloct, 2);
     debug("alloc %u, free %u, total %u\n", alloc, free, alloc+free);
 }
 #endif

--- a/libc/malloc/v7malloc.c
+++ b/libc/malloc/v7malloc.c
@@ -113,7 +113,7 @@ malloc(size_t nbytes)
     ASSERT(allocp>=allocs && allocp<=alloct);
     ASSERT(malloc_check_heap());
 allocp = (union store __wcnear *)allocs;    /* experimental */
-    //debug("search start %p ", allocp);
+    //debug("search start %p ", (unsigned)allocp);
     for(p=allocp; ; ) {
         for(temp=0; ; ) {
             if(!testbusy(p->ptr)) {
@@ -184,7 +184,7 @@ found:
         allocp->ptr = p->ptr;
     }
     p->ptr = setbusy(allocp);
-    debug("= %p\n", p);
+    debug("= %p\n", (unsigned)p);
     malloc_show_heap();
     return((void *)(p+1));
 }
@@ -223,7 +223,7 @@ realloc(void *ptr, size_t nbytes)
 
     if (p == 0)
         return malloc(nbytes);
-    debug("(%d)realloc(%p,%u) ", getpid(), p-1, nbytes);
+    debug("(%d)realloc(%p,%u) ", getpid(), (unsigned)(p-1), nbytes);
 
     ASSERT(testbusy(p[-1].ptr));
     if(testbusy(p[-1].ptr))
@@ -244,10 +244,10 @@ realloc(void *ptr, size_t nbytes)
 
     /* restore old data for special case of malloc link overwrite*/
     if(q<p && q+nw>=p) {
-        debug("allocx patch %p,%p,%d ", q, p, nw);
+        debug("allocx patch %p,%p,%d ", (unsigned)q, (unsigned)p, nw);
         (q+(q+nw-p))->ptr = allocx;
     }
-    debug("= %p\n", q);
+    debug("= %p\n", (unsigned)q);
     return((void *)q);
 }
 
@@ -268,7 +268,7 @@ malloc_check_heap(void)
         if(p==allocp)
             x++;
     }
-    if (p != alloct) debug("%p %p %p\n", p, alloct, p->ptr);
+    if (p != alloct) debug("%p %p %p\n", (unsigned)p, (unsigned)alloct, (unsigned)p->ptr);
     ASSERT(p==alloct);
     return((x==1)|(p==allocp));
 }
@@ -285,8 +285,8 @@ malloc_show_heap(void)
     debug2("--- heap size ---\n");
     malloc_check_heap();
     for(p = (union store __wcnear *)&allocs[0]; clearbusy(p->ptr) > p; p=clearbusy(p->ptr)) {
-        size = (char *)clearbusy(p->ptr) - (char *)clearbusy(p);
-        debug2("%2d: %p %4u", n, p, size);
+        size = (clearbusy(p->ptr) - clearbusy(p)) * sizeof(union store);
+        debug2("%2d: %p %4u", n, (unsigned)p, size);
         if (!testbusy(p->ptr)) {
             debug2(" (free)");
             free += size;
@@ -299,7 +299,7 @@ malloc_show_heap(void)
         debug2("\n");
     }
     alloc += 2;
-    debug2("%2d: %p %4u (top) ", n, alloct, 2);
+    debug2("%2d: %p %4u (top) ", n, (unsigned)alloct, 2);
     debug("alloc %u, free %u, total %u\n", alloc, free, alloc+free);
 }
 #endif


### PR DESCRIPTION
More fixes to v7malloc.c for OWC. 

When an OWC `__near *` pointer is passed to a function, the compiler expands it to a `__far *` pointer in large model by adding SS: as the segment. This caused problems in \_\_dprintf, which is currently using a `va_arg(..., unsigned int)` to get the pointer, which would not increment the va_arg pointer past the full 32-bits. This caused subsequent parameters to be displayed incorrectly. Since the pointers are all near, v7malloc debug statements have been converted from using the %p specification to using %04x for compatibility between \_\_dprintf and fprintf. This  was all caused by trying to build a super-small dprintf that doesn't drag in lots of code, for debugging purposes, possibly to be used in debug builds for all executables.

Dprintf is also enhanced to display %x as hex, and allow field widths, with automatic 0 or space fill for radix 16 or 10, respectively. This allows the previous v7malloc debug output format strings to remain the same as was built for fprintf (which is a lot more to drag in).

I'm thinking the next step will be to rewrite v7malloc to use a base arena with unsigned int offsets into it, rather than near pointers. This will also aid the transition to converting it to a general-purpose arena allocator for near heaps created from far memory.