### PR TITLE
[c86] Build and copy C86 toolchain automatically to ELKS /root

### DIFF
--- a/buildc86.sh
+++ b/buildc86.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# buildc86.sh - build host and native ELKS C86 toolchain
+#
+# Requires that the ELKS, WATCOM and C86 variables have been setup using:
+#   cd ELKS; . env.sh                   (sets TOPDIR=)
+#   cd libc; . wcenv.sh; . c86env.sh    (sets WATCOM= and C86=)
+#
+# Usage: ./buildc86.sh
+#
+set -e
+
+if [ -z "$TOPDIR" ]
+  then
+    echo "ELKS TOPDIR= environment variable not set, run . env.sh"
+    exit
+fi
+
+if [ -z "$WATCOM" ]
+  then
+    echo "OpenWatcom WATCOM= environment variable not set, run cd libc; . wcenv.sh"
+    exit
+fi
+
+if [ -z "$C86" ]
+  then
+    echo "C86= environment variable not set, run cd libc; . c86env.sh"
+    exit
+fi
+
+# build ELKS
+#cd $ELKS
+#make
+
+# build c86 cross compiler toolchain using OWC and GCC in 8086-toolchain/host-bin
+cd $C86
+make clean
+make host
+
+# build native OWC library libc/libc.a usin OWC
+cd $TOPDIR
+make owc
+cd $C86
+
+# build ELKS Version of c86 using host OWC and native OWC libc in 8086-toolchain/elks-bin
+make elks
+
+# build native c86 library libc/libc86.a using host c86
+cd $TOPDIR
+make c86
+
+# build ELKS example apps using host c86 and native c86 libc in 8086-toolchain/examples
+cd $C86/examples
+make 

--- a/copyc86.sh
+++ b/copyc86.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# copyc86.sh - copy native ELKS C86 toolchain, header files and examples to ELKS /root
+#
+# Usage: ./copyc86.sh
+#
+set -e
+
+if [ -z "$TOPDIR" ]
+  then
+    echo "ELKS TOPDIR= environment variable not set, run . env.sh"
+    exit
+fi
+
+if [ -z "$C86" ]
+  then
+    echo "C86= environment variable not set, run cd libc; . c86env.sh"
+    exit
+fi
+
+DEST=$TOPDIR/elkscmd/rootfs_template/root
+
+cd $TOPDIR
+cp -p libc/include/c86/*.h      $DEST
+cp -p libc/libc86.a             $DEST
+
+cd $C86
+cp -p elks-bin/make             $DEST
+cp -p elks-bin/cpp86            $DEST
+cp -p elks-bin/c86              $DEST
+cp -p elks-bin/as86             $DEST
+cp -p elks-bin/ld86             $DEST
+cp -p elks-bin/ar86             $DEST
+cp -p elks-bin/objdump86        $DEST
+cp -p elks-bin/disasm86         $DEST
+cp -p elks-bin/cpp86            $DEST
+cd examples
+cp -p *.c *.h                   $DEST
+cp -p Makefile.elks             $DEST/Makefile


### PR DESCRIPTION
This PR adds a script that will build the entire C86 toolchain from scratch, and and another that will copy all required headers, libraries and example source files to ELKS /root so an image can easily be made to test running C86.

Usage:
```
(edit and run '. env.sh', '. wcenv.sh' and '. c86.sh' first to set TOPDIR=, WATCOM= and C86= environ vars)
$ ./buildc86.sh     # builds host and native ELKS toolchain and libraries
$ ./copyc86.sh     # copies libraries, headers and examples to /root
$ make kimage     # quickly build image (must be 2880k or larger, won't fit on 1440k floppy)
```