### PR TITLE
[owc libc] Fix soft float emulation underflow/overflow

### DIFF
--- a/elks/tools/objtools/ewcc
+++ b/elks/tools/objtools/ewcc
@@ -40,9 +40,9 @@ ELKSINCLUDE2=$TOPDIR/libc/include/watcom
 # unused:
 # -fno-stack-check          # don't generate stack check code
 # -ztNum                    # specify far data threshold (default 32767, or 256 if no Num)
-# -Wc,-fpi87                # inline 8087 fp
+# -Wc,-fpi87                # generate inline 8087 hardware fp
 # -mhard-emu-float          # -Wc,-fpi (inline 8087 w/emulation)
-# -msoft-float              # -Wc,-fpc (software fp)
+# -msoft-float              # -Wc,-fpc (non-IEEE software fp)
 # -fpmath
 # -mabi=cdecl               # push all args
 # -fnonconst-initializers   # -Wc,aa

--- a/libc/watcom.inc
+++ b/libc/watcom.inc
@@ -25,7 +25,7 @@ CARCH =\
     -march=i86                      \
     -std=c99                        \
     -fno-stack-check                \
-    -Wc,-fpc                        \
+    -msoft-float                    \
     -Wc,-zev                        \
     -Wc,-zls                        \
     -Wc,-x                          \

--- a/libc/watcom/asm/fstat386.asm
+++ b/libc/watcom/asm/fstat386.asm
@@ -25,7 +25,9 @@
 ;*  ========================================================================
 ;*
 ;* Description:  Floating-point exception signaling
-;* Modified by ghaerr for 8086 CPU
+;* Modified by ghaerr for 8086 CPU (16-bits)
+;*  32-bit "float"  type stored in DX:AX
+;*  64-bit "double" type stored in AX:BX:CX:DX
 ;*****************************************************************************
 
 
@@ -107,13 +109,15 @@ include fstatus.inc
 ;       F8UnderFlow( void ) : reallong
 ;
         defp    F8UnderFlow
-        xor     dx,dx               ; return zero       FIXME
+        xor     bx,bx               ; return zero
+        xor     cx,cx
 ;
 ;       F4UnderFlow( void ) : real
 ;
         defp    F4UnderFlow
         call    FPUnderFlow         ; handle underflow
-        xor     ax,ax               ; return zero       FIXME
+        xor     dx,dx               ; return zero
+        xor     ax,ax
         ret                         ; return
         endproc F4UnderFlow
         endproc F8UnderFlow
@@ -133,8 +137,9 @@ include fstatus.inc
 ;       F4RetInf( sign : int ) : real
 ;
         defp    F4RetInf
-        ;;;;and     ax,80000000h       ; get sign       FIXME
-        ;;;;or      ax,7F800000h       ; set infinity
+        and     dx,8000h            ; get sign
+        or      dx,7F80h            ; set infinity
+        xor     ax,ax
         ret                         ; return
         endproc F4RetInf
         endproc F4OverFlow
@@ -155,10 +160,11 @@ include fstatus.inc
 ;       F8RetInf( sign : int ) : reallong
 ;
         defp    F8RetInf
-        ;;;;and     ax,80000000h       ; get sign       FIXME
-        ;;;;or      ax,7FF00000h       ; set infinity
-        mov     dx,ax               ;                   FIXME
-        sub     ax,ax               ; ...               FIXME
+        and     ax,8000h            ; get sign
+        or      ax,7FF0h            ; set infinity
+        xor     bx,bx
+        xor     cx,cx
+        xor     dx,dx
         ret                         ; return
         endproc F8RetInf
         endproc F8OverFlow

--- a/libc/watcom/syscall/crt0.c
+++ b/libc/watcom/syscall/crt0.c
@@ -47,11 +47,6 @@ char **environ;
 unsigned int __stacklow;        /* lowest protected SP value */
 unsigned char _HShift = 12;     /* huge pointer support required by pia.asm */
 
-/* floating point globals */
-char _8087;
-char _real87;
-char _chipbug;
-
 #if defined(__SMALL__) || defined(__MEDIUM__)   /* near data models */
 /* no argv/environ rewrite */
 static noreturn void premain(void)

--- a/libc/watcom/syscall/fpexcept.c
+++ b/libc/watcom/syscall/fpexcept.c
@@ -1,6 +1,11 @@
-/* Various routines called from OWC soft float library */
+/* Various routines or globals called/referenced from OWC soft float library */
 #include <assert.h>
 #include <errno.h>
+
+/* floating point globals - FIXME should initialize at startup? */
+char _8087;
+char _real87;
+char _chipbug;
 
 /*
     __FPE_exception is called from machine language with parm in AX


### PR DESCRIPTION
OWC soft float should now return +/- infinity properly, but in most cases program abort is performed, since ELKS doesn't have SIGFPE.

Standardizes soft float options in ewcc and watcom.inc.

Moves soft FP global to syscalls/fpexcept.c.