### PR TITLE
[build] Fix hd64mbr-minix image build and setboot partition write bug

### DIFF
--- a/elks/tools/setboot/setboot.c
+++ b/elks/tools/setboot/setboot.c
@@ -77,7 +77,7 @@ static void writePartition(unsigned char *buf)
 	p->head = 1;
 	p->sector = 1;				/* next cylinder after MBR, standard*/
 	p->cyl = 0;
-	p->start_sect = NumTracks;	/* zero-relative start sector here*/
+	p->start_sect = SecPerTrk;	/* zero-relative start sector here*/
 	nr_sects -= SecPerTrk;
 #else
 	p->head = 0;

--- a/image/Makefile
+++ b/image/Makefile
@@ -208,7 +208,7 @@ hd32mbr-minix: hd32-minix
 
 hd64mbr-minix: hd64-minix
 	dd if=/dev/zero bs=512 count=63 | cat - hd64-minix.img > hd64mbr-minix.img
-	setboot hd64mbr-minix.img -P63,16,63 -Sm $(HD_MBR_BOOT)
+	setboot hd64mbr-minix.img -P63,16,127 -Sm $(HD_MBR_BOOT)
 
 hd32mbr-fat: hd32-fat
 	dd if=/dev/zero bs=512 count=63 | cat - hd32-fat.img > hd32mbr-fat.img

--- a/image/Makefile
+++ b/image/Makefile
@@ -208,7 +208,7 @@ hd32mbr-minix: hd32-minix
 
 hd64mbr-minix: hd64-minix
 	dd if=/dev/zero bs=512 count=63 | cat - hd64-minix.img > hd64mbr-minix.img
-	setboot hd64mbr-minix.img -P63,16,127 -Sm $(HD_MBR_BOOT)
+	setboot hd64mbr-minix.img -P63,16,130 -Sm $(HD_MBR_BOOT)
 
 hd32mbr-fat: hd32-fat
 	dd if=/dev/zero bs=512 count=63 | cat - hd32-fat.img > hd32mbr-fat.img


### PR DESCRIPTION
This fixes first attempt building hd64mbr-minix.img in #2133. 

The problem was the `setboot -P` option which writes the partition table now works properly. The 64M image was then updated to the proper CHS of 130,16,63.