### PR TITLE
[kernel] Fix extraneous iput in sys_link

### DIFF
--- a/elks/fs/namei.c
+++ b/elks/fs/namei.c
@@ -141,7 +141,7 @@ static int follow_link(struct inode *dir, register struct inode *inode,
  * specified name, and the name within that directory.
  */
 
-static int dir_namei(const char *pathname, size_t * namelen,
+static int dir_namei(const char *pathname, size_t *namelen,
     const char **name, register struct inode *base, struct inode **res_inode)
 {
     const char *thisname;
@@ -221,13 +221,13 @@ int _namei(const char *pathname, register struct inode *base, int follow_links,
     size_t namelen;
     struct inode *inode;
 
-    debug("_namei: calling dir_namei\n");
+    debug("_namei: calling dir_namei on %t\n", pathname);
     *res_inode = NULL;
     error = dir_namei(pathname, &namelen, &basename, base, &inode);
     debug("_namei: dir_namei returned %d\n", error);
     if (!error) {
         base = inode;
-        debug("_namei: calling lookup\n");
+        debug("_namei: calling lookup on %t\n", basename);
         error = lookup(base, basename, namelen, &inode);
         debug("_namei: lookup returned %d\n", error);
         if (!error) {
@@ -508,7 +508,8 @@ int sys_link(char *oldname, char *pathname)
     error = namei(oldname, &oldinode, 0, 0);
     if (!error) {
         error = do_mknod(pathname, offsetof(struct inode_operations,link), (int)oldinode, 0);
-        if (error)
+        /* minix_link fails if oldname is directory and iputs oldinode itself */
+        if (error && oldinode->i_count)
             iput(oldinode);
     }
     return error;


### PR DESCRIPTION
Final fix for #2242 `mv` bug inside sys_link -  iput should not be called twice in the case when minix_link is called to link a directory (as part of a directory rename operation from sys_rename calling sys_link), where minix_link already iput the original inode and returns -EPERM.

Fixed code sourced from TLVC https://github.com/Mellvik/TLVC/pull/142 discussed in https://github.com/Mellvik/TLVC/pull/141.