### PR TITLE
[cmds] Display mouse port being opened on mouse command

### DIFF
--- a/elkscmd/sys_utils/mouse.c
+++ b/elkscmd/sys_utils/mouse.c
@@ -100,6 +100,7 @@ open_mouse(void)
 
 	/* open mouse port*/
 	port = getenv("QEMU")? MOUSE_DEVICE2: MOUSE_DEVICE;
+	printf("Opening mouse on %s\n", port);
 	mouse_fd = open(port, O_EXCL | O_NOCTTY | O_NONBLOCK);
 	if (mouse_fd < 0) {
 		printf("Can't open %s, error %d\n", port, errno);


### PR DESCRIPTION
As discussed in https://github.com/ghaerr/microwindows/pull/106 with @toncho11, the `mouse` command will now display the mouse port being used when started.

In addition, Nano-X will display the mouse port on startup. Properly configured, this "message" will display on either /dev/ttyS0 when running on QEMU, or /dev/console otherwise. Because nano-X clears the screen to graphics mode, the mouse message may be erased quickly and not be seen (along with any other error or informative messages). For this reason, it is recommended that emulators set the mouse port to /dev/ttyS1 (along with MOUSE_PORT=/dev/ttyS1) and console output to /dev/ttyS0 so that messages can be seen.

Here's a pre-built image with both fixes for testing.
[fd2880.img.zip](https://github.com/user-attachments/files/18806961/fd2880.img.zip)


