### PR TITLE
[libc] Rewrite mouse and debug console output to work together

### DIFF
--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -21,4 +21,4 @@
 #net=ne0
 #debug=1
 #console=ttyS0,19200 3
-#MOUSE_PORT=/dev/ttyS1
+#MOUSE_PORT=/dev/ttyS0

--- a/elkscmd/sys_utils/mouse.c
+++ b/elkscmd/sys_utils/mouse.c
@@ -14,8 +14,8 @@
 #include <fcntl.h>
 #include <termios.h>
 
-#define	MOUSE_DEVICE  "/dev/ttyS0"	/* real hardware mouse tty device*/
-#define	MOUSE_DEVICE2 "/dev/ttyS1"	/* QEMU mouse tty device*/
+#define	MOUSE_PORT    "/dev/ttyS0"  /* default port unless MOUSE_PORT= env specified */
+#define	MOUSE_QEMU    "/dev/ttyS1"  /* default port on QEMU */
 #define	MOUSE_MICROSOFT		1		/* microsoft mouse*/
 #define	MOUSE_PC			0		/* pc/logitech mouse*/
 #define MAX_BYTES	128				/* number of bytes for buffer*/
@@ -99,7 +99,8 @@ open_mouse(void)
 #endif
 
 	/* open mouse port*/
-	port = getenv("QEMU")? MOUSE_DEVICE2: MOUSE_DEVICE;
+	if (!(port = getenv("MOUSE_PORT")))
+	    port = getenv("QEMU")? MOUSE_QEMU: MOUSE_PORT;
 	printf("Opening mouse on %s\n", port);
 	mouse_fd = open(port, O_EXCL | O_NOCTTY | O_NONBLOCK);
 	if (mouse_fd < 0) {
@@ -109,7 +110,7 @@ open_mouse(void)
 
 	/* set rawmode serial port using termios*/
 	if (tcgetattr(mouse_fd, &termios) < 0) {
-		printf("Can't get termio on %s, error %d\n", MOUSE_DEVICE, errno);
+		printf("Can't get termio on %s, error %d\n", port, errno);
 		close(mouse_fd);
 		return -1;
 	}
@@ -124,7 +125,7 @@ open_mouse(void)
 	termios.c_cc[VMIN] = 0;
 	termios.c_cc[VTIME] = 0;
 	if(tcsetattr(mouse_fd, TCSAFLUSH, &termios) < 0) {
-		printf("Can't set termio on %s, error %d\n", MOUSE_DEVICE, errno);
+		printf("Can't set termio on %s, error %d\n", port, errno);
 		close(mouse_fd);
 		return -1;
 	}

--- a/libc/malloc/dprintf.c
+++ b/libc/malloc/dprintf.c
@@ -1,6 +1,7 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <string.h>
 #include <paths.h>
 #include <fcntl.h>
 
@@ -14,12 +15,19 @@
  */
 int __open_readable_terminal(void)
 {
-    int fd;
+    int fd = -1;
+    char *serial = "/dev/ttyS0";    /* preferred console but could be  mouse port */
+    char *mouse;
 
-    if (!isatty(STDERR_FILENO)) /* continue piping __dprintf to redirected stderr */
+    if (!isatty(STDERR_FILENO))     /* continue piping __dprintf to redirected stderr */
         fd = STDERR_FILENO;
-    else if ((fd = open("/dev/ttyS0", O_NOCTTY | O_WRONLY)) < 0)
-        fd = open(_PATH_CONSOLE, O_WRONLY);
+    else {
+        mouse = getenv("MOUSE_PORT");
+        if (!mouse || strcmp(mouse, serial) != 0)  /* use serial if not used by mouse */
+            fd = open(serial, O_NOCTTY | O_WRONLY);
+        if (fd < 0)
+            fd = open(_PATH_CONSOLE, O_WRONLY);
+    }
     return fd;
 }
 


### PR DESCRIPTION
Both Nano-X and ELKS' mouse programs/driver have been simplified to just work by setting "export MOUSE_PORT=/dev/ttyS0" (or /dev/ttyS1), depending on which serial device the mouse is on. The default line in /bootopts has been updated for COM1 and should work by just uncommenting it.

These changes were made because of the problems discussed by @toncho11 in https://github.com/ghaerr/elks/pull/2226#issuecomment-2661086534. Now, only a single mouse port open is attempted, and the debug console routine was changed to work with the mouse port setting.

@toncho11, this should now work for you. Setting "export MOUSE_PORT=/dev/ttyS0" at the shell prompt, or uncommenting the line in /bootopts should work with 86Box. It seems that 86Box only supports mouse on COM1 and there were also problems in the ELKS debug console code that did not work well with the mouse. The mouse may still work without MOUSE_PORT= being set on your emulator, but definitely will with it set.

Here's a prebuilt image:
[fd2880.img.zip](https://github.com/user-attachments/files/18813375/fd2880.img.zip)
