### PR TITLE
[libc] Add __stackavail and __alloca for C86

### DIFF
--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -284,7 +284,6 @@ int sys_sbrk(int increment, segoff_t *pbrk)
     err = verify_area(VERIFY_WRITE, pbrk, sizeof(*pbrk));
     if (err)
         return err;
-    /* FIXME test for brk+increment overflow/underflow here */
     err = set_brk(brk, increment);
     if (err)
         return err;

--- a/libc/c86/Makefile
+++ b/libc/c86/Makefile
@@ -6,6 +6,7 @@ LIB ?= out.lib
 include $(TOPDIR)/libc/$(COMPILER).inc
 
 OBJS = $(patsubst %.s,%.ocj,$(wildcard *.s))
+OBJS += stackavail.o
 
 all: $(LIB)
 

--- a/libc/c86/c86lib.s
+++ b/libc/c86/c86lib.s
@@ -12,13 +12,26 @@
 ;
 ; C86 helper functions
 ;
-        .global __alloca
-__alloca:
+        .global ___alloca
+        .comm   ___stacklow,2   ; lowest protected SP value
+___alloca:
         pop     bx              ; ret address
         pop     ax              ; alloca size
+        inc     ax
+        and     ax,#0xfffe
+        mov     dx,ax           ; DX = size
+        mov     ax,sp
+        sub     ax,[___stacklow] ; AX = remaining
+        cmp     ax,#0           ; fail if remaining < 0
+        jc      .1
+        cmp     ax,dx           ; fail if remaining < size
+        jc      .1
+        mov     ax,dx           ; OK to extend stack
         sub     sp,ax
         mov     ax,sp           ; AX = mem
         jmp     bx              ; return (compiler won't readjust stack)
+.1:     xor     ax,ax
+        jmp     bx
 
         .global stackcheck
 stackcheck:

--- a/libc/c86/stackavail.c
+++ b/libc/c86/stackavail.c
@@ -1,0 +1,12 @@
+#include <alloca.h>
+/* C86 stack checking helper routines */
+
+/* Return true if stack can be extended by size bytes */
+int __stackavail(unsigned int size)
+{
+    unsigned int remaining = (unsigned)&size - __stacklow;
+
+    if ((int)remaining >= 0 && remaining >= size)
+        return 1;
+    return 0;
+}

--- a/libc/include/alloca.h
+++ b/libc/include/alloca.h
@@ -1,19 +1,17 @@
 #ifndef __ALLOCA_H
 #define __ALLOCA_H
 /*
- * Stack-checking alloca for GCC and OWC
+ * Stack-checking alloca for GCC, OWC and C86
  */
 
-// void *alloca(size_t);
-
-int __stackavail(unsigned int size);
-
-#define alloca(s)           (__stackavail(__ALLOCA_ALIGN(s))?   \
-                                 __alloca(__ALLOCA_ALIGN(s)): (void *)0)
-
-#define __ALLOCA_ALIGN(s)   (((s)+(sizeof(int)-1))&~(sizeof(int)-1))
+int __stackavail(unsigned int size);    /* return 1 if size bytes stack available */
+extern unsigned int __stacklow;         /* lowest protected SP value */
 
 #ifdef __GNUC__
+#define alloca(s)           (__stackavail(__ALLOCA_ALIGN(s))?   \
+                                 __alloca(__ALLOCA_ALIGN(s)): (void *)0)
+#define __ALLOCA_ALIGN(s)   (((s)+(sizeof(int)-1))&~(sizeof(int)-1))
+
 /* The compiler alloca auto-aligns the stack from the parameter somewhat strangely:
  * 0 -> 0, 1 -> 2, 2 -> 4, 3 -> 4, 4 -> 6 etc.
  * Thus, __stackavail should check for two more bytes available than asked for.
@@ -22,6 +20,10 @@ int __stackavail(unsigned int size);
 #endif
 
 #ifdef __WATCOMC__
+#define alloca(s)           (__stackavail(__ALLOCA_ALIGN(s))?   \
+                                 __alloca(__ALLOCA_ALIGN(s)): (void *)0)
+#define __ALLOCA_ALIGN(s)   (((s)+(sizeof(int)-1))&~(sizeof(int)-1))
+
 #pragma aux __stackavail "*" __modify __nomemory
 
 extern void __based(__segname("_STACK")) *__alloca(unsigned int __size);
@@ -30,6 +32,11 @@ extern void __based(__segname("_STACK")) *__alloca(unsigned int __size);
     __parm __nomemory [__ax]            \
     __value [__sp]                      \
     __modify __exact __nomemory [__sp]
+#endif
+
+#ifdef __C86__
+void *__alloca(size_t);
+#define alloca(s)           __alloca(s)
 #endif
 
 #endif

--- a/libc/watcom/syscall/crt0.c
+++ b/libc/watcom/syscall/crt0.c
@@ -44,7 +44,7 @@ int __argc;
 char **__argv;
 char *__program_filename;
 char **environ;
-unsigned int __stacklow;        /* lowest valid SP value */
+unsigned int __stacklow;        /* lowest protected SP value */
 unsigned char _HShift = 12;     /* huge pointer support required by pia.asm */
 
 #if defined(__SMALL__) || defined(__MEDIUM__)   /* near data models */


### PR DESCRIPTION
C86 \_\_alloca had to be modified to perform internal \_\_stackavail check since C86 adjusted the stack after evaluating the defined alloca macro calling both routines. Now internal stack checking is performed inside \_\_alloca. 

There is currently no guard section when computing remaining stack available for alloca. This can result that when one allocates almost all stack, say 'alloca(4000)', calling printf afterwords ends  up using another 150 bytes stack and the kernel prints the STACK USING UNUSED HEAP message.