### PR TITLE
[libc] Fix longstanding signal handling bug with improperly set DS register

### DIFF
--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -132,6 +132,7 @@ void arch_setup_user_stack (register struct task_struct * t, word_t entry)
 void arch_setup_sighandler_stack(register struct task_struct *t,
                                  __kern_sighandler_t addr,unsigned signr)
 {
+    printk("SIGCB %d: DS %x SS %x\n", t->pid, t->t_regs.ds, t->t_regs.ss);
     debug("Stack %x:%x was %x %x %x %x\n", _FP_SEG(addr), _FP_OFF(addr),
            get_ustack(t,0), get_ustack(t,2), get_ustack(t,4), get_ustack(t,6));
     put_ustack(t, -6, (int)get_ustack(t,0));

--- a/elks/arch/i86/kernel/process.c
+++ b/elks/arch/i86/kernel/process.c
@@ -132,7 +132,6 @@ void arch_setup_user_stack (register struct task_struct * t, word_t entry)
 void arch_setup_sighandler_stack(register struct task_struct *t,
                                  __kern_sighandler_t addr,unsigned signr)
 {
-    printk("SIGCB %d: DS %x SS %x\n", t->pid, t->t_regs.ds, t->t_regs.ss);
     debug("Stack %x:%x was %x %x %x %x\n", _FP_SEG(addr), _FP_OFF(addr),
            get_ustack(t,0), get_ustack(t,2), get_ustack(t,4), get_ustack(t,6));
     put_ustack(t, -6, (int)get_ustack(t,0));

--- a/libc/system/signalcb.S
+++ b/libc/system/signalcb.S
@@ -20,7 +20,10 @@ _signal_cbhandler:
 	push %dx
 	push %si
 	push %di
+	push %ds
 	push %es
+	mov %ss,%ax
+	mov %ax,%ds
 
 	mov 6(%bp),%bx
 #ifndef __IA16_CALLCVT_REGPARMCALL
@@ -43,6 +46,7 @@ _signal_cbhandler:
 #endif
 
 	pop %es
+	pop %ds
 	pop %di
 	pop %si
 	pop %dx

--- a/libc/watcom/asm/signalcb.asm
+++ b/libc/watcom/asm/signalcb.asm
@@ -20,6 +20,8 @@ __signal_cbhandler proc far
         push di
         push ds
         push es
+        mov ax,ss                   ; ensure valid DS (=SS)
+        mov ds,ax
 
         mov ax,6[bp]                ; get signal #
         callf _signal_wchandler_    ; call user function from C


### PR DESCRIPTION
After looking at how ia16-elf-gcc and OWC compilers generate some code reloading DS for fast execution when using far pointers, it occurred to me that a ELKS program might be interrupted by the hardware timer or keyboard when the process's DS != SS.

If, on return to execution from an interrupt a signal has been raised for the process and a C signal handler routine registered through `signal`, the kernel sets up the stack to return to the signal handler, rather than the interrupted normal C code. When this happens, the C library signal handling callback code saves all the registers and calls the C interrupt handler - but does not reset DS to a valid value for C signal handler which has been compiled expecting the DS == SS, and as a result the system may read/write data incorrectly and a system hang or crash results. This finding explains how on rare occasions ELKS may crash after ^C a process, even though the kernel has no known crash issues.

This PR tests and fixes the above usually rare event. The following test code has been written which demonstrates the problem - the program busy loops calling a function which loads the DS register for far pointer memory access, but also having registered an interrupt handler for SIGINT (^C typed). Without this fix, the system will crash on ^C or two. With the fix, DS is set to SS and the registered interrupt handler executes normally, then resets DS to its original value before returning to the interrupted process.
```
#include <stdio.h>
#include <signal.h>

#define DS() __extension__ ({             \
        unsigned short _v;                \
        asm volatile ("mov %%ds,%%ax\n"   \
                        :"=a" (_v)        \
                        :                 \
                     );                   \
        _v; })

#define SS() __extension__ ({             \
        unsigned short _v;                \
        asm volatile ("mov %%ss,%%ax\n"   \
                        :"=a" (_v)        \
                        :                 \
                     );                   \
        _v; })

#define _MK_FP(seg,off) ((void __far *)((((unsigned long)(seg)) << 16) | ((unsigned int)(off))))

long __far *p = _MK_FP(2, 4);       /* easy to see DS=2 */
volatile unsigned long l;

void reloadDS(void)
{
    l = *p;     /* generates code to reload DS: lds %ss:p,%bx */
                /*                              mov (%bx),%dx */
}

void sighandler(int signo)
{
    (void)signo;

    printf("DS %04x, SS %04x\n", DS(), SS());
    signal(SIGINT, sighandler);
}

int main(int ac, char **av)
{
    (void)ac; (void)av;

    printf("DS %04x, SS %04x\n", DS(), SS());
    signal(SIGINT, sighandler);
    for (;;)
        reloadDS();
}
```

The revised C library signal callback routines are updated for ia16-elf-gcc and OpenWatcom C compilers. When we implement signal handling in C86, this fix will also be implemented for that compiler.