### PR TITLE
[cmds] Display "Can't run OpenWatcom OS/2 program" when CONFIG_EXEC_OS2 not set

### DIFF
--- a/elkscmd/ash/exec.c
+++ b/elkscmd/ash/exec.c
@@ -168,6 +168,9 @@ tryexec(cmd, argv, envp)
 			argv[0] = cmd;
 			execinterp(argv, envp);
 		}
+		if (parsenleft > 2 && p[0] == 'M' && p[1] == 'Z') {
+			error2("Can't run OpenWatcom OS/2 program", "Set CONFIG_EXEC_OS2=y in kernel");
+		}
 #endif
 		setparam(argv + 1);
 		exraise(EXSHELLPROC);

--- a/elkscmd/rootfs_template/etc/profile
+++ b/elkscmd/rootfs_template/etc/profile
@@ -1,4 +1,4 @@
-export PATH=/bin
+export PATH=.:/bin
 PS1="$HOSTNAME$PS1"
 umask 022
 #FAT permissions fix


### PR DESCRIPTION
The shell will now display an understandable error message when trying to execute OpenWatcom OS/2 executable format programs when CONFIG_EXEC_OS2 isn't set in .config.

Also adds '.' in PATH, so only "make" rather than "./make" are required to run example programs in /root (see https://github.com/ghaerr/8086-toolchain/pull/25).

Here's a screenshot showing what the shell displays:
<img width="832" alt="Screen Shot 2024-12-30 at 2 06 00 PM" src="https://github.com/user-attachments/assets/761555c7-ad80-4f5b-819b-b1d6707a7ec9" />

