### PR TITLE
[libc] Initial support for OpenWatcom soft floating point

### DIFF
--- a/elks/tools/objtools/ewcc
+++ b/elks/tools/objtools/ewcc
@@ -34,16 +34,15 @@ ELKSINCLUDE2=$TOPDIR/libc/include/watcom
 # -Wc,-zev                  # enable void arithmetic
 # -Wc,-zls                  # remove automatically inserted symbols
 # -Wc,-wcd=N                # disable warning N
-# -Wc,-fpi87                # inline 8087 fp
 # -Wc,-x                    # ignore INCLUDE environment variable
 # -Wc,-r                    # save/restore segment registers
 # -fnostdlib                # don't refere standard libraries
 # unused:
 # -fno-stack-check          # don't generate stack check code
 # -ztNum                    # specify far data threshold (default 32767, or 256 if no Num)
+# -Wc,-fpi87                # inline 8087 fp
 # -mhard-emu-float          # -Wc,-fpi (inline 8087 w/emulation)
-# -msoft-float              # -Wc,-fpc
-# -Wc,-fpc                  # non-IEEE soft fp
+# -msoft-float              # -Wc,-fpc (software fp)
 # -fpmath
 # -mabi=cdecl               # push all args
 # -fnonconst-initializers   # -Wc,aa
@@ -57,7 +56,7 @@ CCFLAGS="\
     -march=i86                      \
     -Os                             \
     -std=c99                        \
-    -Wc,-fpi87                      \
+    -msoft-float                    \
     -Wc,-zev                        \
     -Wc,-zls                        \
     -Wc,-x                          \

--- a/libc/include/assert.h
+++ b/libc/include/assert.h
@@ -1,5 +1,6 @@
 #ifndef	__ASSERT_H
 #define	__ASSERT_H
+#include <features.h>
 
 /* If NDEBUG is defined, do nothing.
    If not, and EXPRESSION is zero, print an error message and abort.  */

--- a/libc/stdio/vfprintf.c
+++ b/libc/stdio/vfprintf.c
@@ -63,7 +63,7 @@
 #if !defined(__HAS_NO_FLOATS__) && defined(HAS_WEAKEN)
 #include <sys/weaken.h>
 /*
- * Use '#include <sys/weaken.h>` and '__STDIO_PRINT_FLOATS'
+ * Use '#include <sys/linksym.h>` and '__STDIO_PRINT_FLOATS'
  * in user program to link in libc %e,%f,%g * printf/sprintf support
  * (see below, stdio.h and sys/weaken.h).
  */

--- a/libc/watcom.inc
+++ b/libc/watcom.inc
@@ -25,7 +25,7 @@ CARCH =\
     -march=i86                      \
     -std=c99                        \
     -fno-stack-check                \
-    -Wc,-fpi87                      \
+    -Wc,-fpc                        \
     -Wc,-zev                        \
     -Wc,-zls                        \
     -Wc,-x                          \

--- a/libc/watcom/asm/chipd16.asm
+++ b/libc/watcom/asm/chipd16.asm
@@ -1,0 +1,1167 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
+;*               DESCRIBE IT HERE!
+;*
+;*****************************************************************************
+
+
+;
+; static char sccs_id[] = "@(#)patch16.asm      1.8  12/21/94  14:53:49";
+;
+; This code is being published by Intel to users of the Pentium(tm)
+; processor.  Recipients are authorized to copy, modify, compile, use and
+; distribute the code.
+;
+; Intel makes no warranty of any kind with regard to this code, including
+; but not limited to, implied warranties or merchantability and fitness for
+; a particular purpose. Intel assumes no responsibility for any errors that
+; may appear in this code.
+;
+; No patent licenses are granted, express or implied.
+;
+;
+include mdef.inc
+
+.386
+.387
+                name    fdiv_patch
+
+_TEXT   SEGMENT PARA USE16 PUBLIC 'CODE'
+fdiv_risc_table DB      0, 1, 0, 0, 4, 0, 0, 7, 0, 0, 10, 0, 0, 13, 0, 0
+fdiv_scale_1    DD      03f700000h              ;0.9375
+fdiv_scale_2    DD      03f880000h              ;1.0625
+one_shl_63      DD      05f000000h
+
+
+dispatch_table DW       offset label0
+        DW      offset label1
+        DW      offset label2
+        DW      offset label3
+        DW      offset label4
+        DW      offset label5
+        DW      offset label6
+        DW      offset label7
+        DW      offset label8
+        DW      offset label9
+        DW      offset label10
+        DW      offset label11
+        DW      offset label12
+        DW      offset label13
+        DW      offset label14
+        DW      offset label15
+        DW      offset label16
+        DW      offset label17
+        DW      offset label18
+        DW      offset label19
+        DW      offset label20
+        DW      offset label21
+        DW      offset label22
+        DW      offset label23
+        DW      offset label24
+        DW      offset label25
+        DW      offset label26
+        DW      offset label27
+        DW      offset label28
+        DW      offset label29
+        DW      offset label30
+        DW      offset label31
+        DW      offset label32
+        DW      offset label33
+        DW      offset label34
+        DW      offset label35
+        DW      offset label36
+        DW      offset label37
+        DW      offset label38
+        DW      offset label39
+        DW      offset label40
+        DW      offset label41
+        DW      offset label42
+        DW      offset label43
+        DW      offset label44
+        DW      offset label45
+        DW      offset label46
+        DW      offset label47
+        DW      offset label48
+        DW      offset label49
+        DW      offset label50
+        DW      offset label51
+        DW      offset label52
+        DW      offset label53
+        DW      offset label54
+        DW      offset label55
+        DW      offset label56
+        DW      offset label57
+        DW      offset label58
+        DW      offset label59
+        DW      offset label60
+        DW      offset label61
+        DW      offset label62
+        DW      offset label63
+
+;
+;  Stack variables for divide routines.
+;
+
+DENOM           EQU     0
+NUMER           EQU     12
+PATCH_CW        EQU     28
+PREV_CW         EQU     24
+DENOM_SAVE      EQU     32
+STACK_SIZE      EQU     44
+
+MAIN_DENOM      EQU     0
+MAIN_NUMER      EQU     12
+
+
+SPILL_SIZE      EQU     12
+if _MODEL and _BIG_CODE
+MEM_OPERAND     EQU     10
+else
+MEM_OPERAND     EQU     8
+endif
+SPILL_MEM_OPERAND       EQU     (MEM_OPERAND+SPILL_SIZE)
+
+;
+;  Stack frame locations for MS C/C++
+;
+
+SINGLE1         EQU     6  + STACK_SIZE
+SINGLE2         EQU     10 + STACK_SIZE
+
+DOUBLE1         EQU     6  + STACK_SIZE
+DOUBLE2         EQU     14 + STACK_SIZE
+
+LDOUBLE1        EQU     6  + STACK_SIZE
+LDOUBLE2        EQU     22 + STACK_SIZE
+
+SRESULT         EQU     14
+DRESULT         EQU     22
+LDRESULT        EQU     38
+
+ONESMASK        EQU     0e00h
+
+SINGLE_NAN      EQU     07f80h
+DOUBLE_NAN      EQU     07ff0h
+
+ILLEGAL_OPC     EQU     6
+
+f_stsw  macro   where
+        fstsw   where
+endm
+
+fdivr_st        MACRO   reg_index, reg_index_minus1
+        fstp    tbyte ptr [bp+DENOM]
+IF      reg_index_minus1 GE 1
+        fxch    st(reg_index_minus1)
+ENDIF
+        fstp    tbyte ptr [bp+NUMER]
+        call    fdiv_main_routine
+IF      reg_index_minus1 GE 1
+        fxch    st(reg_index_minus1)
+ENDIF
+        fld     tbyte ptr [bp+NUMER]
+        fxch    st(reg_index)
+        add     sp, STACK_SIZE          ; update stack
+ENDM
+
+fdivr_sti       MACRO   reg_index, reg_index_minus1
+        fstp    tbyte ptr [bp+NUMER]
+IF      reg_index_minus1 GE 1
+        fxch    st(reg_index_minus1)
+ENDIF
+        fstp    tbyte ptr [bp+DENOM]
+        call    fdiv_main_routine
+IF      reg_index_minus1 GE 1
+        fxch    st(reg_index_minus1)
+ENDIF
+        fld     tbyte ptr [bp+NUMER]
+        add     sp, STACK_SIZE          ; update stack
+ENDM
+
+fdivrp_sti      MACRO   reg_index, reg_index_minus1
+        fstp    tbyte ptr [bp+NUMER]
+IF      reg_index_minus1 GE 1
+        fxch    st(reg_index_minus1)
+ENDIF
+        fstp    tbyte ptr [bp+DENOM]
+        call    fdiv_main_routine
+IF      reg_index_minus1 GE 1
+        fxch    st(reg_index_minus1)
+ENDIF
+        add     sp, STACK_SIZE          ; update stack
+ENDM
+
+fdiv_st         MACRO   reg_index, reg_index_minus1
+        fstp    tbyte ptr [bp+NUMER]
+IF      reg_index_minus1 GE 1
+        fxch    st(reg_index_minus1)
+ENDIF
+        fld     st
+        fstp    tbyte ptr [bp+DENOM]
+        fstp    tbyte ptr [bp+DENOM_SAVE]
+        call    fdiv_main_routine
+IF      reg_index_minus1 GE 1
+        fxch    st(reg_index_minus1)
+ENDIF
+        fld     tbyte ptr [bp+DENOM_SAVE]
+        fxch    st(reg_index)
+        add     sp, STACK_SIZE          ; update stack
+ENDM
+
+fdiv_sti        MACRO   reg_index, reg_index_minus1
+        fxch    st(reg_index)
+        fstp    tbyte ptr [bp+NUMER]
+IF      reg_index_minus1 GE 1
+        fxch    st(reg_index_minus1)
+ENDIF
+        fld     st
+        fstp    tbyte ptr [bp+DENOM]
+        fstp    tbyte ptr [bp+DENOM_SAVE]
+        call    fdiv_main_routine
+IF      reg_index_minus1 GE 1
+        fxch    st(reg_index_minus1)
+ENDIF
+        fld     tbyte ptr [bp+DENOM_SAVE]
+        add     sp, STACK_SIZE          ; update stack
+ENDM
+
+fdivp_sti       MACRO   reg_index, reg_index_minus1
+        fstp    tbyte ptr [bp+DENOM]
+IF      reg_index_minus1 GE 1
+        fxch    st(reg_index_minus1)
+ENDIF
+        fstp    tbyte ptr [bp+NUMER]
+        call    fdiv_main_routine
+IF      reg_index_minus1 GE 1
+        fxch    st(reg_index_minus1)
+ENDIF
+        add     sp, STACK_SIZE          ; update stack
+ENDM
+
+
+        assume cs:_TEXT, ds:nothing, ss:nothing
+
+                                        ; In this implementation the
+                                        ; fdiv_main_routine is called,
+                                        ; therefore all the stack frame
+                                        ; locations are adjusted for the
+                                        ; return pointer.
+
+fdiv_main_routine PROC  NEAR
+
+        fld     tbyte ptr [bp+MAIN_NUMER]    ; load the numerator
+        fld     tbyte ptr [bp+MAIN_DENOM]       ; load the denominator
+retry:
+
+;  The following three lines test for denormals and zeros.
+;  A denormal or zero has a 0 in the explicit digit to the left of the
+;  binary point.  Since that bit is the high bit of the word, adding
+;  it to itself will produce a carry if and only if the number is not
+;  denormal or zero.
+;
+        mov     ax, [bp+MAIN_DENOM+6]   ; get mantissa bits 48-64
+        add     ax,ax                   ; shift one's bit into carry
+        jnc     denormal                ; if no carry, we have a denormal
+
+;  The following three lines test the three bits after the four bit
+;  pattern (1,4,7,a,d).  If these three bits are not all one, then
+;  the denominator cannot expose the flaw.  This condition is tested by
+;  inverting the bits and testing that all are equal to zero afterward.
+
+        xor     ax, ONESMASK            ; invert the bits that must be one
+        test    ax, ONESMASK            ; test for needed bits
+        jz      scale_if_needed         ; if all one, it may need scalling
+        fdivp   st(1), st               ; OK to use the hardware
+        ret
+
+;
+;  Now we test the four bits for one of the five patterns.
+;
+scale_if_needed:
+        shr     ax, 12                  ; keep first four bits after point
+        push    bx                      ; save bx
+        mov     bx,ax                   ; bx = index
+        cmp     byte ptr fdiv_risc_table[bx], 0 ; check for (1,4,7,a,d)
+        pop     bx                      ; restore bx
+        jnz     divide_scaled
+        fdivp   st(1), st               ; OK to use the hardware
+        ret
+
+divide_scaled:
+        mov     ax, [bp + MAIN_DENOM+8] ; test denominator exponent
+        and     ax, 07fffh              ; if pseudodenormal ensure that only
+        jz      invalid_denom           ; invalid exception flag is set
+        cmp     ax, 07fffh              ; if NaN or infinity  ensure that only
+        je      invalid_denom           ; invalid exception flag is set
+;
+;  The following six lines turn off exceptions and set the
+;  precision control to 80 bits.  The former is necessary to
+;  force any traps to be taken at the divide instead of the scaling
+;  code.  The latter is necessary in order to get full precision for
+;  codes with incoming 32 and 64 bit precision settings.  If
+;  it can be guaranteed that before reaching this point, the underflow
+;  exception is masked and the precision control is at 80 bits, these
+;  five lines can be omitted.
+;
+        fnstcw  [bp+PREV_CW]            ; save caller's control word
+        mov     ax, [bp+PREV_CW]
+        or      ax, 033fh               ; mask exceptions, pc=80
+        and     ax, 0f3ffh              ; set rounding mode to nearest
+        mov     [bp+PATCH_CW], ax
+        fldcw   [bp+PATCH_CW]           ; mask exceptions & pc=80
+
+;  The following lines check the numerator exponent before scaling.
+;  This in order to prevent undeflow when scaling the numerator,
+;  which will cause a denormal exception flag to be set when the
+;  actual divide is preformed. This flag would not have been set
+;  normally. If there is a risk of underflow, the scale factor is
+;  17/16 instead of 15/16.
+;
+        mov     ax, [bp+MAIN_NUMER+8]   ; test numerator exponent
+        and     ax, 07fffh
+        cmp     ax, 00001h
+        je      small_numer
+
+; perform scaling of both numerator and denominator
+
+        fmul    fdiv_scale_1            ; scale denominator by 15/16
+        fxch
+        fmul    fdiv_scale_1            ; scale numerator by 15/16
+        fxch
+
+;
+;  The next line restores the users control word.  If the incoming
+;  control word had the underflow exception masked and precision
+;  control set to 80 bits, this line can be omitted.
+;
+
+        fldcw   [bp+PREV_CW]            ; restore caller's control word
+        fdivp   st(1), st               ; OK to use the hardware
+        ret
+
+small_numer:
+        fmul    fdiv_scale_2            ; scale denominator by 17/16
+        fxch
+        fmul    fdiv_scale_2            ; scale numerator by 17/16
+        fxch
+
+;
+;  The next line restores the users control word.  If the incoming
+;  control word had the underflow exception masked and precision
+;  control set to 80 bits, this line can be omitted.
+;
+
+        fldcw   [bp+PREV_CW]            ; restore caller's control word
+        fdivp   st(1), st               ; OK to use the hardware
+        ret
+
+denormal:
+        mov     eax, [bp+MAIN_DENOM]            ; test for whole mantissa == 0
+        or      eax, [bp+MAIN_DENOM+4]  ; test for whole mantissa == 0
+        jnz     denormal_divide_scaled  ; denominator is not zero
+invalid_denom:                          ; zero or invalid denominator
+        fdivp   st(1), st               ; OK to use the hardware
+        ret
+
+denormal_divide_scaled:
+        mov     ax, word ptr[bp + MAIN_DENOM + 8]       ; get exponent
+        and     ax, 07fffh              ; check for zero exponent
+        jnz     invalid_denom
+;
+;  The following six lines turn off exceptions and set the
+;  precision control to 80 bits.  The former is necessary to
+;  force any traps to be taken at the divide instead of the scaling
+;  code.  The latter is necessary in order to get full precision for
+;  codes with incoming 32 and 64 bit precision settings.  If
+;  it can be guaranteed that before reaching this point, the underflow
+;  exception is masked and the precision control is at 80 bits, these
+;  six lines can be omitted.
+;
+
+        fnstcw  [bp+PREV_CW]            ; save caller's control word
+        mov     ax, [bp+PREV_CW]
+        or      ax, 033fh               ; mask exceptions, pc=80
+        and     ax, 0f3ffh              ; set rounding mode to nearest
+        mov     [bp+PATCH_CW], ax
+        fldcw   [bp+PATCH_CW]           ; mask exceptions & pc=80
+
+        mov     ax, [bp + MAIN_NUMER +8]        ; test numerator exponent
+        and     ax, 07fffh              ; check for denormal numerator
+        je      denormal_numer
+        cmp     ax, 07fffh              ; NaN or infinity
+        je      invalid_numer
+        mov     ax, [bp + MAIN_NUMER + 6]       ; get bits 48..63 of mantissa
+        add     ax, ax                  ; shift the first bit into carry
+        jnc     invalid_numer           ; if there is no carry, we have an
+                                        ; invalid numer
+        jmp     numer_ok
+
+denormal_numer:
+        mov     ax, [bp + MAIN_NUMER + 6]       ; get bits 48..63 of mantissa
+        add     ax, ax                  ; shift the first bit into carry
+        jc      invalid_numer           ; if there is a carry, we have an
+                                        ; invalid numer
+
+numer_ok:
+        fxch
+        fstp    st                      ; pop numerator
+        fld     st                      ; make copy of denominator
+        fmul    [one_shl_63]            ; make denominator not denormal
+        fstp    tbyte ptr [bp+MAIN_DENOM]
+        fld     tbyte ptr [bp+MAIN_NUMER]       ; load numerator
+        fxch                            ; restore proper order
+        fwait
+
+;  The next line restores the users control word.  If the incoming
+;  control word had the underflow exception masked and precision
+;  control set to 80 bits, this line can be omitted.
+;
+        fldcw   [bp+PREV_CW]            ; restore caller's control word
+        jmp     retry                   ; start the whole thing over
+
+invalid_numer:
+;
+;  The next line restores the users control word.  If the incoming
+;  control word had the underflow exception masked and precision
+;  control set to 80 bits, this line can be omitted.
+;
+        fldcw   [bp + PREV_CW]
+
+        fdivp   st(1), st               ; use of hardware is OK.
+        ret
+
+fdiv_main_routine       ENDP
+
+        public  __fdiv_fpr
+        defpe   __fdiv_fpr
+
+        push    bp
+        push    bx
+        sub     sp, STACK_SIZE
+        shl     ax, 1
+        mov     bx,ax
+        mov     bp,sp
+        jmp     word ptr dispatch_table[bx]
+
+
+label0:
+        fdiv    st,st(0)                ; D8 F0         FDIV    ST,ST(0)
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        ret
+label1:
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        int     ILLEGAL_OPC
+label2:
+        fdivr   st,st(0)                ; D8 F8         FDIVR   ST,ST(0)
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        ret
+label3:
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        int     ILLEGAL_OPC
+label4:
+        fdiv    st(0),st                ; DC F8/D8 F0   FDIV    ST(0),ST
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        ret
+label5:
+        fdivp   st(0),st                ; DE F8         FDIVP   ST(0),ST
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        ret
+label6:
+        fdivr   st(0),st                ; DC F0/DE F8   FDIVR   ST(0),ST
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        ret
+label7:
+        fdivrp  st(0),st                ; DE F0         FDIVRP  ST(0),ST
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        ret
+label8:
+        fdiv_st 1, 0
+        pop     bx
+        pop     bp
+        ret
+label9:
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        int     ILLEGAL_OPC
+label10:
+        fdivr_st 1, 0
+        pop     bx
+        pop     bp
+        ret
+label11:
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        int     ILLEGAL_OPC
+label12:
+        fdiv_sti 1, 0
+        pop     bx
+        pop     bp
+        ret
+label13:
+        fdivp_sti 1, 0
+        pop     bx
+        pop     bp
+        ret
+label14:
+        fdivr_sti 1, 0
+        pop     bx
+        pop     bp
+        ret
+label15:
+        fdivrp_sti 1, 0
+        pop     bx
+        pop     bp
+        ret
+label16:
+        fdiv_st 2, 1
+        pop     bx
+        pop     bp
+        ret
+label17:
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        int     ILLEGAL_OPC
+label18:
+        fdivr_st 2, 1
+        pop     bx
+        pop     bp
+        ret
+label19:
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        int     ILLEGAL_OPC
+label20:
+        fdiv_sti 2, 1
+        pop     bx
+        pop     bp
+        ret
+label21:
+        fdivp_sti 2, 1
+        pop     bx
+        pop     bp
+        ret
+label22:
+        fdivr_sti 2, 1
+        pop     bx
+        pop     bp
+        ret
+label23:
+        fdivrp_sti 2, 1
+        pop     bx
+        pop     bp
+        ret
+label24:
+        fdiv_st 3, 2
+        pop     bx
+        pop     bp
+        ret
+label25:
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        int     ILLEGAL_OPC
+label26:
+        fdivr_st 3, 2
+        pop     bx
+        pop     bp
+        ret
+label27:
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        int     ILLEGAL_OPC
+label28:
+        fdiv_sti 3, 2
+        pop     bx
+        pop     bp
+        ret
+label29:
+        fdivp_sti 3, 2
+        pop     bx
+        pop     bp
+        ret
+label30:
+        fdivr_sti 3, 2
+        pop     bx
+        pop     bp
+        ret
+label31:
+        fdivrp_sti 3, 2
+        pop     bx
+        pop     bp
+        ret
+label32:
+        fdiv_st 4, 3
+        pop     bx
+        pop     bp
+        ret
+label33:
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        int     ILLEGAL_OPC
+label34:
+        fdivr_st 4, 3
+        pop     bx
+        pop     bp
+        ret
+label35:
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        int     ILLEGAL_OPC
+label36:
+        fdiv_sti 4, 3
+        pop     bx
+        pop     bp
+        ret
+label37:
+        fdivp_sti 4, 3
+        pop     bx
+        pop     bp
+        ret
+label38:
+        fdivr_sti 4, 3
+        pop     bx
+        pop     bp
+        ret
+label39:
+        fdivrp_sti 4, 3
+        pop     bx
+        pop     bp
+        ret
+label40:
+        fdiv_st 5, 4
+        pop     bx
+        pop     bp
+        ret
+label41:
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        int     ILLEGAL_OPC
+label42:
+        fdivr_st 5, 4
+        pop     bx
+        pop     bp
+        ret
+label43:
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        int     ILLEGAL_OPC
+label44:
+        fdiv_sti 5, 4
+        pop     bx
+        pop     bp
+        ret
+label45:
+        fdivp_sti 5, 4
+        pop     bx
+        pop     bp
+        ret
+label46:
+        fdivr_sti 5, 4
+        add     bx,bx
+        pop     bx
+        pop     bp
+        ret
+label47:
+        fdivrp_sti 5, 4
+        pop     bx
+        pop     bp
+        ret
+label48:
+        fdiv_st 6, 5
+        pop     bx
+        pop     bp
+        ret
+label49:
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        int     ILLEGAL_OPC
+label50:
+        fdivr_st 6, 5
+        pop     bx
+        pop     bp
+        ret
+label51:
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        int     ILLEGAL_OPC
+label52:
+        fdiv_sti 6, 5
+        pop     bx
+        pop     bp
+        ret
+label53:
+        fdivp_sti 6, 5
+        pop     bx
+        pop     bp
+        ret
+label54:
+        fdivr_sti 6, 5
+        pop     bx
+        pop     bp
+        ret
+label55:
+        fdivrp_sti 6, 5
+        pop     bx
+        pop     bp
+        ret
+label56:
+        fdiv_st 7, 6
+        pop     bx
+        pop     bp
+        ret
+label57:
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        int     ILLEGAL_OPC
+label58:
+        fdivr_st 7, 6
+        pop     bx
+        pop     bp
+        ret
+label59:
+        add     sp, STACK_SIZE
+        pop     bx
+        pop     bp
+        int     ILLEGAL_OPC
+label60:
+        fdiv_sti 7, 6
+        pop     bx
+        pop     bp
+        ret
+label61:
+        fdivp_sti 7, 6
+        pop     bx
+        pop     bp
+        ret
+label62:
+        fdivr_sti 7, 6
+        pop     bx
+        pop     bp
+        ret
+label63:
+        fdivrp_sti 7, 6
+        pop     bx
+        pop     bp
+        ret
+__fdiv_fpr      ENDP
+
+
+__fdivp_sti_st    PROC NEAR
+                                ; for calling from mem routines
+        sub     sp, STACK_SIZE
+        mov     bp,sp
+        fdivp_sti 1, 0
+        ret
+__fdivp_sti_st    ENDP
+
+__fdivrp_sti_st   PROC NEAR
+                                ; for calling from mem routines
+        sub     sp, STACK_SIZE
+        mov     bp,sp
+        fdivrp_sti 1, 0
+        ret
+__fdivrp_sti_st   ENDP
+
+public  __fdiv_chk
+        defpe   __fdiv_chk
+        push    bp
+        sub     sp, STACK_SIZE
+        mov     bp,sp
+        fdivrp_sti 1, 0
+        pop     bp
+        ret
+__fdiv_chk      ENDP
+
+;;; FDIV_M32 - FDIV m32real FIX
+;;
+;;      Input : Value of the m32real in the top of STACK
+;;
+;;      Output: Result of FDIV in ST
+
+        PUBLIC  __fdiv_m32
+        defpe   __fdiv_m32
+
+        push    eax                             ; save eax
+        push    bp
+        mov     bp,sp
+        mov     ax, [bp + MEM_OPERAND + 2]      ; check for
+        and     ax, SINGLE_NAN                  ; NaN
+        cmp     ax, SINGLE_NAN                  ;
+        je      memory_divide_m32               ;
+
+        f_stsw  ax                              ; get status word
+        and     ax, 3800h                       ; get top of stack
+        je      spill_fpstack                   ; is FP stack full?
+        fld     dword ptr[bp + MEM_OPERAND]     ; load m32real in ST
+        call    __fdivp_sti_st                    ; do actual divide
+        jmp     m32_ok                          ; return
+spill_fpstack:
+        fxch
+        sub     sp, SPILL_SIZE          ; make temp space
+        mov     bp,sp
+        fstp    tbyte ptr[bp ]                  ; save user's ST(1)
+        fld     dword ptr[bp + SPILL_MEM_OPERAND] ; load m32 real
+        call    __fdivp_sti_st                    ; do actual divide
+        fld     tbyte ptr[bp]                   ; restore user's ST(1)
+                                                ;sp is adjusted by fdivp fn
+        fxch
+        add     sp, SPILL_SIZE
+m32_ok:
+        pop     bp
+        pop     eax
+        ret     4
+memory_divide_m32:
+        fdiv    dword ptr[bp + MEM_OPERAND]     ; do actual divide
+        pop     bp
+        pop     eax
+        ret     4
+
+__fdiv_m32        ENDP
+
+
+;;; FDIV_M64 - FDIV m64real FIX
+;;
+;;      Input : Value of the m64real in the top of STACK
+;;
+;;      Output: Result of FDIV in ST
+
+        PUBLIC  __fdiv_m64
+        defpe   __fdiv_m64
+
+        push    eax                             ; save eax
+        push    bp
+        mov     bp,sp
+        mov     ax, [bp + MEM_OPERAND + 6]      ; check for
+        and     ax, SINGLE_NAN                  ; NaN
+        cmp     ax, SINGLE_NAN                  ;
+        je      memory_divide_m64               ;
+
+        f_stsw  ax                              ; get status word
+        and     ax, 3800h                       ; get top of stack
+        je      spill_fpstack_m64               ; is FP stack full?
+        fld     qword ptr[bp + MEM_OPERAND]     ; load m64real in ST
+        call    __fdivp_sti_st                    ; do actual divide
+        jmp     m64_ok                          ; return
+spill_fpstack_m64:
+        fxch
+        sub     sp, SPILL_SIZE          ; make temp space
+        mov     bp,sp
+        fstp    tbyte ptr[bp]                   ; save user's ST(1)
+        fld     qword ptr[bp + SPILL_MEM_OPERAND] ; load m64real
+        call    __fdivp_sti_st                    ; do actual divide
+        fld     tbyte ptr[bp]                   ; restore user's ST(1)
+                                                ;sp is adjusted by fdivp fn
+        fxch
+        add     sp, SPILL_SIZE
+m64_ok:
+        pop     bp
+        pop     eax
+        ret     8
+memory_divide_m64:
+        fdiv    qword ptr[bp + MEM_OPERAND]     ; do actual divide
+        pop     bp
+        pop     eax
+        ret     8
+
+__fdiv_m64        ENDP
+
+
+
+;;; FDIVR_M32 - FDIVR m32real FIX
+;;
+;;      Input : Value of the m32real in the top of STACK
+;;
+;;      Output: Result of FDIVR in ST
+
+        PUBLIC  __fdiv_m32r
+        defpe   __fdiv_m32r
+        push    eax                             ; save eax
+        push    bp
+        mov     bp,sp
+        mov     ax, [bp + MEM_OPERAND + 2]      ; check for
+        and     ax, SINGLE_NAN                  ; NaN
+        cmp     ax, SINGLE_NAN                  ;
+        je      memory_divide_m32r              ;
+
+        f_stsw  ax                              ; get status word
+        and     ax, 3800h                       ; get top of stack
+        je      spill_fpstack_m32r              ; is FP stack full?
+        fld     dword ptr[bp + MEM_OPERAND]     ; load m32real in ST
+        call    __fdivrp_sti_st                   ; do actual divide
+        jmp     m32r_ok                         ; return
+spill_fpstack_m32r:
+        fxch
+        sub     sp, SPILL_SIZE          ; make temp space
+        mov     bp,sp
+        fstp    tbyte ptr[bp ]                  ; save user's ST(1)
+        fld     dword ptr[bp + SPILL_MEM_OPERAND] ; load m32 real
+        call    __fdivrp_sti_st                   ; do actual divide
+        fld     tbyte ptr[bp]                   ; restore user's ST(1)
+                                                ;sp is adjusted by fdivrp fn
+        fxch
+        add     sp, SPILL_SIZE
+m32r_ok:
+        pop     bp
+        pop     eax
+        ret     4
+memory_divide_m32r:
+        fdivr   dword ptr[bp + MEM_OPERAND]     ; do actual divide
+        pop     bp
+        pop     eax
+        ret     4
+
+__fdiv_m32r       ENDP
+
+
+;;; FDIVR_M64 - FDIVR m64real FIX
+;;
+;;      Input : Value of the m64real in the top of STACK
+;;
+;;      Output: Result of FDIVR in ST
+
+        PUBLIC  __fdiv_m64r
+        defpe   __fdiv_m64r
+        push    eax                             ; save eax
+        push    bp
+        mov     bp,sp
+        mov     ax, [bp + MEM_OPERAND + 6]      ; check for
+        and     ax, SINGLE_NAN                  ; NaN
+        cmp     ax, SINGLE_NAN                  ;
+        je      memory_divide_m64r              ;
+
+        f_stsw  ax                              ; get status word
+        and     ax, 3800h                       ; get top of stack
+        je      spill_fpstack_m64r              ; is FP stack full?
+        fld     qword ptr[bp + MEM_OPERAND]     ; load m64real in ST
+        call    __fdivrp_sti_st                   ; do actual divide
+        jmp     m64r_ok                         ; return
+spill_fpstack_m64r:
+        fxch
+        sub     sp, SPILL_SIZE          ; make temp space
+        mov     bp,sp
+        fstp    tbyte ptr[bp ]                  ; save user's ST(1)
+        fld     qword ptr[bp + SPILL_MEM_OPERAND] ; load m64real
+        call    __fdivrp_sti_st                   ; do actual divide
+        fld     tbyte ptr[bp]                   ; restore user's ST(1)
+                                                ;sp is adjusted by fdivrp fn
+        fxch
+        add     sp, SPILL_SIZE
+m64r_ok:
+        pop     bp
+        pop     eax
+        ret     8
+memory_divide_m64r:
+        fdivr   qword ptr[bp + MEM_OPERAND]     ; do actual divide
+        pop     bp
+        pop     eax
+        ret     8
+
+
+__fdiv_m64r       ENDP
+
+
+comment ~****************************************************************
+
+;;; FDIV_M16I - FDIV m16int FIX
+;;
+;;      Input : Value of the m16int in the top of STACK
+;;
+;;      Output: Result of FDIV in ST
+
+        PUBLIC  FDIV_M16I
+FDIV_M16I       PROC    FAR
+        push    eax                             ; save eax
+        push    bp
+        f_stsw  ax                              ; get status word
+        and     ax, 3800h                       ; get top of stack
+        je      spill_fpstack_m16i              ; is FP stack full?
+        mov     bp,sp
+        fild    word ptr[bp + MEM_OPERAND]      ; load m16int in ST
+        call    fdivp_sti_st                    ; do actual divide
+        jmp     m16i_ok                         ; return
+spill_fpstack_m16i:
+        fxch
+        sub     sp, SPILL_SIZE          ; make temp space
+        mov     bp,sp
+        fstp    tbyte ptr[bp ]                  ; save user's ST(1)
+        fild    word ptr[bp + SPILL_MEM_OPERAND] ; load m16int
+        call    fdivp_sti_st                    ; do actual divide
+        fld     tbyte ptr[bp]                   ; restore user's ST(1)
+                                                ;sp is adjusted by fdivp fn
+        fxch
+        add     sp, SPILL_SIZE
+m16i_ok:
+        pop     bp
+        pop     eax
+        ret
+
+FDIV_M16I       ENDP
+
+;;; FDIV_M32I - FDIV m16int FIX
+;;
+;;      Input : Value of the m16int in the top of STACK
+;;
+;;      Output: Result of FDIV in ST
+
+        PUBLIC  FDIV_M32I
+FDIV_M32I       PROC    FAR
+        push    eax                             ; save eax
+        push    bp
+        f_stsw  ax                              ; get status word
+        and     ax, 3800h                       ; get top of stack
+        je      spill_fpstack_m32i              ; is FP stack full?
+        mov     bp,sp
+        fild    dword ptr[bp + MEM_OPERAND]     ; load m32int in ST
+        call    fdivp_sti_st                    ; do actual divide
+        jmp     m32i_ok                         ; return
+spill_fpstack_m32i:
+        fxch
+        sub     sp, SPILL_SIZE          ; make temp space
+        mov     bp,sp
+        fstp    tbyte ptr[bp ]                  ; save user's ST(1)
+        fild    dword ptr[bp + SPILL_MEM_OPERAND] ; load m32int
+        call    fdivp_sti_st                    ; do actual divide
+        fld     tbyte ptr[bp]                   ; restore user's ST(1)
+                                                ;sp is adjusted by fdivp fn
+        fxch
+        add     sp, SPILL_SIZE
+m32i_ok:
+        pop     bp
+        pop     eax
+        ret
+
+
+FDIV_M32I       ENDP
+
+
+;;; FDIVR_M16I - FDIVR m16int FIX
+;;
+;;      Input : Value of the m16int in the top of STACK
+;;
+;;      Output: Result of FDIVR in ST
+
+        PUBLIC  FDIVR_M16I
+FDIVR_M16I      PROC    FAR
+        push    eax                             ; save eax
+        push    bp
+        f_stsw  ax                              ; get status word
+        and     ax, 3800h                       ; get top of stack
+        je      spill_fpstack_m16ir             ; is FP stack full?
+        mov     bp,sp
+        fild    word ptr[bp + MEM_OPERAND]      ; load m16int in ST
+        call    fdivrp_sti_st                   ; do actual divide
+        jmp     m16ir_ok                                ; return
+spill_fpstack_m16ir:
+        fxch
+        sub     sp, SPILL_SIZE          ; make temp space
+        mov     bp,sp
+        fstp    tbyte ptr[bp ]                  ; save user's ST(1)
+        fild    word ptr[bp + SPILL_MEM_OPERAND] ; load m16int
+        call    fdivrp_sti_st                   ; do actual divide
+        fld     tbyte ptr[bp]                   ; restore user's ST(1)
+                                                ;sp is adjusted by fdivrp fn
+        fxch
+        add     sp, SPILL_SIZE
+m16ir_ok:
+        pop     bp
+        pop     eax
+        ret
+
+
+FDIVR_M16I      ENDP
+
+
+;;; FDIVR_M32I - FDIVR m32int FIX
+;;
+;;      Input : Value of the m32int in the top of STACK
+;;
+;;      Output: Result of FDIVR in ST
+
+        PUBLIC  FDIVR_M32I
+FDIVR_M32I      PROC    FAR
+        push    eax                             ; save eax
+        push    bp
+        f_stsw  ax                              ; get status word
+        and     ax, 3800h                       ; get top of stack
+        je      spill_fpstack_m32ir             ; is FP stack full?
+        mov     bp,sp
+        fild    dword ptr[bp + MEM_OPERAND]     ; load m32int in ST
+        call    fdivrp_sti_st                   ; do actual divide
+        jmp     m32ir_ok                                ; return
+spill_fpstack_m32ir:
+        fxch
+        sub     sp, SPILL_SIZE          ; make temp space
+        mov     bp,sp
+        fstp    tbyte ptr[bp ]                  ; save user's ST(1)
+        fild    dword ptr[bp + SPILL_MEM_OPERAND] ; load m32int
+        call    fdivrp_sti_st                   ; do actual divide
+        fld     tbyte ptr[bp]                   ; restore user's ST(1)
+                                                ;sp is adjusted by fdivrp fn
+        fxch
+        add     sp, SPILL_SIZE
+m32ir_ok:
+        pop     bp
+        pop     eax
+        ret
+
+FDIVR_M32I      ENDP
+
+************************************************************************~
+
+
+_TEXT   ENDS
+
+        end

--- a/libc/watcom/asm/fdc086.asm
+++ b/libc/watcom/asm/fdc086.asm
@@ -1,0 +1,108 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
+;*               DESCRIBE IT HERE!
+;*
+;*****************************************************************************
+
+
+;<><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+;<>
+;<> __FDC - floating double comparison
+;<>     input:  AX:BX:CX:DX - operand 1
+;<>             DS:SI - address of operand 2
+;<>       if op1 > op2,  1 is returned in AX
+;<>       if op1 < op2, -1 is returned in AX
+;<>       if op1 = op2,  0 is returned in AX
+;<>
+;<>
+;<><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+include mdef.inc
+include struct.inc
+
+        modstart        fdc086
+
+        xdefp   __FDC
+        xdefp   __EDC
+
+        defp    __EDC
+        push    es:6[si]        ; push second operand onto stack
+        push    es:4[si]        ; ...
+        push    es:2[si]        ; ...
+        push    es:[si]         ; ...
+        mov     si,sp           ; point to second operand
+        docall  __FDC           ; do the comparison
+        lahf                    ; save flags
+        add     sp,8            ; clean up stack
+        or      ax,ax           ; clear overflow flag
+        sahf                    ; restore flags
+        cbw                     ; sign extend result
+        ret                     ; return
+        endproc __EDC
+
+        defpe   __FDC
+        push    BP              ; save BP
+        push    DI              ; save DI
+        test    AX,07ff0h       ; check for zero
+        _if     e               ; if it is then
+          sub   AX,AX           ; - make whole damn thing a zero
+        _endif                  ; endif
+        mov     DI,ss:6[SI]     ; get high word of arg2
+        test    DI,07ff0h       ; check for zero
+        _if     e               ; if it is then
+          sub   DI,DI           ; - make whole damn thing a zero
+        _endif                  ; endif
+        mov     BP,DI           ; save op2 exponent
+        xor     BP,AX           ; see about signs of the operands
+        mov     BP,0            ; clear result
+        js      cmpdone         ; quif arg1 & arg2 have diff signs
+        _guess                  ; guess
+          cmp   AX,DI           ; - compare high words of arg1, arg2
+          _quif ne              ; - quif not equal
+          cmp   BX,ss:4[SI]     ; - compare 2nd  words of arg1, arg2
+          _quif ne              ; - quif not equal
+          cmp   CX,ss:2[SI]     ; - compare 3rd  words of arg1, arg2
+          _quif ne              ; - quif not equal
+          cmp   DX,ss:[SI]      ; - compare 4th  words of arg1, arg2
+        _endguess               ; endguess
+        _if     ne              ; if arg1 <> arg2
+          rcr   CX,1            ; - save carry in CX
+          xor   AX,CX           ; - sign of BX is sign of result
+
+cmpdone:  _shl  AX,1            ; - get sign of result into carry
+          sbb   BP,0            ; - BP gets sign of result
+          _shl  BP,1            ; - double BP
+          inc   BP              ; - make BP -1 or 1
+        _endif                  ; endif
+        mov     AX,BP           ; get result
+        pop     DI              ; restore DI
+        pop     BP              ; restore BP
+        ret                     ; return to caller
+        endproc __FDC
+
+        endmod
+        end

--- a/libc/watcom/asm/fdfs086.asm
+++ b/libc/watcom/asm/fdfs086.asm
@@ -1,0 +1,88 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
+;*               DESCRIBE IT HERE!
+;*
+;*****************************************************************************
+
+
+;=========================================================================
+;==     Name:           FDFS                                            ==
+;==     Operation:      Float double to float single conversion         ==
+;==     Inputs:         AX;BX;CX;DX     double precision float          ==
+;==     Outputs:        DX;AX           single precision float          ==
+;==     Volatile:       CX, DX destroyed                                ==
+;=========================================================================
+include mdef.inc
+include struct.inc
+
+        modstart        fdfs086
+
+        xdefp   __FDFS
+
+        defpe   __FDFS
+        test    ax,07ff0h       ; check exponent
+        je      retzero         ; if exponent = 0 then just return 0
+        mov     dh,ah           ; save sign bit in dh
+        and     dh,80h          ; clean rest of dh
+        _shl    cx,1            ; shift number over
+        _rcl    bx,1            ; ...
+        _rcl    ax,1            ; shift out sign bit
+        add     ch,20h          ; round floating point number
+        adc     bx,0            ; ...
+        adc     ax,0            ; increment exponent if need be
+        je      oflow           ; overflow if exponent went to 0
+        cmp     ax,2*16*(03ffh+80h) ; check for maximum exponent
+        jae     oflow           ; overflow if above or equal
+        cmp     ax,2*16*(03ffh-7eh) ; check for minimum exponent
+        jb      uflow           ; underflow if below
+        sub     ax,2*16*(03ffh-7fh) ; correct bias
+        _shl    cx,1            ; do rest of shift
+        _rcl    bx,1            ; ...
+        _rcl    ax,1            ; ...
+        _shl    cx,1            ; ...
+        _rcl    bx,1            ; ...
+        _rcl    ax,1            ; ...
+        or      ah,dh           ; put in sign bit
+        mov     dx,bx           ; put low part of mantissa in correct reg
+        xchg    ax,dx           ; flip results  FWC 86-09-24
+        ret                     ; return
+
+oflow:  mov     ax,7f80h        ; return maximum possible number
+        or      ah,dh           ; put in sign bit
+        sub     dx,dx           ; ...
+        xchg    ax,dx           ; flip results  FWC 86-09-24
+        ret                     ; and return
+
+uflow:
+retzero:sub     ax,ax
+        mov     dx,ax           ; return ax;dx = 0
+        ret
+        endproc __FDFS
+
+        endmod
+        end

--- a/libc/watcom/asm/fdi4086.asm
+++ b/libc/watcom/asm/fdi4086.asm
@@ -1,0 +1,172 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
+;*               DESCRIBE IT HERE!
+;*
+;*****************************************************************************
+
+
+;
+include mdef.inc
+include struct.inc
+
+        modstart        fdi4086
+
+        xdefp   __FDI4
+        xdefp   __RDI4
+
+        xdefp   __FDU4
+        xdefp   __RDU4
+
+;[][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][]
+;[]
+;[] __FDU4      convert double float AX;BX;CX;DX into 32-bit integer DX:AX
+;[]     Input:  AX BX CX DX - double precision floating point number
+;[]     Output: DX:AX       - 32-bit integer
+;[]
+;[][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][]
+;       convert floating double to 4-byte integer with rounding
+
+        defpe   __RDU4
+        mov     DX,0080h+0020h  ; indicate we are rounding
+        jmp     DtoI            ; do it
+
+        defpe   __RDI4
+        mov     DX,0080h+001Fh  ; indicate we are rounding
+        jmp     DtoI            ; do it
+
+        defpe   __FDI4
+        mov     DX,001Fh        ; indicate we are truncating
+        jmp     DtoI            ; do it
+
+;       convert floating double to 4-byte integer with truncation
+
+        defpe   __FDU4
+        mov     DX,0020h        ; indicate we are truncating
+
+DtoI:   _shl    AX,1            ; get sign
+        rcr     DH,1            ; DH <-- sign
+        shr     DH,1            ; shift sign bit over 1
+        or      DH,DL           ; get rounding bit
+        shr     AX,1            ; restore exponent to its place
+
+;       high bit of DH is rounding bit
+;       next bit is the sign bit
+
+;<~> Shift real right four places so that exponent occupies an entire
+;<~> word and the mantissa occupies the remaining words. We do not need
+;<~> DX because we only need 32 sig digits
+
+        shr     AX,1
+        rcr     BX,1
+        rcr     CX,1
+        shr     AX,1
+        rcr     BX,1
+        rcr     CX,1
+        shr     AX,1
+        rcr     BX,1
+        rcr     CX,1
+        shr     AX,1
+        rcr     BX,1
+        rcr     CX,1
+        sub     AX,03FEh        ; remove bias from exponent
+        jl      DIzero          ; if |real| < .5 goto DIzero
+        cmp     AX,20h          ; if exponent > 32
+        jg      DIo_f           ; goto DIo_flow
+        and     DL,3Fh          ; isolate # of significant bits
+        cmp     AL,DL           ; quit if number too big
+        jg      DIo_f           ; goto DIo_flow
+        stc                     ; set carry and
+        rcr     BX,1            ; restore implied 1/2 bit
+        rcr     CX,1
+        rcr     AH,1            ; save rounding bit
+        mov     DL,32           ; # of bits to shift right = 32 - AL
+        sub     DL,AL           ; ...
+        mov     AL,DL           ; ...
+        _guess                  ; guess: exponent >= 16
+          cmp   AL,16           ; - quit if < 16
+          _quif l               ; - ...
+          mov   AH,CH           ; - save rounding bit
+          mov   CX,BX           ; - shift right 16 bits
+          sub   BX,BX           ; - zero high word
+          sub   AL,16           ; - adjust exponent by 16
+        _endguess               ; endguess
+        _guess                  ; guess: exponent >= 8
+          cmp   AL,8            ; - quit if < 8
+          _quif l               ; - . . .
+          mov   AH,CL           ; - save rounding bit
+          mov   CL,CH           ; - shift right 8 bits
+          mov   CH,BL           ; - . . .
+          mov   BL,BH           ; - . . .
+          xor   BH,BH           ; - zero high byte
+          sub   AL,8            ; - adjust exponent by 8
+        _endguess               ; endguess
+
+        cmp     AL,0            ; if there are bits to shift
+        _if     ne              ; then
+          _loop                 ; - loop
+            shr   BX,1          ; - - shift mantissa into integer
+            rcr   CX,1          ; - - . . .
+            rcr   AH,1          ; - - save rounding bit
+            dec   AL            ; - - dec AL
+            _quif e             ; - - quif AL = 0
+            shr   BX,1          ; - - shift mantissa into integer
+            rcr   CX,1          ; - - . . .
+            rcr   AH,1          ; - - save rounding bit
+            dec   AL            ; - - decrement exponent
+          _until  e             ; - until done
+        _endif                  ; endif
+        and     AH,DH           ; trunc or rnd as determined by high bit of DH
+        _shl    DH,1            ; get extra significant bit from mantissa
+        adc     CX,0            ; add it to the integer to round it up
+        adc     BX,0            ; . . .
+        _shl    DH,1            ; get sign
+        _if     c               ; if negative
+          not   BX              ; - negate integer
+          neg   CX              ; - . . .
+          sbb   BX,-1           ; - . . .
+        _endif                  ; endif
+        mov     AX,CX           ; put result in correct registers
+        mov     DX,BX           ; . . .
+        ret                     ; return
+
+DIo_f:
+        mov     DX,8000h        ; set answer to largest negative number
+        sub     AX,AX           ; . . .
+        ret                     ; return
+;       jmp     I4OverFlow      ; report overflow
+
+DIzero: sub     AX,AX           ; set result to zero
+        sub     DX,DX           ; . . .
+        ret
+        endproc __FDU4
+        endproc __FDI4
+        endproc __RDI4
+        endproc __RDU4
+
+        endmod
+        end

--- a/libc/watcom/asm/fdi8086.asm
+++ b/libc/watcom/asm/fdi8086.asm
@@ -1,0 +1,242 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;* Copyright (c) 2002-2019 The Open Watcom Contributors. All Rights Reserved.
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
+;*               DESCRIBE IT HERE!
+;*
+;*****************************************************************************
+
+
+;
+; __FDI8 converts double into signed 64-bit integer
+; __FDU8 converts double into unsigned 64-bit integer
+;
+; Input:    AX BX CX DX = double
+; Output:   AX BX CX DX = 64-bit signed/unsigned integer
+; Volatile: None
+;
+; 16-mar-2000     SJHowe        initial implementation
+;
+
+include mdef.inc
+include struct.inc
+
+        modstart        fdi8086
+
+        xdefp   __FDI8
+        xdefp   __FDU8
+
+        defpe   __FDI8
+        push    SI                      ; save register
+        mov     SI,7FE0h + (63 * 32)    ; maximum exponent 2^63 allowed
+        call    __FD8                   ; convert float to signed __int64
+        pop     SI                      ; restore register
+        ret                             ; return
+        endproc __FDI8
+
+        defpe   __FDU8
+        push    SI                      ; save register
+        mov     SI,7FE0h + (64 * 32)    ; maximum exponent 2^64 allowed
+        call    __FD8                   ; convert float to unsigned __int64
+        pop     SI                      ; restore register
+        ret                             ; return
+        endproc __FDU8
+
+__FD8   proc    near
+        or      ax,ax           ; check sign bit
+        jns     __FDAbs         ; treat as unsigned if positive
+        call    __FDAbs         ; otherwise convert number
+
+; rely on the crucial fact that the Intel instruction "not" does not alter
+; any flags. Borrows from previous register needs to propagated in the
+; direction of the most significant word.
+
+        neg     dx              ; negate
+        not     cx              ; :
+        sbb     cx,0FFFFH       ; :
+        not     bx              ; :
+        sbb     bx,0FFFFH       ; :
+        not     ax              ; :
+        sbb     ax,0FFFFH       ; :
+        ret                     ; and return
+        endproc __FD8
+
+__FDAbs proc near
+        rol     ax,1            ; move sign bit out of way
+        cmp     ax,7FE0h        ; less than +/-1.0?
+        jb      ret_zero        ; yes, return 0
+        cmp     ax,si           ; more than max exponent?
+        jae     ret_max         ; yes, return max
+        shr     ax,1            ; eliminate sign bit
+
+        mov     si,ax           ; save exponent
+        and     ax,0Fh          ; just mantissa
+        or      ax,10h          ; set implied 1
+
+        shr     si,1            ; move exponent
+        shr     si,1            ; :
+        shr     si,1            ; :
+        shr     si,1            ; :
+        inc     si              ; adjust exponent
+
+; need to shift AL left or right depending on exponent
+; note: we cannot lose bits from DX on shifting right, all bits MUST be
+; preserved. Therefore use AH as it is spare (the only register spare).
+
+        test    si,4            ; shift left or right (or none)?
+        jne     shift_left_start; jump if need to shift left
+
+shift_right:
+        shr     al,1            ; shift mantissa right 1 bit
+        rcr     bx,1            ; :
+        rcr     cx,1            ; :
+        rcr     dx,1            ; :
+        rcr     ah,1            ; :
+        inc     si              ; increment exponent
+        test    si,4            ; this bit set ?
+        je      shift_right     ; no, loop again
+        jmp     prepare_table_jmp
+
+shift_left:
+        _shl    dx,1
+        _rcl    cx,1
+        _rcl    bx,1
+        _rcl    ax,1
+shift_left_start:
+        dec     si              ; decrement exponent
+        test    si,4            ; shift left again ?
+        jne     shift_left
+
+; at this point
+; al;bx;cx;dx;ah = mantissa, significant byte is in correct postion within al
+; si = badly mangled exponent of which only bits 3-5 are now relevant
+
+prepare_table_jmp:
+        and     si,38h          ; eliminate surplus bits in exponent
+        shr     si,1            ; prepare for a jump
+        shr     si,1            ; :
+        jmp     word ptr cs:sigbyte_table[si] ; jump to table
+
+ret_zero:
+        xor     ax,ax           ; return 0
+        xor     bx,bx           ; :
+        xor     cx,cx           ; :
+        xor     dx,dx           ; :
+        ret                     ; :
+
+ret_max:
+        mov     ax,0FFFFh       ; return maximum
+        add     si,783Fh        ; complement of 7FE0h + (63 * 32)
+                                ; carry set if unsigned, clear if integer
+        mov     bx,ax           ; :
+        mov     cx,ax           ; :
+        mov     dx,ax           ; :
+        rcr     ax,1            ; 0x7FFF if signed, 0xFFFF if unsigned
+        ret                     ; return
+
+sigbyte_table:
+        DW      byte0_significant
+        DW      byte1_significant
+        DW      byte2_significant
+        DW      byte3_significant
+        DW      byte4_significant
+        DW      byte5_significant
+        DW      byte6_significant
+        DW      byte7_significant
+
+;AL;BX;CX;DX;AH = mantissa
+
+byte0_significant:
+        mov     dl,al           ; move sig byte 0
+        xor     dh,dh           ; zero byte 1
+        xor     cx,cx           ; zero bytes 2-3
+        xor     bx,bx           ; zero bytes 4-5
+        xor     ax,ax           ; zero bytes 6-7
+        ret                     ; return
+
+byte1_significant:
+        mov     dh,al           ; move sig byte 1
+        mov     dl,bh           ; move sig byte 0
+        xor     cx,cx           ; zero bytes 2-3
+        xor     bx,bx           ; zero bytes 4-5
+        xor     ax,ax           ; zero bytes 6-7
+        ret                     ; return
+
+byte2_significant:
+        mov     cl,al           ; move sig byte 2
+        mov     dx,bx           ; move sig bytes 1-0
+        xor     ch,ch           ; zero byte 3
+        xor     ax,ax           ; zero bytes 6-7
+        xor     bx,bx           ; zero bytes 4-5
+        ret                     ; return
+
+byte3_significant:
+        mov     dl,ch           ; move sig byte 0
+        mov     dh,bl           ; move sig byte 1
+        mov     cl,bh           ; move sig byte 2
+        mov     ch,al           ; move sig byte 3
+        xor     bx,bx           ; zero bytes 4-5
+        xor     ax,ax           ; zero bytes 6-7
+        ret                     ; return
+
+byte4_significant:
+        mov     dx,cx           ; move sig bytes 1-0
+        mov     cx,bx           ; move sig bytes 3-2
+        mov     bl,al           ; move sig byte 4
+        xor     bh,bh           ; zero byte 5
+        xor     ax,ax           ; zero bytes 6-7
+        ret                     ; return
+
+byte5_significant:
+        mov     dl,dh           ; move sig byte 0
+        mov     dh,cl           ; move sig byte 1
+        mov     cl,ch           ; move sig byte 2
+        mov     ch,bl           ; move sig byte 3
+        mov     bl,bh           ; move sig byte 4
+        mov     bh,al           ; move sig byte 5
+        xor     ax,ax           ; zero bytes 6-7
+        ret                     ; return
+
+byte6_significant:
+        xor     ah,ah           ; zero byte 7
+        ret                     ; return
+
+byte7_significant:
+        xchg    ah,al           ; shuffle sig byte 7 down to dl
+        xchg    al,bh           ; :
+        xchg    bh,bl           ; :
+        xchg    bl,ch           ; :
+        xchg    ch,cl           ; :
+        xchg    cl,dh           ; :
+        xchg    dh,dl           ; :
+        ret                     ; return
+
+        endproc __FDAbs
+
+        endmod
+        end
+

--- a/libc/watcom/asm/fdmth086.asm
+++ b/libc/watcom/asm/fdmth086.asm
@@ -1,0 +1,1056 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;* Copyright (c) 2002-2022 The Open Watcom Contributors. All Rights Reserved.
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
+;*               DESCRIBE IT HERE!
+;*
+;*****************************************************************************
+
+
+;
+;   real*8 math library
+;
+;   __FDM,__FDD
+;                   floating point routines
+;                   13 June, 1984 @Watcom
+;
+;   All routines have the same calling conventions.
+;   Op_1 and Op_2 are double prec reals, pointed to by DI and SI resp.
+;   The binary operations are perfomed as Op_1 (*) Op_2.
+;
+;   In all cases, BP and DI are returned unaltered.
+;
+;
+;                               have to always point at DGROUP.
+;                               **** This routine does CODE modification ****
+;                               is a power of 2.
+;                               aligning fractions before the add
+;                               No need to push second operand in f8split
+;                               since ss:[si] can already be used to access it
+;                               Moved f8split into each subroutine.
+;                               to get rid of code modification
+;                               we might be running with SS != DGROUP
+;
+include mdef.inc
+include struct.inc
+
+.8087
+        modstart        fdmth086
+
+        xrefp           __8087  ; indicate that NDP instructions are present
+
+        xrefp   F8OverFlow              ; FSTATUS
+        xrefp   F8UnderFlow             ; FSTATUS
+        xrefp   F8DivZero               ; FSTATUS
+        xrefp   __fdiv_m64r
+
+go_to   macro frtn
+if _MODEL and _DS_PEGGED
+        jmp     frtn
+else
+ if _MODEL and (_BIG_DATA or _HUGE_DATA)
+        push    ax
+        push    bp
+        push    ds
+        mov     ax,DGROUP               ; get access to DGROUP
+        mov     bp,sp
+        mov     ds,ax                   ; . . .
+        mov     ax,frtn
+        xchg    ax,4[bp]
+        pop     ds
+        pop     bp
+        retn
+ else
+        jmp     frtn
+ endif
+endif
+endm
+
+;
+        datasegment
+        extrn   __real87 : byte         ; cstart
+        extrn  __chipbug : byte
+fdadd   dw      _chkadd
+fdsub   dw      _chksub
+fdmul   dw      _chkmul
+fddiv   dw      _chkdiv
+        enddata
+
+        xdefp   __FDA
+        xdefp   __EDA
+        xdefp   __FDS
+        xdefp   __EDS
+        xdefp   __FDM
+        xdefp   __EDM
+        xdefp   __FDD
+        xdefp   __EDD
+
+        defp    __EDD
+        push    es:6[si]
+        push    es:4[si]
+        push    es:2[si]
+        push    es:[si]
+        mov     si,sp           ; point to second operand
+        docall  __FDD
+        add     sp,8
+        ret
+        endproc __EDD
+
+        defp    __EDM
+        push    es:6[si]
+        push    es:4[si]
+        push    es:2[si]
+        push    es:[si]
+        mov     si,sp           ; point to second operand
+        docall  __FDM
+        add     sp,8
+        ret
+        endproc __EDM
+
+        defp    __EDS
+        push    es:6[si]
+        push    es:4[si]
+        push    es:2[si]
+        push    es:[si]
+        mov     si,sp           ; point to second operand
+        docall  __FDS
+        add     sp,8
+        ret
+        endproc __EDS
+
+        defp    __EDA
+        push    es:6[si]
+        push    es:4[si]
+        push    es:2[si]
+        push    es:[si]
+        mov     si,sp           ; point to second operand
+        docall  __FDA
+        add     sp,8
+        ret
+        endproc __EDA
+
+
+;
+; __FDS
+;
+
+        defpe   __FDS
+        go_to   fdsub
+
+__FDS87:
+        fld     qword ptr ss:[SI] ; load operand 2
+        push    BP              ; save BP
+        mov     BP,SP           ; get access to stack
+        push    AX              ; push operand 1
+        push    BX              ; . . .
+        push    CX              ; . . .
+        push    DX              ; . . .
+        fsubr   qword ptr -8[BP]; subtract operand 2 from operand 1
+_ret87: fstp    qword ptr -8[BP]; store result
+        fwait                   ; wait
+        pop     DX              ; load result into AX:BX:CX:DX
+        pop     CX              ; . . .
+        pop     BX              ; . . .
+        pop     AX              ; . . .
+        cmp     AX,8000h        ; is it negative zero?          17-mar-91
+        _if     e               ; if it is then
+          sub   AX,AX           ; - turn it into positive zero
+          mov   BX,AX           ; - ... zero other words as well
+          mov   CX,AX           ; - ...
+          mov   DX,AX           ; - ...
+        _endif                  ; endif
+        pop     BP              ; restore BP
+        ret                     ; return
+
+__FDSemu:
+        push    BP              ; save BP
+        mov     BP,8000h        ; indicate that we are doing subtraction
+        jmp     begin
+        endproc __FDS
+
+
+;
+; __FDA
+;
+
+
+        defpe   __FDA
+        go_to   fdadd
+
+__FDA87:
+        fld     qword ptr ss:[SI] ; load operand 2
+        push    BP              ; save BP
+        mov     BP,SP           ; get access to stack
+        push    AX              ; push operand 1
+        push    BX              ; . . .
+        push    CX              ; . . .
+        push    DX              ; . . .
+        fadd    qword ptr -8[BP]; add operand 1
+        jmp     _ret87          ; return result from 8087
+
+retOp_2:
+        sub     bx,bx           ; return op2
+        _shl    cx,1            ; get sign bit into position
+        mov     bp,cx           ; move it to correct reg
+        xor     bp,ss:6[si]     ; see if sign must be reversed
+        and     bp,8000h        ; clear out rest of reg
+                                ; one of the args was found to be zero
+addzero:or      BX,BX           ; check the first argument
+        _if     ne              ; if the first arg is not zero
+          mov   SI,DI           ; - return first argument
+          sub   bp,bp           ; - don't reverse sign
+        _endif                  ; endif
+        mov     ax,ss:6[si]     ; get high word
+        or      ax,ax           ; see if number is zero
+        _if     ne              ; if not then
+          xor   ax,bp           ; - reverse sign if required
+        _endif                  ; endif
+        mov     BX,ss:4[SI]     ; get next sig word
+        mov     CX,ss:2[SI]     ; . . .
+        mov     DX,ss:[SI]      ; . . .
+        add     SP,8            ; clean up stack
+        pop     DI              ; restore DI
+        pop     BP              ; return to caller
+        ret
+
+__FDAemu:
+        push    BP
+        sub     BP,BP           ; indicate that we are doing addition
+begin:  push    DI              ; save DI
+
+;       copy of the f8split routine
+
+        push    AX              ; push operand 1 onto stack
+        push    BX              ; . . .
+        push    CX              ; . . .
+        push    DX              ; . . .
+        mov     DI,SP           ; get address of operand 1
+        _guess                  ; guess
+          mov   BX,AX           ; - get most sig word of op1
+          mov   AX,ss:6[SI]     ; - get most sig word of op2
+          mov   DL,AL           ; - save mantissa-holding part
+          mov   DH,BL           ; - save mantissa-holding part
+          mov   cl,bh           ; - save sign
+          and   BX,7FF0h        ; - isolate exponent
+          je    addzero         ; - quif zero
+          mov   ch,ah           ; - save sign
+          and   AX,7FF0h        ; - isolate exponent
+          je    addzero         ; - quif zero
+          and   cx,8080h        ; - only want sign bits
+          xor   dx,1010h        ; - set implied one bit of mant.
+          xor   DL,AL           ; - . . .
+          xor   DH,BL           ; - . . .
+        _endguess               ; endguess
+
+;       end of f8split
+
+        xor     CX,BP           ; change sign of op_2 if this is sub
+        sar     CH,1            ; prepare sign byte
+        add     CH,CL           ; it is op_2's sign we indicate
+        mov     BP,AX           ; save exponent
+        sub     AX,BX           ; get shift count
+        _if     l               ; - if op_2 < op_1
+          mov   BP,BX           ; - - move op_1's exponent into BP
+          neg   AX              ; - - negate the shift count
+          xchg  SI,DI           ; - - exchange operands
+          xchg  DH,DL           ; - - . . .
+          _shl  CH,1            ; - - make op_1's sign count
+          rcr   CL,1
+          xchg  CL,CH           ; - - . . .
+        _endif                  ; - endif
+        cmp     AX,0400h        ; AX has shift count << 4
+        jae     retOp_2         ; if shift count >= 64, return operand 2
+        shr     AX,1            ; move shift count into bottom bits
+        shr     AX,1
+        shr     AX,1
+        shr     AX,1
+        mov     AH,AL           ; AH := shift count
+        mov     AL,DH           ; AL := high byte of smaller real
+        mov     DH,CH           ; DH := sign byte
+        mov     BX,ss:4[DI]     ; . . .
+        mov     CX,ss:2[DI]     ; . . .
+        mov     DI,ss:[DI]      ; . . .
+        or      AH,AH           ; test AH (shift count)
+        _if     ne              ; if shift count <> 0
+          xchg  DX,DI           ; - get DI into byte registers for shift
+          _loop                 ; - loop (shift by a byte at a time)
+            cmp   AH,8          ; - - quit if less than a byte to do
+            _quif l             ; - - . . .
+            sub   AH,8          ; - - subtract 8 from shift count
+            _if   e             ; - - if exact # of bytes
+              mov   AH,DL       ; - - - get high bit for guard bit
+            _endif              ; - - endif
+            mov   DL,DH         ; - - shift right 1 byte
+            mov   DH,CL         ; - - . . .
+            mov   CL,CH         ; - - . . .
+            mov   CH,BL         ; - - . . .
+            mov   BL,BH         ; - - . . .
+            mov   BH,AL         ; - - . . .
+            mov   AL,0          ; - - . . .
+          _until  e             ; - until done
+          _if   ne              ; - if still more to shift
+            _loop               ; - - loop
+              shr   AL,1        ; - - - shift over fractions
+              rcr   BX,1        ; - - - . . .
+              rcr   CX,1        ; - - - . . .
+              rcr   DX,1        ; - - - . . .
+              dec   AH          ; - - - dec shift count
+            _until  e           ; - - until shift count = 0
+            rcr   AH,1          ; - - save guard bit
+          _endif                ; - endif
+          and   AH,80h          ; - isolate guard bit
+          xchg  DX,DI           ; - exchange regs again
+        _endif                  ; endif
+        _shl    DH,1            ; get bit 7 of sign word. 1 if signs are
+                                ; different, 0 if they are the same
+        _if     nc              ; if signs are the same
+          add   DI,ss:[SI]      ; - add the mantissas
+          adc   CX,ss:2[SI]     ; - . . .
+          adc   BX,ss:4[SI]     ; - . . .
+          adc   AL,DL           ; - . . .
+          test  AL,20h          ; - check for carry
+          je    add_norm        ; - if we haven't carried, normalize now
+          push  DX              ; - put sign onto stack
+          mov   DX,DI           ; - get low word into correct reg
+          jmp   fin_up          ; - common finish up routine
+        _endif                  ; endif
+        sub     DI,ss:[SI]
+        sbb     CX,ss:2[SI]     ; . . .
+        sbb     BX,ss:4[SI]     ; . . .
+        sbb     AL,DL           ; . . .
+        cmc                     ; complement carry
+        rcr     SI,1            ; save complemented carry in SI
+        and     SI,8000h        ; isolate the bit
+        add     DX,SI           ; and use it to calculate sign of result
+        _shl    SI,1            ; restore the complement of the carry
+        _if     c               ; if no borrow, see if result is zero
+          cmp   AL,0            ; - - quif answer is not zero
+          jne   add_norm        ; - - . . .
+          or    SI,BX
+          or    SI,CX
+          or    SI,DI
+          jne   add_norm
+          add   SP,8            ; - clean up stack
+          pop   DI              ; - restore DI
+          pop   BP              ; - restore bp
+          sub   AX,AX           ; - set answer to 0
+          sub   BX,BX           ; - . . .
+          sub   CX,CX           ; - . . .
+          sub   DX,DX           ; - . . .
+          ret                   ; - return
+        _endif
+        neg     DH              ; - sign is that of other operand
+        not     AL              ; - negate the fraction
+        not     BX              ; - . . .
+        not     CX              ; - . . .
+        not     DI              ; - . . .
+        neg     AH              ; - (considering the guard bit as an extension)
+        sbb     DI,-1           ; - . . .
+        sbb     CX,-1           ; - . . .
+        sbb     BX,-1           ; - . . .
+        sbb     AL,-1           ; - . . .
+
+add_norm:                       ; normalizes the mantissa against bit 6
+        add     BP,0010h        ; prepare exponent
+
+;<> please note that this will overflow if the exponent is very close to its
+;<> maximum size but not too large to overflow under normal circumstances.
+;<> since we allow an 11 bit exponent, then, the largest exponent one can
+;<> handle with this routine is (10^) 1022.
+
+        _shl    AH,1            ; get guard bit
+        _loop                   ; loop
+          _rcl  DI,1            ; - shift result left
+          _rcl  CX,1
+          _rcl  BX,1
+          _rcl  AL,1
+          sub   BP,0010h        ; - decrement exponent
+          jbe   add_uflow       ; - ******* handle underflow *******
+          test  AL,20h          ; until msb is in bit 6
+        _until ne
+        and     AL,1Fh          ; turn off implied one bit
+        push    DX              ; push sign
+        mov     DX,DI
+        jmp     fin_up
+
+; over/underflow entry points for __FDA and __FDS
+
+add_oflow:
+        mov     AX,DX           ; put sign into ax
+        add     SP,8            ; clean up stack
+        pop     DI              ; restore DI
+        pop     BP              ; restore bp
+        jmp     F8OverFlow      ; handle overflow
+
+add_uflow:
+        add     SP,8            ; clean up stack
+        pop     DI              ; restore DI
+        pop     BP              ; restore bp
+        jmp     F8UnderFlow     ; handle underflow
+        endproc __FDA
+
+;
+; __FDM
+;
+; Note that if the real pointed to by DI has few sig digits,
+; a short cut is taken.
+;
+        defpe   __FDM
+        go_to   fdmul
+
+__FDM87:
+        fld     qword ptr ss:[SI] ; load operand 2
+        push    BP              ; save BP
+        mov     BP,SP           ; get access to stack
+        push    AX              ; push operand 1
+        push    BX              ; . . .
+        push    CX              ; . . .
+        push    DX              ; . . .
+        fmul    qword ptr -8[BP]; - multiply by operand 1
+        jmp     _ret87          ; goto common epilogue
+
+
+__FDMemu:
+        push    BP              ; save BP
+        push    DI              ; save DI
+
+;       f8split
+
+        push    AX              ; push operand 1 onto stack
+        push    BX              ; . . .
+        push    CX              ; . . .
+        push    DX              ; . . .
+        mov     DI,SP           ; get address of operand 1
+        _guess                  ; guess
+          mov   BX,AX           ; - get most sig word of op1
+          mov   AX,ss:6[SI]     ; - get most sig word of op2
+          mov   DL,AL           ; - save mantissa-holding part
+          mov   DH,BL           ; - save mantissa-holding part
+          mov   cl,bh           ; - save sign
+          and   BX,7FF0h        ; - isolate exponent
+          _quif e               ; - quif zero
+          mov   ch,ah           ; - save sign
+          and   AX,7FF0h        ; - isolate exponent
+          _quif e               ; - quif zero
+          and   cx,8080h        ; - only want sign bits
+          xor   dx,1010h        ; - set implied one bit of mant.
+          xor   DL,AL           ; - . . .
+          xor   DH,BL           ; - . . .
+        _admit                  ; admit: one operand is zero
+          add   SP,8            ; - clean up stack
+          pop   DI              ; - restore DI
+          pop   BP              ; - restore bp
+          sub   AX,AX           ; - set result to 0
+          sub   BX,BX           ; - . . .
+          sub   CX,CX           ; - . . .
+          sub   DX,DX           ; - . . .
+          ret                   ; - return
+        _endguess               ; endguess
+        add     CH,CL           ; determine sign of result
+        _guess                  ; guess: OK
+          add   AX,BX           ; - determine exponent of result
+          sub   ax,3ff0h        ; - remove extra bias
+          _quif e               ; - FP underflow if exponent = 0
+          cmp   ax,0c000h       ; - if exponent >= $c000
+          _quif ae              ; - then FP underflow
+        _admit                  ; admit: underflow
+          add   SP,8            ; - clean up stack
+          pop   DI              ; - restore DI
+          pop   BP              ; - restore bp
+          jmp   F8UnderFlow
+        _endguess               ; endguess
+        cmp     ax,7ff0h        ; if $7ff0 >= exponent > $c000
+        _if     ae              ; then FP overflow
+          mov   AX,CX           ; - put sign into ax
+          add   SP,8            ; - clean up stack
+          pop   DI              ; - restore DI
+          pop   BP              ; - restore bp
+          jmp   F8OverFlow      ; - handle overflow
+        _endif                  ; endif
+        push    CX              ; push sign
+        push    AX              ; push exponent
+
+        mov     BX,ss:[DI]      ; get low order word of op_1
+        or      BX,BX           ; if it is zero
+        _if     e               ; then
+          xchg  SI,DI           ; - flip op_1 and op_2 around
+          xchg  DL,DH           ; - . . .
+        _endif                  ; endif
+        sub     AX,AX           ; clear out AX
+        mov     AL,DH           ; set AX up with high order mant of op_1
+        push    AX              ; save high order mant
+        push    ss:4[DI]        ; save rest of op_1
+        push    ss:2[DI]        ; . . .
+        push    ss:[DI]         ; . . .
+        sub     BX,BX           ; clear out a word
+        push    BX              ; move two clear words onto stack
+        push    BX
+        mov     BP,SP           ; BP points at empty word and op_1
+        mov     AL,DL           ; set AX up with high order mant of op_2
+        push    AX              ; save high order mant
+        push    ss:4[SI]        ; save rest of op_2
+        push    ss:2[SI]        ; . . .
+        mov     BX,ss:[SI]      ; . . .
+        _guess                  ; guess: multiplier has lots of 0's in it
+          mov   CX,0300h        ; - set loop count
+          or    BX,BX           ; - check multiplier
+          _quif ne              ; - quit if not zero
+          pop   BX              ; - get next word of multiplier
+          mov   CH,2            ; - set loop count
+          or    BX,BX           ; - check multiplier
+          _quif ne              ; - quit if not zero
+          pop   BX              ; - get next word of multiplier
+          mov   CH,1            ; - set loop count
+        _endguess               ; endguess
+
+; result will be kept in CL:DI:SI:2[BP]:0[BP]
+
+        sub     SI,SI           ; clear out SI
+        mov     DI,SI           ; clear out DI
+        or      BX,BX           ; if low order multiplier non-zero
+        _if     ne              ; then
+          mov   AX,4[BP]        ; - get low word of op_1
+          mul   BX              ; - multiply low word by A
+          mov   0[BP],DX        ; - save high order word of result
+          mov   AX,6[BP]        ; - get next lowest word of op_1
+          mul   BX              ; - multiply this word by A
+          add   0[BP],AX        ; - add product onto result
+          adc   DI,DX           ; - . . .
+
+          mov   AX,8[BP]        ; - get next lowest word of op_1
+          mul   BX              ; - multiply this word by A
+          add   DI,AX           ; - add product onto result
+          adc   SI,DX           ; - . . .
+          mov   2[BP],DI        ; - save result
+          sub   DI,DI           ; - set back to 0
+
+          mov   AX,10[BP]       ; - get highest word of op_1
+          mul   BX              ; - multiply this word by A
+          add   SI,AX           ; - add product onto result
+          adc   DI,DX           ; - . . .
+        _endif                  ; endif
+
+        _loop                   ; loop
+          dec   CH              ; - decrement loop count
+          pop   BX              ; - lowest word of op_1 not used so far
+          or    BX,BX           ; - check it (call it A) for zero
+          je    shift_16        ; - skip and shift result right if 0
+          mov   AX,4[BP]        ; - get low word of op_1
+          mul   BX              ; - multiply low word by A
+          add    [BP],AX        ; - add product onto result
+          adc   2[BP],DX        ; - . . .
+          adc   SI,0            ; - carry through as neccesary
+          adc   DI,0            ; - . . .
+
+          mov   AX,6[BP]        ; - get next lowest word of op_1
+          mul   BX              ; - multiply this word by A
+          add   2[BP],AX        ; - add product onto result
+          adc   SI,DX           ; - . . .
+          adc   DI,0            ; - carry through as necessary
+
+          mov   AX,8[BP]        ; - get next lowest word of op_1
+          mul   BX              ; - multiply this word by A
+          add   SI,AX           ; - add product onto result
+          adc   DI,DX           ; - . . .
+          adc   CL,0            ; - carry through as necessary
+
+          mov   AX,10[BP]       ; - get highest word of op_1
+          cmp   CH,0            ; - check loop count
+          _quif e               ; - quit if muliplied 4 times
+
+          mul   BX              ; - multiply this word by A
+          add   DI,AX           ; - add product onto result
+          adc   CL,DL           ; - . . .
+
+shift_16:
+          mov   AX,2[BP]        ; - shift result right by 1 word
+          mov    [BP],AX        ; - . . .
+          mov   2[BP],SI        ; - . . .
+          mov   SI,DI           ; - . . .
+          mov   DI,CX           ; - . . .
+          and   DI,00FFh        ; (we only move low word)
+          xor   CL,CL           ; - . . .
+        _endloop                ; endloop
+        mul     BL              ; mulitply 2 most significant bytes
+        add     AX,DI           ; and add to the result
+
+        pop     DX              ; get low order words of result
+        pop     CX              ; . . .
+        mov     BX,SI           ; . . .
+
+        add     SP,8            ; remove operand from stack
+
+        shr     AX,1            ; - shift result right 3 times
+        rcr     BX,1            ; - . . .
+        rcr     CX,1            ; - . . .
+        rcr     DX,1            ; - . . .
+
+        shr     AX,1            ; - . . .
+        rcr     BX,1            ; - . . .
+        rcr     CX,1            ; - . . .
+        rcr     DX,1            ; - . . .
+
+        shr     AX,1            ; - . . .
+        rcr     BX,1            ; - . . .
+        rcr     CX,1            ; - . . .
+        rcr     DX,1            ; - . . .
+
+        pop     BP              ; get exponent
+
+        test    AL,40h          ; find out how many sig bits we got
+        _if     ne
+          add   BP,0010h        ; - increment exponent
+          shr   AL,1            ; - move bits to correct pos in words
+          rcr   BX,1            ; - . . .
+          rcr   CX,1            ; - . . .
+          rcr   DX,1            ; - . . .
+        _endif                  ; endif
+        and     AL,1Fh          ; clear out implied '1' bit
+        jmp     fin_up          ; go to general finish up routine
+        endproc __FDM
+
+
+;
+; __FDD
+;
+
+        defpe   __FDD
+        go_to   fddiv
+
+__FDDbad_div:
+        fld     qword ptr ss:[SI] ; load operand 2
+        push    BP              ; save BP
+        mov     BP,SP           ; get access to stack
+        push    AX              ; push operand 1
+        push    BX              ; . . .
+        push    CX              ; . . .
+        push    DX              ; . . .
+        call    __fdiv_m64r     ; divide op 1 by op 2
+        sub     sp,8            ; rtn popped parm, _ret87 wants it
+        jmp     _ret87          ; goto common epilogue
+
+__FDD87:
+        fld     qword ptr ss:[SI] ; load operand 2
+        push    BP              ; save BP
+        mov     BP,SP           ; get access to stack
+        push    AX              ; push operand 1
+        push    BX              ; . . .
+        push    CX              ; . . .
+        push    DX              ; . . .
+        fdivr   qword ptr -8[BP]; divide operand 1 by operand 2
+        jmp     _ret87          ; goto common epilogue
+
+__FDDemu:
+        push    BP              ; save BP
+        push    DI              ; save DI
+
+;       f8split
+
+        push    AX              ; push operand 1 onto stack
+        push    BX              ; . . .
+        push    CX              ; . . .
+        push    DX              ; . . .
+        mov     DI,SP           ; get address of operand 1
+        _guess                  ; guess
+          mov   BX,AX           ; - get most sig word of op1
+          mov   AX,ss:6[SI]     ; - get most sig word of op2
+          mov   DL,AL           ; - save mantissa-holding part
+          mov   DH,BL           ; - save mantissa-holding part
+          mov   cl,bh           ; - save sign
+          and   BX,7FF0h        ; - isolate exponent
+          _quif e               ; - quif zero
+          mov   ch,ah           ; - save sign
+          and   AX,7FF0h        ; - isolate exponent
+          _quif e               ; - quif zero
+          and   cx,8080h        ; - only want sign bits
+          xor   dx,1010h        ; - set implied one bit of mant.
+          xor   DL,AL           ; - . . .
+          xor   DH,BL           ; - . . .
+        _admit                  ; admit: one of the operands is 0
+          add   SP,8            ; - clean up the stack
+          pop   DI              ; - restore DI
+          pop   BP              ; - restore BP
+          or    ax,ax           ; - if the divisor is zero
+          _if   e               ; - then
+            mov ah,cl           ; - - set sign of inf
+            jmp F8DivZero       ; - - return div by zero status
+          _endif                ; - endif
+          sub   AX,AX           ; - set result to 0
+          sub   BX,BX           ; - . . .
+          sub   CX,CX           ; - . . .
+          sub   DX,DX           ; - . . .
+          ret                   ; - return
+        _endguess               ; endguess
+        add     CH,CL           ; determine sign of quotient
+        sub     BX,AX           ; calculate exponent of result
+        add     bx,3ff0h        ; add in removed bias
+        cmp     bx,0c000h       ; if expon >= $c000
+        _if     ae              ; then FP underflow
+          add   SP,8            ; - clean up the stack
+          pop   DI              ; - restore DI
+          pop   BP              ; - restore BP
+          jmp   F8UnderFlow
+        _endif                  ; endif
+        cmp     bx,7ff0h        ; if $7ff0 >= exponent > $c000
+        _if     ae              ; then FP overflow
+          mov   AX,CX
+          add   SP,8            ; - clean up the stack
+          pop   DI              ; - restore DI
+          pop   BP              ; - restore BP
+          jmp   F8OverFlow
+        _endif                  ; endif
+;
+;       special case if divisor is a power of 2 (added 19-may-88)
+;
+        mov     AX,ss:[SI]      ; get word of divisor into AX
+        or      AX,ss:2[SI]     ; . . .
+        _if     e               ; if fraction bits are zero
+          mov   AX,ss:4[SI]     ; - get second word of divisor into AX
+          test  AL,1Fh          ; - check bottom 5 bits of second word
+        _endif                  ; endif
+        _if     ne              ; if any of the bottom bits are non-zero
+          jmp   long_div        ; - long division is required
+        _endif                  ; endif
+          _guess                ; - guess: divisor is power of 2
+            or    AX,AX         ; - - quit if fraction bits not zero
+            _quif ne            ; - - . . .
+            cmp   DL,10h        ; - - quit if not just the implied 1 bit
+            _quif ne            ; - - . . .
+                                ; - - divisor is a power of 2
+            and   CH,80h        ; - - isolate sign bit
+            and   DH,0Fh        ; - - remove implied 1 bit
+            mov   AX,BX         ; - - get exponent
+            and   AH,7fh        ; - - get rid of sign bit
+            or    AH,CH         ; - - put in correct sign
+            or    AL,DH         ; - - get top 4 bits of mantissa
+
+            mov   BX,ss:4[DI]   ; - - get rest of dividend
+            mov   CX,ss:2[DI]   ; - - . . .
+            mov   DX,ss:[DI]    ; - - . . .
+            add   SP,8          ; - - clean up the stack
+            pop   DI            ; - - restore DI
+            pop   BP            ; - - restore BP
+            ret                 ; - - return
+          _endguess             ; - endguess
+
+;         divisor contains only 1 bits in the most significant 16 bits
+;         dividing DL into DH:4[DI]:2[DI]:0[DI]
+
+          mov   BP,BX           ; - save exponent in BP
+          push  CX              ; - save sign
+          mov   BH,DL           ; - get divisor into BX
+          xor   BL,BL           ; - . . .
+          _shl  BX,1            ; - move to top of register
+          _shl  BX,1            ; - . . .
+          _shl  BX,1            ; - . . .
+          mov   CL,5            ; - get shift count
+          shr   AX,CL           ; - shift next 11 bits to bottom of AX
+          or    BX,AX           ; - get all 16 bits together in BX (divisor)
+
+          mov   DL,DH           ; - set up high order word of dividend
+          xor   DH,DH           ; - . . .
+          mov   AX,ss:4[DI]     ; - get next word of dividend
+          div   BX              ; - do partial divide
+          push  AX              ; - save next word of quotient
+          mov   AX,ss:2[DI]     ; - get next word of dividend
+          div   BX              ; - do partial divide
+          push  AX              ; - save next word of quotient
+          mov   AX,ss:[DI]      ; - get last word of dividend
+          div   BX              ; - do partial divide
+          push  AX              ; - save next word of quotient
+          sub   AX,AX           ; - extend dividend and do 1 more divide
+          div   BX              ; - . . .
+          _shl  DX,1            ; - double remainder
+          _if   nc              ; - if no carry
+            cmp   DX,BX         ; - - compare against divisor
+            cmc                 ; - - change the carry
+          _endif                ; - endif
+          rcr   DI,1            ; - get next bit of quotient from carry
+          mov   DX,AX           ; - get last word of quotient
+          pop   CX              ; - restore next word of quot
+          pop   BX              ; - . . .
+          pop   AX              ; - . . .
+          add   BP,0010h        ; - adjust exponent
+          test  AL,20h          ; - if answer needs aligning
+          _if   e               ; - then
+            sub   BP,0010h      ; - - adjust exponent back
+            _loop               ; - - loop
+              _shl  DI,1        ; - - - shift result left
+              _rcl  DX,1        ; - - - . . .
+              _rcl  CX,1        ; - - - . . .
+              _rcl  BX,1        ; - - - . . .
+              _rcl  AL,1        ; - - - . . .
+              test  AL,20h      ; - - until msb is in bit 6
+            _until ne           ; - - ...
+          _endif                ; - endif
+          and     AL,1Fh        ; - turn off implied one bit
+          jmp     fin_up_div    ; - finish up divide
+long_div:
+        push    CX              ; push sign
+        push    BX              ; push exponent
+
+        mov     BP,3            ; initialize count
+        push    BP              ; and save it on the stack
+
+        mov     AL,DH           ; move high byte of dividend into AL
+        mov     AH,DL           ; move high byte of divisor into AH
+        mov     DX,ss:[DI]      ; move rest of dividend into registers
+        mov     CX,ss:2[DI]     ; . . .
+        mov     BX,ss:4[DI]     ; . . .
+
+        mov     DI,1            ; initialize first quotient word
+
+;<> This bit serves as a count, when it has been shifted left into the carry,
+;<> we know it is time to get a fresh quotient word and save this one
+
+        mov     BP,ss:4[SI]     ; get the next word of divisor into BP
+        _loop                   ; loop
+          _guess                ; - guess
+            cmp  AH,AL          ; - - The purpose of this guess is to
+            jb   try            ; - - determine if the divisor will subtract
+            ja   didnt_go       ; - - from the dividend without a borrow, and to
+            cmp  BP,BX          ; - - branch to the appropriate routine
+            jb   try            ; - -
+            ja   didnt_go       ; - -
+            cmp  ss:2[SI],CX    ; - -
+            _quif ne            ; - -
+            cmp  ss:[SI],DX     ; - -
+            je   try            ; - -
+          _endguess             ; - endguess
+          _if   c               ; - if the carry is set (ie the divisor will
+                                ; - - definitely subtract from the divident
+                                ; - - without a borrow
+try:
+            sub  DX,ss:[SI]     ; - - subtract divisor from dividend
+            sbb  CX,ss:2[SI]    ; - - . . .
+            sbb  BX,BP          ; - - . . .
+            sbb  AL,AH          ; - - . . .
+            stc                 ; - - set carry to indicate that divisor was
+                                ; - - successfully subtracted from dividend
+          _endif                ; - endif
+didnt_go: _rcl  DI,1            ; - rotate 1 (if carry set) into quotient word
+          jc    newquot         ; - if quotient word is full, get another
+sh_div:   _shl  DX,1            ; - shift divident left
+          _rcl  CX,1            ; - . . .
+          _rcl  BX,1            ; - . . .
+          _rcl  AL,1            ; - . . .
+
+          cmp   AL,20h
+          jae   try
+
+;<> If bit 5 of dividend is set here, we didnt subtract the divisor from the
+;<> dividend (recall that the divisor has a 1 in the msb -- if we subtracted
+;<> it from the dividend without a borrow, the dividend would not have a one
+;<> in its msb to be shifted into bit 5 tested for in the condition above. If
+;<> we are rotating a bit into bit 5, the dividend is now big enough that we
+;<> can be sure of subtracting out the divisor without a borrow, as we have
+;<> shifted it left one digit.
+
+          cmp   AL,10h
+        _until  b
+
+;<> If bit 4 of dividend is set and bit 5 is not set, we do not know if
+;<> divisor will subtract from the dividend without a borrow (recall
+;<> that the divisor always has its high bit -- corresponding to bit 4 --
+;<> set to one (as it was normalized), so we jump to the compare code
+
+          cmc
+          jmp   didnt_go
+
+;<> If bit 4 is clear, then we know that the divisor will not subtract
+;<> from dividend without a borrow (see note above) so we just shift in
+;<> a zero
+
+;<><><> we need 55 bits of quotient; 52 will actually be saved, 1 will be
+;<><><> implied, 1 will be used for rounding, and 1 is needed in case the
+;<><><> most significant bit of the quotient turns out to be a zero.
+
+newquot: pop    BP              ; - get loop count
+        dec     BP              ; - decrement loop count
+        js      enddiv          ; - exit if we have filled 55 bits of quotient
+        push    DI              ; - save quotient word
+        _if     e
+          mov   DI,0200h
+        _else
+          mov   DI,1            ; - get a fresh quotient word
+        _endif
+        push    BP              ; - save loop count
+        mov     BP,ss:4[SI]     ; - restore BP to hold part of divisor
+        jmp     sh_div          ; - return to mainstream of code
+
+enddiv: mov     DX,DI           ; put least sig bits in correct register
+        xchg    DH,DL
+        _shl    DH,1            ; and left justify them (there are seven)
+        pop     CX              ; get rest of mantissa
+        pop     BX              ; . . .
+        pop     AX              ; . . .
+        pop     BP              ; get exponent
+        or      AX,AX           ; if high bit of AX is set
+        _if     s               ; then
+          add   BP,0010h        ; - increment exponent
+          shr   AX,1            ; - shift result right by one
+          rcr   BX,1            ; - . . .
+          rcr   CX,1            ; - . . .
+          rcr   DX,1            ; - . . .
+        _endif                  ; endif
+        and     AX,3fffh        ; turn off top bit
+        shr     AX,1            ; shift result right by nine
+        rcr     BX,1
+        rcr     CX,1
+        rcr     DX,1
+        mov     DL,DH
+        mov     DH,CL
+        mov     CL,CH
+        mov     CH,BL
+        mov     BL,BH
+        mov     BH,AL
+        mov     AL,AH
+        sub     AH,AH
+fin_up_div:
+        sub     BP,0010h        ; decrement exponent
+        _if     be              ; if so
+          pop   CX              ; - clear stack
+          add   SP,8            ; - . . .
+          pop   DI              ; - restore DI
+          pop   BP              ; - restore bp
+          jmp   F8UnderFlow     ; - report error
+        _endif                  ; endif
+;;;     jmp     fin_up          ; jump to generic finish up routine
+
+;
+; The following code consists of shared routines for the arithmetic ops
+;
+; fin_up is the exit point for the above routines in most cases
+; fini    is also an exit point
+; f8split is an 'initialization' routine to split the reals into parts
+;
+
+fin_up: add     DX,1            ; use last bit of mantissa
+        adc     CX,0            ; to round it up
+        adc     BX,0            ; . . .
+        adc     AL,0            ; . . .
+        test    AL,20h          ;
+        _if     ne              ; if we carried, increment the exponent
+          add   BP,0010h        ; - increment exponent
+          cmp   BP,7ff0h        ; - if exponent too large
+          _if   ae              ; - if overflow occurs
+            pop   AX            ; - - restore sign
+            add   SP,8          ; - - clean up stack
+            pop   DI            ; - - restore DI
+            pop   BP            ; - - restore BP
+            jmp F8OverFlow      ; - - goto generic overflow handler
+          _endif                ; - endif
+          and   AX,001fh        ; - clear part of AX for the exponent/sign
+                                ; - (for both div and mul)
+        _endif                  ; endif
+        shr     AX,1            ; shift mantissa to correct position
+        rcr     BX,1            ; . . .
+        rcr     CX,1            ; . . .
+        rcr     DX,1            ; . . .
+        or      AX,BP           ; or exponent into the real
+        pop     BP              ; get sign
+        and     BP,8000h        ; isolate it
+        or      AX,BP           ; put it in real
+        add     SP,8            ; clean up stack
+        pop     DI              ; restore DI
+        pop     BP              ; restore BP
+        ret                     ; return to caller
+        endproc __FDD
+
+; F8split 'unnormalizes' two double precision reals.
+; Operand 1 is passed in AX:BX:CX:DX
+; Operand 2 is passed in SS:[SI]
+; The reals are still in 'compressed' form when they arrive -- that is
+; the implied 1 bit is hidden and the numbers are in excess 3FE.
+; f8split moves the biased exponents of the reals into AX and BX.
+; F8split turns on the implied '1' bit in each real,
+; clears out the exponent from the mantissa words of each real, and
+; returns the updated high-bits of the mantissa in DH/DL (op1/op2)
+; The sign of op1 is in CL, sign of op2 in CH.
+; If either real is found to be 0, we return at once with both reals
+; unchanged from their initial states, and the zero flag is set. Note
+; that the OR operation at the end of this routine reset the zero flag
+; otherwise.
+
+
+_chkadd: call   _chk8087
+        go_to   fdadd
+
+_chksub: call   _chk8087
+        go_to   fdsub
+
+_chkmul: call   _chk8087
+        go_to   fdmul
+
+_chkdiv: call   _chk8087
+        go_to   fddiv
+
+_chk8087 proc   near
+        push    ax                      ; save AX
+if (_MODEL and _DS_PEGGED) eq 0
+if _MODEL and (_BIG_DATA or _HUGE_DATA)
+        push    ds                      ; save DS
+        mov     ax,DGROUP               ; get access to DGROUP
+        mov     ds,ax                   ; . . .
+endif
+endif
+        cmp     byte ptr __real87,0     ; if 8087 present
+        _if     ne                      ; then
+          mov   ax,offset __FDA87       ; - get addr of add rtn
+          mov   fdadd,ax                ; - ...
+          mov   ax,offset __FDS87       ; - get addr of sub rtn
+          mov   fdsub,ax                ; - ...
+          mov   ax,offset __FDM87       ; - get addr of mul rtn
+          mov   fdmul,ax                ; - ...
+          test  byte ptr __chipbug,1    ; - if we have a bad divider
+          _if   ne                      ; - then
+            mov ax,offset __FDDbad_div  ; - - get addr of div rtn
+          _else                         ; - else
+            mov ax,offset __FDD87       ; - - get addr of div rtn
+          _endif
+          mov   fddiv,ax                ; - ...
+        _else                           ; else
+          mov   ax,offset __FDAemu      ; - get addr of add rtn
+          mov   fdadd,ax                ; - ...
+          mov   ax,offset __FDSemu      ; - get addr of sub rtn
+          mov   fdsub,ax                ; - ...
+          mov   ax,offset __FDMemu      ; - get addr of mul rtn
+          mov   fdmul,ax                ; - ...
+          mov   ax,offset __FDDemu      ; - get addr of div rtn
+          mov   fddiv,ax                ; - ...
+        _endif                          ; endif
+if (_MODEL and _DS_PEGGED) eq 0
+if _MODEL and (_BIG_DATA or _HUGE_DATA)
+        pop     ds                      ; restore ds
+endif
+endif
+        pop     ax                      ; restore AX
+        ret                             ; return
+        endproc _chk8087
+
+        endmod
+        end

--- a/libc/watcom/asm/fdn086.asm
+++ b/libc/watcom/asm/fdn086.asm
@@ -1,0 +1,65 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
+;*               DESCRIBE IT HERE!
+;*
+;*****************************************************************************
+
+
+;========================================================================
+;==     Name:           FDN                                            ==
+;==     Operation:      Floating double negate                         ==
+;==     Inputs:         AX      high word of float                     ==
+;==     Outputs:        AX      new high word of float                 ==
+;==     Volatile:       none                                           ==
+;========================================================================
+include mdef.inc
+include struct.inc
+
+        modstart        fdn086
+
+        xdefp   __FDN
+
+        defpe   __FDN
+        test    ax,ax           ; if non zero number then
+        _if     e
+          test  dx,dx
+          _if   e
+            test bx,bx
+            _if e
+              test cx,cx
+            _endif
+          _endif
+        _endif
+        _if     ne              ; ...
+          xor   ah,80h          ; - flip the sign bit
+        _endif                  ; endif
+        ret                     ; and return!!!
+        endproc __FDN
+
+        endmod
+        end

--- a/libc/watcom/asm/fsc086.asm
+++ b/libc/watcom/asm/fsc086.asm
@@ -1,0 +1,75 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
+;*               DESCRIBE IT HERE!
+;*
+;*****************************************************************************
+
+
+;<><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+;<>
+;<> __FSC compares DX:AX with CX:BX
+;<>       if DX:AX > CX:BX,  1 is returned in AX
+;<>       if DX:AX = CX:BX,  0 is returned in AX
+;<>       if DX:AX < CX:BX, -1 is returned in AX
+;<>
+;<>  =========    ===           =======
+;<><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+include mdef.inc
+include struct.inc
+
+        modstart        fsc086
+
+        xdefp   __FSC
+
+        defpe   __FSC
+        _guess    have_cmp      ; guess - comparison done
+          xor     DX,CX         ; - check if signs differ
+          _if     ns            ; - if signs are the same
+            xor     DX,CX       ; - - restore DX
+            sub     DX,CX       ; - - find difference, DX=0 if equal
+            _if     e           ; - - if equal
+              cmp     AX,BX     ; - - - compare mantissas
+              mov     AX,0      ; - - - assume equal
+              _quif   e,have_cmp  ; - done if mantissas also equal
+            _endif              ; - - endif
+                                ; - - carry=1 iff |DX:AX| < |CX:BX|
+            rcr     DX,1        ; - - DX sign set iff |DX:AX| < |CX:BX|
+            xor     CX,DX       ; - - CX sign set iff DX:AX < CX:BX
+            not     CX          ; - - CX sign set iff DX:AX > CX:BX
+          _endif                ; - endif
+          sub     AX,AX         ; - clear result
+          _shl    CX,1          ; - carry=1 iff DX:AX > CX:BX
+          adc     AX,AX         ; - AX = 1 iff DX:AX > CX:BX, else AX=0
+          _shl    AX,1          ; - AX = 2 iff DX:AX > CX:BX, else AX=0
+          dec     AX            ; - AX = 1 iff DX:AX > CX:BX, else AX=-1
+        _endguess               ; endguess
+        ret                     ; return with sign in AX, conditions set
+        endproc __FSC
+
+        endmod
+        end

--- a/libc/watcom/asm/fsfd086.asm
+++ b/libc/watcom/asm/fsfd086.asm
@@ -1,0 +1,97 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
+;*               DESCRIBE IT HERE!
+;*
+;*****************************************************************************
+
+
+;=========================================================================
+;==     Name:           FSFD                                            ==
+;==     Operation:      Float single to float double conversion         ==
+;==     Inputs:         DX;AX   single precision float                  ==
+;==     Outputs:        AX;BX;CX;DX     double precision float          ==
+;==     Volatile:       none                                            ==
+;=========================================================================
+include mdef.inc
+include struct.inc
+
+        modstart        fsfd086
+
+        xdefp   __FSFD
+
+        defpe   __FSFD
+        _guess  xx1                 ; guess: number is 0.0 or infinity
+          mov   bx,ax               ; - move rest of mantissa to correct reg.
+          mov   ax,dx               ; - get high word to ax
+          sub   cx,cx               ; - ...
+          or    bx,bx               ; -
+          _quif ne                  ; - quit if low word not 0
+          and   dx,7fffh            ; - get rid of sign bit and check high word for 0
+          _quif e,xx1               ; - quit if 0.0
+          cmp   dx,7f80h            ; - check if infinity
+          _quif ne                  ; - quit if not infinity
+          or    al,0f0h             ; - set result +/- infinity
+        _admit                      ; admit: number is not 0
+          and   dh,7fh              ; - get sign to dx
+          xor   dx,ax               ; - ...
+          xor   ah,dh               ; - reset sign in ax
+          shr   ax,1                ; - now shift everything three bits
+          rcr   bx,1                ; - ...
+          rcr   cx,1                ; - ...
+          shr   ax,1                ; - ...
+          rcr   bx,1                ; - ...
+          rcr   cx,1                ; - ...
+          shr   ax,1                ; - ...
+          rcr   bx,1                ; - ...
+          rcr   cx,1                ; - ...
+          cmp   ax,0ffh shl 4       ; - if exponent is NaN
+          _if   ae                  ; - then
+            or  dx,(7ffh - 0ffh) shl 4 ; - - set result exponent adjustment for NaN
+          _else                     ; - else
+            or  dx,(3ffh - 7fh) shl 4;- - set result exponent adjustment
+            test  ax,0ffh shl 4     ; - - if exponent is 0 (denormal number)
+            _if   e                 ; - - then do normalization
+              add  dx,1 shl 4       ; - - - add 1 to result exponent adjustment
+              _loop                 ; - - - loop (normalize the fraction)
+                sub  dx,1 shl 4     ; - - - - subtract 1 from result exponent adjustment
+                _shl cx,1           ; - - - - shift fraction left
+                _rcl bx,1           ; - - - - . . .
+                _rcl al,1           ; - - - - . . .
+                test al,1 shl 4     ; - - - - check to see if result fraction is normalized
+              _until ne             ; - - - until not normalized
+              and al,not (1 shl 4)  ; - - - reset implied bit after normalization
+            _endif                  ; - - endif
+          _endif                    ; - endif
+          add   ax,dx               ; - adjust result exponent and set result sign
+        _endguess                   ; endguess
+        sub     dx,dx               ; clear result bottom bits of mantissa
+        ret                         ; and return
+        endproc __FSFD
+
+        endmod
+        end

--- a/libc/watcom/asm/fsi4086.asm
+++ b/libc/watcom/asm/fsi4086.asm
@@ -1,0 +1,188 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
+;*               DESCRIBE IT HERE!
+;*
+;*****************************************************************************
+
+
+;========================================================================
+;==     Name:           FSI4, FSU4, FSI2, FSU2, FSI1, FSU1             ==
+;==     Operation:      Convert single precision to integer            ==
+;==     Inputs:         DX;AX   single precision floating point        ==
+;==     Outputs:        DX;AX, AX, AL  integer value                   ==
+;==     Volatile:       none                                           ==
+;==                                                                    ==
+;==                                                                    ==
+;==                                     handle -1.0 -> 0xffffffff      ==
+;========================================================================
+include mdef.inc
+include struct.inc
+
+        modstart        fsi4086
+
+        xdefp   __FSI4
+        xdefp   __FSU4
+        xdefp   __FSI2
+        xdefp   __FSU2
+        xdefp   __FSI1
+        xdefp   __FSU1
+
+        defpe   __FSI4
+        push    cx              ; save cx
+        mov     cl,7fh+31       ; maximum number 2^31-1
+        call    __FSI           ; convert to integer
+        pop     cx              ; restore cx
+        ret                     ; return (overflow already handled
+        endproc __FSI4
+
+        defpe   __FSU4
+        push    cx              ; save cx
+        mov     cl,7fh+32       ; maximum number 2^32-1
+        call    __FSU           ; convert to integer
+        pop     cx              ; restore cx
+        ret                     ; return if no overflow
+        endproc __FSU4
+
+        defpe   __FSI2
+        push    cx              ; save cx
+        mov     cl,7fh+15       ; maximum number 2^15-1
+        call    __FSI           ; convert to integer
+        pop     cx              ; restore cx
+        ret                     ; return (overflow already handled
+        endproc __FSI2
+
+        defpe   __FSU2
+        push    cx              ; save cx
+        mov     cl,7fh+16       ; maximum number 2^16-1
+        call    __FSU           ; convert to integer
+        pop     cx              ; restore cx
+        ret                     ; return if no overflow
+        endproc __FSU2
+
+        defpe   __FSI1
+        push    cx              ; save cx
+        mov     cl,7fh+7        ; maximum number 2^7-1
+        call    __FSI           ; convert to integer
+        pop     cx              ; restore cx
+        ret                     ; return (overflow already handled
+        endproc __FSI1
+
+
+        defpe   __FSU1
+        push    cx              ; save cx
+        mov     cl,7fh+8        ; maximum number 2^8-1
+        call    __FSU           ; convert to integer
+        pop     cx              ; restore cx
+        ret                     ; return if no overflow
+        endproc __FSU1
+
+__FSI   proc    near
+__FSU:
+        or      dx,dx           ; check sign bit
+        jns     __FSAbs         ; treat as unsigned if positive
+        call    __FSAbs         ; otherwise convert number
+        not     dx              ; take two's complement of number
+        neg     ax              ; ...
+        sbb     dx,-1           ; ...
+        ret                     ; and return
+        endproc __FSI
+
+; 18-nov-87 AFS (for WATCOM C)
+;__FSU  proc near
+;       jmp
+;       or      dx,dx           ; check sign bit
+;       jns     __FSAbs         ; just convert if positive
+;       sub     ax,ax           ; return 0 if negative
+;       sub     dx,dx           ; ...
+;       ret
+;       endproc __FSU
+
+;========================================================================
+;==     Name:           FSAbs_                                         ==
+;==     Inputs:         DX;AX float                                    ==
+;==                     CL    maximum exponent excess $7f              ==
+;==     Outputs:        DX;AX integer, absolute value of float         ==
+;==                           if exponent >= maximum then 2^max - 1    ==
+;==                             returned                               ==
+;========================================================================
+
+__FSAbs proc near
+        or      dx,dx           ; check if number 0
+        je      retzero         ; if so, just return it
+        _shl    ax,1            ; shift mantissa over
+        _rcl    dx,1            ; and exponent as well
+        cmp     dh,7fh          ; quit if number < 1.0          15-apr-91
+        jb      uflow           ; ...
+        stc                     ; set carry for implied bit
+        rcr     dl,1            ; put implied '1' bit in
+        rcr     ax,1            ; ...
+        cmp     dh,cl           ; check if exponent exceeds maximum
+        jae     retmax          ; return maximum value if so
+        sub     dh,7fh+23       ; calculate amount to shift (+ve -> left)
+        jae     m_left          ; jump if left shift/no shift
+        _loop                   ; shift mantissa right
+          shr     dl,1          ; - shift mantissa
+          rcr     ax,1          ; - ...
+          inc     dh            ; - increment shift count
+        _until  e               ; until shift count is 0
+
+;       rounding commented out by FWC 30-jan-87
+
+;       adc     ax,0            ; round (nb 'inc' does not affect carry)
+;       adc     dx,0            ; ripple (nb ah was 0)
+        ret                     ; return with number
+
+m_left:
+        _if     ne              ; done if exponent exactly 23
+          mov     cl,dh         ; - get shift count
+          xor     dh,dh         ; - clear high byte
+          _loop                 ; - loop to put mantissa in proper spot
+            _shl  ax,1          ; - - multiply number by 2
+            _rcl  dx,1          ; - - ...
+            dec   cl            ; - - decrement shift count
+          _until  e             ; - until done shift
+        _endif                  ; endif
+        ret                     ; return
+
+retmax: mov     ax,0ffffh       ; return maximum value
+        mov     dx,ax           ; ...
+        _loop                   ; loop to shift maximum value over
+          cmp     cl,7fh+32     ; - quit if exponent reached
+          je      return        ; - ...
+          shr     dx,1          ; - shift number over 1 bit
+          rcr     ax,1          ; - ...
+          inc     cl            ; - increment exponent value
+        _endloop                ; endloop
+
+uflow:  sub     ax,ax           ; set entire number to 0
+retzero:sub     dx,dx           ; ensure entire number 0
+return: ret                     ; return
+        endproc __FSAbs
+
+        endmod
+        end

--- a/libc/watcom/asm/fsi8086.asm
+++ b/libc/watcom/asm/fsi8086.asm
@@ -1,0 +1,235 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
+;*               DESCRIBE IT HERE!
+;*
+;*****************************************************************************
+
+
+;
+; __FSI8 converts double into signed 64-bit integer
+; __FSU8 converts double into unsigned 64-bit integer
+;
+; Input:    DX AX = float
+; Output:   AX BX CX DX = 64-bit signed/unsigned integer
+; Volatile: None
+;
+; 14-mar-2000     SJHowe        initial implementation
+
+include mdef.inc
+include struct.inc
+
+        modstart        fsi8086
+
+        xdefp   __FSI8
+        xdefp   __FSU8
+
+        defpe   __FSI8
+        mov     cl,7fh+63       ; maximum number 2^63-1 + offset
+        jmp     __FS8           ; convert to integer
+        endproc __FSI8
+
+        defpe   __FSU8
+        mov     cl,7fh+64       ; maximum number 2^64-1 + offset
+
+; jmp not needed, fall through
+;       jmp     __FS8           ; convert to integer
+        endproc __FSU8
+
+__FS8   proc    near
+        or      dx,dx           ; check sign bit
+        jns     __FSAbs         ; treat as unsigned if positive
+        call    __FSAbs         ; otherwise convert number
+
+; rely on the crucial fact that the Intel instruction "not" does not alter
+; any flags. Borrows from previous register needs to propagated in the
+; direction of the most significant word.
+
+        neg     dx              ; negate
+        not     cx              ; :
+        sbb     cx,0FFFFH       ; :
+        not     bx              ; :
+        sbb     bx,0FFFFH       ; :
+        not     ax              ; :
+        sbb     ax,0FFFFH       ; :
+        ret                     ; and return
+        endproc __FS8
+
+;
+__FSAbs proc near
+        rol     dx,1            ; rotate sign bit out of way
+        cmp     dh,7Fh          ; exponent less than that for 1.0F ?
+        jb      ret_zero        ; yes, underflow => return 0
+        cmp     dh,cl           ; exponent more than maximum ?
+        jae     ret_max         ; yes, overflow => return max
+        shr     dl,1            ; move mantissa
+        or      dl,80h          ; set implied 1 of mantissa
+        xor     bx,bx           ; need to zero bh, so do bl
+        xor     cx,cx           ; need to zero ch, so do cl
+        xchg    bl,dh           ; move exponent, dh is 0
+
+; at this point
+; DH = 0, DL;AX = mantissa
+; CX = 0                ; in preparation for mantissa bits to be shifted in
+; BH = 0, BL = exponent ; in preparation for jump table below
+
+        add     bx,2            ; this is so, the bottom 3 bits of the exponent
+                                        ; will be 0 when enough shifting has occured
+        jmp     shift_start     ; start shift
+
+shift_loop:
+        shr     dl,1            ; shift mantissa right 1 bit
+        rcr     ax,1            ; :
+        rcr     ch,1            ; :
+        inc     bx              ; increment exponent
+shift_start:
+        test    bx,7            ; bottom 3 bit clear?
+        jne     shift_loop      ; no, loop again
+
+        sub     bx,88H          ; correct exponent for jump table
+        shr     bx,1            ; prepare to use jump table
+        shr     bx,1            ; :
+
+; at this point
+; DH = 0, DL;AX;CH = mantissa, CL = 0
+; BX = jump offset for jump table below
+
+        jmp     word ptr cs:sigbyte_table[bx] ; jump to table
+
+;
+; underflow, 0, denormal in float => return 0
+;
+ret_zero:
+        xor     ax,ax           ; return 0UI64
+        xor     bx,bx           ; :
+        xor     cx,cx           ; :
+        xor     dx,dx           ; :
+        ret                     ; :
+
+;
+; overflow, INF, NAN => return adjusted maximum
+;
+ret_max:
+        mov     ax,0FFFFh       ; return maximum (but adjusted for signed/unsigned)
+        not     cl              ; flip bits
+        mov     bx,ax           ; :
+        and     cl,1            ; now 0 or 1
+        shr     ax,cl           ; now 7FFFh or FFFFh
+        mov     dx,bx           ; :
+        mov     cx,bx           ; :
+        ret                     ; return
+
+sigbyte_table:
+        DW      byte0_significant
+        DW      byte1_significant
+        DW      byte2_significant
+        DW      byte3_significant
+        DW      byte4_significant
+        DW      byte5_significant
+        DW      byte6_significant
+        DW      byte7_significant
+
+comment $
+oldbyte0_significant:
+
+Jump label byte0_significant has been eliminated, because, since the first
+3 instructions are effectively done, the next 3 instructions match the
+trailing end of byte1_significant, therefore merge the two together.
+
+;       xor     dh,dh           ; zero byte  1         ; already 0
+;       mov     dl,dl           ; move sig byte 0      ; no move needed
+;       xor     bx,bx           ; zero bytes 4-5       ; already 0
+        xor     cx,cx           ; zero bytes 2-3
+        xor     ax,ax           ; zero bytes 6-7
+        ret                     ; return
+$
+
+byte1_significant:
+        mov     dh,dl           ; move sig byte 1
+        mov     dl,ah           ; move sig byte 0
+        xor     bx,bx           ; zero bytes 4-5
+
+byte0_significant:
+        xor     cx,cx           ; zero bytes 2-3
+        xor     ax,ax           ; zero bytes 6-7
+        ret                     ; return
+
+byte2_significant:
+        mov     cl,dl           ; move sig byte 2
+        xor     ch,ch           ; zero byte 3
+        mov     dx,ax           ; move sig bytes 0-1
+        xor     bx,bx           ; zero bytes 4-5
+        xor     ax,ax           ; zero bytes 6-7
+        ret                     ; return
+
+byte3_significant:
+        mov     cl,ah           ; move sig byte 2
+        mov     dh,al           ; move sig byte 1
+        xor     bx,bx           ; zero bytes 4-5
+        xor     ax,ax           ; zero bytes 6-7
+        xchg    ch,dl           ; move sig bytes 0,3
+        ret                     ; return
+
+byte4_significant:
+        mov     bl,dl           ; move sig byte 4
+        mov     dh,ch           ; move sig byte 1
+        xor     dl,dl           ; sig byte 0 = 0 (no more mantissa bits)
+        mov     cx,ax           ; move sig bytes 2-3
+;       xor     bh,bh           ; zero byte 5           ; already 0
+        xor     ax,ax           ; zero bytes 6-7
+        ret                     ; return
+
+byte5_significant:
+        mov     bh,dl           ; move sig byte 5
+        mov     cl,ch           ; move sig byte 2
+        mov     bl,ah           ; move sig byte 4
+        mov     ch,al           ; move sig byte 3
+        xor     dx,dx           ; sig bytes 0-1 = 0 (no more mantissa bits)
+        xor     ax,ax           ; zero bytes 6-7
+        ret                     ; return
+
+byte6_significant:
+        mov     bx,ax           ; move sig bytes 4-5
+        mov     al,dl           ; move sig byte 6
+        xor     ah,ah           ; zero byte 7
+;       mov     ch,ch           ; move sig byte 3       ; no move needed
+;       xor     cl,cl           ; sig byte 2 = 0 (no more mantissa bits) ; already zero
+        xor     dx,dx           ; sig bytes 0-1 = 0 (no more mantissa bits)
+        ret                     ; return
+
+byte7_significant:
+        mov     bh,al           ; move sig byte 5
+        mov     bl,ch           ; move sig byte 4
+        mov     al,ah           ; move sig byte 6
+        mov     ah,dl           ; move sig byte 7
+        xor     cx,cx           ; sig bytes 3-2 = 0 (no more mantissa bits)
+        xor     dx,dx           ; sig bytes 0-1 = 0 (no more mantissa bits)
+        ret                     ; return
+        endproc __FSAbs
+
+        endmod
+        end

--- a/libc/watcom/asm/fsmth086.asm
+++ b/libc/watcom/asm/fsmth086.asm
@@ -1,0 +1,651 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
+;*               DESCRIBE IT HERE!
+;*
+;*****************************************************************************
+
+
+;
+;     real*4 math library
+;
+;  04-apr-86    G. Coschi       special over/underflow check in mul,div
+;                               have to always point at DGROUP.
+;                               we might be running with SS != DGROUP
+;
+;     inputs: DX,AX - operand 1 (high word, low word resp. ) (op1)
+;             CX,BX - operand 2                              (op2)
+;
+;     operations are performed as op1 (*) op2 where (*) is the selected
+;     operation
+;
+;     output: DX,AX - result    (high word, low word resp. )
+;
+;     __FSA, __FSS - written  28-apr-84
+;                  - modified by A.Kasapi 15-may-84
+;                  - to:      Calculate sign of result
+;                  -          Guard bit in addition for extra accuracy
+;                             Add documentation
+;     __FSM        - written  16-may-84
+;                  - by       Athos Kasapi
+;     __FSD        - written  may-84 by "
+;
+;
+;
+include mdef.inc
+include struct.inc
+
+.8087
+        modstart        fsmth086
+
+        xrefp           __8087  ; indicate that NDP instructions are present
+
+        xrefp   F4DivZero       ; Fstatus
+        xrefp   F4OverFlow      ; Fstatus
+        xrefp   F4UnderFlow     ; Fstatus
+        xrefp   __fdiv_m32
+
+go_to   macro frtn
+if _MODEL and _DS_PEGGED
+        jmp     frtn
+else
+ if _MODEL and (_BIG_DATA or _HUGE_DATA)
+        push    ax
+        push    bp
+        push    ds
+        mov     ax,DGROUP               ; get access to DGROUP
+        mov     bp,sp
+        mov     ds,ax                   ; . . .
+        mov     ax,frtn
+        xchg    ax,4[bp]
+        pop     ds
+        pop     bp
+        retn
+ else
+        jmp     frtn
+ endif
+endif
+endm
+
+        datasegment
+        extrn   __real87 : byte         ; cstart
+        extern  __chipbug : byte
+fsadd   dw      _chkadd
+fsmul   dw      _chkmul
+fsdiv   dw      _chkdiv
+        enddata
+
+        xdefp   __FSA           ; add real*4 to real*4
+        xdefp   __FSS           ; subtract real*4 from real*4
+        xdefp   __FSM           ; 4-byte real multiply
+        xdefp   __FSD           ; 4-byte real divide
+
+
+        defpe   __FSS
+        jcxz    ret_op1         ; if op2 is 0 then return operand 1
+        xor     CH,80h          ; flip the sign of op2 and add
+
+        defpe   __FSA
+        jcxz    ret_op1         ; if op2 is 0 then return operand 1
+        or      DX,DX           ; if op1 is 0
+        _if     e               ; then
+          mov   DX,CX           ; - return operand 2
+          mov   AX,BX           ; - . . .
+ret_op1:  ret                   ; - return
+        _endif                  ; endif
+        go_to   fsadd
+
+__FSA87:
+        push    BP              ; save BP
+        mov     BP,SP           ; get access to stack
+        push    DX              ; push operand 1
+        push    AX              ; . . .
+        fld     dword ptr -4[BP]; load operand 1
+        push    CX              ; push operand 2
+        push    BX              ; . . .
+        fadd    dword ptr -8[BP]; add operand 2 to operand 1
+_ret87:
+        fstp    dword ptr -4[BP]; store result
+        add     sp,4            ; clean up stack
+        fwait                   ; wait
+        pop     AX              ; load result into DX:AX
+        pop     DX              ; . . .
+        cmp     DX,8000h        ; check for negative zero
+        _if     e               ; if it is then
+          sub     AX,AX         ; - make it positive
+          mov     DX,AX         ; - ...
+        _endif                  ; endif
+        pop     BP              ; restore BP
+        ret                     ; return
+
+__FSAemu:
+        push    DI              ; save DI
+        xchg    AX,BX           ; flip registers around
+        xchg    AX,DX           ; . . .
+;
+;       now have:
+;               AX:BX
+;           +-  CX:DX
+;<> Scheme for calculating sign of result:
+;<>   The sign word is built and kept in DL
+;<>   Bits 0 and 1 hold the sum of the sign bits
+;<>       shifted out of op_1 and op_2
+;<>   Bit 2 holds the sign of the larger operand. It is assumed to be
+;<>       op_1 until op_2 is found larger
+
+        mov     DI,DX           ; put low order word of op2 in DI
+        sub     DX,DX           ; clear DX
+        _shl    AX,1            ; get exponent of op1 into AH
+        _rcl    DL,1            ;
+        mov     DH,DL           ;
+        _shl    DL,1            ;
+        _shl    DL,1            ;
+        add     DL,DH           ;
+        stc                     ; put implied 1 bit into top bit of
+        rcr     AL,1            ; ... fraction
+        _shl    CX,1            ; get exponent of op2 into CH
+        adc     DL,0            ;
+        stc                     ; put implied 1 bit into top bit
+        rcr     CL,1            ; ... of fraction
+        mov     DH,AH           ; assume op1 > op2
+        sub     AH,CH           ; calculate difference in exponents
+        _if     ne              ; if different
+          _if   b               ; - if op1 < op2
+            mov   DH,CH         ; - - get larger exponent for result
+            neg   AH            ; - - negate the shift count
+            xchg  AL,CL         ; - - flip operands
+            xchg  BX,DI         ; - - . . .
+            xor   DL,4
+
+;<> op_2 is larger, so its sign now occupies bit 2 of sign word.  This
+;<> information is only correct if the signs of op-1 and op-2 are different.
+;<> Since we look past bit 1 for sign only if the signs are different, bit2
+;<> will supply the correct information when it is needed. We get the sign of
+;<> op_2 by flipping the sign of op_1, already in bit 2
+
+          _endif                ; - endif
+          mov   CH,AH           ; - get shift count
+          xor   AH,AH           ; - zero guard byte
+          _loop                 ; - loop (align fractions)
+            shr   CL,1          ; - - shift over fraction
+            rcr   DI,1          ; - - . . .
+            dec   CH            ; - - decrement shift count
+          _until e              ; - until fractions aligned
+          rcr   AH,1            ; - only need last bit in guard byte
+
+;<> bit 7 of the guard byte holds an extra significant bit from mantissa
+;<> of the operand we shifted left to allign with the greater operand
+;<> it is added or subtracted from with operands by shifting the bit into
+;<> the carry bit just before the operation
+
+        _endif                  ; endif
+        shr     DL,1            ; get bit 0 of sign word - value is 0 if
+                                ; both operands have same sign, 1 if not
+        _if     nc              ; if signs are the same
+          add   BX,DI           ; - add the fractions
+          adc   AL,CL           ; - . . .
+          _if   c               ; - if carry
+            rcr   AL,1          ; - - shift fraction right 1 bit
+            rcr   BX,1          ; - - . . .
+            rcr   AH,1          ; - - save extra sig bit in guard bit
+            inc   DH            ; - - increment exponent
+            _if   z             ; - - if we overflowed
+              ror dl,1          ; - - - set sign of infinity
+              rcr ah,1          ; - - - . . .
+              jmp add_oflow     ; - - - handle overflow
+            _endif              ; - - endif
+          _endif                ; - endif
+        _else                   ; else (signs are different)
+          shr   DL,1            ; - skip junk bit
+          rol   AH,1            ; - get guard bit
+          ror   AH,1            ; - and put it back
+          sbb   BX,DI           ; - subtract the fractions
+          sbb   AL,CL           ; - . . .
+          _guess                ; - guess
+            _quif nc            ; - - quit if no borrow
+            inc   DL            ; - - sign := sign of op_2
+            not   AL            ; - - negate the fraction (considering
+                                ; - - the guard bit an extension of the
+            not   BX            ; - - fraction)
+            neg   AH            ; - - . . .
+            sbb   BX,-1         ; - - . . .
+            sbb   AL,-1         ; - - . . .
+          _admit                ; - admit
+            cmp   AL,0          ; - - quit if answer is not 0
+            _quif ne            ; - - . . .
+            or    BX,BX         ; - - . . .
+            _quif ne            ; - - . . .
+            sub   AX,AX         ; - - set result to 0
+            sub   DX,DX         ; - - . . .
+            pop   DI            ; - - restore DI
+            ret                 ; - - return (answer is 0)
+          _endguess             ; - endguess
+        _endif                  ; endif
+
+        ; normalize the fraction
+        _shl    AH,1            ; get guard bit
+        adc     BX,0            ; round up fraction if required
+        adc     AL,0            ; . . .
+        _guess  underflow       ; guess
+          _quif nc              ; - quit if round up didn't overflow frac
+          inc   DH              ; - adjust exponent
+        _admit                  ; admit
+          _loop                 ; - loop (shift until high bit appears)
+            _rcl  BX,1          ; - - shift fraction left
+            _rcl  AL,1          ; - - . . .
+            _quif c,underflow   ; - - quit if carry has appeared
+            dec   DH            ; - - decrement exponent
+          _until  e             ; - until underflow
+          jmp   add_uflow       ; - handle underflow
+        _endguess               ; endguess
+        mov     AH,DH           ; get exponent
+        ror     DL,1            ; get sign bit
+        rcr     AX,1            ; shift it into result
+        rcr     BX,1            ; . . .
+        mov     DX,AX           ; get result in DX:AX
+        mov     AX,BX           ; . . .
+        pop     DI              ; restore DI
+        ret                     ; return
+
+add_uflow:                      ; handle underflow
+        pop     DI              ; restore DI
+        jmp     F4UnderFlow     ; goto underflow routine
+
+add_oflow:                      ; handle overflow
+        pop     DI              ; restore DI
+        jmp     F4OverFlow      ; handle overflow
+        endproc __FSA
+        endproc __FSS
+
+;=====================================================================
+
+        defpe   __FSM
+
+;<> multiplies X by Y and places result in C.
+;<> X2 and X1 represent the high and low words of X. Similarly for Y and C
+;<> Special care is taken to use only six registers, so the code is a bit
+;<> obscure
+
+        _guess                  ; guess: answer not 0
+          or    DX,DX           ; - see if first arg is zero
+          _quif e               ; - quit if op1 is 0
+          or    CX,CX           ; - quit if op2 is 0
+          _quif e               ; - . . .
+          go_to fsmul           ; - invoke support rtn
+        _endguess               ; endguess
+        sub     AX,AX           ; set answer to 0
+        sub     DX,DX           ; . . .
+        ret                     ; return
+
+__FSM87:
+        push    BP              ; save BP
+        mov     BP,SP           ; get access to stack
+        push    DX              ; push operand 1
+        push    AX              ; . . .
+        fld     dword ptr -4[BP]; load operand 1
+        push    CX              ; push operand 2
+        push    BX              ; . . .
+        fmul    dword ptr -8[BP]; mulitply operand 1 by operand 2
+        jmp     _ret87          ; goto common epilogue
+
+__FSMemu:
+        push    SI              ; save SI
+        push    DI              ; save DI
+        xchg    AX,BX           ; flip registers around
+        xchg    AX,DX           ; . . .
+;
+;       now have:
+;               AX:BX
+;            *  CX:DX
+;
+        mov     DI,BX           ; move arguments to better registers
+        mov     BX,AX           ; . . .
+        mov     SI,DX           ; move X1 to less volatile register
+
+        _shl    BX,1            ; move sign of X
+        _rcl    AL,1            ; into AL
+        stc                     ; rotate implied high bit into X
+        rcr     BL,1            ; . . .
+        _shl    CX,1            ; use sign of Y
+        adc     AL,0            ; to calculate sign of result in AL
+        stc                     ; rotate implied high bit into Y
+        rcr     CL,1            ; . . .
+
+        xchg    AL,CH           ; put sign in CH and get exponent of Y
+        sub     AL,7Fh          ; remove bias from exponents
+        sub     BH,7Fh          ; . . .
+        add     BH,AL           ; add exponents
+        _if     o               ; if over or underflow
+          js    mul_oflow       ; - report overflow if signed
+          jmp   mul_uflow       ; - handle underflow
+        _endif                  ; endif
+        cmp     BH,81h          ; check for underflow
+        jle     mul_uflow       ; quit if underflow
+        add     BH,7fh+2        ; bias exponent
+        xchg    BH,CL           ; put exponent of result in CL and move Y2
+                                ; into BH. Note that BL holds X2
+        mov     AX,DI           ; get X1
+
+        mul     SI              ; C1 := high_word( X1 * Y1 ) and
+        xchg    DX,DI           ; get X1
+        mov     AX,BX           ; get Y2
+        xchg    AH,AL           ; put factor into lower register
+        sub     AH,AH           ; . . .
+
+        mul     DX              ; C2 := high_word( X1 * Y2 ) and
+        xchg    DX,SI           ; get Y1
+        add     DI,AX           ; (C2_C1) += low_word( X1 * Y2 )
+        adc     SI,0            ; . . .
+        mov     AX,BX           ; get X2
+        sub     AH,AH           ; . . .
+        mul     DX              ; (C2_C1) += low_word( X2 * Y1 )
+        add     DI,AX           ; . . .
+        adc     SI,DX           ; C2 += high_word( X2 * Y1 )
+        mov     AX,BX           ; get X2
+        mul     AH              ; C2 += byte_product( Y2 * X2 )
+        add     SI,AX           ; . . .
+
+        _loop                   ; loop
+          _shl  DI,1            ;   shift result left
+          _rcl  SI,1            ;   . . .
+          dec   CL              ;   and dec exponent for every shift
+        _until  be              ; until( carry flag or zero flag is set )
+        jz      mul_oflow       ; ...
+
+        mov     AX,SI           ; move result to more flexible registers
+        mov     BX,DI           ; . . .
+        mov     BL,BH           ; shift exponent into result
+        mov     BH,AL           ; . . .
+        mov     AL,AH           ; . . .
+        mov     AH,CL           ; . . .
+        add     BX,1            ; round up fraction
+        adc     AX,0            ; and increment exponent if necessary
+        jz      mul_oflow       ; report overflow if required
+        shr     CH,1            ; shift sign into result
+        rcr     AX,1            ; . . .
+        rcr     BX,1            ; . . .
+        mov     DX,AX           ; get result into DX:AX
+        mov     AX,BX           ; . . .
+        pop     DI              ; restore DI
+        pop     SI              ; restore SI
+        ret                     ; return
+
+mul_uflow:                      ; underflow
+        pop     DI              ; restore DI
+        pop     SI              ; restore SI
+        jmp     F4UnderFlow     ; . . .
+
+mul_oflow:                      ; overflow
+        shr     CH,1            ; get sign of infinity
+        rcr     AX,1            ; into proper register
+        pop     DI              ; restore DI
+        pop     SI              ; restore SI
+        jmp     F4OverFlow      ; report overflow
+        endproc __FSM
+
+;====================================================================
+
+        defpe   __FSD
+        go_to   fsdiv
+
+__FSDbad_div:
+        push    BP              ; save BP
+        mov     BP,SP           ; get access to stack
+        push    DX              ; push operand 1
+        push    AX              ; . . .
+        fld     dword ptr -4[BP]; load operand 1
+        push    CX              ; push operand 2
+        push    BX              ; . . .
+        call    __fdiv_m32      ; divide operand 1 by operand 2
+        sub     sp,4            ; rtn pops parm, _ret87 wants it
+        jmp     _ret87          ; goto common epilogue
+
+__FSD87:
+        push    BP              ; save BP
+        mov     BP,SP           ; get access to stack
+        push    DX              ; push operand 1
+        push    AX              ; . . .
+        fld     dword ptr -4[BP]; load operand 1
+        push    CX              ; push operand 2
+        push    BX              ; . . .
+        fdiv    dword ptr -8[BP]; divide operand 1 by operand 2
+        jmp     _ret87          ; goto common epilogue
+
+__FSDemu:
+        _shl    CX,1            ; shift sign of divisor into carry
+        _if     e               ; if divisor is zero
+          jmp   F4DivZero       ; - handle divide by zero
+        _endif                  ; endif
+        push    SI              ; save SI
+        push    DI              ; save DI
+        xchg    AX,BX           ; flip registers around
+        xchg    AX,DX           ; . . .
+;
+;       now have:
+;               AX:BX
+;               -----
+;               CX:DX
+;
+        mov     DI,DX           ; save DX in DI
+                                ; CX:DI is the divisor;  AX:BX is the dividend
+        _rcl    DL,1            ; save sign in DL
+        or      AX,AX           ; check dividend for zero
+        _if     e               ; if so then
+          sub   DX,DX           ; - make sure both parts are 0
+          pop   DI              ; - restore DI
+          pop   SI              ; - restore SI
+          ret                   ; - return
+        _endif                  ; endif
+        stc                     ; rotate implied '1'bit back into divisor
+        rcr     CL,1            ; . . .
+        _shl    AX,1            ; shift sign of divisor into carry
+        adc     DL,0            ; now calculate save sign of result in DL
+        stc                     ; rotate implied '1' bit into dividend
+        rcr     AL,1            ; . . .
+        sub     CH,7Fh          ; calculate exponent of result
+        sub     AH,7Fh          ; . . .
+        sub     AH,CH           ; . . .
+        _if     o               ; if over or underflow
+          _if   s               ; - if overflow
+            shr dl,1            ; - - get sign of infinity
+            rcr ax,1            ; - - . . .
+            jmp div_oflow       ; - - handle overflow
+          _endif                ; - else
+          jmp   div_uflow       ; - - handle underflow
+        _endif                  ; endif
+        cmp     AH,81h          ; check for underflow
+        jle     div_uflow       ; . . .
+        add     AH,7Fh          ; restore bias to exponent
+        mov     DH,AH           ; save calculated exponent
+        mov     CH,25
+        mov     AH,CL
+
+; The count is set to 25.  We do not know if the first digit of our quotient
+; mantissa will be a one or zero.  We do know that if the first calculated
+; digit was not a 1, the second one will be, since we will have by then
+; shifted the dividend left and made it large enough for the divisor to
+; subtract out of  To always calculate 24 SIGNIFICANT digits (ie with a leading
+; one) in the mantissa we must, then, calculate 25, in case the leading digit
+; was a zero.
+
+        _loop                   ; loop
+          _guess                ; - The purpose of this guess is to set the
+            cmp AH,AL           ; - Carry bit by the time we reach endguess
+            jl  try
+            jg  didnt_go
+            cmp DI,BX           ; - . . .
+            je  try             ; - . . .
+          _endguess             ; - . . .
+          _if   c               ; - if
+                                ; - - the carry is set (ie the divisor will
+                                ; - - definitely subract from the dividend
+                                ; - - without a borrow
+try:        sub BX,DI           ; - - subtract the divisor from dividend
+            sbb AL,AH           ; - - . . .
+            stc                 ; - - set cary, to indicate that the divisor
+                                ; - - was subtracted from the dividend
+          _endif                ; - endif
+didnt_go: _rcl  SI,1            ; - rotate a 1 into quotient if carry set
+          _rcl  CL,1            ; - . . .
+          dec   CH              ; - count --
+          jle   done            ; - if( count = 0 ) goto done
+resume:
+          _shl  BX,1            ; - shift divisor left
+          _rcl  AL,1            ; - . . .
+          jc    try
+
+; If the carry is set here, we didnt subtract the divisor from the dividend
+; (recall that the divisor has a 1 in the msb -- if we subtracted it from
+; the dividend without a borrow, the dividend would not have a one in
+; its msb to be shifted into the carry tested for in the condition above.
+; If we are rotating a carry out of the dividend, the dividend
+; is now big enough that we can be sure of subtracting out the divisor
+; without a borrow, as we have shifted it left one digit.
+
+          jno   didnt_go
+
+; If the overflow is not set and the carry is not set, we know there is
+; now a '0' in the msb of the dividend and since there is a '1' in the
+; msb of the divisor, we know that it wont subtract from the dividend
+; without a borrow, so we dont even check --- just jump to a place where
+; we can shift a 0 into the quotient for the current digit
+
+        _endloop
+done:
+
+; The following conditional ensures that not only do we have 24 significant
+; normalized digits in our quotient registers, but we also have the next
+; (would have followed the lsb) bit in the carry.  If we do not have a
+; carry at this point, we only have 24 sig digits.  We can use the carry
+; to hold an extra significant digit, which we go back for in the conditional
+
+        _if     nc
+          dec   DH
+
+; the exponent is decremented because in going back for an extra digit, we
+; shift the quotient left one bit, and hence multiply it by two.
+
+          jnz   resume          ; on not overflow, goto resume
+          jmp   div_uflow       ; handle underflow
+        _endif
+
+; we know that the carry is set here --- ie we have shifted
+; a significant bit of the quotient into the carry in order
+; to make room for an extra significant bit in the lsb position
+; of the word. We now put the msb in the carry back into the msb
+; of the word, and use the lsb shifted into the carry in doing this to
+; round off the quotient. We do this by rotating right the carry into the
+; quotient and saving the least sig bit in the carry. This is added back on to
+; round off the number. we do not alter the exponent when we right, because
+; we shifted left 25 times instead of 24, so the quotent needed right shifting
+
+        rcr     CL,1
+        rcr     SI,1
+        adc     SI,0            ; add back lsb to round off quotient
+        adc     CL,0            ; . . .
+        _guess                  ; guess have to inc exponent
+          _quif nc              ; - quit if no carry
+          inc   dh              ; - increment exponent
+          _quif nz              ; - quit if no overflow
+          shr   dl,1            ; - get sign of infinity
+          rcr   ax,1            ; - . . .
+          jmp   div_oflow       ; - handle overflow
+        _endguess               ; endguess
+
+        ror     DX,1            ; rotate sign bit into high bit
+        or      DX,007Fh        ; prepare sign-exponent word
+        mov     CH,0FFh         ; prepare high word of mantissa word
+        and     CX,DX           ; mask the sign and exponent into quotient
+        mov     DX,CX           ; move high order word of quotent to DX
+        mov     AX,SI           ; move low  ...    ...        ...    AX
+        pop     DI              ; restore DI
+        pop     SI              ; restore SI
+        ret                     ; return to caller
+
+div_uflow:                      ; handle underflow
+        pop     DI              ; restore DI
+        pop     SI              ; restore SI
+        jmp     F4UnderFlow     ; handle underflow
+
+
+div_oflow:                      ; handle overflow
+        pop     DI              ; restore DI
+        pop     SI              ; restore SI
+        jmp     F4OverFlow      ; handle overflow
+        endproc __FSD
+
+
+_chkadd: call   _chk8087
+        go_to   fsadd
+
+_chkmul: call   _chk8087
+        go_to   fsmul
+
+_chkdiv: call   _chk8087
+        go_to   fsdiv
+
+_chk8087 proc   near
+        push    ax                      ; save AX
+if (_MODEL and _DS_PEGGED) eq 0
+if _MODEL and (_BIG_DATA or _HUGE_DATA)
+        push    ds                      ; save DS
+        mov     ax,DGROUP               ; get access to DGROUP
+        mov     ds,ax                   ; . . .
+endif
+endif
+        cmp     byte ptr __real87,0     ; if 8087 present
+        _if     ne                      ; then
+          mov   ax,offset __FSA87       ; - get addr of add rtn
+          mov   fsadd,ax                ; - ...
+          mov   ax,offset __FSM87       ; - get addr of mul rtn
+          mov   fsmul,ax                ; - ...
+          test  byte ptr __chipbug,1    ; - if we have a bad divider
+          _if   ne                      ; - then
+            mov ax,offset __FSDbad_div  ; - - get addr of div rtn
+          _else                         ; - else
+            mov ax,offset __FSD87       ; - - get addr of div rtn
+          _endif
+          mov   fsdiv,ax                ; - ...
+        _else                           ; else
+          mov   ax,offset __FSAemu      ; - get addr of add rtn
+          mov   fsadd,ax                ; - ...
+          mov   ax,offset __FSMemu      ; - get addr of mul rtn
+          mov   fsmul,ax                ; - ...
+          mov   ax,offset __FSDemu      ; - get addr of div rtn
+          mov   fsdiv,ax                ; - ...
+        _endif                          ; endif
+if (_MODEL and _DS_PEGGED) eq 0
+if _MODEL and (_BIG_DATA or _HUGE_DATA)
+        pop     ds                      ; restore ds
+endif
+endif
+        pop     ax                      ; restore AX
+        ret                             ; return
+        endproc _chk8087
+
+        endmod
+        end

--- a/libc/watcom/asm/fsn086.asm
+++ b/libc/watcom/asm/fsn086.asm
@@ -1,0 +1,59 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
+;*               DESCRIBE IT HERE!
+;*
+;*****************************************************************************
+
+
+;========================================================================
+;==     Name:           FSN                                            ==
+;==     Operation:      Floating single negate                         ==
+;==     Inputs:         DX      high word of float                     ==
+;==     Outputs:        DX      new high word of float                 ==
+;==     Volatile:       none                                           ==
+;========================================================================
+include mdef.inc
+include struct.inc
+
+        modstart        fsn086
+
+        xdefp   __FSN
+
+        defpe   __FSN
+        or      ax,ax           ; if number is 0
+        _if     e               ; then
+          or    dx,dx           ; - check other word
+        _endif                  ; endif
+        _if     ne              ; if number not zero
+        xor     dh,80h          ; - flip the sign bit
+        _endif                  ; endif
+        ret                     ; and return!!!
+        endproc __FSN
+
+        endmod
+        end

--- a/libc/watcom/asm/fstat386.asm
+++ b/libc/watcom/asm/fstat386.asm
@@ -1,0 +1,168 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  Floating-point exception signaling
+;*
+;*****************************************************************************
+
+
+include mdef.inc
+include struct.inc
+include fstatus.inc
+
+        modstart        fstat386
+
+        xrefp   "C",__set_ERANGE
+        xrefp   __FPE_exception_
+
+        datasegment
+        enddata
+
+        assume  ss:nothing
+
+        xdefp   FPUnderFlow
+        xdefp   FPInvalidOp
+        xdefp   FPDivZero
+        xdefp   FPOverFlow
+        xdefp   F8UnderFlow
+;        xdefp   F8InvalidOp
+        xdefp   F8DivZero
+        xdefp   F8OverFlow
+        xdefp   F8RetInf
+        xdefp   F4UnderFlow
+;        xdefp   F4InvalidOp
+        xdefp   F4DivZero
+        xdefp   F4OverFlow
+        xdefp   F4RetInf
+
+;
+;       FPUnderFlow( void ) : void
+;
+        defpe   FPUnderFlow
+        push    eax                 ; save EAX
+;;      mov     eax,FPE_UNDERFLOW   ; indicate underflow
+;;      call    __FPE_exception_    ;
+        pop     eax                 ; restore EAX
+        ret                         ; return
+        endproc FPUnderFlow
+
+;
+;       FPInvalidOp( void ) : void
+;
+        defpe   FPInvalidOp
+        push    eax                 ; save EAX
+        mov     eax,FPE_ZERODIVIDE  ; indicate divide by 0
+        call    __FPE_exception_    ;
+        pop     eax                 ; restore EAX
+        ret                         ; return
+        endproc FPInvalidOp
+
+;
+;       FPDivZero( void ) : void
+;
+        defpe   FPDivZero
+        push    eax                 ; save EAX
+        mov     eax,FPE_ZERODIVIDE  ; indicate divide by 0
+        call    __FPE_exception_    ;
+        pop     eax                 ; restore EAX
+        ret                         ; return
+        endproc FPDivZero
+
+;
+;       FPOverFlow( void ) : void
+;
+        defpe   FPOverFlow
+        push    eax                 ; save EAX
+        call    __set_ERANGE        ; errno = ERANGE
+        mov     eax,FPE_OVERFLOW    ; indicate overflow
+        call    __FPE_exception_    ;
+        pop     eax                 ; restore EAX
+        ret                         ; return
+        endproc FPOverFlow
+
+;
+;       F8UnderFlow( void ) : reallong
+;
+        defp    F8UnderFlow
+        xor     edx,edx             ; return zero
+;
+;       F4UnderFlow( void ) : real
+;
+        defp    F4UnderFlow
+        call    FPUnderFlow         ; handle underflow
+        xor     eax,eax             ; return zero
+        ret                         ; return
+        endproc F4UnderFlow
+        endproc F8UnderFlow
+
+;
+;       F4DivZero( sign : int ) : real
+;
+        defp    F4DivZero
+        call    FPDivZero           ; handle divide by 0
+        jmp short F4RetInf          ; return Infinity
+;
+;       F4OverFlow( sign : int ) : real
+;
+        defp    F4OverFlow
+        call    FPOverFlow          ; handle overflow
+;
+;       F4RetInf( sign : int ) : real
+;
+        defp    F4RetInf
+        and     eax,80000000h       ; get sign
+        or      eax,7F800000h       ; set infinity
+        ret                         ; return
+        endproc F4RetInf
+        endproc F4OverFlow
+        endproc F4DivZero
+
+;
+;       F8DivZero( sign : int ) : reallong
+;
+        defp    F8DivZero
+        call    FPDivZero           ; handle divide by 0
+        jmp short F8RetInf          ; return Infinity
+;
+;       F8OverFlow( sign : int ) : reallong
+;
+        defp    F8OverFlow
+        call    FPOverFlow          ; handle overflow
+;
+;       F8RetInf( sign : int ) : reallong
+;
+        defp    F8RetInf
+        and     eax,80000000h       ; get sign
+        or      eax,7FF00000h       ; set infinity
+        mov     edx,eax             ;
+        sub     eax,eax             ; ...
+        ret                         ; return
+        endproc F8RetInf
+        endproc F8OverFlow
+        endproc F8DivZero
+
+        endmod
+        end

--- a/libc/watcom/asm/fstat386.asm
+++ b/libc/watcom/asm/fstat386.asm
@@ -25,7 +25,7 @@
 ;*  ========================================================================
 ;*
 ;* Description:  Floating-point exception signaling
-;*
+;* Modified by ghaerr for 8086 CPU
 ;*****************************************************************************
 
 
@@ -62,10 +62,10 @@ include fstatus.inc
 ;       FPUnderFlow( void ) : void
 ;
         defpe   FPUnderFlow
-        push    eax                 ; save EAX
-;;      mov     eax,FPE_UNDERFLOW   ; indicate underflow
+        push    ax                  ; save EAX
+;;      mov     ax,FPE_UNDERFLOW    ; indicate underflow
 ;;      call    __FPE_exception_    ;
-        pop     eax                 ; restore EAX
+        pop     ax                  ; restore EAX
         ret                         ; return
         endproc FPUnderFlow
 
@@ -73,10 +73,10 @@ include fstatus.inc
 ;       FPInvalidOp( void ) : void
 ;
         defpe   FPInvalidOp
-        push    eax                 ; save EAX
-        mov     eax,FPE_ZERODIVIDE  ; indicate divide by 0
+        push    ax                  ; save EAX
+        mov     ax,FPE_ZERODIVIDE   ; indicate divide by 0
         call    __FPE_exception_    ;
-        pop     eax                 ; restore EAX
+        pop     ax                  ; restore EAX
         ret                         ; return
         endproc FPInvalidOp
 
@@ -84,10 +84,10 @@ include fstatus.inc
 ;       FPDivZero( void ) : void
 ;
         defpe   FPDivZero
-        push    eax                 ; save EAX
-        mov     eax,FPE_ZERODIVIDE  ; indicate divide by 0
+        push    ax                  ; save EAX
+        mov     ax,FPE_ZERODIVIDE   ; indicate divide by 0
         call    __FPE_exception_    ;
-        pop     eax                 ; restore EAX
+        pop     ax                  ; restore EAX
         ret                         ; return
         endproc FPDivZero
 
@@ -95,11 +95,11 @@ include fstatus.inc
 ;       FPOverFlow( void ) : void
 ;
         defpe   FPOverFlow
-        push    eax                 ; save EAX
+        push    ax                  ; save EAX
         call    __set_ERANGE        ; errno = ERANGE
-        mov     eax,FPE_OVERFLOW    ; indicate overflow
+        mov     ax,FPE_OVERFLOW     ; indicate overflow
         call    __FPE_exception_    ;
-        pop     eax                 ; restore EAX
+        pop     ax                  ; restore EAX
         ret                         ; return
         endproc FPOverFlow
 
@@ -107,13 +107,13 @@ include fstatus.inc
 ;       F8UnderFlow( void ) : reallong
 ;
         defp    F8UnderFlow
-        xor     edx,edx             ; return zero
+        xor     dx,dx               ; return zero       FIXME
 ;
 ;       F4UnderFlow( void ) : real
 ;
         defp    F4UnderFlow
         call    FPUnderFlow         ; handle underflow
-        xor     eax,eax             ; return zero
+        xor     ax,ax               ; return zero       FIXME
         ret                         ; return
         endproc F4UnderFlow
         endproc F8UnderFlow
@@ -133,8 +133,8 @@ include fstatus.inc
 ;       F4RetInf( sign : int ) : real
 ;
         defp    F4RetInf
-        and     eax,80000000h       ; get sign
-        or      eax,7F800000h       ; set infinity
+        ;;;;and     ax,80000000h       ; get sign       FIXME
+        ;;;;or      ax,7F800000h       ; set infinity
         ret                         ; return
         endproc F4RetInf
         endproc F4OverFlow
@@ -155,10 +155,10 @@ include fstatus.inc
 ;       F8RetInf( sign : int ) : reallong
 ;
         defp    F8RetInf
-        and     eax,80000000h       ; get sign
-        or      eax,7FF00000h       ; set infinity
-        mov     edx,eax             ;
-        sub     eax,eax             ; ...
+        ;;;;and     ax,80000000h       ; get sign       FIXME
+        ;;;;or      ax,7FF00000h       ; set infinity
+        mov     dx,ax               ;                   FIXME
+        sub     ax,ax               ; ...               FIXME
         ret                         ; return
         endproc F8RetInf
         endproc F8OverFlow

--- a/libc/watcom/asm/fstatus.inc
+++ b/libc/watcom/asm/fstatus.inc
@@ -1,0 +1,47 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
+;*               DESCRIBE IT HERE!
+;*
+;*****************************************************************************
+
+
+FPE_OK                  equ     0
+FPE_INVALID             equ     81h
+FPE_DENORMAL            equ     82h
+FPE_ZERODIVIDE          equ     83h
+FPE_OVERFLOW            equ     84h
+FPE_UNDERFLOW           equ     85h
+FPE_INEXACT             equ     86h
+FPE_UNEMULATED          equ     87h
+FPE_SQRTNEG             equ     88h
+FPE_STACKOVERFLOW       equ     8ah
+FPE_STACKUNDERFLOW      equ     8bh
+FPE_EXPLICITGEN         equ     8ch
+FPE_IOVERFLOW           equ     8dh
+FPE_LOGERR              equ     8eh
+FPE_MODERR              equ     8fh

--- a/libc/watcom/asm/i4fd086.asm
+++ b/libc/watcom/asm/i4fd086.asm
@@ -1,0 +1,158 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
+;*               DESCRIBE IT HERE!
+;*
+;*****************************************************************************
+
+
+; Name:         __I4FD, __U4FD
+; Operation:    __I4FD convert signed 32-bit integer in DX:AX into double float
+;               __U4FD convert unsigned 32-bit integer in DX:AX into double float
+; Inputs:       DX:AX       - 32-bit integer
+; Outputs:      AX BX CX DX - double precision representation of integer
+; Volatile:     none
+;
+;
+include mdef.inc
+include struct.inc
+
+        modstart        i4fd086
+
+        xdefp   __I4FD
+        xdefp   __U4FD
+
+
+        defpe   __I4FD
+        or      DX,DX           ; if number is negative
+        _if     s               ; then
+          not   DX              ; - negate number
+          neg   AX              ; - . . .
+          sbb   DX,-1           ; - . . .
+          mov   CX,0BFF0h+(36*16); - set exponent
+        _else                   ; else
+
+;       convert unsigned 32-bit integer to double
+
+        defpe   __U4FD
+          mov   CX,3FF0h+(36*16); - set exponent
+        _endif                  ; endif
+        sub     BX,BX           ; zero registers
+        or      BX,DX           ; put high order word in BX
+        mov     DX,AX           ; put low order word in DX
+        _if     e               ; if high order word is 0
+          sub   DX,DX           ; - set DX back to 0
+          or    BX,AX           ; - place low order word in BX
+          _if   e               ; - if # is 0
+            sub   CX,CX         ; - - zero rest
+            ret                 ; - - return
+          _endif                ; - endif
+          sub   CX,0100h        ; - adjust exponent by 16
+        _endif                  ; endif
+        xchg    CX,DX           ; DX <- exp, CX <- mantissa
+        sub     AX,AX           ; set rest of mantissa to 0
+        cmp     BH,0            ; if high byte is 0
+        _if     e               ; then
+          mov   AX,BX           ; - shift left by 16
+          mov   BX,CX           ; - ...
+          sub   CX,CX           ; - ...
+          sub   DX,0100h        ; - adjust exponent by 16
+        _else                   ; else
+          mov   AL,BH           ; - shift integer left by 8 bits
+          mov   BH,BL           ; - . . .
+          mov   BL,CH           ; - . . .
+          mov   CH,CL           ; - . . .
+          xor   CL,CL           ; - . . .
+          sub   DX,0080h        ; - exp <-- exp - 8
+        _endif                  ; endif
+
+;       At this point AL will be non-zero, must determine if we have to shift
+;       left or right.
+
+        test    AL,0F0h         ; see if we have to shift forward or backward
+        _if     e               ; if (we haven't shifted msb into bit 53)
+          _guess                ; - guess: have to shift up to 4 bits
+            sub   DX,0010h      ; - - exp <-- exp - 1
+            _shl  CX,1          ; - - shift integer left by 1 bit
+            _rcl  BX,1          ; - - . . .
+            _rcl  AL,1          ; - - . . .
+            test  AL,0F0h       ; - - check to see if done
+            _quif ne            ; - - quit if done
+            sub   DX,0010h      ; - - exp <-- exp - 1
+            _shl  CX,1          ; - - shift integer left by 1 bit
+            _rcl  BX,1          ; - - . . .
+            _rcl  AL,1          ; - - . . .
+            test  AL,0F0h       ; - - check to see if done
+            _quif ne            ; - - quit if done
+            sub   DX,0010h      ; - - exp <-- exp - 1
+            _shl  CX,1          ; - - shift integer left by 1 bit
+            _rcl  BX,1          ; - - . . .
+            _rcl  AL,1          ; - - . . .
+            test  AL,0F0h       ; - - check to see if done
+            _quif ne            ; - - quit if done
+            sub   DX,0010h      ; - - exp <-- exp - 1
+            _shl  CX,1          ; - - shift integer left by 1 bit
+            _rcl  BX,1          ; - - . . .
+            _rcl  AL,1          ; - - . . .
+          _endguess             ; - endguess
+          and   AL,0Fh          ; - clear out implied bit
+          or    AX,DX           ; - put in exponent
+          sub   DX,DX           ; - set low word to 0
+          ret                   ; - return
+        _endif                  ; endif
+
+;       we must shift to the right
+
+          _guess                ; - guess
+            test  AL,0E0h       ; - - see if done
+            _quif e             ; - - quit if we are done
+            add   DX,0010h      ; - - exp <-- exp + 1
+            shr   AX,1          ; - - shift integer right by 1 bit
+            rcr   BX,1          ; - - . . .
+            rcr   CX,1          ; - - . . .
+            test  AL,0E0h       ; - - see if done
+            _quif e             ; - - quit if we are done
+            add   DX,0010h      ; - - exp <-- exp + 1
+            shr   AX,1          ; - - shift integer right by 1 bit
+            rcr   BX,1          ; - - . . .
+            rcr   CX,1          ; - - . . .
+            test  AL,0E0h       ; - - see if done
+            _quif e             ; - - quit if we are done
+            add   DX,0010h      ; - - exp <-- exp + 1
+            shr   AX,1          ; - - shift integer right by 1 bit
+            rcr   BX,1          ; - - . . .
+            rcr   CX,1          ; - - . . .
+          _endguess             ; - endguess
+        and     AL,0Fh          ; clear out implied bit
+        or      AX,DX           ; put in exponent
+        sub     DX,DX           ; set low word to 0
+        ret                     ; return
+        endproc __U4FD
+        endproc __I4FD
+
+        endmod
+        end

--- a/libc/watcom/asm/i4fs086.asm
+++ b/libc/watcom/asm/i4fs086.asm
@@ -1,0 +1,120 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
+;*               DESCRIBE IT HERE!
+;*
+;*****************************************************************************
+
+
+; Name:         I4FS, U4FS
+; Operation:    Convert Integer types to single precision
+; Inputs:       DX;AX, unsigned or signed integer
+; Outputs:      DX;AX single precision floating point (DX exp)
+; Volatile:     none
+;
+include mdef.inc
+include struct.inc
+
+        modstart        i4fs086
+
+        xdefp   __I4FS
+        xdefp   __U4FS
+
+        defpe   __I4FS
+        or      dx,dx           ; check sign
+        jns     __U4FS          ; if positive, just convert
+        not     dx              ; take absolute value of number
+        neg     ax
+        sbb     dx,-1           ; (tricky negation)
+        call    U4FS            ; convert to FS
+        or      dh,080h         ; set sign bit on
+        ret                     ; and return
+        endproc __I4FS
+
+
+        defpe   __U4FS
+        call    U4FS            ; convert integer to float
+        ret                     ; return
+        endproc __U4FS
+
+
+U4FS    proc    near
+        or      dx,dx           ; check if high 16 bits zero
+        jne     int32           ; do extra code if not
+        or      ax,ax           ; if number is 0
+        _if     e               ; then
+          ret                   ; - return
+        _endif                  ; endif
+        mov     dx,7f00h+16*256 ; initialize exponent and dl
+        _loop                   ; loop to normalize 16 bit mantissa
+          dec     dh            ; - decrement exponent
+          _shl    ax,1          ; - shift mantissa
+        _until  c               ; until implied '1' bit shifted out
+        mov     dl,ah           ; high bits of mantissa to dl
+        mov     ah,al           ; low bits to ah
+        xor     al,al           ; zero the rest
+        shr     dx,1            ; move exponent & mantissa over
+        rcr     ax,1            ; ...
+        ret                     ; return
+
+int32:  cmp     dh,0            ; first check if only 24 bits
+        jne     full32          ; must do full 32 bits (could lose bits)
+        mov     dh,7fh+24       ; initial exponent
+        _loop                   ; loop to normalize 24 bit mantissa
+          dec     dh            ; - decrement exponent
+          _shl    ax,1          ; - shift mantissa
+          _rcl    dl,1          ; - ...
+        _until  c               ; until implied '1' bit shifted out
+        shr     dx,1            ; shift exponent & mantissa
+        rcr     ax,1            ; ...
+        ret                     ; and return
+
+                                ; 25 to 32 bit integer
+full32: push    cx              ; save cx
+        mov     cl,7fh+32       ; initial exponent
+        _loop                   ; loop to normalize 32 bit mantissa
+          dec     cl            ; - decrement exponent
+          _shl    ax,1          ; - shift number over
+          _rcl    dx,1          ; - ...
+        _until  c               ; until implied '1' bit shifted out
+        _shl    al,1            ; get next bit into carry
+        mov     al,ah           ; move mantissa over 8 bits
+        mov     ah,dl           ; . . .
+        mov     dl,dh           ; . . .
+        mov     dh,cl           ; get exponent
+
+        adc     ax,0            ; round up if necessary
+        adc     dx,0            ; (increment exponent if necessary)
+
+        shr     dx,1            ; shift exponent & mantissa over
+        rcr     ax,1            ; ...
+        pop     cx              ; restore cx
+        ret                     ; return
+        endproc U4FS
+
+        endmod
+        end

--- a/libc/watcom/asm/i8fd086.asm
+++ b/libc/watcom/asm/i8fd086.asm
@@ -1,0 +1,232 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
+;*               DESCRIBE IT HERE!
+;*
+;*****************************************************************************
+
+
+;
+; __I8FD converts signed 64-bit integer into a double
+; __U8FD converts unsigned 64-bit integer into a double
+;
+; Input:    AX BX CX DX = 64-bit signed/unsigned integer
+; Output:   AX BX CX DX = double
+; Volatile: None
+;
+; 24-jan-2000   SJHowe          initial implementation
+
+include mdef.inc
+include struct.inc
+
+        modstart        i8fd086
+
+        xrefp   __U4FD
+
+        xdefp   __I8FD
+        defp    __I8FD
+        or      ax,ax           ; test top word for being 0, +ve or -ve
+        je      chkuint48       ; 0 => check next word down within __U8FD
+        jg      uint64          ; +ve => convert as unsigned __int64
+                                ; -ve => need to negate before calling __U8FD
+
+                                ; negate 64-bit integer
+
+; rely on the crucial fact that the Intel instruction "not" does not alter
+; any flags. Borrows from previous register needs to propagated in the
+; direction of the most significant word.
+
+        neg     dx              ; negate
+        not     cx              ; :
+        sbb     cx,0FFFFH       ; :
+        not     bx              ; :
+        sbb     bx,0FFFFH       ; :
+        not     ax              ; :
+        sbb     ax,0FFFFH       ; :
+        lcall   __U8FD          ; convert as unsigned 64-bit
+        or      ah,80h          ; set sign bit
+        ret                     ; return
+        endproc __I8FD
+
+; Convert unsigned 64-bit integer to double for x86
+; Input: [AX BX CX DX] = 64-bit integer
+; Output: [AX BX CX DX] = 64-bit double
+
+        xdefp   __U8FD
+        defp    __U8FD
+        or      ax,ax           ; check if 0
+        jne     uint64          ; no, do 64-bit conversion
+chkuint48:
+        or      bx,bx           ; check if 0
+        jne     uint48          ; no, do 48-bit conversion
+
+; high dword is 0, therefore use __U4FD for conversion
+        mov     ax,dx           ; prepare registers for __U4FD
+        mov     dx,cx           ; :
+        jmp     __U4FD          ; call unsigned long => double cast function
+
+; up to 48-bits set, rounding due to 54th bit cannot occur, therefore
+; adjust exponent and do the easy conversion
+uint48:
+        push    si              ; save register
+        mov     si,3FF0h+(36*16); create double's exponent
+        mov     ax,bx           ; shift registers left 16 bits ...
+        mov     bx,cx           ; :
+        mov     cx,dx           ; :
+        sub     dx,dx           ; :
+        jmp     uint64easy      ; ... and continue as uint64 easy case
+
+uint64:
+        push    si              ; save register
+        mov     si,3FF0h+(52*16); create double's exponent
+        test    dx,07FFh        ; see if last bits of mantissa set ?
+        je      uint64easy      ; no, do not worry about 54th bit
+
+; the hard case, have to worry about rounding from 54th bit in mantissa
+
+; a small optimisation, it is only the final right shift where the 54th bit
+; matters, therefore telescope right shifting 1-11 times down to 1-8,1-3
+
+        test    ah,0E0h         ; top 3 bits set?
+        je      uint64hard1     ; no, jump
+        mov     dl,dh           ; move registers right 8 bits ...
+        mov     dh,cl           ; :
+        mov     cl,ch           ; :
+        mov     ch,bl           ; :
+        mov     bl,bh           ; :
+        mov     bh,al           ; :
+        mov     al,ah           ; :
+        sub     ah,ah           ; :
+        add     si,0080h        ; adjust exponent
+        jmp     uintshiftr      ; now shift just these 3 bits
+
+uint64hard1:
+        test    ax,0FFE0h       ; shift bits right ?
+        je      uint64easy      ; no, treat as easy case
+uintshiftr:
+        push    di              ; save register
+uintshiftr1:
+        shr     ax,1            ; shifting right by 1 bit
+        rcr     bx,1            ; :
+        rcr     cx,1            ; :
+        rcr     dx,1            ; :
+        rcr     di,1            ; :
+        add     si,0010h        ; adjust exponent
+        test    ax,0FFE0h       ; implied 1 in place ?
+        jne     uintshiftr1     ; no, loop again
+        and     al,0Fh          ; get rid of implied 1
+        or      ax,si           ; merge in exponent
+        shl     di,1            ; move 54th sig bit into carry
+        adc     dx,0            ; round up as necessary
+        adc     cx,0            ; :
+        adc     bx,0            ; :
+        adc     ax,0            ; :
+        pop     di              ; restore registers
+        pop     si              ; :
+        ret                     ; return
+
+; shift without worry, no rounding problems
+uint64easy:
+        or      ah,ah           ; top word 0 ?
+        _if ne
+           mov  dl,dh           ; move registers right 8 bits ...
+           mov  dh,cl           ; :
+           mov  cl,ch           ; :
+           mov  ch,bl           ; :
+           mov  bl,bh           ; :
+           mov  bh,al           ; :
+           mov  al,ah           ; :
+           sub  ah,ah           ; :
+           add  si,0080h        ; adjust exponent
+        _endif
+
+; at this point, al is non-zero, see if shift right up to 3 times or left up
+; to 4 times, or none. The sequence is borrowed from __U4FD
+
+        test    al,0E0h         ; leading 1 to right of implied 1 ?
+        _if ne                  ; yes, shift right up to 3 times
+          shr   ax,1
+          rcr   bx,1
+          rcr   cx,1
+          rcr   dx,1
+          add   si,0010h        ; exponent++
+          test  al,0E0h         ; leading 1 in implied 1 position ?
+          je    uint64quit      ; must be, quit
+          shr   ax,1
+          rcr   bx,1
+          rcr   cx,1
+          rcr   dx,1
+          add   si,0010h        ; exponent++
+          test  al,0E0h         ; leading 1 in implied 1 position ?
+          je    uint64quit      ; must be, quit
+          shr   ax,1
+          rcr   bx,1
+          rcr   cx,1
+          rcr   dx,1
+          add   si,0010h        ; exponent++
+          jmp   uint64quit      ; leading 1 must be in implied 1 position, quit
+        _else
+          test  al,10h          ; leading 1 in implied 1 position ?
+          jne   uint64quit      ; yes, quit
+          _shl  dx,1            ; shift mantissa left by 1 bit
+          _rcl  cx,1            ; :
+          _rcl  bx,1            ; :
+          _rcl  ax,1            ; :
+          sub   si,0010h        ; exponent--
+          test  al,10h          ; leading 1 in implied 1 position ?
+          jne   uint64quit      ; yes, quit
+          _shl  dx,1            ; shift mantissa left by 1 bit
+          _rcl  cx,1            ; :
+          _rcl  bx,1            ; :
+          _rcl  ax,1            ; :
+          sub   si,0010h        ; exponent--
+          test  al,10h          ; leading 1 in implied 1 position ?
+          jne   uint64quit      ; yes, quit
+          _shl  dx,1            ; shift mantissa left by 1 bit
+          _rcl  cx,1            ; :
+          _rcl  bx,1            ; :
+          _rcl  ax,1            ; :
+          sub   si,0010h        ; exponent--
+          test  al,10h          ; leading 1 in implied 1 position ?
+          jne   uint64quit      ; yes, quit
+          _shl  dx,1            ; shift mantissa left by 1 bit
+          _rcl  cx,1            ; :
+          _rcl  bx,1            ; :
+          _rcl  ax,1            ; :
+          sub   si,0010h        ; exponent--
+        _endif
+
+uint64quit:
+        and     al,0Fh          ; get rid of implied 1
+        or      ax,si           ; merge in exponent
+        pop     si              ; restore register
+        ret                     ; return
+        endproc __U8FD
+
+        endmod
+        end
+

--- a/libc/watcom/asm/i8fs086.asm
+++ b/libc/watcom/asm/i8fs086.asm
@@ -1,0 +1,141 @@
+;*****************************************************************************
+;*
+;*                            Open Watcom Project
+;*
+;*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+;*
+;*  ========================================================================
+;*
+;*    This file contains Original Code and/or Modifications of Original
+;*    Code as defined in and that are subject to the Sybase Open Watcom
+;*    Public License version 1.0 (the 'License'). You may not use this file
+;*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+;*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+;*    provided with the Original Code and Modifications, and is also
+;*    available at www.sybase.com/developer/opensource.
+;*
+;*    The Original Code and all software distributed under the License are
+;*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+;*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+;*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+;*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+;*    NON-INFRINGEMENT. Please see the License for the specific language
+;*    governing rights and limitations under the License.
+;*
+;*  ========================================================================
+;*
+;* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
+;*               DESCRIBE IT HERE!
+;*
+;*****************************************************************************
+
+
+;
+; __I8FD converts signed 64-bit integer into a float
+; __U8FD converts unsigned 64-bit integer into a float
+;
+; Input:    AX BX CX DX = 64-bit signed/unsigned integer
+; Output:   DX AX = float
+; Volatile: None
+;
+; 12-jan-2000   SJHowe          initial implementation
+
+include mdef.inc
+include struct.inc
+
+        modstart        i8fs086
+
+        xrefp   __U4FS
+
+        xdefp   __I8FS
+        defp    __I8FS
+        or      ax,ax           ; test top word for being 0, +ve or -ve
+        je      chkuint48       ; 0 => check next word down within __U8FS
+        jg      uint64          ; +ve => convert as unsigned __int64
+                                ; -ve => need to negate before calling __U8FS
+
+                                ; negate 64-bit integer
+
+; rely on the crucial fact that the Intel instruction "not" does not alter
+; any flags. Borrows from previous register needs to propagated in the
+; direction of the most significant word.
+
+        neg     dx              ; negate
+        not     cx              ; :
+        sbb     cx,0FFFFH       ; :
+        not     bx              ; :
+        sbb     bx,0FFFFH       ; :
+        not     ax              ; :
+        sbb     ax,0FFFFH       ; :
+        lcall   __U8FS          ; convert as unsigned 64-bit
+        or      dh,80h          ; set sign bit
+        ret                     ; return
+        endproc __I8FS
+
+; Convert unsigned 64-bit integer to single precision float
+; Input: [AX BX CX DX] = 64-bit integer
+; Output: [DX AX] = 32-bit float
+
+        xdefp   __U8FS
+        defp    __U8FS
+        or      ax,ax           ; check if 0
+        jne     uint64          ; no, do 64-bit conversion
+chkuint48:
+        or      bx,bx           ; check if 0
+        jne     uint48          ; no, do 48-bit conversion
+
+; do a 32-bit unsigned conversion, use __U4FS
+        mov     ax,dx           ; prepare registers for __U4FS
+        mov     dx,cx           ; :
+        jmp     __U4FS          ; call unsigned long => float cast function
+
+; up to 48-bits set
+uint48:
+        mov     ax,bx           ; shift registers left 16 bits ...
+        mov     bx,cx           ; :
+        mov     ch,dh           ; :
+        mov     dx,7F00h+(32*128); create float's exponent
+        jmp     uint641         ; ... and continue as uint64 easy case
+
+uint64:
+        mov     dx,7F00h+(32*128); create float's exponent
+
+
+; at this point
+; dx holds exponent
+; ax holds most significant bits (could be just 1)
+; bx holds next significant bits (16)
+; ch holds next significant bits (could be 8)
+
+uint641:
+        test    ah,ah           ; any bits set ?
+        je      uint642         ; no, jump
+        mov     ch,bl           ; :
+        mov     bl,bh           ; :
+        mov     bh,al           ; :
+        mov     al,ah           ; :
+        add     dh,40h          ; adjust exponent
+        jmp     uint642
+
+uint64loop:
+        add     ch,ch           ; shift mantisa
+        adc     bx,bx           ; :
+        adc     al,al           ; :
+        sub     dx,80h          ; correct exponent
+uint642:
+        test    al,80H          ; implied 1 seen ?
+        jne     uint64loop      ; no loop again
+
+        and     al,7Fh          ; get rid of implied 1...
+        or      dl,al           ; ...and move mantissa into correct place
+
+; use 25th bit of mantissa to round
+        add     ch,ch           ; move 25th bit into carry
+        adc     bx,0            ; round
+        adc     dx,0            ; :
+        mov     ax,bx           ; move mantissa lo word into correct place
+        ret                     ; return
+        endproc __U8FS
+
+        endmod
+        end

--- a/libc/watcom/syscall/crt0.c
+++ b/libc/watcom/syscall/crt0.c
@@ -47,6 +47,11 @@ char **environ;
 unsigned int __stacklow;        /* lowest protected SP value */
 unsigned char _HShift = 12;     /* huge pointer support required by pia.asm */
 
+/* floating point globals */
+char _8087;
+char _real87;
+char _chipbug;
+
 #if defined(__SMALL__) || defined(__MEDIUM__)   /* near data models */
 /* no argv/environ rewrite */
 static noreturn void premain(void)

--- a/libc/watcom/syscall/fpexcept.c
+++ b/libc/watcom/syscall/fpexcept.c
@@ -1,0 +1,19 @@
+/* Various routines called from OWC soft float library */
+#include <assert.h>
+#include <errno.h>
+
+/*
+    __FPE_exception is called from machine language with parm in AX
+    (see "fstatus" module in CGSUPP)
+*/
+void __FPE_exception( int fpe_type )
+{
+    //_RWD_FPE_handler( fpe_type );
+    assert(0);      /* FIXME abort for now */
+}
+
+void __set_ERANGE( void )
+{
+    errno = ERANGE;
+}
+


### PR DESCRIPTION
Adds initial support for software (emulated) floating point to ELKS programs compiled with OpenWatcom C.

Discussed in https://github.com/ghaerr/elks/issues/2239#issuecomment-2683612940.

By default, inline 8087 support is turned off, and `ewcc` uses the `-msoft-float` option (-Wc,-fpc) to produce calls to software floating point routines contained in the C library for `float` and `double` precision floating point.

In order to turn on %f, %e and %g printf output, the following must be included in the application source in a function somewhere, or the dtostr() double-to-string formatting routines will not be linked in, and nothing will be output. Due to technical issues with weak symbols, only medium and large models are currently supported:
```
#include <sys/linksym.h>
#include <stdio.h>
int main(int ac, char **av)
{
    __STDIO_PRINT_FLOATS;  /* link in libc floating point printf support */
    ...
}
```
The above code is not necessary if floating point numbers do not need to be displayed using printf.

There is currently no math library for OWC. OWC documentation states that software emulated floating point is not IEEE 754 compliant; it is unknown exactly what that means.

This is a feature preview, it is *not recommended* to start using floating point in your own programs without special testing. This PR has been tested with ELKS basic, which seems to work, although still no math library. Producing a math library may not be easily possible, depending on learning more about non-IEEE support for emulated floating point, and/or porting the OWC math library vs the ELKS math library.

Programmers should remove any inline hardware 8087 code generation options (e.g. -Wc,-fpi or -Wc,-fpi87) and use `ewcc` or add `-msoft-float` to their OWCC command line.

Support for FP overflow and underflow is non-existent, and may produce entirely incorrect results and/or abort program execution. Fix coming.

The OWC floating point emulation library has some 8087 and 80386 code in it that had to be included - it is not known whether or how well OWC programs will run on older 8086 hardware - this still needs testing. In the future, a `basic.os2` built with OWC will be supplied for testing on 8086 hardware.

