### PR TITLE
[cmds] Speed up Paint code drawing on slow 8088 systems

### DIFF
--- a/elkscmd/gui/Makefile
+++ b/elkscmd/gui/Makefile
@@ -7,7 +7,7 @@ ALL += owc
 endif
 
 ifdef C86
-ALL += c86
+#ALL += c86
 endif
 
 all: $(ALL)

--- a/elkscmd/gui/Makefile.gcc
+++ b/elkscmd/gui/Makefile.gcc
@@ -26,11 +26,15 @@ BINDIR = .
 LOCALFLAGS =
 PROG = $(BINDIR)/paint
 SRCS = app.c gui.c input.c render.c event.c mouse.c graphics.c drawbmp.c cursor.c
+OBJS += vga-ia16.oaj
 
 all: $(PROG)
 
 $(PROG): $(OBJS)
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+
+vga-ia16.oaj: vga-ia16.o
+	mv vga-ia16.o vga-ia16.oaj
 
 clean:
 	rm -f $(PROG) *.oaj

--- a/elkscmd/gui/app.c
+++ b/elkscmd/gui/app.c
@@ -7,8 +7,6 @@
 #include "graphics.h"
 #include "mouse.h"
 
-#define LIBPATH     "/lib/"     // path to images
-
 // --------------------------------------------
 // Definition of Globals
 // --------------------------------------------

--- a/elkscmd/gui/app.h
+++ b/elkscmd/gui/app.h
@@ -7,6 +7,8 @@
 
 #define PALETTE_WIDTH 148
 
+#define LIBPATH     "/lib/"     // path to images
+
 // Boolean Data Type
 typedef enum boolean_e
 {

--- a/elkscmd/gui/event.c
+++ b/elkscmd/gui/event.c
@@ -34,11 +34,11 @@ int event_wait_timeout(struct event *e, int timeout)
     fd_set fdset;
     struct timeval timeint, *tv;
 
-    if (timeout == -1)
+    if (timeout == EV_BLOCK)
         tv = NULL;
-    else {
-        timeint.tv_sec = timeout / 1000;
-        timeint.tv_usec = (timeout % 1000) << 10;   /* approximation for C86 */
+    else {                          /* approximation for speed for C86 and 8088 */
+        timeint.tv_sec = timeout >> 10;
+        timeint.tv_usec = (timeout & 0x3FF) << 10;
         tv = &timeint;
     }
     FD_ZERO(&fdset);

--- a/elkscmd/gui/graphics.h
+++ b/elkscmd/gui/graphics.h
@@ -13,11 +13,19 @@ extern int VGA;                         /* VGA vs PAL mode */
 /* start/stop graphics mode */
 int graphics_open(int mode);
 void graphics_close(void);
-void drawpixel(int x,int y, int color);
 void fill_rect(int x1, int y1, int x2, int y2, int c);
-int readpixel(int x, int y);
 int draw_bmp(char *path, int x, int y);
 int save_bmp(char *pathname);
+
+#ifdef __ia16__                 /* ASM routines in vga-ia16.S */
+#define drawpixel(x,y,c)        vga_drawpixel(x,y,c)
+#define drawhline(x1,x2,y,c)    vga_drawhline(x1,x2,y,c)
+#define readpixel(x,y)          vga_readpixel(x,y)
+#else
+void drawpixel(int x,int y, int color);
+void drawhline(int x1, int x2, int y, int c);
+int readpixel(int x, int y);
+#endif
 
 /* VGA 16 color, 4bpp routines */
 void vga_init(void);

--- a/elkscmd/gui/render.c
+++ b/elkscmd/gui/render.c
@@ -20,9 +20,14 @@ void R_DrawFullColumn(int x, int color)
 // ----------------------------------------------------
 void R_ClearCanvas(void)
 {
+#ifdef __ia16__
+    for(int y = 0; y < SCREEN_HEIGHT; y++)
+        drawhline(0, SCREEN_WIDTH-1, y, BLACK);
+#else
     for(int y = 0; y < SCREEN_HEIGHT; y++)
       for(int x = 0; x < SCREEN_WIDTH; x++)
         drawpixel(x, y, BLACK);
+#endif
 }
 
 
@@ -35,16 +40,19 @@ void R_DrawPalette()
     R_DrawFullColumn(SCREEN_WIDTH+1, WHITE);
     int paletteX = SCREEN_WIDTH+2;
 
+#ifdef __ia16__
+    for (int y=0; y<SCREEN_HEIGHT; y++)
+        drawhline(paletteX, SCREEN_WIDTH + PALETTE_WIDTH - 1, y, GRAY);
+#else
     while(paletteX < SCREEN_WIDTH + PALETTE_WIDTH)
         R_DrawFullColumn(paletteX++, GRAY);
-
+#endif
     R_DrawAllButtons();
 
     // Draw Logo if VGA 640x480
     if(SCREEN_HEIGHT==480)
     {
-        char* fileName = "/lib/paint.bmp";
-        draw_bmp(fileName, SCREEN_WIDTH + 10, 350);
+        //draw_bmp(LIBPATH "paint.bmp", SCREEN_WIDTH + 10, 350);
     }
 
     R_UpdateColorPicker();
@@ -161,7 +169,7 @@ void R_DrawCurrentColor(void)
 void R_Paint(int x1, int y1, int x2, int y2) {
     // Draw initial point
     if (bushSize <= 1) {
-        if (x1 >= 0 && x1 < SCREEN_WIDTH && y1 >= 0 && y1 < SCREEN_HEIGHT) {
+        if (x1 < SCREEN_WIDTH && y1 < SCREEN_HEIGHT) {
             drawpixel(x1, y1, drawing ? currentMainColor : currentAltColor);
         }
     } else {
@@ -177,7 +185,7 @@ void R_Paint(int x1, int y1, int x2, int y2) {
 
     while (x1 != x2 || y1 != y2) {
         if (bushSize <= 1) {
-            if (x1 >= 0 && x1 < SCREEN_WIDTH && y1 >= 0 && y1 < SCREEN_HEIGHT) {
+            if (x1 < SCREEN_WIDTH && y1 < SCREEN_HEIGHT) {
                 drawpixel(x1, y1, drawing ? currentMainColor : currentAltColor);
             }
         } else {
@@ -202,17 +210,14 @@ void R_Paint(int x1, int y1, int x2, int y2) {
 // ----------------------------------------------------
 void R_DrawCircle(int x0, int y0, int r)
 {
-    if(r > 1)
-    {
+    if(r > 1) {
         for(int y=-r; y<=r; y++)
             for(int x=-r; x<=r; x++)
                 if((2*x+1)*(2*x+1) + (2*y+1)*(2*y+1) <= 4*r*r)
                     if(x0+x >= 0 && x0+x < SCREEN_WIDTH && y0+y >= 0 && y0+y < SCREEN_HEIGHT)
                         drawpixel(x0+x, y0+y, drawing ? currentMainColor : currentAltColor);
-    }
-    else
-    {
-        if(x0 >= 0 && x0 < SCREEN_WIDTH && y0 >= 0 && y0 < SCREEN_HEIGHT)
+    } else {
+        if(x0 < SCREEN_WIDTH && y0 < SCREEN_HEIGHT)
             drawpixel(x0, y0, drawing ? currentMainColor : currentAltColor);
     }
 

--- a/elkscmd/gui/render.c
+++ b/elkscmd/gui/render.c
@@ -41,21 +41,19 @@ void R_DrawPalette()
     int paletteX = SCREEN_WIDTH+2;
 
 #ifdef __ia16__
-    for (int y=0; y<SCREEN_HEIGHT; y++)
+    for(int y=0; y<SCREEN_HEIGHT; y++)
         drawhline(paletteX, SCREEN_WIDTH + PALETTE_WIDTH - 1, y, GRAY);
 #else
     while(paletteX < SCREEN_WIDTH + PALETTE_WIDTH)
         R_DrawFullColumn(paletteX++, GRAY);
 #endif
+    R_UpdateColorPicker();
+
     R_DrawAllButtons();
 
     // Draw Logo if VGA 640x480
-    if(SCREEN_HEIGHT==480)
-    {
-        //draw_bmp(LIBPATH "paint.bmp", SCREEN_WIDTH + 10, 350);
-    }
-
-    R_UpdateColorPicker();
+    if(SCREEN_HEIGHT == 480)
+        draw_bmp(LIBPATH "paint.bmp", SCREEN_WIDTH + 10, 350);
 }
 
 // ----------------------------------------------------

--- a/elkscmd/gui/vga-4bpp.s
+++ b/elkscmd/gui/vga-4bpp.s
@@ -108,7 +108,7 @@ _vga_drawpixel:
 ;   char far *dst = SCREENBASE + x1 / 8 + y * BYTESPERLN;
 ;   select_mask();
 ;   if (x1 / 8 == x2 / 8) {
-;       set_mask((0xff >> (x1 & 7)) & (0xff << (7 - x2 & 7)));
+;       set_mask((0xff >> (x1 & 7)) & (0xff << (7 - (x2 & 7))));
 ;       *dst |= 1;
 ;   } else {
 ;       set_mask(0xff >> (x1 & 7));
@@ -116,7 +116,7 @@ _vga_drawpixel:
 ;       set_mask(0xff);
 ;       last = SCREENBASE + x2 / 8 + y * BYTESPERLN;
 ;       while (dst < last)
-;           *dst++ = 1;
+;           *dst++ |= 1;
 ;       set_mask(0xff << (7 - x2 & 7));
 ;       *dst |= 1;
 ;   }
@@ -127,7 +127,7 @@ y       = arg1 + 4      ; second Y coordinate
 color   = arg1 + 6      ; pixel value
 
         .global _vga_drawhline
- _vga_drawhline:
+_vga_drawhline:
         push    bp              ; setup stack frame and preserve registers
         mov     bp, sp
         push    si
@@ -334,7 +334,7 @@ L1111:  or      [bx], al        ; set pixel
 
 ;
 ; Read the value of an individual pixel.
-; int ega_readpixel(int x, int y);
+; int vga_readpixel(int x, int y);
 ;
         .global _vga_readpixel
 _vga_readpixel:

--- a/elkscmd/gui/vga-ia16.S
+++ b/elkscmd/gui/vga-ia16.S
@@ -1,0 +1,417 @@
+// Routines to draw pixels and lines for EGA/VGA 16 color 4 planes modes.
+// High speed version for ia16-elf-gcc using GAS assembly
+// Supports  the following EGA and VGA 16 color modes:
+//       640x480 16 color (mode 0x12)
+//       350 line modes
+//       200 line modes
+//
+// The algorithms for some of these routines are taken from the book:
+// Programmer's Guide to PC and PS/2 Video Systems by Richard Wilton.
+//
+// Copyright (c) 1999 Greg Haerr <greg@censoft.com>
+// Copyright (c) 1991 David I. Bell
+// Permission is granted to use, distribute, or modify this source,
+// provided that this copyright notice remains intact.
+//
+// 1 Feb 2025 Greg Haerr rewritten for ELKS AS86
+// 4 Apr 2025 Greg Haerr written for ELKS ia16-elf-gcc
+//
+        .code16
+        .text
+#define BYTESPERLN  80                // number of bytes in scan line
+#define arg1        4                 // small model
+
+//
+// void vga_init(void)
+//
+// C version:
+//   set_enable_sr(0x0f);
+//   set_op(0);
+//   set_write_mode(0);
+//
+    .global vga_init
+vga_init:
+        mov     $0x03ce, %dx    // graphics controller port address
+        mov     $0xff01, %ax    // set enable set/reset register 1 mask FF
+        out     %ax, %dx
+
+        mov     $0x0003, %ax    // data rotate register 3 NOP 0
+        out     %ax, %dx
+
+        mov     $0x0005, %ax    // set graphics mode register 5 write mode 0
+        out     %ax, %dx        // [load value 0 into mode register 5]
+        ret
+
+//
+// Draw an individual pixel.
+// void vga_drawpixel(int x, int y, int color)
+//
+// C version:
+//   static unsigned char mask[8] = { 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01 };
+//   //set_op(0);
+//   set_color(c);
+//   select_mask();
+//   set_mask(mask[x&7]);
+//
+        .global  vga_drawpixel
+vga_drawpixel:
+        push    %bp
+        mov     %sp, %bp
+
+        //mov     dx, #0x03ce     // graphics controller port address
+        //mov     ax, #0x0003     // data rotate register 3 NOP 0
+        //out     dx, ax
+
+        mov     arg1(%bp), %cx  // CX := x
+        mov     %cx, %bx        // BX := x
+        mov     arg1+2(%bp), %ax// AX := y
+
+        //mov     $BYTESPERLN, %dx // AX := [y * BYTESPERLN]
+        //mul     %dx
+        shl     $1, %ax         // AX := [y * 80] (= y*64 + y*16)
+        shl     $1, %ax
+        shl     $1, %ax
+        shl     $1, %ax
+        mov     %ax, %dx
+        shl     $1, %dx
+        shl     $1, %dx
+        add     %dx, %ax
+
+        and     $7, %cl         // CL := x & 7
+        xor     $7, %cl         // CL := 7 - (x & 7)
+        mov     $1, %ch         // CH := 1 << (7 - (x & 7))
+        shl     %cl, %ch        // CH is mask
+
+        mov     $3, %cl         // BX := x / 8
+        shr     %cl, %bx
+        add     %ax, %bx        // BX := [y * BYTESPERLN] + [x / 8]
+
+        mov     $0x03ce, %dx    // graphics controller port address
+        xor     %ax, %ax         // set color register 0
+        mov     arg1+4(%bp), %ah// color pixel value
+        out     %ax, %dx
+
+        mov     $8, %al         // set bit mask register 8
+        mov     %ch, %ah        // [load bit mask into register 8]
+        out     %ax, %dx
+
+        mov     %ds, %cx
+        mov     $0xA000, %ax    // DS := EGA buffer segment address
+        mov     %ax, %ds
+        or      %al,(%bx)       // quick rmw to set pixel
+        mov     %cx, %ds        // restore registers and return
+
+        //mov     ax, #0x0005     // restore default write mode 0
+        //out     dx, ax          // [load value 0 into mode register 5]
+
+        pop     %bp
+        ret
+
+//
+// Draw a horizontal line from x1,1 to x2,y including final point
+// void vga_drawhine(int x1, int x2, int y, int color)
+//
+// C version:
+//   set_color(c);
+//   //set_op(0);
+//   char far *dst = SCREENBASE + x1 / 8 + y * BYTESPERLN;
+//   select_mask();
+//   if (x1 / 8 == x2 / 8) {
+//       set_mask((0xff >> (x1 & 7)) & (0xff << (7 - (x2 & 7))));
+//       *dst |= 1;
+//   } else {
+//       set_mask(0xff >> (x1 & 7));
+//       *dst++ |= 1;
+//       set_mask(0xff);
+//       last = SCREENBASE + x2 / 8 + y * BYTESPERLN;
+//       while (dst < last)
+//           *dst++ |= 1;
+//       set_mask(0xff << (7 - x2 & 7));
+//       *dst |= 1;
+//   }
+
+#define x1      arg1            // first X coordinate
+#define x2      arg1 + 2        // second X coordinate
+#define y       arg1 + 4        // second Y coordinate
+#define color   arg1 + 6        // pixel value
+
+        .global vga_drawhline
+vga_drawhline:
+        push    %bp             // setup stack frame and preserve registers
+        mov     %sp,%bp
+        push    %si
+        push    %di
+        push    %es
+        push    %ds
+
+        mov     $0x03ce, %dx    // Graphics Controller port address
+        //mov     ax, #0x0003   // data rotate register 3 NOP 0
+        //out     dx, ax
+
+        xor     %al, %al        // set Set/Reset register 0 with color
+        mov     color(%bp), %ah
+        out     %ax, %dx
+
+        mov     $0x0f01, %ax    // AH := bit plane mask for Enable Set/Reset
+        out     %ax, %dx        // AL := Enable Set/Reset register 1
+
+        mov     y(%bp), %ax
+        mov     x1(%bp), %bx
+
+        // compute pixel address
+        //mov     $BYTESPERLN, %dx // AX := [row * BYTESPERLN]
+        //mul     %dx
+        shl     $1, %ax         // AX := [y * 80] (= y*64 + y*16)
+        shl     $1, %ax
+        shl     $1, %ax
+        shl     $1, %ax
+        mov     %ax, %dx
+        shl     $1, %dx
+        shl     $1, %dx
+        add     %dx, %ax
+
+        mov     %bl, %cl        // save low order column bits
+        shr     $1, %bx         // BX := [col / 8]
+        shr     $1, %bx
+        shr     $1, %bx
+        add     %ax, %bx        // BX := [row * BYTESPERLN] + [col / 8]
+        and     $7, %cl         // CL := [col & 7]
+        xor     $7, %cl         // CL := 7 - [col & 7]
+        mov     $1, %ah         // AH := 1 << [7 - [col & 7]]    [mask]
+        mov     $0xA000, %dx    // ES := EGA buffer segment address
+        mov     %dx, %es        // ES:BX -> video buffer
+                                // AH := bit mask
+                                // CL := number bits to shift left
+        mov     %bx, %di        // ES:DI -> buffer
+        mov     %ah, %dh        // DH := unshifted bit mask for left byte
+
+        not     %dh
+        shl     %cl, %dh        // DH := reverse bit mask for first byte
+        not     %dh             // DH := bit mask for first byte
+
+        mov     x2(%bp), %cx
+        and     $7, %cl
+        xor     $7, %cl         // CL := number of bits to shift left
+        mov     $0xff, %dl      // DL := unshifted bit mask for right byte
+        shl     %cl, %dl        // DL := bit mask for last byte
+
+        // determine byte offset of first and last pixel in the line
+        mov     x2(%bp), %ax    // AX := x2
+        mov     x1(%bp), %bx    // BX := x1
+
+        mov     $3, %cl         // bits to convert pixels to bytes
+
+        shr     %cl, %ax        // AX := byte offset of X2
+        shr     %cl, %bx        // BX := byte offset of X1
+        mov     %ax, %cx
+        sub     %bx, %cx        // CX := [number of bytes in line] - 1
+
+        // get Graphics Controller port address into DX
+        mov     %dx, %bx        // BH := bit mask for first byte
+                                // BL := bit mask for last byte
+        mov     $0x3ce, %dx     // DX := Graphics Controller port
+        mov     $8, %al         // AL := Bit mask Register number
+
+        // make video buffer addressable through DS:SI
+        push    %es
+        pop     %ds
+        mov     %di, %si        // DS:SI -> video buffer
+
+        // set pixels in leftmost byte of the line
+        or      %bh, %bh
+        js      L43             // jump if byte-aligned [x1 is leftmost]
+
+        or      %cx, %cx
+        jnz     L42             // jump if more than one byte in the line
+
+        and     %bl, %bh        // BL := bit mask for the line
+        jmp     L44
+
+L42:    mov     %bh, %ah        // AH := bit mask for first byte
+        out     %ax, %dx        // update graphics controller
+
+        movsb                   // update bit planes
+        dec     %cx
+
+        // use a fast 8086 machine instruction to draw the remainder of the line
+L43:    mov     $0xff, %ah      // AH := bit mask
+        out     %ax, %dx        // update Bit Mask register
+        rep
+        movsb                   // update all pixels in the line
+
+        // set pixels in the rightmost byte of the line
+
+L44:    mov     %bl, %ah        // AH := bit mask for last byte
+        out     %ax, %dx        // update Graphics Controller
+        movsb                   // update bit planes
+
+        // restore default Graphics Controller state and return to caller
+        //xor   ax, ax          // AH := 0, AL := 0
+        //out   dx, ax          // restore Set/Reset register
+        //inc   ax              // AH := 0, AL := 1
+        //out   dx, ax          // restore Enable Set/Reset register
+        //mov   ax, #0xff08     // AH := 0xff, AL := 0
+        //out   dx, ax          // restore Bit Mask register
+
+        pop     %ds
+        pop     %es
+        pop     %di
+        pop     %si
+        pop     %bp
+        ret
+
+#if UNUSED
+;
+; Draw a vertical line from x,y1 to x,y2 including final point
+; void vga_drawvline(int x, int y1, int y2, int color);
+;
+; C version:
+;   //set_op(0);
+;   set_color(c);
+;   select_mask();
+;   set_mask(mask[x&7]);
+;   char far *dst = SCREENBASE + x / 8 + y1 * BYTESPERLN;
+;   char far *last = SCREENBASE + x / 8 + y2 * BYTESPERLN;
+;   while (dst < last) {
+;       *dst |= 1;
+;       dst += BYTESPERLN;
+;   }
+;
+
+x       = arg1          ; first X coordinate
+y1      = arg1 + 2      ; first Y coordinate
+y2      = arg1 + 4      ; second Y coordinate
+color   = arg1 + 6      ; pixel value
+
+        .global  _vga_drawvline
+_vga_drawvline:
+        push    bp              ; setup stack frame and preserve registers
+        mov     bp, sp
+        push    ds
+
+        mov     dx, #0x03ce     ; DX := Graphics Controller port address
+        ;mov     ax, #0x0003     ; data rotate register 3 NOP 0
+        ;out     dx, ax
+
+        xor     al, al          ; set Set/Reset register 0 with color
+        mov     ah, color[bp]
+        out     dx, ax
+
+        mov     ax, #0x0f01     ; AH := bit plane mask for Enable Set/Reset
+        out     dx, ax          ; AL := Enable Set/Reset register number
+
+        ; prepare to draw vertical line
+        mov     ax, y1[bp]      ; AX := y1
+        mov     cx, y2[bp]      ; BX := y2
+        sub     cx, ax          ; CX := dy
+
+L311:   inc     cx              ; CX := number of pixels to draw
+        mov     bx, x[bp]       ; BX := x
+        push    cx              ; save register
+
+        ; compute pixel address
+        push    dx
+        mov     dx, #BYTESPERLN ; AX := [row * BYTESPERLN]
+        mul     dx
+        mov     cl, bl          ; save low order column bits
+        shr     bx, #1          ; BX := [col / 8]
+        shr     bx, #1
+        shr     bx, #1
+        add     bx, ax          ; BX := [row * BYTESPERLN] + [col / 8]
+        and     cl, #7          ; CL := [col & 7]
+        xor     cl, #7          ; CL := 7 - [col & 7]
+        mov     ah, #1          ; AH := 1 << [7 - [col & 7]]    [mask]
+        mov     dx, #0x0A000    ; DS := EGA buffer segment address
+        mov     ds, dx          ; DS:BX -> video buffer
+        pop     dx
+                                ; AH := bit mask
+                                ; CL := number bits to shift left
+        ; set up Graphics controller
+        shl     ah, cl          ; AH := bit mask in proper position
+        mov     al, #8          ; AL := Bit Mask register number 8
+        out     dx, ax
+
+        pop     cx              ; restore number of pixels to draw
+
+        ; draw the line
+        mov     dx, #BYTESPERLN ; increment for video buffer
+L1111:  or      [bx], al        ; set pixel
+        add     bx, dx          ; increment to next line
+        loop    L1111
+
+        ; restore default Graphics Controller state and return to caller
+        ;xor   ax, ax          ; AH := 0, AL := 0
+        ;out   dx, ax          ; restore Set/Reset register
+        ;inc   ax              ; AH := 0, AL := 1
+        ;out   dx, ax          ; restore Enable Set/Reset register
+        ;mov   ax, #0xff08     ; AH := 0xff, AL := 0
+        ;out   dx, ax          ; restore Bit Mask register
+
+        pop     ds
+        pop     bp
+        ret
+#endif
+
+//
+// Read the value of an individual pixel.
+// int ega_readpixel(int x, int y)
+//
+        .global vga_readpixel
+vga_readpixel:
+        push    %bp
+        mov     %sp, %bp
+        push    %si
+        push    %ds
+
+        mov     arg1+2(%bp), %ax// AX := y
+        mov     arg1(%bp), %bx  // BX := x
+        //mov     $BYTESPERLN, %dx // AX := [y * BYTESPERLN]
+        //mul     %dx
+        shl     $1, %ax         // AX := [y * 80] (= y*64 + y*16)
+        shl     $1, %ax
+        shl     $1, %ax
+        shl     $1, %ax
+        mov     %ax, %dx
+        shl     $1, %dx
+        shl     $1, %dx
+        add     %dx, %ax
+
+        mov     %bl, %cl        // save low order column bits
+        shr     $1, %bx         // BX := [x / 8]
+        shr     $1, %bx
+        shr     $1, %bx
+
+        add     %ax, %bx        // BX := [y * BYTESPERLN] + [x / 8]
+
+        and     $7, %cl         // CL := [x & 7]
+        xor     $7, %cl         // CL := 7 - [x & 7]
+
+        mov     $0xA000, %dx    // DS := EGA buffer segment address
+        mov     %dx, %ds
+
+        mov     $1, %ch         // CH := 1 << [7 - [col & 7]]
+        shl     %cl, %ch        // CH := bit mask in proper position
+
+        mov     %bx, %si        // DS:SI -> region buffer byte
+        xor     %bl, %bl        // BL is used to accumulate the pixel value
+
+        mov     $0x03ce, %dx    // DX := Graphics Controller port
+        mov     $0x0304, %ax    // AH := initial bit plane number 3
+                                // AL := Read Map Select register number 4
+
+L112:   out     %ax, %dx        // select bit plane
+        mov     (%si), %bh      // BH := byte from current bit plane
+        and     %ch, %bh        // mask one bit
+        neg     %bh             // bit 7 of BH := 1 if masked bit = 1
+                                // bit 7 of BH := 0 if masked bit = 0
+        rol     $1, %bx         // bit 0 of BL := next bit from pixel value
+        dec     %ah             // AH := next bit plane number
+        jge     L112
+
+        xor     %ax, %ax        // AL := pixel value
+        mov     %bl, %al
+
+        pop     %ds
+        pop     %si
+        pop     %bp      
+        ret


### PR DESCRIPTION
Speeds up drawing in Paint program considerably, discussed in https://github.com/ghaerr/elks/issues/2269#issuecomment-2779789406.

This turned out to be an interesting exercise, and an ia16-elf-gcc compiler bug was found in the process of trying to get it to not translate (x << 6) + (x << 4) to (x * 80) and emit a MUL instruction. On the 8088, MUL instructions are very slow and using left shifts will be much faster.

What was found with regards to ia16-elf-gcc is:
- The default code generation option -Os (optimize for size) is not well suited for 8088 code generation. Specifically, it generates small code with no regard to speed.
- Replacing the global optimization option for paint to -O3 (or -O2 or -O1) caused the compiler to emit code which crashed paint when drawing. This is still being investigated.
- Trying to use the GCC \_\_attribute\_\_((0))) to turn off optimization for a single function generated very sloppy code which was deemed too slow.
- When optimizing in the default -Os (small size) mode, GCC actually replaces (x << 6) + (x << 4) with (x * 80) and generates a MUL instruction.
- In the same -Os default optimization, writing (x / 8) actually generates a DIV instruction (!!!). Coding (x >> 3) generates a right shift, which was nice to see.

After playing way too long trying to get GCC to work without potentially putting each graphics function in a separate file, it was finally decided that translating the entire C86 ASM language vga-4pp.s fast draw routines from AS86 format to GCC AS format was the way to go, and it now works very well.

As a result of conversations with @Vutshi and @dbalsom in #2269, the following changes were made to greatly increase the speed of paint on 8088. This has been tested with QEMU slowing it down considerably by adding `-singlestep -icount 8,align` to the QEMU command line. Soon I hope to get [MartyPC](https://github.com/dbalsom/martypc) running on my macOS laptop for cycle-accurate 8088 emulation.
- Rewrite the VGA 4-planar C86 ASM routines in vga-4bpp.s to GCC assembly in vga-ia16.S.
- Rewrite the cursor show/hide routines so that only the masked cursor bits are saved and restored. This sped up cursor drawing by about 50%.
- Remove MUL and DIV instructions from the main loop event_wait_timeout routine.
- Replace previous y * 80 code with (y << 6) + (y << 4) in C and the new vga-ia16.S code. vga-4bpp.s not done yet (for C86).
- Slightly rewrote and got working @Vutshi's C drawhline routine. This is where I later found the GCC bug when compiling in -O3 mode. This routine is commented out now since it has been replaced with fast ASM code in vga-ia16.S.
- Add a mouse acceleration filter which allows the mouse to speed up when moved rapidly. Seems to work well but needs to be more throughly tested on different speed systems.
- Removed x >= 0 and y >= 0 clipping checks in render.c.
- Rewrote R_ClearCanvas and R_DrawPalette to use drawhline for ia16.
