### PR TITLE
[c86 libc] Ensure no data has address zero

### DIFF
--- a/libc/c86/syscall.s
+++ b/libc/c86/syscall.s
@@ -7,7 +7,9 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
         use16   86
 
-        .data
+        .sect   1               ; first data seg
+        dw      0,0             ; prevent data having address 0
+        .data                   ; default data seg 3
         .align  2
         .comm   _errno,2
         .comm   _environ,2

--- a/libc/stdio/vfprintf.c
+++ b/libc/stdio/vfprintf.c
@@ -294,9 +294,7 @@ vfprintf(FILE *op, const char *fmt, va_list ap)
 
          case 's':              /* String */
             p = va_arg(ap, char *);
-#ifndef __C86__     /* FIXME add 4 bytes nullptr at start of .data */
             if (!p) p = "(null)";
-#endif
           nopad:
             sign = '\0';
             pad = ' ';


### PR DESCRIPTION
Uses AS86 pseudo op change in https://github.com/ghaerr/8086-toolchain/pull/27.

In startup code, ".sect 1" is used to force 4 bytes of zeroes to be allocated by LD86 before the normal .data segment. This in turn allows for C86-generated static data to never be assigned address zero.

Removes previous vprintf null pointer display hack for C86.