### PR TITLE
[kernel] Support modern Nano-X on ELKS

### DIFF
--- a/elks/fs/select.c
+++ b/elks/fs/select.c
@@ -79,7 +79,7 @@ int select_poll (struct task_struct * t, struct wait_queue *q)
         if (p == q) return 1;
     }
 
-    panic ("select_poll");      /* no slot found */
+    panic ("select_poll: no slots");      /* no slot found */
 }
 
 /*

--- a/elks/include/linuxmt/limits.h
+++ b/elks/include/linuxmt/limits.h
@@ -21,7 +21,7 @@
 
 #define KSTACK_GUARD    100     /* bytes before CHECK_KSTACK overflow warning */
 
-#define MAX_POLLFD      6       /* Maximum number of polled filedescs per process */
+#define MAX_POLLFD      10      /* Maximum number of polled filedescs per process */
 
 #define MAX_SEGS        5       /* Maximum number of application code/data segments */
 

--- a/elks/include/linuxmt/un.h
+++ b/elks/include/linuxmt/un.h
@@ -1,7 +1,7 @@
 #ifndef __LINUXMT_UN_H
 #define __LINUXMT_UN_H
 
-#define UNIX_PATH_MAX	108
+#define UNIX_PATH_MAX   16          /* keep size of unix_proto_data small, incl/NUL */
 
 struct sockaddr_un {
     unsigned short sun_family;		/* AF_UNIX */

--- a/elks/net/unix/af_unix.c
+++ b/elks/net/unix/af_unix.c
@@ -15,6 +15,8 @@
 #include <linuxmt/mm.h>
 #include <linuxmt/stat.h>
 #include <linuxmt/fcntl.h>
+#include <linuxmt/string.h>
+#include <linuxmt/heap.h>
 #include <linuxmt/debug.h>
 
 #include <arch/segment.h>
@@ -33,44 +35,43 @@
 #define FLAG    0                       /* created seperately using do_mknod */
 #endif
 
-struct unix_proto_data unix_datas[NSOCKETS_UNIX];
+struct unix_proto_data *unix_data[NSOCKETS_UNIX];
 
 static struct unix_proto_data *unix_data_alloc(void)
 {
     struct unix_proto_data *upd;
+    int i;
 
-    clr_irq();
-    for (upd = unix_datas; upd <= last_unix_data; ++upd) {
-	if (!upd->refcnt) {
-	    /* unix domain socket not yet in itialised - bgm */
-	    upd->refcnt = -1;
-	    set_irq();
-	    upd->socket = NULL;
-	    upd->sockaddr_len = 0;
-	    upd->sockaddr_un.sun_family = 0;
-	    upd->bp_head = upd->bp_tail = 0;
-	    upd->inode = NULL;
-	    upd->peerupd = NULL;
-	    upd->sem = 0;
-	    return upd;
+    for (i = 0; i < NSOCKETS_UNIX ; ++i) {
+        if (!unix_data[i]) {
+                upd = heap_alloc(sizeof(struct unix_proto_data), HEAP_TAG_PIPE);
+            if (!upd) {
+                printk("No memory for UNIX socket\n");
+                return NULL;
+            }
+            memset(upd, 0, sizeof(*upd));
+            upd->index = i;
+            unix_data[i] = upd;
+            return upd;
 	}
     }
-    set_irq();
     return NULL;
 }
 
-static struct unix_proto_data *unix_data_lookup(struct sockaddr_un *sockun,
-						int sockaddr_len,
-						struct inode *inode)
+static struct unix_proto_data *
+unix_data_lookup(struct sockaddr_un *sockun, int sockaddr_len, struct inode *inode)
 {
     struct unix_proto_data *upd;
+    int i;
 
-    for (upd = unix_datas; upd <= last_unix_data; ++upd)
-	if (upd->refcnt > 0 && upd->socket)
+    for (i = 0; i < NSOCKETS_UNIX; ++i) {
+	upd = unix_data[i];
+	if (upd && upd->refcnt > 0 && upd->socket)
 	    if (upd->socket->state == SS_UNCONNECTED)
 		if (upd->sockaddr_un.sun_family == sockun->sun_family &&
 		    upd->inode == inode)
 		    return upd;
+    }
     return NULL;
 }
 
@@ -83,9 +84,11 @@ static void unix_data_ref(struct unix_proto_data *upd)
 
 static void unix_data_deref(struct unix_proto_data *upd)
 {
-    if (upd->refcnt == 1)
-	upd->bp_head = upd->bp_tail = 0;
     --upd->refcnt;
+    if (upd->refcnt == 0) {
+        unix_data[upd->index] = NULL;
+        heap_free(upd);
+    }
 }
 
 static int unix_create(struct socket *sock, int protocol)
@@ -99,8 +102,8 @@ static int unix_create(struct socket *sock, int protocol)
 	return -ENOMEM;
 
     upd->socket = sock;
-    sock->data = upd;
     upd->refcnt = 1;
+    sock->data = upd;
 
     return 0;
 }
@@ -119,7 +122,7 @@ static int unix_release(struct socket *sock, struct socket *peer)
 	return 0;
 
     if (upd->socket != sock) {
-	printk("UNIX: release: socket link mismatch\n");
+	printk("UNIX_release: socket link mismatch\n");
 	return -EINVAL;
     }
 
@@ -139,8 +142,7 @@ static int unix_release(struct socket *sock, struct socket *peer)
     return 0;
 }
 
-static int unix_bind(struct socket *sock,
-		     struct sockaddr *umyaddr, int sockaddr_len)
+static int unix_bind(struct socket *sock, struct sockaddr *umyaddr, int sockaddr_len)
 {
     struct unix_proto_data *upd = sock->data;
     unsigned short old_ds;
@@ -181,9 +183,8 @@ static int unix_bind(struct socket *sock,
     return 0;
 }
 
-static int unix_connect(struct socket *sock,
-			struct sockaddr *uservaddr,
-			int sockaddr_len, int flags)
+static int
+unix_connect(struct socket *sock, struct sockaddr *uservaddr, int sockaddr_len, int flags)
 {
     struct sockaddr_un sockun;
     struct unix_proto_data *serv_upd;
@@ -296,9 +297,8 @@ static int unix_accept(struct socket *sock, struct socket *newsock, int flags)
     return 0;
 }
 
-static int unix_getname(struct socket *sock,
-			struct sockaddr *usockaddr,
-			int *usockaddr_len, int peer)
+static int
+unix_getname(struct socket *sock, struct sockaddr *usockaddr, int *usockaddr_len, int peer)
 {
     struct unix_proto_data *upd;
 
@@ -397,7 +397,7 @@ static int unix_write(struct socket *sock, char *ubuf, int size, int nonblock)
     pupd = UN_DATA(sock)->peerupd;	/* safer than sock->conn */
 
     while (!(space = UN_BUF_SPACE(pupd))) {
-	printk("NO SPACE on WRITE pid %d size %d\n", current->pid, size);
+	debug("(%P) NO SPACE on WRITE pid %d size %d\n", current->pid, size);
 	sock->flags |= SF_NOSPACE;
 
 	if (nonblock)
@@ -544,8 +544,8 @@ static int unix_send(struct socket *sock,
  *      Receive data. This version of AF_UNIX also lacks MSG_PEEK 8(
  */
 
-static int unix_recv(struct socket *sock,
-		     void *buff, int len, int nonblock, unsigned flags)
+static int
+unix_recv(struct socket *sock, void *buff, int len, int nonblock, unsigned flags)
 {
     if (flags != 0)
 	return -EINVAL;

--- a/elks/net/unix/af_unix.h
+++ b/elks/net/unix/af_unix.h
@@ -5,26 +5,24 @@
 
 #define NSOCKETS_UNIX 16
 
-#define last_unix_data (unix_datas + NSOCKETS_UNIX - 1)
 #define UN_DATA(SOCK) ((struct unix_proto_data *)(SOCK)->data)
-#define UN_BUF_SIZE 64
+#define UN_BUF_SIZE 128      /* must be power of 2 */
 
-#define UN_BUF_AVAIL(UPD)	(((UPD)->bp_head - (UPD)->bp_tail) & \
-							(UN_BUF_SIZE-1))
+#define UN_BUF_AVAIL(UPD)	(((UPD)->bp_head - (UPD)->bp_tail) & (UN_BUF_SIZE-1))
 #define UN_BUF_SPACE(UPD)	((UN_BUF_SIZE-1) - UN_BUF_AVAIL(UPD))
 
 struct unix_proto_data {
-    int refcnt;
-    struct socket *socket;
-    struct sockaddr_un sockaddr_un;
-    short sockaddr_len;
-    char buf[UN_BUF_SIZE];
     int bp_head, bp_tail;
+    int refcnt;
+    int index;
+    struct socket *socket;
     struct inode *inode;
     struct unix_proto_data *peerupd;
-    struct wait_queue wait;
-    int lock_flag;
+    struct sockaddr_un sockaddr_un;
+    short sockaddr_len;
     sem_t sem;
+    struct wait_queue wait;
+    char buf[UN_BUF_SIZE];
 };
 
 #endif

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,4 +1,4 @@
-## ELKS /bootopts boot options file, max 1023 bytes
+## /bootopts 1023 max
 #TZ=MDT6
 #LOCALIP=10.0.2.16
 #HOSTNAME=elks16
@@ -21,3 +21,4 @@
 #net=ne0
 #debug=1
 #console=ttyS0,19200 3
+#MOUSE_PORT=/dev/ttyS1

--- a/qemu.sh
+++ b/qemu.sh
@@ -71,6 +71,8 @@ KEYBOARD=
 # Select pty serial port or serial mouse driver
 #SERIAL="-chardev pty,id=chardev1 -device isa-serial,chardev=chardev1,id=serial1"
 #SERIAL="-chardev msmouse,id=chardev1 -device isa-serial,chardev=chardev1,id=serial1"
+# Uncomment the following line to emulate two serial devices, required for Nano-X:
+#SERIAL="-chardev msmouse,id=c1 -device isa-serial,chardev=c1,id=s1 -chardev msmouse,id=c2 -device isa-serial,chardev=c2,id=s2"
 
 # Uncomment this to route ELKS /dev/ttyS0 to host terminal
 CONSOLE="-serial stdio"


### PR DESCRIPTION
Adds kernel enhancements required to support the port of the current [Nano-X Project](https://github.com/ghaerr/microwindows/pull/95) to ELKS.

Changes include:
- Support 10 rather than 6 poll file descriptors (several required plus one for each client in NX server).
- Reduce the size of struct sockaddr_un to to not waste kernel space. PATH limit now 16 instead of 108.
- Rewrite UNIX sockets code to dynamically allocate UNIX socket structure.
- Increase UNIX socket buffer size from 64 to 128 for best response speed.
- Add SERIAL= line to qemu.sh to allow two serial ports to be emulated in QEMU: the first /dev/ttyS0 is used for debug output, and the second /dev/ttS1 is used for the mouse device. The SERIAL= line must be uncommented from qemu.sh before running Nano-X using it.

The /bootopts file must set serial console for the mouse to work, for some reason. This would be done by adding the following line to /bootopts:
```
console=/dev/ttyS0,19200
```