### PR TITLE
[cmds] Display offending source line on tokenization error in BASIC

### DIFF
--- a/elkscmd/basic/host.c
+++ b/elkscmd/basic/host.c
@@ -342,6 +342,8 @@ static int loop(FILE *infile) {
         if (lineNumber != 0) {
             host_outputLong(lineNumber);
             host_outputChar('-');
+        } else {
+            printf("Tokenization error near '%s'\n", input);
         }
         printf("%s\n\n", errorTable[ret]);
     } else if (!infile)

--- a/libc/c86.mk
+++ b/libc/c86.mk
@@ -30,9 +30,9 @@ all:
 	$(MAKE) -C system -f out.mk COMPILER=c86 LIB=out.lib
 	for DIR in $(SUBDIRS); do $(MAKE) -C $$DIR COMPILER=c86 LIB=out.lib || exit 1; done
 	$(AR) $(ARFLAGS_SUB) libc86.a */*.lib
-ifeq "$(TOPDIR)" "/Users/greg/net/elks-gh"
-	cp libc86.a $(TOPDIR)/elkscmd/rootfs_template/root
-endif
+#ifeq "$(TOPDIR)" "/Users/greg/net/elks-gh"
+#	cp libc86.a $(TOPDIR)/elkscmd/rootfs_template/root
+#endif
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Addresses issue brought up in #2199.

Also removes libc86.a copy to /root in libc/c86.mk, forgotten about in earlier commit.