### PR TITLE
[libc] Add malloc_usable_size, write general-purpose realloc

### DIFF
--- a/libc/include/malloc.h
+++ b/libc/include/malloc.h
@@ -4,27 +4,32 @@
 #include <sys/types.h>
 
 /* default malloc (dev86) */
-void *malloc(size_t);
-void *realloc(void *, size_t);
-void  free(void *);
+void  *malloc(size_t);
+void   free(void *);
+size_t malloc_usable_size(void *);
 
 /* debug malloc (v7 malloc) */
-void *__dmalloc(size_t);
-void *__drealloc(void *, size_t);
-void  __dfree(void *);
+void  *__dmalloc(size_t);
+void  *__drealloc(void *, size_t);
+void   __dfree(void *);
+size_t __dmalloc_usable_size(void *);
 
 /* arena malloc (64k near/unlimited far heap) */
-void *__amalloc(size_t);
-int   __amalloc_add_heap(char __far *start, size_t size);
-void *__arealloc(void *, size_t);       /* NYI */
-void  __afree(void *);
+void  *__amalloc(size_t);
+int    __amalloc_add_heap(char __far *start, size_t size);
+void  *__arealloc(void *, size_t);       /* NYI */
+void   __afree(void *);
+size_t __dmalloc_usable_size(void *);
 
-void *calloc(size_t elm, size_t sz);
+/* usable with all mallocs */
+void  *realloc(void *, size_t);
+void  *calloc(size_t elm, size_t sz);
 
 /* alloc/free from main memory */
 void __far *fmemalloc(unsigned long size);
-int fmemfree(void __far *ptr);
-int _fmemalloc(int paras, unsigned short *pseg);
-int _fmemfree(unsigned short seg);
+int         fmemfree(void __far *ptr);
+
+int        _fmemalloc(int paras, unsigned short *pseg); /* syscall */
+int        _fmemfree(unsigned short seg);               /* syscall */
 
 #endif

--- a/libc/malloc/Makefile
+++ b/libc/malloc/Makefile
@@ -18,7 +18,6 @@ CFLAGS	+= -DMCHUNK=16
 DEFAULT_MALLOC_OBJS = \
 	malloc.o \
 	free.o \
-	realloc.o \
 	__mini_malloc.o \
 	__alloca_alloc.o \
 	__freed_list.o \
@@ -33,6 +32,7 @@ ARENA_MALLOC_OBJS = amalloc.o
 
 # these objects work with any malloc
 OBJS = \
+	realloc.o \
 	calloc.o \
 	brk.o \
 	sbrk.o \

--- a/libc/malloc/amalloc.c
+++ b/libc/malloc/amalloc.c
@@ -249,6 +249,19 @@ __afree(void *ptr)
     malloc_show_heap();
 }
 
+size_t __amalloc_usable_size(void *ptr)
+{
+    NPTR p = (NPTR)ptr;
+
+    if (p == NULL)
+        return 0;
+    ASSERT(FP_SEG(ptr)==allocseg);
+    ASSERT(p>clearbusy(allocs[allocsize-1].ptr)&&p<=alloct);
+    --p;
+    ASSERT(testbusy(next(p)));
+    return (clearbusy(next(p)) - clearbusy(p)) * sizeof(union store);
+}
+
 #if LATER
 /*  realloc(p, nbytes) reallocates a block obtained from malloc()
  *  and freed since last call of malloc()

--- a/libc/malloc/malloc.c
+++ b/libc/malloc/malloc.c
@@ -188,6 +188,13 @@ __search_chunk(unsigned int mem_size)
    return p1;
 }
 
+size_t malloc_usable_size(void *ptr)
+{
+    if (ptr == 0)
+        return 0;
+    return (m_size(((mem *) ptr) - 1) - 1) * sizeof(mem);
+}
+
 void *
 malloc(size_t size)
 {

--- a/libc/malloc/realloc.c
+++ b/libc/malloc/realloc.c
@@ -1,26 +1,22 @@
 #include <malloc.h>
 #include <string.h>
 
-#include "_malloc.h"
-
-#undef malloc
-
-void *
-realloc(void *ptr, size_t size)
+/* this realloc usable with all malloc allocators */
+void *realloc(void *ptr, size_t size)
 {
 	void *nptr;
-	unsigned int osize;
+    size_t osize;
 
 	if (ptr == 0)
 		return malloc(size);
 
-	osize = (m_size(((mem *) ptr) - 1) - 1) * sizeof(mem);
-
+	osize = malloc_usable_size(ptr);
+#if LATER
 	if (size <= osize)
 		return ptr;
+#endif
 
 	nptr = malloc(size);
-
 	if (nptr == 0)
 		return 0;
 


### PR DESCRIPTION
Adds `size_t malloc_usable_size(void *ptr)` which returns the allocated size of a malloc'd pointer.

Used that routine in writing a general-purpose realloc which then calls malloc/free with the correct size for memcpy. This general purpose realloc will allow for replacing malloc and free wholesale with \_\_amalloc and \_\_afree wholesale in the 8086 toolchain. The toolchain will be ready for updating after writing that wrapper function which also switches out large requests to fmemalloc. Next PR coming shortly.