### PR TITLE
[watcom] Save DS register across syscalls, don't set DS on NULL pointers

### DIFF
--- a/elks/tools/objtools/ecc
+++ b/elks/tools/objtools/ecc
@@ -51,8 +51,8 @@ CFLAGS="\
 
 ASFLAGS="\
     -0                          \
-    -O                          \
     -j                          \
+    -O                          \
     -w-                         \
     "
 

--- a/elks/tools/objtools/ewcc
+++ b/elks/tools/objtools/ewcc
@@ -37,6 +37,7 @@ WATCINCLUDE=$WATCOM/h
 # -Wc,-wcd=N                # disable warning N
 # -Wc,-fpi87                # inline 8087 fp
 # -Wc,-x                    # ignore INCLUDE environment variable
+# -Wc,-r                    # save/restore segment registers
 # -fnostdlib                # don't refere standard libraries
 # unused:
 # -fno-stack-check          # don't generate stack check code

--- a/libc/include/string.h
+++ b/libc/include/string.h
@@ -29,6 +29,7 @@ int memcmp(const void*, const void*, size_t);
 void * memmove(void*, const void*, size_t);
 
 void __far *fmemset(void __far *buf, int c, size_t l);
+int fmemcmp(void __far *s1, void __far *s2, size_t n);  /* Watcom C only, in ASM */
 
 /* Error messages */
 char * strerror(int);

--- a/libc/include/watcom/syselks.h
+++ b/libc/include/watcom/syselks.h
@@ -202,7 +202,7 @@ syscall_res sys_call5( unsigned func, unsigned r_bx, unsigned r_cx, unsigned r_d
 
 /* Set the DS register from passed far address before system call */
 #if defined(__COMPACT__) || defined(__LARGE__)
-#define sys_setseg(ptr)     sys_setds(((unsigned long)ptr) >> 16)
+#define sys_setseg(ptr)         if (ptr) sys_setds(((unsigned long)ptr) >> 16)
 #else
 #define sys_setseg(ptr)         /* DS already set in small and medium models */
 #endif

--- a/libc/watcom/asm/fmemcmp.asm
+++ b/libc/watcom/asm/fmemcmp.asm
@@ -1,0 +1,46 @@
+; int fmemcmp(void __far *s1, void __far *s2, size_t n)
+;   returns 0 on match, otherwise nonzero
+;
+; 2 Jan 2025 Greg Haerr
+
+include mdef.inc
+include struct.inc
+
+        modstart    fmemcmp
+
+        xdefp   "C",fmemcmp
+        defpe    fmemcmp
+
+; s1 in DX:AX, s2 in CX:BX, n on stack
+        push    bp
+        mov     bp,sp
+        push    si
+        push    di
+
+        mov     ds,dx
+        mov     si,ax
+        mov     es,cx
+        mov     di,bx
+if _MODEL and _BIG_CODE
+        mov     cx,6[bp]    ; n
+else
+        mov     cx,4[bp]    ; n
+endif
+        cld
+        repz cmpsb
+        jz     L1           ; equal
+
+        mov     ax,1        ; not equal, returns nonzero
+        pop     di
+        pop     si
+        pop     bp
+        ret     2
+L1:     xor     ax,ax
+        pop     di
+        pop     si
+        pop     bp
+        ret     2
+
+fmemcmp endp
+        endmod
+        end

--- a/libc/watcom/syscall/Makefile
+++ b/libc/watcom/syscall/Makefile
@@ -5,6 +5,8 @@ LIB ?= out.lib
 
 include $(TOPDIR)/libc/$(COMPILER).inc
 
+# save/restore segment registers for all functions using sys_setseg
+CFLAGS += -Wc,-r
 OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 
 all: $(LIB)

--- a/libc/watcom/syscall/access.c
+++ b/libc/watcom/syscall/access.c
@@ -32,9 +32,9 @@
 #include <unistd.h>
 #include "watcom/syselks.h"
 
-int access( const char *filename, int mode )
+int access( const char *__filename, int mode )
 {
-    sys_setseg(filename);
-    syscall_res res = sys_call2( SYS_access, (unsigned)filename, mode );
+    sys_setseg(__filename);
+    syscall_res res = sys_call2( SYS_access, (unsigned)__filename, mode );
     __syscall_return( int, res );
 }

--- a/libc/watcom/syscall/execve.c
+++ b/libc/watcom/syscall/execve.c
@@ -10,6 +10,7 @@
 int _execve(const char *__fname, char *__stk_ptr, int __stack_bytes)
 {
     sys_setseg(__fname);
+    sys_setseg(__stk_ptr);
     syscall_res res = sys_call3( SYS_execve, (unsigned)__fname, (unsigned)__stk_ptr,
         __stack_bytes);
     __syscall_return( int, res );

--- a/libc/watcom/syscall/gettimeofday.c
+++ b/libc/watcom/syscall/gettimeofday.c
@@ -8,8 +8,8 @@
 
 int gettimeofday(struct timeval * restrict __tv, void * restrict __tzp)
 {
-    if (__tv) sys_setseg(__tv);
-    else if (__tzp) sys_setseg(__tzp);
+    sys_setseg(__tv);
+    sys_setseg(__tzp);
     syscall_res res = sys_call2(SYS_gettimeofday, (unsigned)__tv, (unsigned)__tzp);
     __syscall_return(int, res);
 }

--- a/libc/watcom/syscall/link.c
+++ b/libc/watcom/syscall/link.c
@@ -35,6 +35,7 @@
 int link( const char *__path1, const char *__path2 )
 {
     sys_setseg(__path1);
+    sys_setseg(__path2);
     syscall_res res = sys_call2( SYS_link, (unsigned)__path1, (unsigned)__path2 );
     __syscall_return( int, res );
 }

--- a/libc/watcom/syscall/lstat.c
+++ b/libc/watcom/syscall/lstat.c
@@ -32,9 +32,10 @@
 #include <sys/stat.h>
 #include "watcom/syselks.h"
 
-int lstat( const char *filename, struct stat * __buf )
+int lstat( const char *__filename, struct stat * __buf )
 {
+    sys_setseg(__filename);
     sys_setseg(__buf);
-    syscall_res res = sys_call2( SYS_lstat, (unsigned)filename, (unsigned)__buf );
+    syscall_res res = sys_call2( SYS_lstat, (unsigned)__filename, (unsigned)__buf );
     __syscall_return( int, res );
 }

--- a/libc/watcom/syscall/mount.c
+++ b/libc/watcom/syscall/mount.c
@@ -10,6 +10,7 @@
 int mount(const char *__dev, const char *__dir, int __type, int __flags)
 {
     sys_setseg(__dev);
+    sys_setseg(__dir);
     syscall_res res = sys_call4( SYS_mount, (unsigned)__dev, (unsigned)__dir, __type,
         __flags);
     __syscall_return( int, res );

--- a/libc/watcom/syscall/readlink.c
+++ b/libc/watcom/syscall/readlink.c
@@ -34,6 +34,7 @@
 
 int readlink( const char *__path, char *__buf, size_t __bufsiz )
 {
+    sys_setseg(__path);
     sys_setseg(__buf);
     syscall_res res = sys_call3( SYS_readlink, (unsigned)__path, (unsigned)__buf, __bufsiz );
     __syscall_return( int, res );

--- a/libc/watcom/syscall/remove.c
+++ b/libc/watcom/syscall/remove.c
@@ -34,9 +34,9 @@
 #include "watcom/syselks.h"
 
 
-int remove( const char *filename )
+int remove( const char *__filename )
 {
-    sys_setseg(filename);
-    syscall_res res = sys_call1( SYS_unlink, (unsigned)filename );
+    sys_setseg(__filename);
+    syscall_res res = sys_call1( SYS_unlink, (unsigned)__filename );
     __syscall_return( int, res );
 }

--- a/libc/watcom/syscall/rename.c
+++ b/libc/watcom/syscall/rename.c
@@ -35,6 +35,7 @@
 int rename( const char *__old, const char *__new )
 {
     sys_setseg(__old);
+    sys_setseg(__new);
     syscall_res res = sys_call2( SYS_rename, (unsigned)__old, (unsigned)__new );
     __syscall_return( int, res );
 }

--- a/libc/watcom/syscall/select.c
+++ b/libc/watcom/syscall/select.c
@@ -36,9 +36,10 @@
 
 int select( int __width, fd_set * __readfds, fd_set * __writefds, fd_set * __exceptfds, struct timeval * __timeout )
 {
-    if (__readfds) sys_setseg(__readfds);
-    else if (__writefds) sys_setseg(__writefds);
-    else if (__timeout) sys_setseg(__timeout);
+    sys_setseg(__readfds);
+    sys_setseg(__writefds);
+    sys_setseg(__exceptfds);
+    sys_setseg(__timeout);
     syscall_res res = sys_call5( SYS_select, __width, (unsigned)__readfds, (unsigned)__writefds, (unsigned)__exceptfds, (unsigned)__timeout );
     __syscall_return( int, res );
 }

--- a/libc/watcom/syscall/stat.c
+++ b/libc/watcom/syscall/stat.c
@@ -36,6 +36,7 @@
 /* in large/compact mode, __filename and __buf must be from same segment! */
 int stat( const char *__filename, struct stat * __buf )
 {
+    sys_setseg(__filename);
     sys_setseg(__buf);
     syscall_res res = sys_call2( SYS_stat, (unsigned)__filename, (unsigned)__buf);
     __syscall_return( int, res );

--- a/libc/watcom/syscall/symlink.c
+++ b/libc/watcom/syscall/symlink.c
@@ -35,6 +35,7 @@
 int symlink( const char *__pname, const char *__slink )
 {
     sys_setseg(__pname);
+    sys_setseg(__slink);
     syscall_res res = sys_call2( SYS_symlink, (unsigned)__pname, (unsigned)__slink );
     __syscall_return( int, res );
 }

--- a/libc/watcom/syscall/sysctl.c
+++ b/libc/watcom/syscall/sysctl.c
@@ -10,6 +10,7 @@
 int sysctl( int op, char * __name, int * __value)
 {
     sys_setseg(__name);
+    sys_setseg(__value);
     syscall_res res = sys_call3( SYS_sysctl, op, (unsigned)__name, (unsigned)__value);
     __syscall_return( int, res );
 }

--- a/libc/watcom/syscall/unlink.c
+++ b/libc/watcom/syscall/unlink.c
@@ -34,9 +34,9 @@
 #include "watcom/syselks.h"
 
 
-int unlink( const char *filename )
+int unlink( const char *__filename )
 {
-    sys_setseg(filename);
-    syscall_res res = sys_call1( SYS_unlink, (unsigned)filename );
+    sys_setseg(__filename);
+    syscall_res res = sys_call1( SYS_unlink, (unsigned)__filename );
     __syscall_return( int, res );
 }

--- a/libc/watcom/syscall/utime.c
+++ b/libc/watcom/syscall/utime.c
@@ -35,6 +35,7 @@
 int utime( const char *__path, struct utimbuf * __times )
 {
     sys_setseg(__path);
+    sys_setseg(__times);
     syscall_res res = sys_call2( SYS_utime, (unsigned)__path, (unsigned)__times );
     __syscall_return( int, res );
 }

--- a/libc/watcom/syscall/wait4.c
+++ b/libc/watcom/syscall/wait4.c
@@ -33,11 +33,11 @@
 #include <sys/wait.h>
 #include "watcom/syselks.h"
 
-pid_t wait4( pid_t __pid, int *__stat_loc, int __options, struct rusage *rusage )
+pid_t wait4( pid_t __pid, int *__stat_loc, int __options, struct rusage *__rusage )
 {
-    if (__stat_loc)
-        sys_setseg(__stat_loc);
+    sys_setseg(__stat_loc);
+    sys_setseg(__rusage);
     syscall_res res = sys_call4( SYS_wait4, __pid, (unsigned)__stat_loc, __options,
-        (unsigned)rusage );
+        (unsigned)__rusage );
     __syscall_return( pid_t, res );
 }


### PR DESCRIPTION
The DS register would be set to zero when NULL was passed to system calls in the OpenWatcom version of the ELKS C library. This then allowed a NULL DS register to be write outside the process address space in the previous commit.

This PR now saves DS across Watcom system call wrappers using the OWC -Wc,-r option so this won't ever happen. In addition, the sys_setseg macro checks for NULL and won't set DS if so.

All pointer arguments to Watcom syscalls are now checked/set with sys_setseg, and the OWC syscall wrappers cleaned up.

A Watcom ASM version of fmemcmp is added to the C library, although still unused by 8086 toolchain as an inline version was written within AS86 for highest speed.
