### PR TITLE
[cmds] Add paintbucket fill to C86 paint

### DIFF
--- a/elkscmd/gui/app.c
+++ b/elkscmd/gui/app.c
@@ -236,7 +236,6 @@ void A_GameLoop(void)
         {
             R_Paint(omx, omy, mx, my);
         }
-#ifndef __C86__
         if(floodFillCalled == true)
         {
             floodFillCalled = false;
@@ -244,7 +243,6 @@ void A_GameLoop(void)
             R_LineFloodFill(omx, omy, currentMainColor, readpixel(mx, my));
             showcursor();
         }
-#endif
     }
     else // In toolbar
     {

--- a/elkscmd/gui/render.c
+++ b/elkscmd/gui/render.c
@@ -236,8 +236,8 @@ void R_LineFloodFill(int x, int y, int color, int ogColor)
         // Find leftest
         while(leftestX >= 0 && readpixel(leftestX, curElement.y) == ogColor) 
             leftestX--;
-
         leftestX++;
+
         alreadyCheckedAbove = false;
         alreadyCheckedBelow = false;
 

--- a/elkscmd/gui/render.c
+++ b/elkscmd/gui/render.c
@@ -205,7 +205,6 @@ static transform2d_t FF_StackPop(transform2d_t stack[], int* top)
     return stack[(*top)--];
 }
 
-#ifndef __C86__     /* FIXME C86 */
 // ----------------------------------------------------
 // Line Flood Fill, for the bucket tool
 // ----------------------------------------------------
@@ -225,16 +224,20 @@ void R_LineFloodFill(int x, int y, int color, int ogColor)
     while(stackTop >= 0)    // While there are elements
     {
         // Take the first one
+#ifdef __C86__     /* FIXME C86 compiler bug calling FF_StackPop*/
+        curElement = stack[stackTop];
+        stackTop--;
+#else
         curElement = FF_StackPop(stack, &stackTop);
-
+#endif
         mRight = false;
         int leftestX = curElement.x;
 
         // Find leftest
         while(leftestX >= 0 && readpixel(leftestX, curElement.y) == ogColor) 
             leftestX--;
-        leftestX++;
 
+        leftestX++;
         alreadyCheckedAbove = false;
         alreadyCheckedBelow = false;
 
@@ -288,7 +291,6 @@ void R_LineFloodFill(int x, int y, int color, int ogColor)
         }
     }
 }
-#endif
 
 #if UNUSED
 // ----------------------------------------------------


### PR DESCRIPTION
Adds flood color fill to C86 `paint`, which is already present in OWC and GCC versions.

The C86 compiler crash has been isolated to a source statement calling a function that passes a value by reference and returns a value:
```
x = FF_StackPush(stack, x, y, &stackTop);
```
to be investigated separately.