### PR TITLE
[cmds] Increase frame rate on ttytetris

### DIFF
--- a/elkscmd/tui/tetris-frame.c
+++ b/elkscmd/tui/tetris-frame.c
@@ -65,61 +65,18 @@ frame_init(void)
 }
 
 void
-frame_nextbox_init(void)
-{
-     int i;
-
-     for(i = 0; i < FRAMEH_NB; ++i)
-     {
-          frame_nextbox[i][0] = Border;
-          frame_nextbox[i][1] = Border;
-          frame_nextbox[i][FRAMEW_NB - 1] = Border;
-          frame_nextbox[i][FRAMEW_NB] = Border;
-
-     }
-     for(i = 0; i < FRAMEW_NB + 1; ++i)
-          frame_nextbox[0][i] = frame_nextbox[FRAMEH_NB][i] = Border;
-
-     frame_nextbox_refresh();
-
-     return;
-}
-
-void
 frame_refresh(void)
 {
      int i, j;
 
-     for(i = 0; i < FRAMEH + 1; ++i)
-          for(j = 0; j < FRAMEW + 1; ++j)
+     /* Diff frames and print changes */
+     for(i = 0; i < FRAMEH + 1; ++i) {
+          for(j = 0; j < FRAMEW + 1; ++j) {
+               if(frame[i][j] != frame_prev[i][j]) {
                     printxy(frame[i][j], i, j, " ");
+                    frame_prev[i][j] = frame[i][j];
+               }
+          }
+     }
      return;
 }
-
-void
-frame_nextbox_refresh(void)
-{
-     int i, j;
-
-     /* Clean frame_nextbox[][] */
-     for(i = 1; i < FRAMEH_NB; ++i)
-          for(j = 2; j < FRAMEW_NB - 1; ++j)
-               frame_nextbox[i][j] = 0;
-
-     /* Set the shape in the frame */
-     for(i = 0; i < 4; ++i)
-          for(j = 0; j < EXP_FACT; ++j)
-               frame_nextbox
-                    [2 + shapes[current.next][sattr[current.next][2]][i][0] + sattr[current.next][0]]
-                    [4 + shapes[current.next][sattr[current.next][2]][i][1] * EXP_FACT + j + sattr[current.next][1]]
-                    = current.next + 1;
-
-     /* Draw the frame */
-     for(i = 0; i < FRAMEH_NB + 1; ++i)
-          for(j = 0; j < FRAMEW_NB + 1; ++j)
-               printxy(frame_nextbox[i][j], i, j + FRAMEW + 3, " ");
-
-     return;
-}
-
-

--- a/elkscmd/tui/tetris-shapes.c
+++ b/elkscmd/tui/tetris-shapes.c
@@ -135,8 +135,6 @@ shape_new(void)
      current.y = (FRAMEW / 2) - 1;;
      current.next = nrand(0, 6);
 
-     frame_nextbox_refresh();
-
      if(current.x > 1)
           for(i = 2; i < FRAMEW - 1; ++i)
                frame[1][i] = 0;

--- a/elkscmd/tui/ttytetris.c
+++ b/elkscmd/tui/ttytetris.c
@@ -54,8 +54,8 @@ init(void)
      current.next = nrand(0, 6);
 
      /* Score */
-     printxy(0, FRAMEH_NB + 2, FRAMEW + 3, "Score:");
-     printxy(0, FRAMEH_NB + 3, FRAMEW + 3, "Lines:");
+     printxy(0, FRAMEH + 2, 2, "Score:");
+     printxy(0, FRAMEH + 3, 2, "Lines:");
      DRAW_SCORE();
 
      /* Init signal */
@@ -99,7 +99,9 @@ get_key_event(void)
      {
      case KEY_MOVE_LEFT:            shape_move(-EXP_FACT);              break;
      case KEY_MOVE_RIGHT:           shape_move(EXP_FACT);               break;
+     case 'd':
      case KEY_CHANGE_POSITION_NEXT: shape_set_position(N_POS);          break;
+     case 's':
      case KEY_CHANGE_POSITION_PREV: shape_set_position(P_POS);          break;
      case KEY_DROP_SHAPE:           shape_drop();                       break;
      case KEY_SPEED:                ++current.x; ++score; DRAW_SCORE(); break;
@@ -184,7 +186,6 @@ main(int argc, char **argv)
 {
      init();
      frame_init();
-     frame_nextbox_init();;
 
      current.last_move = False;
 

--- a/elkscmd/tui/ttytetris.h
+++ b/elkscmd/tui/ttytetris.h
@@ -47,8 +47,8 @@
 #define KEY_MOVE_RIGHT 'l'
 
 /* Change the shape position */
-#define KEY_CHANGE_POSITION_NEXT 'k'
-#define KEY_CHANGE_POSITION_PREV 'j'
+#define KEY_CHANGE_POSITION_NEXT 'k'    /* also 'd' */
+#define KEY_CHANGE_POSITION_PREV 'j'    /* also 's' */
 
 /* ' ' for space key */
 #define KEY_DROP_SHAPE ' '
@@ -56,7 +56,7 @@
 /* Other key */
 #define KEY_PAUSE 'p'
 #define KEY_QUIT  'q'
-#define KEY_SPEED 's'
+#define KEY_SPEED '-'
 
 /* Timing in milisecond */
 #define TIMING 300000
@@ -80,9 +80,9 @@
 #define P_POS ((current.pos > 0) ? current.pos - 1 : 3)
 
 /* Draw the score.. */
-#define DRAW_SCORE() set_color(Score);                             \
-     printf("\033[%d;%dH %d", FRAMEH_NB + 3, FRAMEW + 10, score);   \
-     printf("\033[%d;%dH %d", FRAMEH_NB + 4, FRAMEW + 10, lines);   \
+#define DRAW_SCORE() set_color(Score);                 \
+     printf("\033[%d;%dH %d", FRAMEH + 3, 9, score);   \
+     printf("\033[%d;%dH %d", FRAMEH + 4, 9, lines);   \
      set_color(0);
 
 /* Bool type */
@@ -113,9 +113,7 @@ void sig_handler(int);
 
 /* frame.c */
 void frame_init(void);
-void frame_nextbox_init(void);
 void frame_refresh(void);
-void frame_nextbox_refresh(void);
 
 /* shapes.c */
 void shape_set(void);
@@ -138,7 +136,7 @@ struct itimerval tv;
 struct termios back_attr;
 shape_t current;
 int frame[FRAMEH + 1][FRAMEW + 1];
-int frame_nextbox[FRAMEH_NB+1][FRAMEW_NB+1];
+int frame_prev[FRAMEH + 1][FRAMEW + 1];
 int score;
 int lines;
 Bool running;


### PR DESCRIPTION
This enhancement was written by @decrazyo as part of his awesome [NES86 IBM PC Emulator](https://github.com/decrazyo/nes86) project (also introduced in #2230).

I noticed as part of the massive work undertaken to get ELKS running on the NES, ttytetris was enhanced to display only changed blocks on the screen, rather than the entire tetris display, every cycle. (I'm guessing that was needed in order to get some decent speed from the game - see his [video](https://www.youtube.com/watch?v=OooHTDMUSGY), well worth watching). So I figured lets enhance it here too.

I also added 's' and 'd' keys to rotate the block (instead of just 'j' and 'k'), to be more compatible with our Nano-X nxtetris version.

I've pulled this change out of the NES86's ELKS fork, thank you @decrazyo :) Let me know if you'd like anything else included from your fork into master.