### PR TITLE
[Nano-X] Fix various problems with multiple client/server Nano-X

### DIFF
--- a/elks/net/unix/af_unix.c
+++ b/elks/net/unix/af_unix.c
@@ -385,6 +385,7 @@ static int unix_write(struct socket *sock, char *ubuf, int size, int nonblock)
     pupd = UN_DATA(sock)->peerupd;	/* safer than sock->conn */
 
     while (!(space = UN_BUF_SPACE(pupd))) {
+	printk("NO SPACE on WRITE pid %d size %d\n", current->pid, size);
 	sock->flags |= SF_NOSPACE;
 
 	if (nonblock)

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -202,9 +202,10 @@ test/libc/test_libc             :test                           :1440c
 test/other/test_fd              :test
 test/other/test_float           :test
 #nano/nano-2.0.6/src/nano       :other
+nano-X/bin/nano-X               :other                              :1440c
 nano-X/bin/nxclock              :other                              :1440c
 nano-X/bin/nxdemo               :other
-nano-X/bin/nxtest               :other
+#nano-X/bin/nxtest               :other
 nano-X/bin/nxtetris             :nanox                  :1200k
 nano-X/bin/nxlandmine           :nanox                   :1232k :1440k
 nano-X/bin/nxterm               :nanox                   :1232k     :1440c

--- a/elkscmd/nano-X/Makefile
+++ b/elkscmd/nano-X/Makefile
@@ -7,6 +7,7 @@ BASEDIR = ..
 include $(BASEDIR)/Makefile-rules
 
 LOCALFLAGS = -DELKS=1 -DUNIX=1 -DDEBUG=1 -I.
+AR = ia16-elf-ar
 MATHLIB =
 
 # nano-X demo programs
@@ -61,7 +62,7 @@ endif
 
 # The following line links the nano-X application with the server.
 # This is required if no network is present, or for speed or debugging.
-LINK_APP_INTO_SERVER=1
+#LINK_APP_INTO_SERVER=1
 
 NANOXFILES = nanox/srvmain.o nanox/srvfunc.o nanox/srvutil.o nanox/srvevent.o
 CLNTFILES = nanox/client.o
@@ -134,6 +135,7 @@ nxdemos: libnano-X.a demos/demo.o demos/demo2.o demos/landmine.o demos/nclock.o 
 	$(LD) $(LDFLAGS) demos/demo2.o $(DEMOLIBS) -o bin/nxdemo2 $(MATHLIB) $(LDLIBS)
 	$(LD) $(LDFLAGS) demos/landmine.o $(DEMOLIBS) -o bin/nxlandmine $(MATHLIB) $(LDLIBS)
 	$(LD) $(LDFLAGS) demos/world.o $(DEMOLIBS) -o bin/nxworld $(MATHLIB) $(LDLIBS)
+	cp demos/nxworld.map bin/nxworld.map
 	$(LD) $(LDFLAGS) demos/nclock.o $(DEMOLIBS) -o bin/nxclock $(MATHLIB)	 $(LDLIBS)
 	$(LD) $(LDFLAGS) demos/nterm.o $(DEMOLIBS) -o bin/nxterm $(MATHLIB)	 $(LDLIBS)
 	$(LD) $(LDFLAGS) demos/ntetris.o $(DEMOLIBS) -o bin/nxtetris $(MATHLIB)	 $(LDLIBS)

--- a/elkscmd/nano-X/demos/nclock.c
+++ b/elkscmd/nano-X/demos/nclock.c
@@ -66,7 +66,7 @@ main(int argc,char **argv)
 
 	GrSetErrorHandler(errorcatcher);
 
-	w1 = GrNewWindow(GR_ROOT_WINDOW_ID, 100, 50, CWIDTH + 1,
+	w1 = GrNewWindow(GR_ROOT_WINDOW_ID, -1, -1, CWIDTH + 1,
 		CHEIGHT + 1, 1, WHITE, BLACK);
 
 	GrSelectEvents(w1, GR_EVENT_MASK_EXPOSURE);
@@ -108,8 +108,9 @@ main(int argc,char **argv)
 
 	GrMapWindow(w1);
 
+	do_idle();
 	while (1) {
-		GrCheckNextEvent(&event);
+		GrGetNextEventTimeout(&event, 400);
 
 		switch (event.type) {
 			case GR_EVENT_TYPE_EXPOSURE:

--- a/elkscmd/nano-X/drivers/kbd_tty.c
+++ b/elkscmd/nano-X/drivers/kbd_tty.c
@@ -58,8 +58,8 @@ TTY_Open(KBDDEVICE *pkd)
 
 	new = old;
 	/* If you uncomment ISIG and BRKINT below, then ^C will be ignored.*/
-	new.c_lflag &= ~(ECHO | ICANON | IEXTEN /*| ISIG*/);
-	new.c_iflag &= ~(ICRNL | INPCK | ISTRIP | IXON /*| BRKINT*/);
+	new.c_lflag &= ~(ECHO | ICANON | IEXTEN | ISIG);
+	new.c_iflag &= ~(ICRNL | INPCK | ISTRIP | IXON | BRKINT);
 	new.c_cflag &= ~(CSIZE | PARENB);
 	new.c_cflag |= CS8;
 	new.c_cc[VMIN] = 0;

--- a/elkscmd/nano-X/nanox/client.c
+++ b/elkscmd/nano-X/nanox/client.c
@@ -10,6 +10,8 @@
 #include <unistd.h>
 #include <string.h>
 #include <signal.h>
+#include <stdlib.h>
+#include <errno.h>
 #include <linuxmt/un.h>
 #include <sys/socket.h>
 #include <sys/select.h>
@@ -41,7 +43,10 @@ static int GrReadBlock(void *b, int n)
 
 	while(v < ((char *) b + n)) {
 		i = read(sock, v, ((char *) b + n - v));
-		if(i <= 0) return -1;
+		if(i <= 0) {
+			//__dprintf("GrReadBlock read error %d, errno %d\n", i, errno);
+			return -1;
+		}
 		v += i;
 	}
 
@@ -59,6 +64,7 @@ static int GrReadByte()
 	else return (int) c;
 }
 
+#if UNUSED
 /*
  * Read an error event structure from the server and deliver it to the client.
  */
@@ -76,13 +82,14 @@ static int GrDeliverErrorEvent(void)
 
 	return 0;
 }
+#endif
 
 /*
  * Send a block of data to the server and read it's reply.
  */
 static int GrSendBlock(void *b, long n)
 {
-	int i = 0, z;
+	int i = 0;
 	unsigned char *c;
 
 	c = (unsigned char *) b;
@@ -90,24 +97,30 @@ static int GrSendBlock(void *b, long n)
 	/* FIXME: n > 64k will fail here if sizeof(int) == 2*/
 	while(c < ((unsigned char *) b + n)) {
 		i = write(sock, c, ((unsigned char *) b + n - c));
-		if(i <= 0) return -1;
+		if(i <= 0) {
+			//__dprintf("GrSendBlock write error %d, errno %d\n", i, errno);
+			return -1;
+		}
 		c += i;
 	}
 
 	do {
-		if((i = GrReadByte()) < 0) return -1;
+		if((i = GrReadByte()) < 0) {
+			//__dprintf("GrSendBlock readbyte error %d, errno %d\n", i, errno);
+			return -1;
+		}
+#if UNUSED
 		else if(i == GrRetESig) {
-			z = GrReadByte();
+			int z = GrReadByte();
 			if(z == -1) return -1;
-printf("client bad GrSendBlock\r\n");
-			//raise(z);
+			raise(z);
 		}
 		else if(i == GrRetErrorPending)
 			if(GrDeliverErrorEvent() == -1) return -1;
-			
+#endif
 	} while((i == GrRetESig) | (i == GrRetErrorPending));
 
-	return((int) i);
+	return i;
 }
 
 /*
@@ -127,7 +140,6 @@ int GrOpen(void)
 	struct sockaddr_un name;
 	size_t size;
 
-	
 	if(!sock)
 		if((sock = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
 			sock = 0;
@@ -157,6 +169,7 @@ int GrClose(void)
 	return 0;
 }
 
+#if UNUSED
 /* 
  * The default error handler which is called when the server reports an error event
  * and the client hasn't set a handler for error events.
@@ -213,6 +226,7 @@ void GrDefaultErrorHandler(GR_EVENT_ERROR err)
 	fprintf(stderr,"Error event recieved from server:\n"
 		"\t%s() failed because %s.\n", err.name, why);
 }
+#endif
 
 /*
  * Set an error handling routine, which will be called on any errors from
@@ -221,6 +235,8 @@ void GrDefaultErrorHandler(GR_EVENT_ERROR err)
  */
 GR_ERROR_FUNC GrSetErrorHandler(GR_ERROR_FUNC func)
 {
+        return NULL;
+#if UNUSED
 #ifndef __linux__ 
 	GR_ERROR_FUNC temp = GrDefaultErrorHandler;
 #else  
@@ -229,6 +245,7 @@ GR_ERROR_FUNC GrSetErrorHandler(GR_ERROR_FUNC func)
 	else GrErrorFunc = func;
 #endif	
 	return temp;
+#endif
 }
 
 /*
@@ -324,6 +341,7 @@ int GrRegisterInput(int fd)
 	return 0;
 }
 
+#if 0
 /*
  * Return the next event from the event queue.
  * This waits for a new one if one is not ready.
@@ -365,13 +383,17 @@ int GrGetNextEvent(GR_EVENT *ep)
 			return -1;
 
 readevent:
-		/* this will never be GR_EVENT_IDLE
-		 * with current implementation
-		 */
+		/* this will never be GR_EVENT_NONE with current implementation */
 		if(GrReadBlock(ep, sizeof(*ep)) == -1)
 			return -1;
 	}
 	return 0;
+}
+#endif
+
+int GrGetNextEvent(GR_EVENT *ep)
+{
+	return GrGetNextEventTimeout(ep, GR_TIMEOUT_BLOCK);
 }
 
 int GrGetNextEventTimeout(GR_EVENT *ep, GR_TIMEOUT timeout)
@@ -380,9 +402,9 @@ int GrGetNextEventTimeout(GR_EVENT *ep, GR_TIMEOUT timeout)
 	fd_set 	rfds;
 	int	setsize = 0;
 
-	if(regfd != -1) {
-		c = GrNumGetNextEventTimeout;
-		write(sock, &c, 1); /* fixme: check return code*/
+	if(regfd != -1) {	/* GrRegisterInput not supported with timeout */
+		GrSendByte(GrNumGetNextEventTimeout);
+		/* don't wait for GrRetDataFollows */
 		write(sock, &timeout, sizeof(timeout));
 		FD_ZERO(&rfds);
 		FD_SET(sock, &rfds);
@@ -411,12 +433,7 @@ int GrGetNextEventTimeout(GR_EVENT *ep, GR_TIMEOUT timeout)
 
 		if(GrSendBlock(&timeout, sizeof(timeout)) != GrRetDataFollows)
 			return -1;
-
-
 readevent:
-		/* this will never be GR_EVENT_IDLE
-		 * with current implementation
-		 */
 		if(GrReadBlock(ep, sizeof(*ep)) == -1)
 			return -1;
 	}

--- a/elkscmd/nano-X/nanox/serv.h
+++ b/elkscmd/nano-X/nanox/serv.h
@@ -41,6 +41,7 @@ struct gr_client {
 	GR_CLIENT	*next;		/* the next client in the list */
 	GR_CLIENT	*prev;		/* the previous client in the list */
 	int		waiting_for_event; /* used to implement GrGetNextEvent*/
+	unsigned long   wakeup_time;    /* mstime to wakeup on timeout */
 };
 
 /*

--- a/elkscmd/nano-X/nanox/srvfunc.c
+++ b/elkscmd/nano-X/nanox/srvfunc.c
@@ -574,6 +574,7 @@ GsNewWindow(GR_WINDOW_ID parent, GR_COORD x, GR_COORD y, GR_SIZE width,
 	GR_WINDOW	*pwp;		/* parent window */
 	GR_WINDOW	*wp;		/* new window */
 	static int	nextid = GR_ROOT_WINDOW_ID + 1;
+	static nextx = 10, nexty = 10;
 
 	if ((width <= 0) || (height <= 0) || (bordersize < 0)) {
 		GsError(GR_ERROR_BAD_WINDOW_SIZE, 0);
@@ -594,6 +595,10 @@ GsNewWindow(GR_WINDOW_ID parent, GR_COORD x, GR_COORD y, GR_SIZE width,
 		GsError(GR_ERROR_MALLOC_FAILED, 0);
 		return 0;
 	}
+	if (x < 0)
+		x = nextx, nextx += 100;
+	if (y < 0)
+		y = nexty, nexty += 100;
 
 	wp->id = nextid++;
 	wp->parent = pwp;

--- a/elkscmd/nano-X/nanox/srvmain.c
+++ b/elkscmd/nano-X/nanox/srvmain.c
@@ -88,7 +88,7 @@ GsAcceptClientFd(int i)
 	client->eventtail = NULL;
 	client->errorevent.type = GR_EVENT_TYPE_NONE;
 	client->next = NULL;
-	client->waiting_for_event = FALSE;
+	client->waiting_for_event = 0;
 
 	if(connectcount++ == 0)
 		root_client = client;
@@ -199,11 +199,12 @@ GsSelect(GR_TIMEOUT timeout)
 	if (un_sock > setsize) setsize = un_sock;
 	curclient = root_client;
 	while(curclient) {
-		if(curclient->waiting_for_event && curclient->eventhead) {
-			curclient->waiting_for_event = FALSE;
+		if(curclient->waiting_for_event == 1 && curclient->eventhead) {
 			GsGetNextEventWrapperFinish();
-			return;
+			//return;
 		}
+		if (curclient->waiting_for_event == 2)
+			timeout = 50;       /* 50 msec min timeout resolution */
 		FD_SET(curclient->id, &rfds);
 		if(curclient->id > setsize) setsize = curclient->id;
 		curclient = curclient->next;
@@ -250,9 +251,11 @@ GsSelect(GR_TIMEOUT timeout)
 		if(FD_ISSET(un_sock, &rfds))
 			GsAcceptClient();
 
-		/* If a client is sending us a command, handle it: */
+		/* If a client is sending us a command or timed out, handle it: */
 		curclient = root_client;
 		while(curclient) {
+			if(e == 0 && curclient->waiting_for_event == 2)
+				GsGetNextEventWrapperFinish();
 			if(FD_ISSET(curclient->id, &rfds))
 				GsHandleClient(curclient->id);
 			curclient = curclient->next;
@@ -260,17 +263,6 @@ GsSelect(GR_TIMEOUT timeout)
 #endif
 
 	} 
-#if 0
-	else if(!e) {
-#if FRAMEBUFFER | BOGL
-		if(fb_CheckVtChange())
-			GsRedrawScreen();
-#endif
-	}
-#endif
-    else
-		if(errno != EINTR)
-			perror("Select() call in main failed");
 }
 #endif
 

--- a/elkscmd/rootfs_template/etc/profile
+++ b/elkscmd/rootfs_template/etc/profile
@@ -4,6 +4,7 @@ umask 022
 #FAT permissions fix
 #if test "$USER" = "root"; then chmod 777 /tmp; fi
 #uname -v
+#export MOUSE_PORT=none
 #export MANPATH=/root/man:/lib
 #export TZ=GMT0
 # if TZ= set in /bootopts or above it overrides CONFIG_TIME_TZ, so don't set TZ= below


### PR DESCRIPTION
Debug and fix nxtetris problem using GrGetNextTimeout described in https://github.com/ghaerr/elks/discussions/1810#discussioncomment-11873949.

Fixes server error when handling multiple clients.
Ignores ^C instead of exiting (use ESC to exit).

Sets default Nano-X build to client/server.

@tyama501, finding all the problems and getting this working proved to be far more complicated than I thought. Long story short, we can't directly send a timeout to the nano-X server because it is servicing multiple clients - thus when a timeout is required when getting an event, the server is put into a "polling" mode where it times out every 50msecs and then calls back to each client waiting for a timeout to measure whether the elapsed time has been long enough. There was also a major bug where the server would reply to the wrong client in certain cases.

So far, I've been able to get two clients or so working well with the server. Adding more in some cases causes some window remapping problems. So for now I'm staying with just getting one or two clients working well. Go ahead and experiment and see what other problems you might find. I see there are a couple ifdef CONFIG_PC98 in the srvmain.c code which will likely have to removed or changed, as soon as I get the UNIX sockets working on FAT, which is my next step.

After spending all day in this code, I'm seeing there's still a lot of cleanup to be done, but this should be a big step forward.

Here's a video of nxclock running with nxtetris, run using the following script:
```
nano-X & sleep 1; nxclock & exec nxtetris
```

https://github.com/user-attachments/assets/c545c67f-23cf-438b-b83c-a402007e9b2d



