### PR TITLE
[libc] Update libc headers to allow compilation with -std=c99

### DIFF
--- a/elks/include/arch/cdefs.h
+++ b/elks/include/arch/cdefs.h
@@ -43,7 +43,6 @@
 
 #ifdef __C86__
 #define __HAS_NO_FLOATS__   1
-#define __far
 #define noreturn
 #define stdcall
 #define restrict

--- a/elks/include/linuxmt/signal.h
+++ b/elks/include/linuxmt/signal.h
@@ -177,6 +177,8 @@ typedef unsigned long sigset_t; /* at least 32 bits */
 
 /* Type of a signal handler within userland.  */
 typedef void (*sighandler_t)(int);
+
+#ifndef __STRICT_ANSI__
 /* Type of a signal handler which interfaces with the kernel.  This is always
    a far function that uses the `stdcall' calling convention, even for a
    user program that is being compiled for a different calling convention.  */
@@ -194,6 +196,7 @@ typedef void stdcall (__far *__kern_sighandler_t)(int);
 #ifdef __C86__
 typedef void (*__kern_sighandler_t)(int);   /* CS passed separately to _signal */
 #endif
+#endif /* !__STRICT_ANSI__ */
 
 /*
  * Because this stuff can get pretty confusing:

--- a/libc/include/malloc.h
+++ b/libc/include/malloc.h
@@ -15,6 +15,7 @@ void   *_drealloc(void *, size_t);
 void    _dfree(void *);
 size_t  _dmalloc_usable_size(void *);
 
+#ifndef __STRICT_ANSI__
 /* _fmalloc (single arena 64k far heap) */
 void __far *_fmalloc(size_t);
 int         _fmalloc_add_heap(char __far *start, size_t size);
@@ -24,15 +25,16 @@ size_t      _fmalloc_usable_size(void __far *);
 extern unsigned int malloc_arena_size;          /* mem.c wrapper function */
 extern unsigned int malloc_arena_thresh;        /* mem.c wrapper function */
 
-/* usable with all mallocs */
-void   *calloc(size_t elm, size_t sz);
-
 /* alloc/free from main memory */
 void __far *fmemalloc(unsigned long size);
 int         fmemfree(void __far *ptr);
 
 int        _fmemalloc(int paras, unsigned short *pseg); /* syscall */
 int        _fmemfree(unsigned short seg);               /* syscall */
+#endif
+
+/* usable with all mallocs */
+void   *calloc(size_t elm, size_t sz);
 
 /* debug output */
 int __dprintf(const char *fmt, ...);

--- a/libc/include/signal.h
+++ b/libc/include/signal.h
@@ -9,8 +9,8 @@
 sighandler_t signal(int number, sighandler_t pointer);
 
 #ifdef __C86__
-int _signal(int __sig, __kern_sighandler_t __cbfunc, unsigned int cs);   /* syscall */
-#else
+int _signal(int __sig, sighandler_t __cbfunc, unsigned int cs);   /* syscall */
+#elif !defined(__STRICT_ANSI__)
 int _signal(int __sig, __kern_sighandler_t __cbfunc);   /* syscall */
 #endif
 

--- a/libc/include/stdlib.h
+++ b/libc/include/stdlib.h
@@ -64,7 +64,7 @@ void qsort(void *base, size_t nel, size_t width,
 	int (*compar)(/*const void *, const void * */));
 char *devname(dev_t dev, mode_t type);
 
-#ifndef __STRICT_ANSI__
+/* non-standard routines */
 int (bsr)(int x);
 char *itoa(int val);
 char *uitoa(unsigned int val);
@@ -74,6 +74,5 @@ char *ltostr(long val, int radix);
 char *lltostr(long long val, int radix);
 char *ultostr(unsigned long val, int radix);
 char *ulltostr(unsigned long long val, int radix);
-#endif
 
 #endif /* __STDLIB_H */

--- a/libc/include/string.h
+++ b/libc/include/string.h
@@ -28,8 +28,10 @@ void * memset(void*, int, size_t);
 int memcmp(const void*, const void*, size_t);
 void * memmove(void*, const void*, size_t);
 
+#ifndef __STRICT_ANSI__
 void __far *fmemset(void __far *buf, int c, size_t l);
 int fmemcmp(void __far *s1, void __far *s2, size_t n);  /* Watcom C only, in ASM */
+#endif
 
 /* Error messages */
 char * strerror(int);

--- a/libc/malloc/Makefile
+++ b/libc/malloc/Makefile
@@ -36,7 +36,6 @@ OBJS = \
 	calloc.o \
 	brk.o \
 	sbrk.o \
-	fmemalloc.o \
 	dprintf.o \
 
 # default and debug mallocs for all compilers
@@ -44,14 +43,14 @@ OBJS += $(DEFAULT_MALLOC_OBJS) $(DEBUG_MALLOC_OBJS)
 
 # far malloc works with OWC only for now
 ifeq "$(COMPILER)" "watcom"
-OBJS += $(FAR_MALLOC_OBJS)
+OBJS += $(FAR_MALLOC_OBJS) fmemalloc.o
 endif
 
 IA16OBJS = \
 	stackcheck.o \
 
 ifeq "$(COMPILER)" "ia16"
-OBJS += $(IA16OBJS)
+OBJS += $(IA16OBJS) fmemalloc.o
 endif
 
 .PHONY: all

--- a/libc/malloc/fmemalloc.c
+++ b/libc/malloc/fmemalloc.c
@@ -4,9 +4,7 @@
 #include <sys/sysctl.h>
 /* fmemalloc/fmemfree - allocate/free from main memory */
 
-#ifndef __C86__
 #define DEBUG       1       /* =1 use sysctl, =2 debug output */
-#endif
 
 #if DEBUG
 #define debug(...)  do { if (debug_level > 1) __dprintf(__VA_ARGS__); } while (0)

--- a/libc/string/fmemset-c.c
+++ b/libc/string/fmemset-c.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <asm/config.h>
 
+#ifndef __C86__
 #ifndef LIBC_ASM_FMEMSET
 
 void __far *fmemset(void __far *str, int c, size_t l)
@@ -12,4 +13,5 @@ void __far *fmemset(void __far *str, int c, size_t l)
     return str;
 }
 
+#endif
 #endif

--- a/libc/system/signal.c
+++ b/libc/system/signal.c
@@ -61,9 +61,9 @@ sighandler_t signal(int number, sighandler_t pointer)
 
 #ifdef __C86__
     if (pointer == SIG_DFL || pointer == SIG_IGN)
-        rv = _signal(number, (__kern_sighandler_t) pointer, 0);
+        rv = _signal(number, pointer, 0);
     else
-        rv = _signal(number, (__kern_sighandler_t) _signal_cbhandler, _CS());
+        rv = _signal(number, _signal_cbhandler, _CS());
 #else
     if (pointer == SIG_DFL || pointer == SIG_IGN)
         rv = _signal(number, (__kern_sighandler_t) (unsigned long)pointer);


### PR DESCRIPTION
Allows ELKS C library and headers to be used with strict C99-compliant ANSI compilers.
Discussed in https://github.com/ghaerr/elks/issues/2239#issuecomment-2683568808.

Protects non-ANSI declarations using \_\_STRICT\_ANSI\_\_. 

C86/CPP86 now defines \_\_STRICT\_ANSI\_\_ since \_\_far is not implemented. `__far` is now not defined to blank for C86 so as to cause an error rather than ignoring the keyword.

@rafael2k, your idea of allowing -std=c99 to be enabled caused finding a few more future problems with ELKS libc using C86: the `fmemalloc`, `fmemfree` and `fmemset` could be called with no error, which would have previously resulted in improper operation, since far pointers are not implemented in C86. 

The C library headers should now be able to be used with ia16-elf-gcc using -std=c99, although I have not tried that on non-ELKS sources. You should also try recompiling elks-viewer and your other projects to ensure that they are also working with the more-restricted C86. Please report any problems. Note that -std=c99 cannot be used with ia16-elf-gcc if any \_\_far data access is required, as this isn't ANSI-compliant.

I have tested the 8086 toolchain build on ELKS and it continues to function properly.