### PR TITLE
Remove . from PATH in /etc/profile

### DIFF
--- a/copyc86.sh
+++ b/copyc86.sh
@@ -35,5 +35,5 @@ cp -p elks-bin/objdump86        $DEST
 cp -p elks-bin/disasm86         $DEST
 cp -p elks-bin/cpp86            $DEST
 cd examples
-cp -p *.c *.h                   $DEST
+cp -p *.c *.h *.s               $DEST
 cp -p Makefile.elks             $DEST/Makefile

--- a/elkscmd/rootfs_template/etc/profile
+++ b/elkscmd/rootfs_template/etc/profile
@@ -1,4 +1,4 @@
-export PATH=.:/bin
+export PATH=/bin
 PS1="$HOSTNAME$PS1"
 umask 022
 #FAT permissions fix


### PR DESCRIPTION
Removes current directory from /etc/profile for root user safety. 8086-toolchain Makefiles updated in https://github.com/ghaerr/8086-toolchain/pull/39 to accommodate.