### PR TITLE
[cmds] Fix mouse release bug in paint event code

### DIFF
--- a/elkscmd/gui/cursor.c
+++ b/elkscmd/gui/cursor.c
@@ -55,61 +55,54 @@ static MWPIXELVALHW cursavbits[MWMAX_CURSOR_SIZE * MWMAX_CURSOR_SIZE];
 static MWIMAGEBITS cursormask[MWMAX_CURSOR_BUFLEN];
 static MWIMAGEBITS cursorcolor[MWMAX_CURSOR_BUFLEN];
 
+/* Small 8x8 cursor for machines to slow for 16x16 cursors */
+static MWIMAGEBITS smcursormask[8] = {
+    MASK(X,X,X,X,X,X,_),
+    MASK(X,X,X,X,X,_,_),
+    MASK(X,X,X,X,_,_,_),
+    MASK(X,X,X,X,X,_,_),
+    MASK(X,X,X,X,X,X,_),
+    MASK(X,_,_,X,X,X,X),
+    MASK(_,_,_,_,X,X,X)
+};
+static MWIMAGEBITS smcursorbits[8] = {
+    MASK(_,_,_,_,_,_,_),
+    MASK(_,X,X,X,X,_,_),
+    MASK(_,X,X,X,_,_,_),
+    MASK(_,X,X,X,_,_,_),
+    MASK(_,X,_,X,X,_,_),
+    MASK(_,_,_,_,X,X,_),
+    MASK(_,_,_,_,_,X,X)
+};
+struct cursor cursor_sm = {
+    8, 8, 1, 1, WHITE, BLACK, smcursorbits, smcursormask
+};
+
+/* Full size 16x16 cursor */
+static MWIMAGEBITS lgcursorbits[16] = {
+    0xe000, 0x9800, 0x8600, 0x4180,
+    0x4060, 0x2018, 0x2004, 0x107c,
+    0x1020, 0x0910, 0x0988, 0x0544,
+    0x0522, 0x0211, 0x000a, 0x0004
+};
+static MWIMAGEBITS lgcursormask[16] = {
+    0xe000, 0xf800, 0xfe00, 0x7f80,
+    0x7fe0, 0x3ff8, 0x3ffc, 0x1ffc,
+    0x1fe0, 0x0ff0, 0x0ff8, 0x077c,
+    0x073e, 0x021f, 0x000e, 0x0004
+};
+struct cursor cursor_lg = {
+    16, 16, 0, 0, WHITE, BLACK, lgcursorbits, lgcursormask
+};
+
 void initcursor(void)
 {
-#if USE_SMALL_CURSOR
-/* Small 8x8 cursor for machines to slow for 16x16 cursors */
-    static MWIMAGEBITS cursormask[8];
-    static MWIMAGEBITS cursorbits[8];
-#define HOTX    1
-#define HOTY    1
-#define CURSW   8
-#define CURSH   8
-    cursormask[0] = MASK(X,X,X,X,X,X,_);
-    cursormask[1] = MASK(X,X,X,X,X,_,_);
-    cursormask[2] = MASK(X,X,X,X,_,_,_);
-    cursormask[3] = MASK(X,X,X,X,X,_,_);
-    cursormask[4] = MASK(X,X,X,X,X,X,_);
-    cursormask[5] = MASK(X,_,_,X,X,X,X);
-    cursormask[6] = MASK(_,_,_,_,X,X,X);
-
-    cursorbits[0] = MASK(_,_,_,_,_,_,_);
-    cursorbits[1] = MASK(_,X,X,X,X,_,_);
-    cursorbits[2] = MASK(_,X,X,X,_,_,_);
-    cursorbits[3] = MASK(_,X,X,X,_,_,_);
-    cursorbits[4] = MASK(_,X,_,X,X,_,_);
-    cursorbits[5] = MASK(_,_,_,_,X,X,_);
-    cursorbits[6] = MASK(_,_,_,_,_,X,X);
-
-#else
-
-#define HOTX    0
-#define HOTY    0
-#define CURSW   16
-#define CURSH   16
-    static MWIMAGEBITS cursorbits[16] = {
-          0xe000, 0x9800, 0x8600, 0x4180,
-          0x4060, 0x2018, 0x2004, 0x107c,
-          0x1020, 0x0910, 0x0988, 0x0544,
-          0x0522, 0x0211, 0x000a, 0x0004
-    };
-    static MWIMAGEBITS cursormask[16] = {
-          0xe000, 0xf800, 0xfe00, 0x7f80,
-          0x7fe0, 0x3ff8, 0x3ffc, 0x1ffc,
-          0x1fe0, 0x0ff0, 0x0ff8, 0x077c,
-          0x073e, 0x021f, 0x000e, 0x0004
-    };
-#endif
-    static struct cursor cursor = {
-        CURSW, CURSH, HOTX, HOTY, WHITE, BLACK, cursorbits, cursormask
-    };
-
     /* init cursor position and size*/
     curvisible = 0;
     curneedsrestore = FALSE;
     curminx = 0;
     curminy = 0;
-    setcursor(&cursor);
+    setcursor(&cursor_lg);
     movecursor(posx, posy);
     showcursor();
 }

--- a/elkscmd/gui/event.h
+++ b/elkscmd/gui/event.h
@@ -23,18 +23,22 @@
 struct event {
     int     type;           /* event type */
     int     keychar;        /* keyboard character on EVT_KEYBOARD */
-    int     button;         /* mouse BUTTON_xxx on EVT_MOUSE* events */
-    int     x;              /* mouse or wheel location on EVT_MOUSE* ior EVT_WHEEL* */
+    int     button;         /* mouse BUTTON_L/BUTTON_R on EVT_MOUSE* events */
+    int     x;              /* mouse position on all events */
     int     y;
-    int     xrel;           /* relative location on EVT_WHEEL* events */
+    int     xrel;           /* relative location on EVT_MOUSEMOVE events */
     int     yrel;
+    int     w;              /* wheel movement on EVT_WHEEL* events */
 };
 
 /* event handling */
 int event_open(void);
 void event_close(void);
 
-/* wait/poll on event, timeout in msecs or = -1 blocking */
+/* wait/poll on event, timeout in msecs or EV_BLOCK/EV_POLL */
+#define EV_BLOCK    (-1)
+#define EV_POLL     0
+
 int event_wait_timeout(struct event *e, int timeout);   /* returns 0 on EVT_QUIT */
 int event_poll(struct event *event);                    /* polls if event == NULL */
 

--- a/elkscmd/gui/input.c
+++ b/elkscmd/gui/input.c
@@ -6,6 +6,8 @@
 #include "graphics.h"
 #include "mouse.h"
 
+static int cursor_sz;
+
 // -------------------------------
 // Handles SDL Events and input
 // -------------------------------
@@ -13,7 +15,7 @@ void I_HandleInput(void)
 {
     struct event event;
 
-    if (event_poll(&event))
+    if (event_wait_timeout(&event, EV_BLOCK))
     {
         switch (event.type)
         {
@@ -49,7 +51,21 @@ void I_HandleInput(void)
                 switch (event.keychar)
                 {
                     case 'c':
+                        hidecursor();
                         R_ClearCanvas();
+                        showcursor();
+                    break;
+
+                    case 'e':
+                        G_SaveButtonOnClick(NULL);
+                    break;
+
+                    case 'f':
+                        floodFillCalled = true;
+                    break;
+
+                    case 'm':
+                        setcursor((++cursor_sz & 1)? &cursor_sm: &cursor_lg);
                     break;
 
                     case 'q':
@@ -94,14 +110,6 @@ void I_HandleInput(void)
 
                     case '0':
                         bushSize = 10;
-                    break;
-
-                    case 'e':
-                        G_SaveButtonOnClick(NULL);
-                    break;
-
-                    case 'f':
-                        floodFillCalled = true;
                     break;
                 }
             break;

--- a/elkscmd/gui/mouse.c
+++ b/elkscmd/gui/mouse.c
@@ -23,7 +23,6 @@
 #define MOUSE_MICROSOFT     1       /* microsoft mouse*/
 #define MOUSE_PC            0       /* pc/logitech mouse*/
 #define MOUSE_PS2           0       /* PS/2 mouse */
-#define MAX_BYTES   128             /* number of bytes for buffer*/
 
 /* states for the mouse*/
 #define IDLE            0       /* start of byte sequence */
@@ -64,15 +63,20 @@ static int      right;      /* redefined */
 
 static unsigned char    *bp;/* buffer pointer */
 static int      nbytes;     /* number of bytes left */
-static unsigned char    buffer[MAX_BYTES];  /* data bytes read */
 static int      (*parse)(); /* parse routine */
 
-/* local routines*/
+/*
+ * NOTE: MAX_BYTES can't be larger than 1 mouse read packet or select() can fail,
+ * as mouse driver would be storing unprocessed data not seen by select.
+ */
 #if MOUSE_PC
 static int      parsePC(int);       /* routine to interpret PC mouse */
+#define MAX_BYTES   5               /* max read() w/o storing excess mouse data */
 #endif
+
 #if MOUSE_MICROSOFT
 static int      parseMS(int);       /* routine to interpret MS mouse */
+#define MAX_BYTES   3               /* max read() w/o storing excess mouse data */
 #endif
 
 /*
@@ -225,6 +229,7 @@ int read_mouse(int *dx, int *dy, int *dw, int *bp)
 int read_mouse(int *dx, int *dy, int *dz, int *bptr)
 {
     int b;
+    static unsigned char buffer[MAX_BYTES];
 
     /*
      * If there are no more bytes left, then read some more,

--- a/elkscmd/gui/mouse.h
+++ b/elkscmd/gui/mouse.h
@@ -39,4 +39,6 @@ void fixcursor(void);
         (((((((((((((a * 2) + b) * 2) + c) * 2) + d) * 2) \
         + e) * 2) + f) * 2) + g) << 9)
 
+extern struct cursor cursor_lg;
+extern struct cursor cursor_sm;
 #endif


### PR DESCRIPTION
Fixes occasional problem where mouse button up processing was delayed until after next mouse movement in portable event code used in `paint`. 

Also adds 'm' command to `paint` to switch between 16x16 and 8x8 mouse cursor for slow systems. Discussed with @toncho11 in https://github.com/ghaerr/elks/pull/2259#issuecomment-2727669559.

`paint` main loop moved from polling to hanging on select for all events, thus reducing CPU load for any other applications running.

Event code cleaned up and mouse position returned in all events. This code will be ported back to 8086-toolchain/examples in the future.