### PR TITLE
[kernel] Fix verfy_area off-by-one user mode buffer address verification

### DIFF
--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -359,7 +359,7 @@ int seg_verify_area(pid_t pid, seg_t base, segoff_t offset)
         segment_s * seg = structof (n, segment_s, all);
 
         if (seg->pid == pid && seg->base == base)
-            return offset < (seg->size << 4);
+            return offset <= (seg->size << 4);
         n = seg->all.next;
     }
     return 0;

--- a/elks/arch/i86/mm/user.c
+++ b/elks/arch/i86/mm/user.c
@@ -21,7 +21,7 @@ int verfy_area(void *p, size_t len)
 
     /* use fast method when DS == SS indicating default data segment request */
     if (current->t_regs.ds == current->t_regs.ss)
-         return (offset < current->t_endseg)? 0: -EFAULT;
+         return (offset <= current->t_endseg)? 0: -EFAULT;
 
     /* check allocated code and data segments with syscall DS segment */
     for (i = 0; i < MAX_SEGS; i++) {


### PR DESCRIPTION
Fixes off-by-one calculation when large model programs read/write directly to/from full-sized far memory allocation.

This should fix the gzip problem brought up in https://github.com/ghaerr/elks/issues/2200#issuecomment-2629112920.