### PR TITLE
[cmds] Fix vga_drawhline in Paint

### DIFF
--- a/elkscmd/gui/event.c
+++ b/elkscmd/gui/event.c
@@ -115,13 +115,13 @@ out:
                     posy += y;
                     if (posx < 0) posx = 0;
                     if (posy < 0) posy = 0;
-                    if ((drawing || altdrawing)){
-                        if (posx >= SCREEN_WIDTH) posx = SCREEN_WIDTH - 1;
-                        if (posy >= SCREEN_HEIGHT) posy = SCREEN_HEIGHT - 1;
-                    } else {
+                    //if ((drawing || altdrawing)){
+                        //if (posx >= SCREEN_WIDTH) posx = SCREEN_WIDTH - 1;
+                        //if (posy >= SCREEN_HEIGHT) posy = SCREEN_HEIGHT - 1;
+                    //} else {
                         if (posx >= SCREENWIDTH) posx = SCREENWIDTH - 1;
                         if (posy >= SCREENHEIGHT) posy = SCREENHEIGHT - 1;
-                    }
+                    //}
                     event->x = posx;
                     event->y = posy;
                     event->xrel = x;

--- a/elkscmd/gui/graphics.c
+++ b/elkscmd/gui/graphics.c
@@ -230,13 +230,6 @@ void graphics_close(void)
     set_mode(TEXT_MODE);
 }
 
-// Draw a horizontal line from x1,1 to x2,y including final point
-void drawhline(int x1, int x2, int y, int c)
-{
-    while (x1 <= x2)
-        drawpixel(x1++, y, c);
-}
-
 #ifdef __WATCOMC__
 void drawpixel(int x, int y, int color)
 {

--- a/elkscmd/gui/graphics.h
+++ b/elkscmd/gui/graphics.h
@@ -24,11 +24,9 @@ int save_bmp(char *pathname);
 #define readpixel(x,y)          pal_readpixel(x,y)
 #elif defined(__C86__) || defined(__ia16__)   /* use ASM vga_ routines */
 #define drawpixel(x,y,c)        vga_drawpixel(x,y,c)
-// #define drawhline(x1,x2,y,c)    vga_drawhline(x1,x2,y,c)
+#define drawhline(x1,x2,y,c)    vga_drawhline(x1,x2,y,c)
 #define drawvline(x,y1,y2,c)    vga_drawvline(x,y1,y2,c)
 #define readpixel(x,y)          vga_readpixel(x,y)
-
-void drawhline(int x1, int x2, int y, int c);
 #else
 void drawpixel(int x,int y, int color);
 void drawhline(int x1, int x2, int y, int c);
@@ -40,7 +38,7 @@ void fillrect(int x1, int y1, int x2, int y2, int c);
 /* VGA 16 color, 4bpp routines implemented in ASM in vga-ia16.S and vga-c86.s */
 void vga_init(void);
 void vga_drawpixel(int x, int y, int c);
-// void vga_drawhline(int x1, int x2, int y, int c);
+void vga_drawhline(int x1, int x2, int y, int c);
 void vga_drawvline(int x, int y1, int y2, int c);
 int  vga_readpixel(int x, int y);
 

--- a/elkscmd/gui/render.c
+++ b/elkscmd/gui/render.c
@@ -115,7 +115,7 @@ void R_DrawCurrentColor(void)
     int startingPixelXOffset = SCREEN_WIDTH + 10 + 32 + 1;
     int startingPixelYOffset = 10 + 128 + 10;
 
-    fillrect(startingPixelXOffset, startingPixelYOffset, startingPixelXOffset + 61, \
+    fillrect(startingPixelXOffset, startingPixelYOffset, startingPixelXOffset + 61,
         startingPixelYOffset + 29, currentMainColor);
 
     // Draw white frame if the main color matches the panel backgound

--- a/elkscmd/gui/vga-c86.s
+++ b/elkscmd/gui/vga-c86.s
@@ -48,7 +48,6 @@ _vga_init:
 ;   static unsigned char mask[8] = { 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01 };
 ;   //set_op(0);
 ;   set_color(c);
-;   select_mask();
 ;   set_mask(mask[x&7]);
 ;
         .global  _vga_drawpixel
@@ -113,7 +112,6 @@ _vga_drawpixel:
 ;   set_color(c);
 ;   //set_op(0);
 ;   char far *dst = SCREENBASE + x1 / 8 + y * BYTESPERLN;
-;   select_mask();
 ;   if (x1 / 8 == x2 / 8) {
 ;       set_mask((0xff >> (x1 & 7)) & (0xff << (7 - (x2 & 7))));
 ;       *dst |= 1;
@@ -265,7 +263,6 @@ L44:    mov     ah, bl          ; AH := bit mask for last byte
 ; C version:
 ;   //set_op(0);
 ;   set_color(c);
-;   select_mask();
 ;   set_mask(mask[x&7]);
 ;   char far *dst = SCREENBASE + x / 8 + y1 * BYTESPERLN;
 ;   char far *last = SCREENBASE + x / 8 + y2 * BYTESPERLN;

--- a/elkscmd/gui/vga-c86.s
+++ b/elkscmd/gui/vga-c86.s
@@ -105,7 +105,7 @@ _vga_drawpixel:
         ret
 
 ;
-; Draw a horizontal line from x1,1 to x2,y including final point
+; Draw a horizontal line from x1,y to x2,y including final point
 ; void vga_drawhine(int x1, int x2, int y, int color);
 ;
 ; C version:

--- a/elkscmd/gui/vga-ia16.S
+++ b/elkscmd/gui/vga-ia16.S
@@ -106,7 +106,7 @@ vga_drawpixel:
         ret
 
 //
-// Draw a horizontal line from x1,1 to x2,y including final point
+// Draw a horizontal line from x1,y to x2,y including final point
 // void vga_drawhine(int x1, int x2, int y, int color)
 //
 // C version:

--- a/elkscmd/gui/vga-ia16.S
+++ b/elkscmd/gui/vga-ia16.S
@@ -49,7 +49,6 @@ vga_init:
 //   static unsigned char mask[8] = { 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01 };
 //   //set_op(0);
 //   set_color(c);
-//   select_mask();
 //   set_mask(mask[x&7]);
 //
         .global  vga_drawpixel
@@ -114,7 +113,6 @@ vga_drawpixel:
 //   set_color(c);
 //   //set_op(0);
 //   char far *dst = SCREENBASE + x1 / 8 + y * BYTESPERLN;
-//   select_mask();
 //   if (x1 / 8 == x2 / 8) {
 //       set_mask((0xff >> (x1 & 7)) & (0xff << (7 - (x2 & 7))));
 //       *dst |= 1;
@@ -208,7 +206,7 @@ vga_drawhline:
         // get Graphics Controller port address into DX
         mov     %dx, %bx        // BH := bit mask for first byte
                                 // BL := bit mask for last byte
-        mov     $0x3ce, %dx     // DX := Graphics Controller port
+        mov     $0x03ce, %dx    // DX := Graphics Controller port
         mov     $8, %al         // AL := Bit mask Register number
 
         // make video buffer addressable through DS:SI
@@ -223,7 +221,7 @@ vga_drawhline:
         or      %cx, %cx
         jnz     L42             // jump if more than one byte in the line
 
-        and     %bl, %bh        // BL := bit mask for the line
+        and     %bh, %bl        // BL := bit mask for the line
         jmp     L44
 
 L42:    mov     %bh, %ah        // AH := bit mask for first byte
@@ -266,7 +264,6 @@ L44:    mov     %bl, %ah        // AH := bit mask for last byte
 // C version:
 //   //set_op(0);
 //   set_color(c);
-//   select_mask();
 //   set_mask(mask[x&7]);
 //   char far *dst = SCREENBASE + x / 8 + y1 * BYTESPERLN;
 //   char far *last = SCREENBASE + x / 8 + y2 * BYTESPERLN;


### PR DESCRIPTION
Fixes error in IA16 vga_drawhline found in https://github.com/ghaerr/elks/pull/2278#issuecomment-2781111983.

The problem was a single ASM line with reversed arguments (you have to thank Intel vs AT&T for that)!!

@Vutshi, I had to remove the mouse clipping (when drawing) you added into event.c, as when selecting various colors one after another in the control panel, after a bit of doing just that the entire screen would get filled with the color selected. It seems that this is the same problem you were trying to fix when moving the cursor off the canvas when drawing, when using the new R_DrawDisk function.

I think this is a new bug that has to do with R_DrawDisk, as I'd never seen it before, but not sure.

In any case, we don't want to/can't keep the mouse clipping code in event.c anyways, as it contains app.h and application globals (drawing, altduawing). The event.c code is meant to be a library routine, so I'd like to ask that you clip the mouse coordinates and fix the problem in input.c during mouse down processing, instead of in the shared app main event code. I haven't figured out exactly why the problem is, but just commented it out for the time being. With it commented out, the buttons never fail but you can get in trouble when mouse down drawing going off the canvas.

On another note, I am closely comparing the circle code and there are definitely differences. TBH, I'm not sure the new code looks better - the 4th pixel size in particular was very round in the before version, and now seems to have points on it and kind of looks like a diamond (see screenshots below, you may want download them and quickly switch between them with mac Preview "spacebar" in order to really check them out). I can see that the single pixel circle is now correct whereas in the old version it was a bit larger. Nonetheless, the new code draws a circle that is a little bit larger (you need to quickly switch between them to see it).

The new circle looks are fine with me, I just wanted to bring this up, in case you handn't already noticed it. I did notice that the new draw code is much faster, undoubtedly from drawing using drawhline, is that the main benefit of this rewrite?

I had already written the above when I realized that there must be a strict way that circles have to be rasterized if they are to easily use drawhline to draw them, rather than the very slow original drawpixel method.

Before
<img width="752" alt="before" src="https://github.com/user-attachments/assets/5fc2148d-75fd-4c05-8fb4-63c2af841762" />

After
<img width="752" alt="after" src="https://github.com/user-attachments/assets/d403b34f-0e4f-428e-bc5b-f540c9bcc855" />

Thank you for your enhancements!
