### PR TITLE
[watcom libc] Improve fmemcmp

### DIFF
--- a/libc/watcom/asm/fmemcmp.asm
+++ b/libc/watcom/asm/fmemcmp.asm
@@ -1,5 +1,5 @@
 ; int fmemcmp(void __far *s1, void __far *s2, size_t n)
-;   returns 0 on match, otherwise nonzero
+;   returns 0 on match, otherwise -1/1.
 ;
 ; 2 Jan 2025 Greg Haerr
 
@@ -26,17 +26,13 @@ if _MODEL and _BIG_CODE
 else
         mov     cx,4[bp]    ; n
 endif
+        xor     ax,ax       ; assume match
         cld
         repz cmpsb
-        jz     L1           ; equal
-
-        mov     ax,1        ; not equal, returns nonzero
-        pop     di
-        pop     si
-        pop     bp
-        ret     2
-L1:     xor     ax,ax
-        pop     di
+        jz      L1          ; equal
+        sbb     ax,ax       ; not equal, AX now 0 or -1
+        or      ax,1        ; AX now 1 or -1
+L1:     pop     di
         pop     si
         pop     bp
         ret     2

--- a/libc/watcom/asm/fmemcmp.asm
+++ b/libc/watcom/asm/fmemcmp.asm
@@ -1,5 +1,6 @@
-; int fmemcmp(void __far *s1, void __far *s2, size_t n)
-;   returns 0 on match, otherwise -1/1.
+;  int fmemcmp(void __far *s1, void __far *s2, size_t n)
+;   returns 0 on match, otherwise -1/1 on the difference
+;   of the first differing bytes as unsigned char values
 ;
 ; 2 Jan 2025 Greg Haerr
 


### PR DESCRIPTION
Improves fmemcmp for OWC by returning -1/1 based on the difference of the first differing bytes, treated as unsigned char values. While not yet used, this is required by the C86 toolchain memcmp function in compiler/expr.c.