### PR TITLE
[libc] Enhance debugging output for amalloc and dmalloc

### DIFF
--- a/libc/malloc/Makefile
+++ b/libc/malloc/Makefile
@@ -37,7 +37,6 @@ OBJS = \
 	brk.o \
 	sbrk.o \
 	fmemalloc.o \
-	fmemfree.o \
 	dprintf.o \
 
 # default and debug mallocs available for ia16 and OWC

--- a/libc/malloc/amalloc.c
+++ b/libc/malloc/amalloc.c
@@ -17,7 +17,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <sys/sysctl.h>
-#define DEBUG       2       /* =1 heap checking asserts, =2 sysctl, =3 show heap */
+#define DEBUG       1       /* =1 use sysctl, =2 debug output, =3 show heap */
 
 /*  C storage allocator
  *  circular first-fit strategy
@@ -41,7 +41,7 @@
 #define ALIGN int
 #define NALIGN 1
 #define BUSY 1
-#define BLOCK       34              /* min+WORD amount to sbrk */
+#define BLOCK       34              /* min+WORD amount to sbrk (was 514) */
 #define MINALLOC    14              /* minimum actual malloc size */
 #define GRANULE     0               /* sbrk granularity */
 
@@ -71,21 +71,17 @@ static  NPTR alloct;   /*arena top*/
 static  NPTR allocx;   /*for benefit of realloc*/
 
 #if DEBUG
-#define ASSERT(p)   if(!(p))malloc_assert_fail(#p);else {}
-static void malloc_assert_fail(char *s);
+#define ASSERT(p)   if(!(p))malloc_assert_fail(#p,__LINE__);else {}
+#define debug(...)  do { if (debug_level > 1) __dprintf(__VA_ARGS__); } while (0)
+#define debug2(...) do { if (debug_level > 2) __dprintf(__VA_ARGS__); } while (0)
+static int debug_level = DEBUG;
+static void malloc_assert_fail(char *s, int);
+static void malloc_show_heap(void);
 static int malloc_check_heap(void);
 #else
 #define ASSERT(p)
-#endif
-
-#if DEBUG > 1
-#define debug(...)  do { if (debug_level > 1) __dprintf(__VA_ARGS__); } while (0)
-#define debug2(...) do { if (debug_level > 2) __dprintf(__VA_ARGS__); } while (0)
-int __dprintf(const char *fmt, ...);
-static void malloc_show_heap(void);
-static int debug_level = DEBUG;
-#else
 #define debug(...)
+#define debug2(...)
 #define malloc_show_heap()
 #endif
 
@@ -96,7 +92,7 @@ int __amalloc_add_heap(char __far *start, size_t size)
     allocs = (FPTR)start;
     allocseg = FP_SEG(start);
     allocsize = size / sizeof(union store);
-    debug("Adding %04x %04x size %d DS %04x %04x\n", start, size, &size);
+    debug("Adding SEG %04x size %d DS %04x\n", FP_SEG(start), size, FP_SEG(&size));
 
     allocs[0].ptr = setbusy(&allocs[1]);
     allocs[1].ptr = (NPTR)&allocs[allocsize-2];
@@ -113,11 +109,11 @@ __amalloc(size_t nbytes)
     NPTR p, q;
     unsigned int nw, temp;
 
-#if DEBUG == 2
+#if DEBUG == 1
     sysctl(CTL_GET, "malloc.debug", &debug_level);
 #endif
 
-    debug("(%d)malloc(%u) ", getpid(), nbytes);
+    debug("(%d)malloc(%5u) ", getpid(), nbytes);
     if (!allocs)
         return NULL;
     errno = 0;
@@ -147,7 +143,7 @@ __amalloc(size_t nbytes)
                     if (debug_level > 2) malloc_show_heap();
                     ASSERT(q>p);
                     ASSERT(q<alloct);
-                    debug("(combine %u and %u) ",
+                    debug2("(combine %u and %u) ",
                         (next(p) - p) * sizeof(union store),
                         (next(q) - q) * sizeof(union store));
                     next(p) = next(q);
@@ -182,7 +178,7 @@ __amalloc(size_t nbytes)
             temp = nw + 1; /* NOTE always allocates full req w/o looking at free at top */
 
         if (debug_level > 2) malloc_show_heap();
-        debug("sbrk(%d) ", temp*WORD);
+        debug2("sbrk(%d) ", temp*WORD);
 #if 0   /* not required and slow, initial break always even */
         q = (NPTR)sbrk(0);
         if((INT)q & (sizeof(union store) - 1))
@@ -208,7 +204,7 @@ __amalloc(size_t nbytes)
         if(q!=alloct+1)         /* mark any gap as permanently allocated*/
             next(alloct) = setbusy(next(alloct));
         alloct = next(q) = q+temp-1;
-        debug("(TOTAL %u) ",
+        debug2("(TOTAL %u) ",
             sizeof(union store) +
             (clearbusy(alloct) - clearbusy(allocs[allocsize-1].ptr)) * sizeof(union store));
         next(alloct) = setbusy(allocs);
@@ -222,7 +218,7 @@ found:
         next(allocp) = next(p);
     }
     next(p) = setbusy(allocp);
-    debug("= %04x\n", (unsigned)p);
+    debug2("= %04x\n", (unsigned)p);
     malloc_show_heap();
     return MK_FPTR(allocseg, p+1);
 }
@@ -236,8 +232,8 @@ __afree(void *ptr)
 
     if (p == NULL)
         return;
-    debug("(%d)  free(%d) = %04x\n", getpid(),
-        (unsigned)(next(p-1) - p) * sizeof(union store), p-1);
+    debug("(%d)  free(%5u) ", getpid(), (unsigned)(next(p-1) - p) * sizeof(union store));
+    debug2("= %04x\n", p-1);
     ASSERT(FP_SEG(ptr)==allocseg);
     ASSERT(p>clearbusy(allocs[allocsize-1].ptr)&&p<=alloct);
     ASSERT(malloc_check_heap());
@@ -307,9 +303,9 @@ __arealloc(void *ptr, size_t nbytes)
 #endif
 
 #if DEBUG
-static void malloc_assert_fail(char *s)
+static void malloc_assert_fail(char *s, int line)
 {
-    __dprintf("malloc assert fail: %s\n", s);
+    __dprintf("amalloc assert fail: %s (line %d)\n", s, line);
     abort();
 }
 
@@ -330,15 +326,14 @@ malloc_check_heap(void)
     ASSERT(p==alloct);
     return((x==1)|(p==allocp));
 }
-#endif
 
-#if DEBUG > 1
 static void
 malloc_show_heap(void)
 {
     NPTR p;
     int n = 1;
     unsigned int size, alloc = 0, free = 0;
+    static unsigned int maxalloc;
 
     debug2("--- heap size ---\n");
     malloc_check_heap();
@@ -357,7 +352,8 @@ malloc_show_heap(void)
         debug2("\n");
     }
     alloc += sizeof(union store);
+    if (alloc > maxalloc) maxalloc = alloc;
     debug2("%2d: %04x %4u (top) ", n, (unsigned)alloct, 2);
-    debug("alloc %u, free %u, total %u\n", alloc, free, alloc+free);
+    debug("alloc %5u, free %5u, arena %5u/%5u\n", alloc, free, maxalloc, alloc+free);
 }
 #endif

--- a/libc/malloc/amalloc.c
+++ b/libc/malloc/amalloc.c
@@ -70,11 +70,11 @@ static  NPTR allocp;   /*search ptr*/
 static  NPTR alloct;   /*arena top*/
 static  NPTR allocx;   /*for benefit of realloc*/
 
+static int debug_level = DEBUG;
 #if DEBUG
 #define ASSERT(p)   if(!(p))malloc_assert_fail(#p,__LINE__);else {}
 #define debug(...)  do { if (debug_level > 1) __dprintf(__VA_ARGS__); } while (0)
 #define debug2(...) do { if (debug_level > 2) __dprintf(__VA_ARGS__); } while (0)
-static int debug_level = DEBUG;
 static void malloc_assert_fail(char *s, int);
 static void malloc_show_heap(void);
 static int malloc_check_heap(void);
@@ -335,6 +335,7 @@ malloc_show_heap(void)
     unsigned int size, alloc = 0, free = 0;
     static unsigned int maxalloc;
 
+    if (!debug_level) return;
     debug2("--- heap size ---\n");
     malloc_check_heap();
     for(p = (NPTR)&allocs[0]; clearbusy(next(p)) > p; p=clearbusy(next(p))) {

--- a/libc/malloc/amalloc.c
+++ b/libc/malloc/amalloc.c
@@ -9,7 +9,7 @@
  * Enhancements:
  * Minimum BLOCK allocate from kernel sbrk, > BLOCK allocates requested size
  * Much improved size and heap overflow handling with errno returns
- * Full heap integrity checking and reporting with DEBUG options
+ * Full heap integrity checking and reporting with debug options
  * Use near heap pointers to work with OpenWatcom large model
  * Combine free areas at heap start before allocating from free area at end of heap
  */

--- a/libc/malloc/dprintf.c
+++ b/libc/malloc/dprintf.c
@@ -44,8 +44,12 @@ int __dprintf(const char *fmt, ...)
     char b[80];
     static int fd = -1;
 
-    if (fd < 0)
-        fd = open(_PATH_CONSOLE, O_WRONLY);
+    if (fd < 0) {
+        if (!isatty(STDERR_FILENO))
+            fd = STDERR_FILENO;
+        else
+            fd = open(_PATH_CONSOLE, O_WRONLY);
+    }
     va_start(va, fmt);
     for (n = 0; *fmt; fmt++) {
         if (*fmt == '%') {

--- a/libc/malloc/dprintf.c
+++ b/libc/malloc/dprintf.c
@@ -59,7 +59,10 @@ int __dprintf(const char *fmt, ...)
                 width = width * 10 + *fmt - '0';
                 fmt++;
             }
+        again:
             switch (*fmt) {
+            case 'l':
+                fmt++; goto again;
             case 's':
                 p = va_arg(va, char *);
                 goto outstr;

--- a/libc/malloc/dprintf.c
+++ b/libc/malloc/dprintf.c
@@ -4,16 +4,21 @@
 #include <paths.h>
 #include <fcntl.h>
 
-static char *uitostr(unsigned int val, int radix, int width)
+static char *fmtultostr(unsigned long val, int radix, int width)
 {
-    static char buf[6];
+    static char buf[34];
     char *p = buf + sizeof(buf) - 1;
     unsigned int c;
 
     *p = '\0';
     do {
+#ifdef _M_I86
+        c = radix;
+        val = __divmod(val, &c);
+#else
         c = val % radix;
         val = val / radix;
+#endif
         if (c > 9)
             *--p = 'a' - 10 + c;
         else
@@ -28,19 +33,22 @@ static char *uitostr(unsigned int val, int radix, int width)
 /*
  * Very tiny printf to console.
  * Supports:
- *  %{0-9}  width
+ *  %{0-9}  field width
+ *  %l{u,d,x,p}
  *  %u      unsigned decimal
  *  %d      decimal (positive numbers only)
- *  %p      zero-fill hexadecimal width 4
+ *  %p      pointer (zero-filled hexadecimal)
  *  %x      hexadecimal
  *  %s      string
  */
 int __dprintf(const char *fmt, ...)
 {
     unsigned int n;
+    unsigned long val;
     int radix, width;
     char *p;
     va_list va;
+    int lval;
     char b[80];
     static int fd = -1;
 
@@ -55,6 +63,7 @@ int __dprintf(const char *fmt, ...)
         if (*fmt == '%') {
             ++fmt;
             width = 0;
+            lval = 0;
             while (*fmt >= '0' && *fmt <= '9') {
                 width = width * 10 + *fmt - '0';
                 fmt++;
@@ -62,12 +71,17 @@ int __dprintf(const char *fmt, ...)
         again:
             switch (*fmt) {
             case 'l':
-                fmt++; goto again;
+                lval = 1;
+                fmt++;
+                goto again;
             case 's':
                 p = va_arg(va, char *);
                 goto outstr;
             case 'p':
-                width = 4;
+                if (sizeof(char *) == sizeof(unsigned long))
+                    lval = 1;
+                width = lval? 8: 4;
+                /* fall through */
             case 'x':
                 radix = 16;
                 goto convert;
@@ -75,7 +89,8 @@ int __dprintf(const char *fmt, ...)
             case 'u':
                 radix = 10;
         convert:
-                p = uitostr(va_arg(va, unsigned int), radix, width);
+                val = lval? va_arg(va, unsigned long): va_arg(va, unsigned int);
+                p = fmtultostr(val, radix, width);
         outstr:
                 while (*p && n < sizeof(b))
                     b[n++] = *p++;

--- a/libc/malloc/fmemalloc.c
+++ b/libc/malloc/fmemalloc.c
@@ -36,7 +36,7 @@ void __far *fmemalloc(unsigned long size)
 #if DEBUG
     total += size;
     if (size > maxsize) maxsize = size;
-    debug("total %lu, maxsize %lu\n", (unsigned)total, (unsigned)maxsize);
+    debug("total %lu, maxsize %lu\n", total, maxsize);
 #endif
     return MK_FP(seg, 0);
 }

--- a/libc/malloc/fmemalloc.c
+++ b/libc/malloc/fmemalloc.c
@@ -1,14 +1,53 @@
 #include <malloc.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/sysctl.h>
+/* fmemalloc/fmemfree - allocate/free from main memory */
 
-#define _MK_FP(seg,off) ((void __far *)((((unsigned long)(seg)) << 16) | (off)))
+#define DEBUG       1       /* =1 use sysctl, =2 debug output */
 
-/* alloc from main memory */
+#if DEBUG
+#define debug(...)  do { if (debug_level > 1) __dprintf(__VA_ARGS__); } while (0)
+static int debug_level = DEBUG;
+static unsigned long total;
+static unsigned long maxsize;
+#else
+#define debug(...)
+#endif
+
+#define FP_SEG(fp)       ((unsigned)((unsigned long)(void __far *)(fp) >> 16))
+#define FP_OFF(fp)       ((unsigned)(unsigned long)(void __far *)(fp))
+#define MK_FP(seg,off)   ((void __far *)((((unsigned long)(seg)) << 16) | \
+                                           ((unsigned int)(off))))
+
 void __far *fmemalloc(unsigned long size)
 {
     unsigned short seg;
     unsigned int paras = (unsigned int)((size + 15) >> 4);
 
-    if (_fmemalloc(paras, &seg))
+#if DEBUG == 1
+    sysctl(CTL_GET, "malloc.debug", &debug_level);
+#endif
+    debug("(%d)FMEMALLOC(%5lu) ", getpid(), size);
+    if (_fmemalloc(paras, &seg)) {
+        debug("= FAIL\n");
         return 0;
-    return _MK_FP(seg, 0);
+    }
+#if DEBUG
+    total += size;
+    if (size > maxsize) maxsize = size;
+    debug("total %lu, maxsize %lu\n", (unsigned)total, (unsigned)maxsize);
+#endif
+    return MK_FP(seg, 0);
+}
+
+int fmemfree(void __far *ptr)
+{
+    debug("(%d) fmemfree()\n", getpid());    // FIXME get size of allocation
+    if (FP_OFF(ptr)) {
+        debug("  FAIL (bad pointer)\n");    // FIXME convert to ASSERT
+        errno = EINVAL;
+        return -1;
+    }
+    return _fmemfree(FP_SEG(ptr));
 }

--- a/libc/malloc/fmemfree.c
+++ b/libc/malloc/fmemfree.c
@@ -1,7 +1,0 @@
-#include <malloc.h>
-
-/* free from main memory */
-int fmemfree(void __far *ptr)
-{
-    return _fmemfree((unsigned short)((unsigned long)ptr >> 16));
-}

--- a/libc/malloc/v7malloc.c
+++ b/libc/malloc/v7malloc.c
@@ -5,7 +5,7 @@
  * Enhancements:
  * Minimum BLOCK allocate from kernel sbrk, > BLOCK allocates requested size
  * Much improved size and heap overflow handling with errno returns
- * Full heap integrity checking and reporting with DEBUG options
+ * Full heap integrity checking and reporting with debug options
  * Use near heap pointers to work with OpenWatcom large model
  * Combine free areas at heap start before allocating from free area at end of heap
  */

--- a/libc/malloc/v7malloc.c
+++ b/libc/malloc/v7malloc.c
@@ -59,11 +59,11 @@ static  NPTR allocp;   /*search ptr*/
 static  NPTR alloct;   /*arena top*/
 static  NPTR allocx;   /*for benefit of realloc*/
 
+static int debug_level = DEBUG;
 #if DEBUG
 #define ASSERT(p)   if(!(p))malloc_assert_fail(#p,__LINE__);else {}
 #define debug(...)  do { if (debug_level > 1) __dprintf(__VA_ARGS__); } while (0)
 #define debug2(...) do { if (debug_level > 2) __dprintf(__VA_ARGS__); } while (0)
-static int debug_level = DEBUG;
 static void malloc_assert_fail(char *s, int);
 static void malloc_show_heap(void);
 static int malloc_check_heap(void);
@@ -308,6 +308,7 @@ malloc_show_heap(void)
     unsigned int size, alloc = 0, free = 0;
     static unsigned int maxalloc;
 
+    if (!debug_level) return;
     debug2("--- heap size ---\n");
     malloc_check_heap();
     for(p = (NPTR)&allocs[0]; clearbusy(next(p)) > p; p=clearbusy(next(p))) {


### PR DESCRIPTION
This PR allows for better understanding of debug output from the arena and debug malloc allocators, and new debug output was added to fmemalloc.

Now, when running `sysctl malloc.debug=2` before the toolchain, a one-line summary is displayed when malloc, free or fmemalloc is called. This information has been used to tune the 8086 toolchain programs.

For instance, the following is output when CPP86 is run:
```
(13)FMEMALLOC(16000) total 16000, maxsize 16000
(13)malloc(   17) alloc    26, free 15974, arena    26/16000
(13)malloc( 1024) alloc  1052, free 14948, arena  1052/16000
(13)malloc(   19) alloc  1074, free 14926, arena  1074/16000
(13)malloc(   17) alloc  1094, free 14906, arena  1094/16000
(13)malloc(   20) alloc  1116, free 14884, arena  1116/16000
(13)malloc(   36) alloc  1154, free 14846, arena  1154/16000
(13)malloc( 1024) alloc  2180, free 13820, arena  2180/16000
(13)malloc(   26) alloc  2208, free 13792, arena  2208/16000
(13)malloc(   20) alloc  2230, free 13770, arena  2230/16000
(13)malloc(   29) alloc  2262, free 13738, arena  2262/16000
(13)malloc(   20) alloc  2284, free 13716, arena  2284/16000
(13)malloc(   36) alloc  2322, free 13678, arena  2322/16000
(13)malloc( 1024) alloc  3348, free 12652, arena  3348/16000
(13)  free( 1024) alloc  2322, free 13678, arena  3348/16000
(13)  free(   36) alloc  2284, free 13716, arena  3348/16000
```
This shows the single fmemalloc for the arena malloc init, followed by each of the malloc/free's that CPP86 performs. It also shows the maximum use of the arena heap is 3348 bytes out of 16000. (I have lowered this from 64K significantly as a result). CPP86 does not use any fmemalloc calls from the arena malloc wrapper.

Here is the result from running C86:
```
(15)FMEMALLOC(16000) total 16000, maxsize 16000
(15)malloc(   36) alloc    44, free 15956, arena    44/16000
(15)malloc( 1024) alloc  1070, free 14930, arena  1070/16000
(15)malloc(   36) alloc  1108, free 14892, arena  1108/16000
(15)malloc( 1024) alloc  2134, free 13866, arena  2134/16000
(15)FMEMALLOC( 3076) total 19076, maxsize 16000
(15)malloc(  640) alloc  2776, free 13224, arena  2776/16000
(15)malloc(  512) alloc  3290, free 12710, arena  3290/16000
(15)FMEMALLOC( 3076) total 22152, maxsize 16000
(15) fmemfree()
(15)  free(  512) alloc  2776, free 13224, arena  3290/16000
(15)  free(  640) alloc  2134, free 13866, arena  3290/16000
(15) fmemfree()
```
Note only 3290 bytes of 16000 from arena heap, and two separate fmemallocs of 3076 bytes.

NASM86, on the other hand, ends up making thousands of malloc/free requests, all small, and can run in as little as 8K arena heap. However, it also makes tons of fmemalloc calls of large sizes. Nonetheless, I have used this information to reduce the memory requirements of NASM86 to an 8K arena with a 64 byte arena/main memory threshold.

I have used the results of this testing to lower the memory requirements of the 8086 toolchain. I will be submitting a PR there shortly.

Tested on QEMU making test.c. Not tested with chess.c - it will be interesting to see how much more memory is used.
