### PR TITLE
[build] Rename cpp, as, ld, ar, objdump in copyc86.sh

### DIFF
--- a/copyc86.sh
+++ b/copyc86.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 #
 # copyc86.sh - copy native ELKS C86 toolchain, header files and examples to ELKS /usr
+# Also creates $TOPDIR/devc86.tar development tarball
 #
-# Usage: ./copyc86.sh
+# Usage: ./copyc86.sh; cd image; make hd32-minix
 #
 set -e
 
@@ -20,6 +21,8 @@ fi
 
 # create and copy to /usr/bin, /usr/lib, /usr/include, /usr/src on destination
 DEST=$TOPDIR/elkscmd/rootfs_template/usr
+rm -rf $DEST
+rm -rf $TOPDIR/target/usr
 mkdir -p $DEST
 mkdir -p $DEST/bin
 mkdir -p $DEST/lib
@@ -73,13 +76,17 @@ cp -p libc/libc86.a                         $DEST/lib
 
 cd $C86
 cp -p elks-bin/make             $DEST/bin
-cp -p elks-bin/cpp86            $DEST/bin
+cp -p elks-bin/cpp              $DEST/bin
 cp -p elks-bin/c86              $DEST/bin
-cp -p elks-bin/as86             $DEST/bin
-cp -p elks-bin/ld86             $DEST/bin
-cp -p elks-bin/ar86             $DEST/bin
-cp -p elks-bin/objdump86        $DEST/bin
+cp -p elks-bin/as               $DEST/bin
+cp -p elks-bin/ld               $DEST/bin
+cp -p elks-bin/ar               $DEST/bin
+cp -p elks-bin/objdump          $DEST/bin
 cp -p elks-bin/disasm86         $DEST/bin
 cd examples
 cp -p *.c *.h *.s               $DEST/src
 cp -p Makefile.elks             $DEST/src/Makefile
+
+cd $TOPDIR/elkscmd/rootfs_template
+tar cf $TOPDIR/devc86.tar usr
+echo "Files copied and devc86.tar produced"

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -214,6 +214,6 @@ basic/basic                     :basic                  :1200k
 advent/advent                     :other                            :1440c
 advent/advent.db ::lib/advent.db  :other                            :1440c
 debug/disasm                      :other                        :1440k
-debug/nm86                        :other                            :1440c
+#debug/nm86                        :other                            :1440c
 debug/system.sym ::lib/system.sym :other                            :1440c
 debug/testsym                     :other                            :1440c

--- a/libc/c86.mk
+++ b/libc/c86.mk
@@ -30,9 +30,6 @@ all:
 	$(MAKE) -C system -f out.mk COMPILER=c86 LIB=out.lib
 	for DIR in $(SUBDIRS); do $(MAKE) -C $$DIR COMPILER=c86 LIB=out.lib || exit 1; done
 	$(AR) $(ARFLAGS_SUB) libc86.a */*.lib
-#ifeq "$(TOPDIR)" "/Users/greg/net/elks-gh"
-#	cp libc86.a $(TOPDIR)/elkscmd/rootfs_template/root
-#endif
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Renames 8086 toolchain ELKS executables in `copyc86.sh` without -86 suffix. See https://github.com/ghaerr/8086-toolchain/pull/42.

Running ./copyc86.sh now creates a 8086 toolchain development "disk" tarball in $TOPDIR/devc86.tar.

A 32M HD MINIX image with the full 8086 toolchain pre-installed by running:
```
$ make
$ ./buildc86.sh
$ ./copyc86.sh
$ cd image
$ make hd32-minix
```