### PR TITLE
Fallback to 8x16 font in case 8x14 not present in VGA ROM

### DIFF
--- a/elkscmd/nano-X/Makefile
+++ b/elkscmd/nano-X/Makefile
@@ -53,8 +53,7 @@ ifeq ($(CONFIG_ARCH_PC98), y)
 DRIVERS += drivers/ramfont.o drivers/X6x13.o drivers/elksutilasm.o
 else
 ifeq ($(CONFIG_HW_VGA), y)
-# DRIVERS += drivers/romfont.o drivers/elksutilasm.o
-DRIVERS += drivers/ramfont.o drivers/X6x13.o drivers/elksutilasm.o
+ DRIVERS += drivers/romfont.o drivers/elksutilasm.o
 else
 DRIVERS += drivers/ramfont.o drivers/X6x13.o drivers/elksutilasm.o
 endif

--- a/elkscmd/nano-X/Makefile
+++ b/elkscmd/nano-X/Makefile
@@ -53,7 +53,8 @@ ifeq ($(CONFIG_ARCH_PC98), y)
 DRIVERS += drivers/ramfont.o drivers/X6x13.o drivers/elksutilasm.o
 else
 ifeq ($(CONFIG_HW_VGA), y)
-DRIVERS += drivers/romfont.o drivers/elksutilasm.o
+# DRIVERS += drivers/romfont.o drivers/elksutilasm.o
+DRIVERS += drivers/ramfont.o drivers/X6x13.o drivers/elksutilasm.o
 else
 DRIVERS += drivers/ramfont.o drivers/X6x13.o drivers/elksutilasm.o
 endif

--- a/elkscmd/nano-X/Makefile
+++ b/elkscmd/nano-X/Makefile
@@ -53,7 +53,7 @@ ifeq ($(CONFIG_ARCH_PC98), y)
 DRIVERS += drivers/ramfont.o drivers/X6x13.o drivers/elksutilasm.o
 else
 ifeq ($(CONFIG_HW_VGA), y)
- DRIVERS += drivers/romfont.o drivers/elksutilasm.o
+DRIVERS += drivers/romfont.o drivers/elksutilasm.o
 else
 DRIVERS += drivers/ramfont.o drivers/X6x13.o drivers/elksutilasm.o
 endif

--- a/elkscmd/nano-X/drivers/romfont.c
+++ b/elkscmd/nano-X/drivers/romfont.c
@@ -18,7 +18,7 @@
 #include "romfont.h"
 
 /* local data*/
-int	ROM_CHAR_HEIGHT = 16;	/* number of scan lines in fonts in ROM */
+int	ROM_CHAR_HEIGHT;	/* number of scan lines in fonts in ROM */
 FARADDR rom_char_addr;
 
 /* init PC ROM routines, must be called in graphics mode*/
@@ -26,10 +26,27 @@ void
 pcrom_init(PSD psd)
 {
 	char *	p;
+	FARADDR rom_char_addr_temp;
 
 	/* use INT 10h to get address of rom character table*/
-	// rom_char_addr = int10(FNGETROMADDR, GETROM8x14);
-	rom_char_addr = int10(FNGETROMADDR, GETROM8x16);
+
+	/* we first compare of 8x14 fonts address is equal
+	 * to the 8x16 fonts address. If yes, it means
+	 * the 8x14 are not present, so we fallback to
+	 * 8x16 fonts. Source:
+	 * https://www.bttr-software.de/products/fix8x14/
+	 */
+
+	rom_char_addr = int10(FNGETROMADDR, GETROM8x14);
+	rom_char_addr_temp = int10(FNGETROMADDR, GETROM8x16);
+
+	if (rom_char_addr == rom_char_addr_temp) {
+		ROM_CHAR_HEIGHT = 16;
+		rom_char_addr = rom_char_addr_temp;
+	}
+	else {
+		ROM_CHAR_HEIGHT = 14;
+	}
 
 #if 0
 	/* check bios data area for actual character height,
@@ -39,9 +56,7 @@ pcrom_init(PSD psd)
 	if(ROM_CHAR_HEIGHT > MAX_ROM_HEIGHT)
 		ROM_CHAR_HEIGHT = MAX_ROM_HEIGHT;
 #endif
-#if ELKS
-	ROM_CHAR_HEIGHT = 16;
-#endif
+
 	p = getenv("CHARHEIGHT");
 	if(p)
 		ROM_CHAR_HEIGHT = atoi(p);

--- a/elkscmd/nano-X/drivers/romfont.c
+++ b/elkscmd/nano-X/drivers/romfont.c
@@ -30,8 +30,8 @@ pcrom_init(PSD psd)
 
 	/* use INT 10h to get address of rom character table*/
 
-	/* we first compare of 8x14 fonts address is equal
-	 * to the 8x16 fonts address. If yes, it means
+	/* we first compare if 8x14 font address is equal
+	 * to the 8x16 font address. If yes, it means
 	 * the 8x14 are not present, so we fallback to
 	 * 8x16 fonts. Source:
 	 * https://www.bttr-software.de/products/fix8x14/

--- a/elkscmd/nano-X/drivers/romfont.c
+++ b/elkscmd/nano-X/drivers/romfont.c
@@ -43,8 +43,7 @@ pcrom_init(PSD psd)
 	if (rom_char_addr == rom_char_addr_temp) {
 		ROM_CHAR_HEIGHT = 16;
 		rom_char_addr = rom_char_addr_temp;
-	}
-	else {
+	} else {
 		ROM_CHAR_HEIGHT = 14;
 	}
 

--- a/elkscmd/nano-X/drivers/romfont.c
+++ b/elkscmd/nano-X/drivers/romfont.c
@@ -18,7 +18,7 @@
 #include "romfont.h"
 
 /* local data*/
-int	ROM_CHAR_HEIGHT = 14;	/* number of scan lines in fonts in ROM */
+int	ROM_CHAR_HEIGHT = 16;	/* number of scan lines in fonts in ROM */
 FARADDR rom_char_addr;
 
 /* init PC ROM routines, must be called in graphics mode*/
@@ -28,7 +28,9 @@ pcrom_init(PSD psd)
 	char *	p;
 
 	/* use INT 10h to get address of rom character table*/
-	rom_char_addr = int10(FNGETROMADDR, GETROM8x14);
+	// rom_char_addr = int10(FNGETROMADDR, GETROM8x14);
+	rom_char_addr = int10(FNGETROMADDR, GETROM8x16);
+
 #if 0
 	/* check bios data area for actual character height,
 	 * as the returned font isn't always 14 high
@@ -38,7 +40,7 @@ pcrom_init(PSD psd)
 		ROM_CHAR_HEIGHT = MAX_ROM_HEIGHT;
 #endif
 #if ELKS
-	ROM_CHAR_HEIGHT = 14;
+	ROM_CHAR_HEIGHT = 16;
 #endif
 	p = getenv("CHARHEIGHT");
 	if(p)

--- a/elkscmd/nano-X/drivers/romfont.h
+++ b/elkscmd/nano-X/drivers/romfont.h
@@ -18,6 +18,7 @@
 /* int10 functions*/
 #define FNGETROMADDR	0x1130	/* function for address of rom character table*/
 #define GETROM8x14	0x0200	/* want address of ROM 8x14 char table*/
+#define GETROM8x16	0x0600	/* want address of ROM 8x16 char table*/
 
 /* entry points*/
 void	pcrom_init(PSD psd);


### PR DESCRIPTION
We do a test to check if the 8x14 is present based on a VGA BIOS behaviour found in:
https://github.com/rafael2k/fix8x14/blob/9d7dfd4d13d54e2d42f2bf0b9734632599c0e67b/SRC/DIAG8X14/DIAG8X14.C--#L124
and fall back to 8x16 is the font is not present.

ps: can you do a squash merge if all good?