### PR TITLE
[owc libc] Make signed char default for OpenWatcom C

### DIFF
--- a/elks/tools/objtools/ewcc
+++ b/elks/tools/objtools/ewcc
@@ -31,6 +31,8 @@ ELKSINCLUDE2=$TOPDIR/libc/include/watcom
 # -mcmodel={s,m,c,l}        # memory model
 # -march=i86                # 8086 codegen
 # -std=c99                  # -Wc,-za99
+# -fsigned-char             # -Wc,-j plain char is signed (as gcc)
+# -msoft-float              # -Wc,-fpc (non-IEEE software fp)
 # -Wc,-zev                  # enable void arithmetic
 # -Wc,-zls                  # remove automatically inserted symbols
 # -Wc,-wcd=N                # disable warning N
@@ -42,11 +44,9 @@ ELKSINCLUDE2=$TOPDIR/libc/include/watcom
 # -ztNum                    # specify far data threshold (default 32767, or 256 if no Num)
 # -Wc,-fpi87                # generate inline 8087 hardware fp
 # -mhard-emu-float          # -Wc,-fpi (inline 8087 w/emulation)
-# -msoft-float              # -Wc,-fpc (non-IEEE software fp)
-# -fpmath
+# -fpmath=87                # produce code for 8087 FPU
 # -mabi=cdecl               # push all args
 # -fnonconst-initializers   # -Wc,aa
-# -fsigned-char             # plain char is signed (as gcc)
 
 source $TOPDIR/libc/watcom.model
 
@@ -56,6 +56,7 @@ CCFLAGS="\
     -march=i86                      \
     -Os                             \
     -std=c99                        \
+    -fsigned-char                   \
     -msoft-float                    \
     -Wc,-zev                        \
     -Wc,-zls                        \

--- a/libc/watcom.inc
+++ b/libc/watcom.inc
@@ -24,8 +24,9 @@ CARCH =\
     -mcmodel=$(MODEL)               \
     -march=i86                      \
     -std=c99                        \
-    -fno-stack-check                \
+    -fsigned-char                   \
     -msoft-float                    \
+    -fno-stack-check                \
     -Wc,-zev                        \
     -Wc,-zls                        \
     -Wc,-x                          \


### PR DESCRIPTION
From suggestion by @jmalak in #1942.

Plain `char` type is now default to `signed` rather than `unsigned` for the C library and all programs compiled with `ewcc`. This should be the default for all programs compiled for ELKS, including programs compiled outside of the ELKS repo.

This is being done so that the C library and other code is also compatible with ia16-elf-gcc, which treats plain `char` as signed.

@rafael2k, you should probably add `-fsigned-char` to the make instructions for your projects (as well as `-msoft-float` for those programs with any floating point if you haven't already). I'll be making the change to 8086-toolchain shortly.