### PR TITLE
[nanox] Initial changes to build Server/Client mode for ELKS

### DIFF
--- a/elkscmd/nano-X/Makefile
+++ b/elkscmd/nano-X/Makefile
@@ -126,16 +126,18 @@ bin/nxvgatest: demos/demo-vga.o
 # client/server
 #
 nano-X: $(SERVFILES) $(NANOXFILES)
-	$(LD) $(LDFLAGS) $(NANOXFILES) $(SERVFILES) $(NANOLIBS) $(LIBS) -o bin/nano-X $(MATHLIB) $(LDFLAGS)
+	$(LD) $(LDFLAGS) $(NANOXFILES) $(SERVFILES) $(NANOLIBS) $(LIBS) -o bin/nano-X $(MATHLIB) $(LDLIBS)
 
 # only a few demos work in client/server mode
-nxdemos: libnano-X.a
-	$(LD) $(LDFLAGS) demos/demo.o $(DEMOLIBS) -o bin/demo $(MATHLIB) $(LDFLAGS)
-	$(LD) $(LDFLAGS) demos/demo2.o $(DEMOLIBS) -o bin/demo2 $(MATHLIB) $(LDFLAGS)
-	$(LD) $(LDFLAGS) demos/landmine.o $(DEMOLIBS) -o bin/landmine $(MATHLIB) $(LDFLAGS)
-#	$(LD) $(LDFLAGS) demos/nterm.o $(DEMOLIBS) -o bin/nterm $(MATHLIB)	 $(LDFLAGS)
-#	$(LD) $(LDFLAGS) demos/nclock.o $(DEMOLIBS) -o bin/nclock $(MATHLIB)	 $(LDFLAGS)
-#	$(LD) $(LDFLAGS) demos/world.o $(DEMOLIBS) -o bin/world $(MATHLIB) $(LDFLAGS)
+nxdemos: libnano-X.a demos/demo.o demos/demo2.o demos/landmine.o demos/nclock.o demos/world.o demos/nterm.o demos/ntetris.o
+	$(LD) $(LDFLAGS) demos/demo.o $(DEMOLIBS) -o bin/nxdemo $(MATHLIB) $(LDLIBS)
+	$(LD) $(LDFLAGS) demos/demo2.o $(DEMOLIBS) -o bin/nxdemo2 $(MATHLIB) $(LDLIBS)
+	$(LD) $(LDFLAGS) demos/landmine.o $(DEMOLIBS) -o bin/nxlandmine $(MATHLIB) $(LDLIBS)
+	$(LD) $(LDFLAGS) demos/world.o $(DEMOLIBS) -o bin/nxworld $(MATHLIB) $(LDLIBS)
+	$(LD) $(LDFLAGS) demos/nclock.o $(DEMOLIBS) -o bin/nxclock $(MATHLIB)	 $(LDLIBS)
+	$(LD) $(LDFLAGS) demos/nterm.o $(DEMOLIBS) -o bin/nxterm $(MATHLIB)	 $(LDLIBS)
+	$(LD) $(LDFLAGS) demos/ntetris.o $(DEMOLIBS) -o bin/nxtetris $(MATHLIB)	 $(LDLIBS)
+
 #	cp demos/demo.sh bin/demo.sh
 
 install: $(NANOXDEMOS)

--- a/elkscmd/nano-X/nanox/serv.h
+++ b/elkscmd/nano-X/nanox/serv.h
@@ -336,7 +336,7 @@ extern	GR_FONT_INFO	curfont;		/* current font information */
  * The filename to use for the named socket. If we ever support multiple
  * servers on one machine, the last digit will be that of the FB used for it.
  */
-#define GR_NAMED_SOCKET "/var/uds"
+#define GR_NAMED_SOCKET "/tmp/nxsock"
 
 /*
  * The network interface version number. Increment this if you make a change
@@ -411,7 +411,8 @@ extern	GR_FONT_INFO	curfont;		/* current font information */
 #define GrNumText               43
 #define GrNumSetCursor          44
 #define GrNumMoveCursor         45
-#define GrTotalNumCalls         46
+#define GrNumGetNextEventTimeout 46
+#define GrTotalNumCalls         47
 
 /*
  * The values the server can return in response to a command.


### PR DESCRIPTION
Hello,

This is the initial PR to build nano-X Server/Client mode for the current ELKS,
as the discussion https://github.com/ghaerr/elks/discussions/1810#discussioncomment-12026927

Makefile has been changed to build the basic applications with nano-X Server/Client mode
if LINK_APP_INTO_SERVER=1 is comment out.

The include headers are changed to use sys/socket.h instead of linuxmt/socket.h.

GR_NAMED_SOCKET is changed to /tmp/nxsock instead of /var/uds.

Timeouts are added. (still need debugs)

I have commented out raise(z); in client.c since there is no raise in our signal.h.
Is this OK?

Thank you.