### PR TITLE
[c86 libc] Correct signed compare in alloca

### DIFF
--- a/libc/c86/c86lib.s
+++ b/libc/c86/c86lib.s
@@ -22,9 +22,9 @@ ___alloca:
         mov     dx,ax           ; DX = size
         mov     ax,sp
         sub     ax,[___stacklow] ; AX = remaining
-        cmp     ax,#0           ; fail if remaining < 0
+        cmp     ax,#0           ; fail if (int)remaining < 0
         jl      .1
-        cmp     ax,dx           ; fail if remaining < size
+        cmp     ax,dx           ; fail if (unsigned)remaining < size
         jc      .1
         mov     ax,dx           ; OK to extend stack
         sub     sp,ax

--- a/libc/c86/c86lib.s
+++ b/libc/c86/c86lib.s
@@ -23,7 +23,7 @@ ___alloca:
         mov     ax,sp
         sub     ax,[___stacklow] ; AX = remaining
         cmp     ax,#0           ; fail if remaining < 0
-        jc      .1
+        jl      .1
         cmp     ax,dx           ; fail if remaining < size
         jc      .1
         mov     ax,dx           ; OK to extend stack

--- a/libc/misc/qsort.c
+++ b/libc/misc/qsort.c
@@ -61,7 +61,7 @@ void qsort(void *a, size_t n, size_t width, int (*cmp)(void *, void *))
 	for (i = (n + 1) >> 1; i; i--)
 		fix(a, i - 1, n - 1, width, cmp);
 	for (i = n - 1; i; i--) {
-		swap(a, ((char *)a) + i * width, width);
+		swap(a, (char *)a + i * width, width);
 		fix(a, 0, i - 1, width, cmp);
 	}
 }


### PR DESCRIPTION
Corrects comparison from unsigned to signed in alloca for 'if ((int)remaining < 0)'.

Fixes correct handling of right-associative cast by C86 for qsort.c from previous commit.