### PR TITLE
[libc] More memory allocation changes for 8086 toolchain

### DIFF
--- a/elkscmd/tui/Makefile
+++ b/elkscmd/tui/Makefile
@@ -13,7 +13,7 @@ PRGS = fm matrix cons ttyinfo sl ttyclock ttypong ttytetris invaders
 #PRGS_HOST =
 
 TUILIB = tty.o runes.o unikey.o
-MALLOC=../../libc/malloc/v7malloc.o
+MALLOC=v7stub.o
 
 all: $(PRGS) $(PRGS_HOST)
 

--- a/elkscmd/tui/v7stub.c
+++ b/elkscmd/tui/v7stub.c
@@ -1,0 +1,17 @@
+/* stub to force inclusion of debug malloc (v7) */
+#include <stdlib.h>
+
+void *malloc(size_t size)
+{
+    return __dmalloc(size);
+}
+
+void free(void *ptr)
+{
+    __dfree(ptr);
+}
+
+void *realloc(void *ptr, size_t size)
+{
+    return __drealloc(ptr, size);
+}

--- a/libc/include/malloc.h
+++ b/libc/include/malloc.h
@@ -4,26 +4,26 @@
 #include <sys/types.h>
 
 /* default malloc (dev86) */
-void  *malloc(size_t);
-void   free(void *);
-size_t malloc_usable_size(void *);
+void   *malloc(size_t);
+void   *realloc(void *, size_t);
+void    free(void *);
+size_t  malloc_usable_size(void *);
 
 /* debug malloc (v7 malloc) */
-void  *__dmalloc(size_t);
-void  *__drealloc(void *, size_t);
-void   __dfree(void *);
-size_t __dmalloc_usable_size(void *);
+void   *__dmalloc(size_t);
+void   *__drealloc(void *, size_t);
+void    __dfree(void *);
+size_t  __dmalloc_usable_size(void *);
 
 /* arena malloc (64k near/unlimited far heap) */
-void  *__amalloc(size_t);
-int    __amalloc_add_heap(char __far *start, size_t size);
-void  *__arealloc(void *, size_t);       /* NYI */
-void   __afree(void *);
-size_t __dmalloc_usable_size(void *);
+void   *__amalloc(size_t);
+int     __amalloc_add_heap(char __far *start, size_t size);
+void   *__arealloc(void *, size_t);         /* not implemented */
+void    __afree(void *);
+size_t  __amalloc_usable_size(void *);
 
 /* usable with all mallocs */
-void  *realloc(void *, size_t);
-void  *calloc(size_t elm, size_t sz);
+void   *calloc(size_t elm, size_t sz);
 
 /* alloc/free from main memory */
 void __far *fmemalloc(unsigned long size);
@@ -31,5 +31,8 @@ int         fmemfree(void __far *ptr);
 
 int        _fmemalloc(int paras, unsigned short *pseg); /* syscall */
 int        _fmemfree(unsigned short seg);               /* syscall */
+
+extern unsigned int malloc_arena_size;
+extern unsigned int malloc_arena_thresh;
 
 #endif

--- a/libc/malloc/Makefile
+++ b/libc/malloc/Makefile
@@ -17,6 +17,7 @@ CFLAGS	+= -DMCHUNK=16
 # default malloc (dev86)
 DEFAULT_MALLOC_OBJS = \
 	malloc.o \
+	realloc.o \
 	free.o \
 	__mini_malloc.o \
 	__alloca_alloc.o \
@@ -32,7 +33,6 @@ ARENA_MALLOC_OBJS = amalloc.o
 
 # these objects work with any malloc
 OBJS = \
-	realloc.o \
 	calloc.o \
 	brk.o \
 	sbrk.o \

--- a/libc/malloc/realloc.c
+++ b/libc/malloc/realloc.c
@@ -1,7 +1,6 @@
 #include <malloc.h>
 #include <string.h>
 
-/* this realloc usable with all malloc allocators */
 void *realloc(void *ptr, size_t size)
 {
 	void *nptr;
@@ -11,15 +10,17 @@ void *realloc(void *ptr, size_t size)
 		return malloc(size);
 
 	osize = malloc_usable_size(ptr);
-#if LATER
+#if 0
 	if (size <= osize)
-		return ptr;
+		return ptr;         /* don't reallocate, do nothing */
+#else
+	if (size <= osize)
+        osize = size;       /* copy less bytes in memcpy below */
 #endif
 
 	nptr = malloc(size);
 	if (nptr == 0)
 		return 0;
-
 	memcpy(nptr, ptr, osize);
 	free(ptr);
 

--- a/libc/malloc/v7malloc.c
+++ b/libc/malloc/v7malloc.c
@@ -217,7 +217,8 @@ __dfree(void *ptr)
 
     if (p == NULL)
         return;
-    debug("(%d)  free(%d) = %04x\n", getpid(), (unsigned)(p[-1].ptr - p) << 1, p-1);
+    debug("(%d)  free(%d) = %04x\n", getpid(),
+        (unsigned)(next(p-1) - p) * sizeof(union store), p-1);
     ASSERT(p>clearbusy(allocs[SIZE-1].ptr)&&p<=alloct);
     ASSERT(malloc_check_heap());
     allocp = --p;
@@ -256,10 +257,10 @@ __drealloc(void *ptr, size_t nbytes)
         return __dmalloc(nbytes);
     debug("(%d)realloc(%04x,%u) ", getpid(), (unsigned)(p-1), nbytes);
 
-    ASSERT(testbusy(p[-1].ptr));
-    if(testbusy(p[-1].ptr))
-        free(p);
-    onw = p[-1].ptr - p;
+    ASSERT(testbusy(next(p-1)));
+    if(testbusy(next(p-1)))
+        __dfree(p);
+    onw = next(p-1) - p;
     q = (NPTR)__dmalloc(nbytes);   // FIXME and also use memcpy
     if(q==NULL || q==p)
         return((void *)q);


### PR DESCRIPTION
Last of bug fixes and enhancements to our new arena-based malloc for the 8086 toolchain. These enhancements currently only work for OpenWatcom C and large/compact model (i.e. 32-bit data pointers).

@rafael2k, The whole arena malloc is a bit complicated to explain, but basically a single wrapper file, mem.c (see below) will be used in each tool to fully encapsulate malloc, realloc and free. There will/can be no ifdefs or renames of malloc to memalloc in each tool, that will all have to be removed or replaced back to what it originally was. (Easily done by just deleting the ifdef ELKS portions entirely). The reason for this is that the C library routines themselves call malloc, and we need replace *all* memory allocation calls, as a C library returned-from-malloc pointer could be passed around inside a tool and then passed to our renamed malloc, which would cause a problem. With the full wrapper, even the C library routines that call malloc end up in our allocator. There are lots of other linker issues with the multiple memory allocators we now have available, but I think I've got it all straightened out to normally work and link automatically.

So, long story short, the following file mem.c will be added to each tool's project Makefile. Hopefully we will not need customization of the arena vs fmemalloc threshold (MALLOC_ARENA_THRESH) since the default small heap is 64K, but this can now be done programmatically using an extern int malloc_arena_thresh instead of changing mem.c source code. For now, the arena allocator allocates a maximum 65520 bytes from main memory, and then subdivides that for any allocations <= 1K bytes each, the rest going to fmemalloc. The other good news is that by setting the following in a shell script before running a tool, a full heap analysis showing every allocation will be dumped:
```
# sysctl malloc.debug=3   (turn on debug malloc output to level 3 max)
# sysctl kern.debug=1     (turn on debug kernel sbrk/fmemalloc display)
```
Since it's a bit complicated at the moment, I'll try to take a first pass by pulling down your repo (I've saved my compiler bug fixes for later) and see if I can get all the tools running with the new allocator. I'll then post a PR for your review and we can go from there with regards to tuning. 

The following 'mem.c' file wrapper must be included in each tool, as this can't go in the C library directly. The net effect is to force malloc, free and realloc from the tool or the C library to use the arena allocator and fmemalloc, instead of the default malloc/free/realloc.
```
/* malloc/free wholesale replacement for 8086 toolchain */
#include <stdlib.h>

#define MALLOC_ARENA_SIZE   65520U  /* size of initial arena fmemalloc (max 65520)*/
#define MALLOC_ARENA_THRESH 1024U   /* max size to allocate from arena-managed heap */

unsigned int malloc_arena_size = MALLOC_ARENA_SIZE;
unsigned int malloc_arena_thresh = MALLOC_ARENA_THRESH;

#define FP_SEG(fp)          ((unsigned)((unsigned long)(void __far *)(fp) >> 16))
#define FP_OFF(fp)          ((unsigned)(unsigned long)(void __far *)(fp))

static void __far *heap;

void *malloc(size_t size)
{
    char *p;

    if (heap == NULL) {
        heap = fmemalloc(malloc_arena_size);
        __amalloc_add_heap(heap, malloc_arena_size);
    }

    if (size <= malloc_arena_thresh)
        p = __amalloc(size);
    else p = fmemalloc(size);
    return p;
}

void free(void *ptr)
{
    if (ptr == NULL)
        return;
    if (FP_OFF(ptr) == 0)       /* non-arena pointer */
        fmemfree(ptr);
    else
        __afree(ptr);
}

void *realloc(void *ptr, size_t size)
{
    void *new;
    size_t osize = size;

    if (ptr == 0)
        return malloc(size);

#if LATER
    /* we can't yet get size from fmemalloc'd block */
    osize = malloc_usable_size(ptr);
    if (size <= osize)
        osize = size;           /* copy less bytes in memcpy below */
#endif

    new = malloc(size);
    if (new == 0)
        return 0;
    memcpy(new, ptr, osize);    /* FIXME copies too much but can't get real osize */
    free(ptr);
    return new;
}
```
If you have more questions, please ask, thanks!