### PR TITLE
[kernel] Create UNIX named socket as regular file for FAT compatibility w/Nano-X

### DIFF
--- a/elks/net/unix/af_unix.c
+++ b/elks/net/unix/af_unix.c
@@ -23,14 +23,14 @@
 
 #ifdef CONFIG_UNIX
 
-#define NO_MKNOD 1  /* =1 use normal file rather than named socket for FAT filesystems*/
+#define USE_IFREG 1     /* =1 for FAT filesystem compatibility */
 
-#if NO_MKNOD
-#define MODE    S_IFREG
-#define FLAG    (O_CREAT|FMODE_WRITE)
+#if USE_IFREG   /* use regular file rather than named socket for bind and connect */
+#define MODE    S_IFREG                 /* regular file type */
+#define FLAG    (O_CREAT|FMODE_WRITE)   /* create using open_namei */
 #else
-#define MODE    S_IFSOCK
-#define FLAG    0
+#define MODE    S_IFSOCK                /* named pipe/socket file type */
+#define FLAG    0                       /* created seperately using do_mknod */
 #endif
 
 struct unix_proto_data unix_datas[NSOCKETS_UNIX];
@@ -161,7 +161,7 @@ static int unix_bind(struct socket *sock,
     old_ds = current->t_regs.ds;
     current->t_regs.ds = kernel_ds;
 
-#if !NO_MKNOD
+#if !USE_IFREG
     i = do_mknod(upd->sockaddr_un.sun_path,
 	    offsetof(struct inode_operations,mknod), MODE | S_IRWXUGO, 0);
 

--- a/elks/net/unix/af_unix.c
+++ b/elks/net/unix/af_unix.c
@@ -23,6 +23,16 @@
 
 #ifdef CONFIG_UNIX
 
+#define NO_MKNOD 1  /* =1 use normal file rather than named socket for FAT filesystems*/
+
+#if NO_MKNOD
+#define MODE    S_IFREG
+#define FLAG    (O_CREAT|FMODE_WRITE)
+#else
+#define MODE    S_IFSOCK
+#define FLAG    0
+#endif
+
 struct unix_proto_data unix_datas[NSOCKETS_UNIX];
 
 static struct unix_proto_data *unix_data_alloc(void)
@@ -151,11 +161,13 @@ static int unix_bind(struct socket *sock,
     old_ds = current->t_regs.ds;
     current->t_regs.ds = kernel_ds;
 
+#if !NO_MKNOD
     i = do_mknod(upd->sockaddr_un.sun_path,
-	    offsetof(struct inode_operations,mknod), S_IFSOCK | S_IRWXUGO, 0);
+	    offsetof(struct inode_operations,mknod), MODE | S_IRWXUGO, 0);
 
     if (i == 0)
-	i = open_namei(upd->sockaddr_un.sun_path, 0, S_IFSOCK, &upd->inode, NULL);
+#endif
+	i = open_namei(upd->sockaddr_un.sun_path, FLAG, MODE, &upd->inode, NULL);
 
     current->t_regs.ds = old_ds;
     if (i < 0) {
@@ -203,7 +215,7 @@ static int unix_connect(struct socket *sock,
     old_ds = current->t_regs.ds;
     current->t_regs.ds = kernel_ds;
 
-    i = open_namei(sockun.sun_path, 2, S_IFSOCK, &inode, NULL);
+    i = open_namei(sockun.sun_path, 2, MODE, &inode, NULL);
     current->t_regs.ds = old_ds;
 
     if (i < 0)


### PR DESCRIPTION
Allows Nano-X to function on FAT filesystems, requested in discussion https://github.com/ghaerr/elks/discussions/1810#discussioncomment-12031986. 

Nano-X now creates and attaches its UNIX socket to a regular file (/tmp/nxsock in this case) rather than requiring a Named Socket file type, as is standard in Linux/UNIX. This exception is being made for ELKS so that Nano-X can run client/server on FAT filesystems.

The `bind` and `connect` operations in the UNIX socket driver are now configured in net/unix/af_unix.c using "\#define USE_IFREG 1" to turn on using a regular file instead of a named socket/pipe for the client/server connection. For strict UNIX comptability, the define can be set to 0 and a named socket/pipe will be used.

@tyama501, I have tested this on QEMU, this should now allow you to run Nano-X client/server on PC-98. Be aware that the special ifdef CONFIG_ARCH_PC98 in nanox/srvmain.c may have to be removed in the !NONETWORK (i.e. client/server) case in order to work on PC-98. I didn't test with those in, as I'm testing on IBM PC. It is possible those defines must remain in the NONETWORK case. If so, please submit a PR after you have everything working. I have tested with two nxclocks running, as well a single nxclock and nxtetris, using the shell script previously described for starting them.