### PR TITLE
[net] Fix network hang in bind() when only single TCP socket open

### DIFF
--- a/elkscmd/ktcp/tcp_cb.c
+++ b/elkscmd/ktcp/tcp_cb.c
@@ -84,8 +84,12 @@ struct tcpcb_list_s *tcpcb_new(int bufsize)
 	n->prev = NULL;
 	tcpcbs->prev = n;
 	tcpcbs = n;
-    } else
+    } else {
 	tcpcbs = n;
+	n->next = NULL;
+	n->prev = NULL;
+	tcpcbs = n;
+    }
     tcpcb_num++;	/* for netstat*/
 
     return n;


### PR DESCRIPTION
Fixes #2266. Looks like this was in ktcp for a very long time.