### PR TITLE
[kernel] Update syscall buffer verify FAULT to show bad address

### DIFF
--- a/elks/arch/i86/mm/user.c
+++ b/elks/arch/i86/mm/user.c
@@ -34,7 +34,7 @@ int verfy_area(void *p, size_t len)
     if (seg_verify_area(current->pid, current->t_regs.ds, offset))
         return 0;
 
-    printk("FAULT\n");
+    printk("FAULT at user DS %04x:%04x size %u\n", current->t_regs.ds, p, len);
     return -EFAULT;
 }
 

--- a/libc/watcom/asm/divmod.asm
+++ b/libc/watcom/asm/divmod.asm
@@ -27,6 +27,7 @@ include struct.inc
 ;  divides DX:AX / [BX]
 ;  returns DX:AX with remainder in [BX]
 
+        push   cx
         xor    cx,cx                ; temp CX = 0
         cmp    dx,[bx]              ; is upper 16 bits numerator less than denominator
         jb     short fast           ; yes - only one DIV needed
@@ -38,6 +39,7 @@ include struct.inc
         div    word ptr [bx]        ; AX = lower numerator / base, DX = remainder
         mov    [bx],dx              ; store remainder
         mov    dx,cx                ; DX = high quotient, AX = low quotient
+        pop    cx
         ret
 
 __divmod endp


### PR DESCRIPTION
Adds more verbose error message to FAULT output when large model programs pass a buffer that seemingly does not belong to the process address space. Discussed in https://github.com/ghaerr/elks/issues/2200#issuecomment-2629112920.

Also fixes unsaved CX register in OWC \_\_divmod routine. The C library should be recompiled for Watcom using either "make owc" or ./buildc86.sh.

@rafael2k: It would be worth a try to remove the "return 0" hack in verfy_area and then rerun gzip after recompiling the OW C library. This will then give better output as to what is happening with gzip, especially if run with strace.