### PR TITLE
[c86 libc] Renumber sections in c86 startup code

### DIFF
--- a/libc/c86/syscall.s
+++ b/libc/c86/syscall.s
@@ -8,10 +8,13 @@
         use16   86
 
         .sect   0               ; first text seg
-        dw      0,0             ; prevent text having address 0 for SIG_DFL,SIG_IGN
-        .sect   1               ; first data seg
+        nop                     ; prevent text having address 0 for SIG_DFL,SIG_IGN
+        nop
+        nop
+        nop
+        .sect   4               ; first data seg
         dw      0,0             ; prevent data having address 0
-        .data                   ; default data seg 3
+        .data                   ; default data seg 7
         .align  2
         .comm   _errno,2
         .comm   _environ,2


### PR DESCRIPTION
Changes for ld86 enhancements made in https://github.com/ghaerr/8086-toolchain/pull/56. 

Removes requirement for "zero function" used in C86 applications temporarily required in https://github.com/ghaerr/elks/pull/2227.

