### PR TITLE
[libc] Rename __amalloc -> _fmalloc, __dmalloc -> _dmalloc

### DIFF
--- a/elkscmd/ash/Makefile
+++ b/elkscmd/ash/Makefile
@@ -26,7 +26,7 @@ OBJS=	builtins.o cd.o dirent.o error.o eval.o exec.o expand.o input.o \
 	linenoise_elks.o autocomplete.o
 
 # heap debugging using v7 debug malloc
-#OBJS += v7stub.o
+#OBJS += dmalloc.o
 
 # builtins must be manually added
 OBJS += bltin/echo.o

--- a/elkscmd/ash/dmalloc.c
+++ b/elkscmd/ash/dmalloc.c
@@ -3,15 +3,15 @@
 
 void *malloc(size_t size)
 {
-    return __dmalloc(size);
+    return _dmalloc(size);
 }
 
 void free(void *ptr)
 {
-    __dfree(ptr);
+    _dfree(ptr);
 }
 
 void *realloc(void *ptr, size_t size)
 {
-    return __drealloc(ptr, size);
+    return _drealloc(ptr, size);
 }

--- a/elkscmd/tui/Makefile
+++ b/elkscmd/tui/Makefile
@@ -13,7 +13,7 @@ PRGS = fm matrix cons ttyinfo sl ttyclock ttypong ttytetris invaders
 #PRGS_HOST =
 
 TUILIB = tty.o runes.o unikey.o
-MALLOC=v7stub.o
+MALLOC=dmalloc.o
 
 all: $(PRGS) $(PRGS_HOST)
 

--- a/elkscmd/tui/dmalloc.c
+++ b/elkscmd/tui/dmalloc.c
@@ -3,15 +3,15 @@
 
 void *malloc(size_t size)
 {
-    return __dmalloc(size);
+    return _dmalloc(size);
 }
 
 void free(void *ptr)
 {
-    __dfree(ptr);
+    _dfree(ptr);
 }
 
 void *realloc(void *ptr, size_t size)
 {
-    return __drealloc(ptr, size);
+    return _drealloc(ptr, size);
 }

--- a/libc/include/malloc.h
+++ b/libc/include/malloc.h
@@ -3,26 +3,26 @@
 
 #include <sys/types.h>
 
-/* default malloc (dev86) */
+/* default malloc (dev86 near heap) */
 void   *malloc(size_t);
 void   *realloc(void *, size_t);
 void    free(void *);
 size_t  malloc_usable_size(void *);
 
-/* debug malloc (v7 malloc) */
-void   *__dmalloc(size_t);
-void   *__drealloc(void *, size_t);
-void    __dfree(void *);
-size_t  __dmalloc_usable_size(void *);
+/* debug malloc (v7 malloc near heap) */
+void   *_dmalloc(size_t);
+void   *_drealloc(void *, size_t);
+void    _dfree(void *);
+size_t  _dmalloc_usable_size(void *);
 
-/* arena malloc (64k near/unlimited far heap) */
-void   *__amalloc(size_t);
-int     __amalloc_add_heap(char __far *start, size_t size);
-void   *__arealloc(void *, size_t);         /* not implemented */
-void    __afree(void *);
-size_t  __amalloc_usable_size(void *);
-extern unsigned int malloc_arena_size;
-extern unsigned int malloc_arena_thresh;
+/* _fmalloc (single arena 64k far heap) */
+void __far *_fmalloc(size_t);
+int         _fmalloc_add_heap(char __far *start, size_t size);
+void __far *_frealloc(void *, size_t);         /* not implemented */
+void        _ffree(void __far *);
+size_t      _fmalloc_usable_size(void __far *);
+extern unsigned int malloc_arena_size;          /* mem.c wrapper function */
+extern unsigned int malloc_arena_thresh;        /* mem.c wrapper function */
 
 /* usable with all mallocs */
 void   *calloc(size_t elm, size_t sz);

--- a/libc/malloc/Makefile
+++ b/libc/malloc/Makefile
@@ -26,10 +26,10 @@ DEFAULT_MALLOC_OBJS = \
 	alloca.o \
 
 # debug malloc (v7)
-DEBUG_MALLOC_OBJS = v7malloc.o
+DEBUG_MALLOC_OBJS = dmalloc.o
 
-# arena malloc
-ARENA_MALLOC_OBJS = amalloc.o
+# far malloc (single arena)
+FAR_MALLOC_OBJS = fmalloc.o
 
 # these objects work with any malloc
 OBJS = \
@@ -42,9 +42,9 @@ OBJS = \
 # default and debug mallocs for all compilers
 OBJS += $(DEFAULT_MALLOC_OBJS) $(DEBUG_MALLOC_OBJS)
 
-# arena malloc works with OWC only for now
+# far malloc works with OWC only for now
 ifeq "$(COMPILER)" "watcom"
-OBJS += $(ARENA_MALLOC_OBJS)
+OBJS += $(FAR_MALLOC_OBJS)
 endif
 
 IA16OBJS = \


### PR DESCRIPTION
Renames \_\_amalloc to \_fmalloc in preparation for multi-heap arena malloc. 
Renames \_\_dmalloc to \_dmalloc because adopting only single-underbar for libc internal functions. C86 has external symbol table limit of 8 characters, though this doesn't affect symbol linkage.

General cleanup of both functions; increases speed for \_dmalloc slightly when DEBUG != 3 (previously fixed in \_\_amalloc).