### PR TITLE
[cmds] Update 'sys' and 'mknod' to work for updating ELKS

### DIFF
--- a/elkscmd/file_utils/cp.c
+++ b/elkscmd/file_utils/cp.c
@@ -428,6 +428,8 @@ int do_symlink(char *symlnk, char *file)
 {
 	if (opt_verbose) printf("Symlink %s -> %s\n", file, symlnk);
 
+	if (opt_force)
+		unlink(file);
 	if (symlink(symlnk, file) < 0) {
 		fprintf(stderr, "Can't create symlink "); fflush(stderr);
 		perror(symlnk);

--- a/elkscmd/file_utils/mknod.c
+++ b/elkscmd/file_utils/mknod.c
@@ -17,9 +17,9 @@ int main(int argc, char **argv)
 		/* preserve option */
 		struct stat sb;
 		if (stat(argv[2], &sb) == 0) {
-			if (S_ISCHR(sb.st_mode) && argv[3] && (argv[3][0] == 'c' || argv[3][0] == 'u')) return 1;
-			if (S_ISBLK(sb.st_mode)  && argv[3] && argv[3][0] == 'b') return 1;
-			if (S_ISFIFO(sb.st_mode) && argv[3] && argv[3][0] == 'p') return 1;
+			if (S_ISCHR(sb.st_mode) && argv[3] && (argv[3][0] == 'c' || argv[3][0] == 'u')) return 0;
+			if (S_ISBLK(sb.st_mode)  && argv[3] && argv[3][0] == 'b') return 0;
+			if (S_ISFIFO(sb.st_mode) && argv[3] && argv[3][0] == 'p') return 0;
 		}
 		/* valid node not there yet, so we advance and create it */
 		argc--;

--- a/elkscmd/rootfs_template/bin/sys
+++ b/elkscmd/rootfs_template/bin/sys
@@ -1,4 +1,6 @@
-# sys - create bootable system
+# sys - create or update system from booted volume
+#   Creates and/or updates /dev, /etc, /bin and /linux on drive passed as argument
+set -e
 
 usage()
 {
@@ -116,7 +118,7 @@ copy_etc_files()
 }
 
 # sys script starts here
-echo "Installing/Updating ELKS"
+echo "Installing/updating ELKS on $1"
 MNT=/tmp/mnt
 small=0
 arg=-s
@@ -126,8 +128,10 @@ if test "$1" = "-3"; then shift; small=1; fi
 if test "$#" -lt 1; then usage; fi
 
 # returns fstype, 1=MINIX, 2=FAT
+set +e
 makeboot $arg $1
 FSTYPE=$?
+set -e
 if test "$FSTYPE" = "255"; then exit 1; fi;
 
 mkdir -p $MNT
@@ -143,4 +147,4 @@ sync
 umount $1
 rmdir $MNT
 sync
-echo "Finished."
+echo "Finished successfully."


### PR DESCRIPTION
Enhances the bin/sys shell script and mknod command to update an existing ELKS volume from the boot volume. 

Discussed in https://github.com/ghaerr/elks/pull/2181#issuecomment-2586083027.

@floriangit: I created this PR as there might have been a misunderstanding about the need for set -e/set +e in bin/sys.
(set -e tells the shell to stop execution on an error). This PR fixes `sys` so that any error will stop the script, *except* for the `makeboot` execution, which as you pointed out returns the filesystem type as it's return value. So a set +e is required only before `makeboot`, and otherwise set -e is always set. Should `makeboot` encounter an error, it returns 255, and sys will return 1 (error) to its caller. Otherwise the script now will report "Finished successfully." to the user.

`mknod` was changed to return 0 on successful -p option, as discussed.

Also fixed is "Can't create symlink: File Exists", which is reported by `cp -fR` when copying a full system and encountering the symlink already created on the destination volume. The fix is to unlink the symlink prior to creating it, when the -f option is in effect.