### PR TITLE
[libc] Fix libc OpenWatcom memcmp routine

### DIFF
--- a/libc/string/memcmp.c
+++ b/libc/string/memcmp.c
@@ -5,7 +5,7 @@ memcmp(const void *s1, const void *s2, size_t n)
 {
     const unsigned char *su1 = s1;
     const unsigned char *su2 = s2;
-    char res = 0;
+    signed char res = 0;
 
     for (; n > 0; n--)
 	if ((res = *su1++ - *su2++))


### PR DESCRIPTION
Fixes libc `memcmp` routine which never returned negative values when built with OpenWatcom. This was because 'char' is default 'unsigned char' for OWC.

Described in detail in https://github.com/ghaerr/8086-toolchain/pull/4.