### PR TITLE
[libc] Have __dprintf try to open terminal/ttyS0 on QEMU for messages

### DIFF
--- a/elkscmd/sys_utils/mouse.c
+++ b/elkscmd/sys_utils/mouse.c
@@ -14,7 +14,8 @@
 #include <fcntl.h>
 #include <termios.h>
 
-#define	MOUSE_DEVICE "/dev/ttyS0"	/* mouse tty device*/
+#define	MOUSE_DEVICE  "/dev/ttyS0"	/* real hardware mouse tty device*/
+#define	MOUSE_DEVICE2 "/dev/ttyS1"	/* QEMU mouse tty device*/
 #define	MOUSE_MICROSOFT		1		/* microsoft mouse*/
 #define	MOUSE_PC			0		/* pc/logitech mouse*/
 #define MAX_BYTES	128				/* number of bytes for buffer*/
@@ -77,6 +78,7 @@ int  	        parseMS(int);		/* routine to interpret MS mouse */
 int
 open_mouse(void)
 {
+    char *port;
 	struct termios termios;
 
 	/* set button bits and parse procedure*/
@@ -97,9 +99,10 @@ open_mouse(void)
 #endif
 
 	/* open mouse port*/
-	mouse_fd = open(MOUSE_DEVICE, O_EXCL | O_NOCTTY | O_NONBLOCK);
+	port = getenv("QEMU")? MOUSE_DEVICE2: MOUSE_DEVICE;
+	mouse_fd = open(port, O_EXCL | O_NOCTTY | O_NONBLOCK);
 	if (mouse_fd < 0) {
-		printf("Can't open %s, error %d\n", MOUSE_DEVICE, errno);
+		printf("Can't open %s, error %d\n", port, errno);
  		return -1;
 	}
 

--- a/libc/include/malloc.h
+++ b/libc/include/malloc.h
@@ -36,5 +36,6 @@ int        _fmemfree(unsigned short seg);               /* syscall */
 
 /* debug output */
 int __dprintf(const char *fmt, ...);
+int __open_readable_terminal(void);
 
 #endif

--- a/qemu.sh
+++ b/qemu.sh
@@ -72,7 +72,7 @@ KEYBOARD=
 #SERIAL="-chardev pty,id=chardev1 -device isa-serial,chardev=chardev1,id=serial1"
 #SERIAL="-chardev msmouse,id=chardev1 -device isa-serial,chardev=chardev1,id=serial1"
 # Uncomment the following line to emulate two serial devices, required for Nano-X:
-#SERIAL="-chardev msmouse,id=c1 -device isa-serial,chardev=c1,id=s1 -chardev msmouse,id=c2 -device isa-serial,chardev=c2,id=s2"
+SERIAL="-chardev msmouse,id=c1 -device isa-serial,chardev=c1,id=s1 -chardev msmouse,id=c2 -device isa-serial,chardev=c2,id=s2"
 
 # Uncomment this to route ELKS /dev/ttyS0 to host terminal
 CONSOLE="-serial stdio"


### PR DESCRIPTION
Allows \_\_dprintf to find best display option for debug messages: when using QEMU and mouse, it will open /dev/ttyS0 which is normally the terminal QEMU is running from. This works and allows seeing debug messages from Nano-X or other programs even if the kernel serial console option is not set in /bootopts. 

A QEMU mouse is now supposed to be connected to /dev/ttyS1, which qemu.sh now sets up by default.