### PR TITLE
[Nano-X] Speed up VGA 4-plane 16-color display output

### DIFF
--- a/elkscmd/nano-X/drivers/elksutilasm.s
+++ b/elkscmd/nano-X/drivers/elksutilasm.s
@@ -13,15 +13,13 @@
 GETBYTE_FP:
 	push	%bp
 	mov		%sp,%bp
-	push	%ds
+	mov		%ds,%dx
 
-	mov		4(%bp),%bx	// bx = lo addr
-	mov		6(%bp),%ax	// ds = hi addr
-	mov		%ax,%ds
+	lds		4(%bp),%bx
 	mov		(%bx),%al	// get byte at ds:bx
 	xor		%ah,%ah
 
-	pop		%ds
+	mov		%dx,%ds
 	pop		%bp
 	ret
 
@@ -34,15 +32,13 @@ GETBYTE_FP:
 PUTBYTE_FP:
 	push	%bp
 	mov		%sp,%bp
-	push	%ds
+	mov		%ds,%dx
 
-	mov		4(%bp),%bx	// bx = lo addr
-	mov		6(%bp),%ax	// ds = hi addr
-	mov		%ax,%ds
+	lds		4(%bp),%bx
 	mov		8(%bp),%al	// al = val
 	mov		%al,(%bx)	// put type at ds:bx
 
-	pop		%ds
+	mov		%dx,%ds
 	pop		%bp
 	ret
 
@@ -54,14 +50,12 @@ PUTBYTE_FP:
 RMW_FP:
 	push	%bp
 	mov		%sp,%bp
-	push	%ds
+	mov		%ds,%dx
 
-	mov		4(%bp),%bx	// bx = lo addr
-	mov		6(%bp),%ax	// ds = hi addr
-	mov		%ax,%ds
+	lds		4(%bp),%bx
 	or		%al,(%bx)	// rmw byte at ds:bx, al value doesn't matter
 
-	pop		%ds
+	mov		%dx,%ds
 	pop		%bp
 	ret
 
@@ -73,15 +67,13 @@ RMW_FP:
 ORBYTE_FP:
 	push	%bp
 	mov		%sp,%bp
-	push	%ds
+	mov		%ds,%dx
 
-	mov		4(%bp),%bx	// bx = lo addr
-	mov		6(%bp),%ax	// ds = hi addr
-	mov		%ax,%ds
+	lds		4(%bp),%bx
 	mov		8(%bp),%al	// al = val
 	or		%al,(%bx)	// or byte at ds:bx
 
-	pop		%ds
+	mov		%dx,%ds
 	pop		%bp
 	ret
 
@@ -93,15 +85,13 @@ ORBYTE_FP:
 ANDBYTE_FP:
 	push	%bp
 	mov		%sp,%bp
-	push	%ds
+	mov		%ds,%dx
 
-	mov		4(%bp),%bx	// bx = lo addr
-	mov		6(%bp),%ax	// ds = hi addr
-	mov		%ax,%ds
+	lds		4(%bp),%bx
 	mov		8(%bp),%al	// al = val
 	and		%al,(%bx)	// and byte at ds:bx
 
-	pop		%ds
+	mov		%dx,%ds
 	pop		%bp
 	ret
 

--- a/elkscmd/nano-X/drivers/vgaplan4.h
+++ b/elkscmd/nano-X/drivers/vgaplan4.h
@@ -67,6 +67,8 @@ extern void ANDBYTE_FP(FARADDR,unsigned char);
 #endif
 
 #if ELKS
+#include <arch/io.h>
+#elif 0
 #define outb(val,port)	outportb(port,val)
 #define outw(val,port)	outport(port,val)
 
@@ -112,32 +114,29 @@ void 	 vga_to_vga_blit(PSD dstpsd,COORD dstx,COORD dsty,COORD w,COORD h,
 		PSD srcpsd,COORD srcx,COORD srcy,int op);
 #endif
 
-/* Program the Set/Reset Register for drawing in color COLOR for write
-   mode 0. */
-#define set_color(c)		{ outb (0, 0x3ce); outb (c, 0x3cf); }
+/* Program the Set/Reset Register for drawing in color COLOR for write mode 0. */
+#define set_color(c)            { outw (0|((c)<<8), 0x3ce); }
 
 /* Set the Enable Set/Reset Register. */
-#define set_enable_sr(mask) { outb (1, 0x3ce); outb (mask, 0x3cf); }
+#define set_enable_sr(mask) 	{ outw (1|((mask)<<8), 0x3ce); }
 
 /* Select the Bit Mask Register on the Graphics Controller. */
-#define select_mask() 		{ outb (8, 0x3ce); }
+#define select_mask()           { outb (8, 0x3ce); }
 
-
-/* Program the Bit Mask Register to affect only the pixels selected in
-   MASK.  The Bit Mask Register must already have been selected with
-   select_mask (). */
-#define set_mask(mask)		{ outb (mask, 0x3cf); }
+/* Program the Bit Mask Register to affect only the pixels selected in MASK.
+   The Bit Mask Register must already have been selected with select_mask (). */
+#define set_mask(mask)          { outb (mask, 0x3cf); }
 
 /* Set the Data Rotate Register.  Bits 0-2 are rotate count, bits 3-4
    are logical operation (0=NOP, 1=AND, 2=OR, 3=XOR). */
-#define set_op(op) 		{ outb (3, 0x3ce); outb (op, 0x3cf); }
+#define set_op(op)              { outw (3|((op)<<8), 0x3ce); }
 
 /* Set the Memory Plane Write Enable register. */
-#define set_write_planes(mask) { outb (2, 0x3c4); outb (mask, 0x3c5); }
+#define set_write_planes(mask)	{ outw (2|((mask)<<8), 0x3c4); }
 
 /* Set the Read Map Select register. */
-#define set_read_plane(plane)	{ outb (4, 0x3ce); outb (plane, 0x3cf); }
+#define set_read_plane(plane)	{ outw (4|((plane)<<8), 0x3ce); }
 
-/* Set the Graphics Mode Register.  The write mode is in bits 0-1, the
-   read mode is in bit 3. */
-#define set_mode(mode) 		{ outb (5, 0x3ce); outb (mode, 0x3cf); }
+/* Set the Graphics Mode Register.  The write mode is in bits 0-1,
+   the read mode is in bit 3. */
+#define set_mode(mode)          { outw (5|((mode)<<8), 0x3ce); }


### PR DESCRIPTION
Should speed up VGA display output by quite a bit on real hardware. After (re)writing an AS86 assembly VGA driver for the 8086-toolchain in https://github.com/ghaerr/8086-toolchain/pull/46, I noticed quite a few speed improvements that could be made to the C driver currently used in Nano-X.

The enhancements to the C vgaplan4.c driver include:
- Use OUTW instead of OUTB for writing VGA control registers
- Use kernel arch/io.h outw macro instead of calling function to output bytes to VGA
- Use LDS BX instead of loading DS and BX separately in RMW_FP, OR_BYTE, etc routines
- Save DS in DX instead of pushing to stack in same routines

@tyama501, I would be interested to know whether this speeds Nano-X up much on PC-98. In particular, large rectangle fills or screen clears should be much faster. (I am working next on getting UNIX sockets working on FAT filesystem).

The screen driver could probably be sped up even more by moving to a GCC assembly language version. I haven't done this yet, as that entails rewriting (again) the new C86 vga-4bp.s driver from Intel AS86 format to AT&T GCC format. 