### PR TITLE
[build] Fix make clean and add comments to wcenv.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,13 +35,17 @@ kclean:
 
 clean:
 	$(MAKE) -C libc clean
-	$(MAKE) -C libc -f watcom.mk clean
-	$(MAKE) -C libc -f c86.mk
 	$(MAKE) -C libc DESTDIR='$(TOPDIR)/cross' uninstall
 	$(MAKE) -C elks clean
 	$(MAKE) -C bootblocks clean
 	$(MAKE) -C elkscmd clean
 	$(MAKE) -C image clean
+ifneq "$(WATCOM)" ""
+	$(MAKE) -C libc -f watcom.mk clean
+endif
+ifneq "$(C86)" ""
+	$(MAKE) -C libc -f c86.mk clean
+endif
 ifeq ($(shell uname), Linux)
 	$(MAKE) -C elksemu clean
 endif

--- a/libc/wcenv.sh
+++ b/libc/wcenv.sh
@@ -3,9 +3,11 @@
 # Set up Watcom build environment
 #
 # Usage: . ./wcenv.sh
+#
+# NOTE: The export= and add_path lines below need to be edited for your system.
 
-# change to OpenWatcom installation root it is full path to OpenWatcom location
-# if you use your own OpenWatcom build than it is located in rel subdirectory
+# Change below to OpenWatcom installation root: the full path to OpenWatcom location.
+# If you use your own OpenWatcom build than it is located in rel subdirectory.
 export WATCOM=/Users/greg/net/open-watcom-v2/rel
 
 add_path () {
@@ -14,6 +16,7 @@ add_path () {
 	fi
 }
 
+# Change below according to whether your host system is Linux or macOS
 #add_path "$WATCOM/binl"    # for Linux-32
 #add_path "$WATCOM/binl64"  # for Linux-64
 add_path "$WATCOM/bino64"   # for macOS


### PR DESCRIPTION
Fixes "make clean" when OpenWatcom or 8086-toolchain are not installed, as discussed in https://github.com/ghaerr/elks/issues/2159#issuecomment-2564718401.

Adds a note in libc/wcenv.sh so that users don't miss the need to edit 'add_path' for Linux.