### PR TITLE
[owc libc] Fix OWC link errors with small and compact models using _weaken

### DIFF
--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -209,7 +209,7 @@ test/other/test_float           :test
 #nano-X/bin/nxlandmine           :nanox                   :1232k :1440k
 #nano-X/bin/nxterm               :nanox                   :1232k     :1440c
 #nano-X/bin/nxworld              :nanox                   :1232c :1440k
-nano-X/bin/nxworld.map ::lib/nxworld.map :nanox          :1232c :1440k
+#nano-X/bin/nxworld.map ::lib/nxworld.map :nanox          :1232c :1440k
 basic/basic                     :basic                  :1200k
 advent/advent                     :other                            :1440c
 advent/advent.db ::lib/advent.db  :other                            :1440c


### PR DESCRIPTION
Fixes #2237.

OWC wlink was failing to link vfprintf.obj in small and compact models due to the mechanism used to make "weak" symbols work using the \_weaken macro, because the OWC compiler generates a far segment relocation entry which causes wlink to fail with a "relocation not in same segment" error.

This all happens because vfprintf attempts to be smart about dragging in the large dtostr and ptostr routines into printf when floating point/ptick display aren't used. One fix would be to always link in dtostr in small model OWC programs, which would make them considerably larger, so instead this fix eliminates automatically including dtostr/ptostr entirely, eliminating automatic floating point display using printf %f/%g or %k (ptick) format specifiers. Instead, the application will need to call dtostr or ptostr explicitly if needed.

Also removes /lib/nxworld.map from the image as Nano-X is now built outside of ELKS in the Microwindows repo, and it is installed from there when built.