### PR TITLE
[kernel] Fix mv bug on FAT filesystems due to error in previous commit

### DIFF
--- a/elks/fs/namei.c
+++ b/elks/fs/namei.c
@@ -508,6 +508,8 @@ int sys_link(char *oldname, char *pathname)
     error = namei(oldname, &oldinode, 0, 0);
     if (!error) {
         error = do_mknod(pathname, offsetof(struct inode_operations,link), (int)oldinode, 0);
+        if (error)
+            iput(oldinode);
     }
     return error;
 }


### PR DESCRIPTION
Fixes newly-introduced `mv` bug on FAT filesystems, reported in https://github.com/Mellvik/TLVC/pull/141, due to an error in  ELKS previous commit #2225, which was copied from TLVC commit/fix https://github.com/Mellvik/TLVC/pull/139, originally reported in https://github.com/Mellvik/TLVC/issues/138.

A bit confusing, but the original `mv` bug on MINIX filesystems remains fixed, but the "iput: trying to free free inode dev 0000" display now remains. The root cause of this is under investigation in TLVC https://github.com/Mellvik/TLVC/pull/141.

