### PR TITLE
[kernel] Fix mv directory bug in MINIX empty directory check

### DIFF
--- a/elks/fs/minix/namei.c
+++ b/elks/fs/minix/namei.c
@@ -344,12 +344,11 @@ static int empty_dir(register struct inode *inode)
 	    return 0;
 	}
     }
-    brelse(bh);
     goto empt_dir;
   bad_dir:
-    unmap_brelse(bh);
     printk("Bad directory on device %D\n", inode->i_dev);
   empt_dir:
+    unmap_brelse(bh);
     return 1;
 }
 

--- a/elks/fs/namei.c
+++ b/elks/fs/namei.c
@@ -508,8 +508,6 @@ int sys_link(char *oldname, char *pathname)
     error = namei(oldname, &oldinode, 0, 0);
     if (!error) {
         error = do_mknod(pathname, offsetof(struct inode_operations,link), (int)oldinode, 0);
-        if (error)
-            iput(oldinode);
     }
     return error;
 }

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -202,13 +202,13 @@ test/libc/test_libc             :test                           :1440c
 test/other/test_fd              :test
 test/other/test_float           :test
 #nano/nano-2.0.6/src/nano       :other
-nano-X/bin/nano-X               :nanox                              :1440c
-nano-X/bin/nxclock              :nanox                              :1440c
-nano-X/bin/nxdemo               :nanox
-nano-X/bin/nxtetris             :nanox                  :1200k
-nano-X/bin/nxlandmine           :nanox                   :1232k :1440k
-nano-X/bin/nxterm               :nanox                   :1232k     :1440c
-nano-X/bin/nxworld              :nanox                   :1232c :1440k
+#nano-X/bin/nano-X               :nanox                   :1232c     :1440c
+#nano-X/bin/nxclock              :nanox                   :1232c     :1440c
+#nano-X/bin/nxdemo               :nanox
+#nano-X/bin/nxtetris             :nanox                  :1200k
+#nano-X/bin/nxlandmine           :nanox                   :1232k :1440k
+#nano-X/bin/nxterm               :nanox                   :1232k     :1440c
+#nano-X/bin/nxworld              :nanox                   :1232c :1440k
 nano-X/bin/nxworld.map ::lib/nxworld.map :nanox          :1232c :1440k
 basic/basic                     :basic                  :1200k
 advent/advent                     :other                            :1440c


### PR DESCRIPTION
Fixes system hang when moving directories on MINIX filesystems, uncovered and fixed in TLVC https://github.com/Mellvik/TLVC/pull/139. Thanks @Mellvik!

Also removes ELKS-repo built Nano-X applications from distribution images to make room for the now working modern client/server versions from the Microwindows repository.