### PR TITLE
[c86 libc] Add support for signal() for C86 programs

### DIFF
--- a/elks/include/linuxmt/signal.h
+++ b/elks/include/linuxmt/signal.h
@@ -187,9 +187,12 @@ typedef stdcall __far void (*__kern_sighandler_t)(int);
 #pragma GCC diagnostic pop
 #endif
 
-#if defined(__WATCOMC__) || defined(__C86__)
-/* FIXME broken for C86 w/o stdcall and __far */
+#ifdef __WATCOMC__
 typedef void stdcall (__far *__kern_sighandler_t)(int);
+#endif
+
+#ifdef __C86__
+typedef void (*__kern_sighandler_t)(int);   /* CS passed separately to _signal */
 #endif
 
 /*

--- a/libc/c86/signalcb.s
+++ b/libc/c86/signalcb.s
@@ -1,0 +1,51 @@
+;
+; signalcb.s - signal callback from ELKS kernel for C86
+;
+; 15 Feb 2025 Greg Haerr
+;
+        use16   86
+
+        .data
+        .extern __sigtable
+        .text
+        .align  2
+
+        .global __signal_cbhandler
+__signal_cbhandler:
+        push bp
+        mov bp,sp
+
+        pushf
+        push ax
+        push bx
+        push cx
+        push dx
+        push si
+        push di
+        push ds
+        push es
+        mov ax,ss                   ; ensure valid DS (=SS)
+        mov ds,ax
+
+        mov ax,6[bp]                ; get signal #
+        push ax
+        dec ax
+        shl ax,#1
+        mov si,ax
+        add si,#__sigtable
+        mov bx,[si]
+        call bx                     ; call _sigtable[sig-1]
+        add sp,#2
+
+        pop es
+        pop ds
+        pop di
+        pop si
+        pop dx
+        pop cx
+        pop bx
+        pop ax
+        popf
+
+        pop bp
+        retf 2                      ; get rid of the signum

--- a/libc/c86/syscall.s
+++ b/libc/c86/syscall.s
@@ -7,6 +7,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
         use16   86
 
+        .sect   0               ; first text seg
+        dw      0,0             ; prevent text having address 0 for SIG_DFL,SIG_IGN
         .sect   1               ; first data seg
         dw      0,0             ; prevent data having address 0
         .data                   ; default data seg 3

--- a/libc/include/signal.h
+++ b/libc/include/signal.h
@@ -7,7 +7,12 @@
 #include __SYSINC__(signal.h)
 
 sighandler_t signal(int number, sighandler_t pointer);
+
+#ifdef __C86__
+int _signal(int __sig, __kern_sighandler_t __cbfunc, unsigned int cs);   /* syscall */
+#else
 int _signal(int __sig, __kern_sighandler_t __cbfunc);   /* syscall */
+#endif
 
 typedef struct siginfo_t siginfo_t;
 

--- a/libc/system/out.mk
+++ b/libc/system/out.mk
@@ -40,6 +40,7 @@ OBJS = \
 	seekdir.o \
 	setpgrp.o \
 	sigaction.o \
+	signal.o \
 	sleep.o \
 	telldir.o \
 	time.o \
@@ -48,12 +49,6 @@ OBJS = \
 	wait.o \
 	wait3.o \
 	waitpid.o \
-
-# C86 doesn't have these yet
-ifneq "$(COMPILER)" "c86"
-OBJS += \
-	signal.o
-endif
 
 # these files written in assembly language
 IA16OBJS = \


### PR DESCRIPTION
Adds support for `signal` system call in C86 C library, requested by @rafael2k in https://github.com/ghaerr/8086-toolchain/issues/48.

Using signals in C86 programs is now fully supported, with a caveat: the C handler specified to be called back using `signal` must not be the first function declared in your C program. This is because currently the linker assigns the first function it sees address 0, which happens also to be the value of SIG_DFL (default signal action). If this callback function is the first function in your C program, it will also be assigned address 0.

Thus, the following "zero()" function declaration as the first function is necessary in C86 applications to avoid this problem:
```
#include <signal.h>
#include <stdio.h>
#include <unistd.h>
#include <errno.h>

void zero(void) {}      /* required to keep catch() from having address 0 */
void catch(int sig)
{
    printf("GOT %d\n", sig);
    signal(SIGINT, catch);
}

int main(int ac, char **av)
{
    sighandler_t rv = signal(SIGINT, catch);
    printf("ret %x errno %d\n", rv, errno);

    for (;;)
        sleep(1);
    return 0;
}
```

A later update will provide a linker modification and/or manually supplying the C86 crt0.o file as the first file to ld86, which will solves this issue.