### PR TITLE
[kernel] Fix FAT filesystem adding blocks when seeking past EOF

### DIFF
--- a/elks/fs/msdos/fat.c
+++ b/elks/fs/msdos/fat.c
@@ -248,6 +248,7 @@ cluster_t FATPROC get_cluster(register struct inode *inode, cluster_t cluster)
 	cluster_t this, count;
 
 	if (!(this = inode->u.msdos_i.i_start)) return 0;
+	debug("get_cluster %ld = %ld\n", cluster, this);
 	if (!cluster) return this;
 	count = 0;
 	for (cache_lookup(inode,cluster,&count,&this); count < cluster; count++) {

--- a/elks/fs/msdos/namei.c
+++ b/elks/fs/msdos/namei.c
@@ -182,7 +182,7 @@ static int FATPROC msdos_create_entry(struct inode *dir,const char *name,int is_
 		/* if rootdir return no space*/
 		if (dir->i_ino == MSDOS_ROOT_INO) return -ENOSPC;
 		/* try adding space to directory*/
-		if ((res = msdos_add_cluster(dir)) < 0) return res;
+		if ((res = msdos_add_cluster(dir, 0)) < 0) return res;
 		/* if can't find empty entry return error*/
 		if ((res = msdos_scan(dir,NULL,&bh,&de,&ino)) < 0) return res;
 	}
@@ -259,7 +259,7 @@ int msdos_mkdir(struct inode *dir,const const char *name,size_t len,mode_t mode)
 	}
 
 	inode->u.msdos_i.i_busy = 1; /* prevent lookups */
-	if ((res = msdos_add_cluster(inode)) < 0) goto mkdir_error;
+	if ((res = msdos_add_cluster(inode, 0)) < 0) goto mkdir_error;
 	if ((res = msdos_create_entry(inode,MSDOS_DOT,1,&dot)) < 0)
 		goto mkdir_error;
 

--- a/elks/fs/open.c
+++ b/elks/fs/open.c
@@ -240,7 +240,7 @@ int sys_open(const char *filename, int flags, mode_t mode)
     if ((flags + 1) & O_ACCMODE) flag++;
     if (flag & (O_TRUNC | O_CREAT)) flag |= FMODE_WRITE;
 
-    debug_cache("\nOPEN '%t' flags %02x ", filename, flags);
+    debug_file("\nOPEN '%t' flags %02x ", filename, flags);
     error = open_namei(filename, flag, mode, &inode, NULL);
     if (!error) {
         if ((error = open_fd(flags, inode)) < 0)

--- a/elks/fs/read_write.c
+++ b/elks/fs/read_write.c
@@ -22,6 +22,7 @@ int sys_lseek(unsigned int fd, loff_t * p_offset, unsigned int origin)
     loff_t offset;
 
     offset = (loff_t) get_user_long(p_offset);
+    debug_file("lseek %d, %ld, %d\n", fd, offset, origin);
     if (fd >= NR_OPEN || !(file = current->files.fd[fd]) || !(file->f_inode))
 	return -EBADF;
     if (origin > 2) return -EINVAL;
@@ -97,6 +98,7 @@ int sys_write(unsigned int fd, char *buf, size_t count)
     register struct inode *inode;
     int written;
 
+    debug_file("write %d, buf, %u\n", fd, count);
     if (((written = fd_check(fd, buf, count, FMODE_WRITE, &file)) == 0) && count) {
 	written = -EINVAL;
 	fop = file->f_op;

--- a/elks/include/linuxmt/msdos_fs.h
+++ b/elks/include/linuxmt/msdos_fs.h
@@ -121,7 +121,7 @@ struct buffer_head * FATPROC msdos_sread_nomap(struct super_block *s, sector_t s
 struct buffer_head * FATPROC msdos_sread(struct super_block *s, sector_t sector, void **start);
 void FATPROC lock_creation(void);
 void FATPROC unlock_creation(void);
-int  FATPROC msdos_add_cluster(struct inode *inode);
+int  FATPROC msdos_add_cluster(struct inode *inode, int dontuseisize);
 long FATPROC date_dos2unix(unsigned short time,unsigned short date);
 void FATPROC date_unix2dos(long unix_date,unsigned short *time, unsigned short *date);
 ino_t FATPROC msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head **bh,


### PR DESCRIPTION
This PR fixes the recently found issue with the FAT filesystem not properly adding file blocks to a file when seeking past EOF and then writing. The 8086 toolchain linker LD86 does this and would not function properly on FAT filesystems.

Discussed in https://github.com/ghaerr/elks/issues/2159#issuecomment-2565962085 and issued opened with #2166.

The 8086 toolchain now runs properly on FAT and MINIX filesystems.