### PR TITLE
Separate strace_elksemu compilation

### DIFF
--- a/elksemu/.gitignore
+++ b/elksemu/.gitignore
@@ -1,3 +1,4 @@
 elksemu
+strace_elksemu
 efile.h
 *.v

--- a/elksemu/Makefile
+++ b/elksemu/Makefile
@@ -26,12 +26,21 @@ endif
 # CFLAGS=-O2 -fno-strength-reduce -b i486-linuxaout -N -s -static
 
 OBJ=elks.o elks_sys.o elks_signal.o elks_pid.o minix.o
+OBJ_STRACE=elks.o elks_sys_strace.o elks_signal.o elks_pid.o minix.o
+
+all:	elksemu strace_elksemu
 
 elksemu:	$(OBJ)
 		$(CC) $(CFLAGS) -o $@ $^
 
+strace_elksemu:	$(OBJ_STRACE)
+		$(CC) $(CFLAGS) -o $@ $^
+
 elks_sys.o:	call_tab.v defn_tab.v efile.h
 $(OBJ):		elks.h
+
+elks_sys_strace.o:	elks_sys.c elks.h call_tab.v defn_tab.v efile.h
+		$(CC) $(CFLAGS) -DSTRACE=1 -c -o $@ $<
 
 ifdef PREFIX
 INSTALLED_CALL_TAB = $(PREFIX)/share/misc/elks/call_tab.v
@@ -84,7 +93,7 @@ install: elksemu
 	install -s -o root -g root -m 4555 elksemu $(DIST)/lib/elksemu
 
 clean realclean:
-	rm -f $(OBJ) binfmt_elks.o elksemu call_tab.v defn_tab.v efile.h
+	rm -f $(OBJ) $(OBJ_STRACE) binfmt_elks.o elksemu strace_elksemu call_tab.v defn_tab.v efile.h
 
 module: binfmt_elks.o
 
@@ -103,4 +112,6 @@ binfmt_elks.o:	binfmt_elks.c
 #MODCFLAGS=-O -fomit-frame-pointer -DCPU=386 -D__KERNEL__ -DMODULE
 # Or this ...
 #MODCFLAGS=-O -fomit-frame-pointer -D__KERNEL__ -DMODULE -DCONFIG_MODVERSIONS
+
+.PHONY:	all
 

--- a/elksemu/elks_sys.c
+++ b/elksemu/elks_sys.c
@@ -29,6 +29,10 @@
 
 #ifdef DEBUG
 #define dbprintf(x) db_printf x
+#elif defined STRACE
+#include <stdarg.h>
+static void strace(const char *fmt, ...);
+#define dbprintf(x) strace x
 #else
 #define dbprintf(x)
 #endif
@@ -909,3 +913,17 @@ elks_syscall(void)
     else
         return -errno;
 }
+
+#ifdef STRACE
+#undef strace
+static void
+strace(const char * fmt, ...)
+{
+  va_list ptr;
+  int rv;
+  va_start(ptr, fmt);
+  rv = vfprintf(stderr,fmt,ptr);
+  va_end(ptr);
+  fflush(stderr);
+}
+#endif


### PR DESCRIPTION
Native strace does not work well with elksemu, and while the elksemu sources permit enabling tracing ELKS system calls, this requires a recompilation of elksemu. This pull request make it possible to compile two separate binaries, one for elksemu and one for straced elkesmu.