### PR TITLE
[paint] Move VGA access macros to vgalib.h file

### DIFF
--- a/elkscmd/gui/Makefile.owc
+++ b/elkscmd/gui/Makefile.owc
@@ -40,6 +40,7 @@ BINDIR = .
 LOCALFLAGS =
 PROG = $(BINDIR)/opaint
 SRCS = app.c gui.c input.c render.c event.c mouse.c graphics.c drawbmp.c cursor.c
+SRCS += drawscanline.c
 
 all: $(PROG)
 

--- a/elkscmd/gui/drawbmp.c
+++ b/elkscmd/gui/drawbmp.c
@@ -298,13 +298,13 @@ draw_bmp(char *path, int x, int y)
                     c = find_nearest_color(pal->r, pal->g, pal->b);
                     cache[image[w]] = c;
                 }
-#ifdef __ia16__
+#if defined(__ia16__) || defined(__WATCOMC__)
                 image[w] = c;
 #else
                 drawpixel(x+w, y+h, c);
 #endif
             }
-#ifdef __ia16__
+#if defined(__ia16__) || defined(__WATCOMC__)
             vga_drawscanline(image, x, y+h, width);
 #endif
             break;

--- a/elkscmd/gui/graphics.c
+++ b/elkscmd/gui/graphics.c
@@ -66,6 +66,19 @@ static void set_bios_mode(int mode)
     );
 }
 
+int asm_getbyte(int offset)
+{
+    asm(
+        "mov cx,ds\n"
+        "mov bx,[bp+4]\n"
+        "mov ax,0xa000\n"
+        "mov ds,ax\n"
+        "mov al,[bx]\n"
+        "xor ah,ah\n"
+        "mov ds,cx\n"
+    );
+}
+
 /* PAL write color byte at video offset */
 static void pal_writevid(unsigned int offset, int c)
 {
@@ -135,8 +148,6 @@ int readpixel(int x, int y)
     }
     return c;
 }
-
-#define EGA_BASE ((char __far *)0xA0000000L)
 
 // Draw a horizontal line from x1,1 to x2,y including final point
 void drawhline(int x1, int x2, int y, int c)

--- a/elkscmd/gui/graphics.c
+++ b/elkscmd/gui/graphics.c
@@ -142,19 +142,20 @@ int readpixel(int x, int y)
 void drawhline(int x1, int x2, int y, int c)
 {
     set_color(c);
-    char __far *dst = EGA_BASE + (x1>>3) + (y<<6) + (y<<4);  /* y * 80 + x / 8 */
+    unsigned int dst = (y<<6) + (y<<4) + (x1>>3);  /* y * 80 + x / 8 */
     if ((x1 >> 3) == (x2 >> 3)) {
         set_mask((0xff >> (x1 & 7)) & (0xff << (7 - (x2 & 7))));
-        *dst |= 1;
+        asm_orbyte(dst);
     } else {
         set_mask(0xff >> (x1 & 7));
-        *dst++ |= 1;
+        asm_orbyte(dst); dst++;
         set_mask(0xff);
-        char __far *last = EGA_BASE + (x2>>3) + (y<<6) + (y<<4);
-        while (dst < last)
-            *dst++ |= 1;
+        unsigned int last = (y<<6) + (y<<4) + (x2>>3);
+        while (dst < last) {
+            asm_orbyte(dst); dst++;
+        }
         set_mask(0xff << (7 - (x2 & 7)));
-        *dst |= 1;
+        asm_orbyte(dst);
     }
 }
 

--- a/elkscmd/gui/vga-c86.s
+++ b/elkscmd/gui/vga-c86.s
@@ -23,7 +23,7 @@ arg1        = 4                 ; small model
 ; void vga_init(void)
 ;
 ; C version:
-;   set_enable_sr(0x0f);
+;   set_enable_sr(0xff);
 ;   set_op(0);
 ;   set_write_mode(0);
 ;

--- a/elkscmd/gui/vga-ia16.S
+++ b/elkscmd/gui/vga-ia16.S
@@ -24,7 +24,7 @@
 // void vga_init(void)
 //
 // C version:
-//   set_enable_sr(0x0f);
+//   set_enable_sr(0xff);
 //   set_op(0);
 //   set_write_mode(0);
 //

--- a/elkscmd/gui/vgalib.h
+++ b/elkscmd/gui/vgalib.h
@@ -1,0 +1,299 @@
+#ifndef VGALIB_H
+#define VGALIB_H
+
+/* vgalib.h */
+
+/*
+ * VGA hardware manipulation from C
+ *
+ * A set of macros for accessing VGA registers for ia-elf-gcc,
+ * OpenWatcom and C86 compilers.
+ *
+ * Functions/Macros:
+ *  set_color(color)            // 03ce REG 0 Set/Reset Register color for write mode 0
+ *  set_enable_sr(flag)         // 03ce REG 1 Set Enable/Set/Reset Register
+ *  set_op(op)                  // 03ce REG 3 Set Data Rotate Register
+ *  set_read_plane(plane)       // 03ce REG 4 Set Read Map Select Register
+ *  set_write_mode(mode)        // 03ce REG 5 Set Graphics Mode Register
+ *  set_mask(mask)              // 03ce REG 8 Set Bit Mask Register
+ *  set_write_planes(mask)      // 03c4 REG 2 Set Memory Plane Write Enable Register
+ *
+ *  void set_bios_mode(mode)    // set BIOS graphics/text mode
+ *  void asm_orbyte(int offset) // OR byte at A000:offset
+ *  int  asm_getbyte(int offset)// read byte at A000:offset
+ *
+ * Some defaults:
+ *  set_color(0)                // REG 0
+ *  set_enable_sr(0xff)         // REG 1
+ *  set_op(0)                   // REG 3
+ *  set_read_plane(0)           // REG 4
+ *  set_write_mode(0)           // REG 5
+ *  set_mask(0xff)              // REG 8
+ *  set_write_planes(0x0f)      // REG 2
+ *
+ * 6 Apr 2025 Greg Haerr
+ */
+
+#define EGA_BASE 0xA000         /* segment address of EGA/VGA video memory */
+
+#ifdef __ia16__
+
+#define set_color(color)                        \
+    asm volatile (                              \
+        "mov $0x03ce,%%dx\n"                    \
+        "mov %%al,%%ah\n"                       \
+        "xor %%al,%%al\n"                       \
+        "out %%ax,%%dx\n"                       \
+        : /* no output */                       \
+        : "a" ((unsigned short)(color))         \
+        : "d"                                   \
+        )
+
+#define set_enable_sr(flag)                     \
+    asm volatile (                              \
+        "mov $0x03ce,%%dx\n"                    \
+        "mov %%al,%%ah\n"                       \
+        "mov $1,%%al\n"                         \
+        "out %%ax,%%dx\n"                       \
+        : /* no output */                       \
+        : "a" ((unsigned short)(flag))          \
+        : "d"                                   \
+        )
+
+#define set_op(op)                              \
+    asm volatile (                              \
+        "mov $0x03ce,%%dx\n"                    \
+        "mov %%al,%%ah\n"                       \
+        "mov $3,%%al\n"                         \
+        "out %%ax,%%dx\n"                       \
+        : /* no output */                       \
+        : "a" ((unsigned short)(op))            \
+        : "d"                                   \
+        )
+
+#define set_read_plane(plane)                   \
+    asm volatile (                              \
+        "mov $0x03ce,%%dx\n"                    \
+        "mov %%al,%%ah\n"                       \
+        "mov $4,%%al\n"                         \
+        "out %%ax,%%dx\n"                       \
+        : /* no output */                       \
+        : "a" ((unsigned short)(plane))         \
+        : "d"                                   \
+        )
+
+#define set_write_mode(mode)                    \
+    asm volatile (                              \
+        "mov $0x03ce,%%dx\n"                    \
+        "mov %%al,%%ah\n"                       \
+        "mov $5,%%al\n"                         \
+        "out %%ax,%%dx\n"                       \
+        : /* no output */                       \
+        : "a" ((unsigned short)(mode))          \
+        : "d"                                   \
+        )
+
+#define set_mask(mask)                          \
+    asm volatile (                              \
+        "mov $0x03ce,%%dx\n"                    \
+        "mov %%al,%%ah\n"                       \
+        "mov $8,%%al\n"                         \
+        "out %%ax,%%dx\n"                       \
+        : /* no output */                       \
+        : "a" ((unsigned short)(mask))          \
+        : "d"                                   \
+        )
+
+#define set_write_planes(mask)                  \
+    asm volatile (                              \
+        "mov $0x03c4,%%dx\n"                    \
+        "mov %%al,%%ah\n"                       \
+        "mov $2,%%al\n"                         \
+        "out %%ax,%%dx\n"                       \
+        : /* no output */                       \
+        : "a" ((unsigned short)(mask))          \
+        : "d"                                   \
+        )
+
+#define set_bios_mode(mode)                     \
+    asm volatile (                              \
+        "int $0x10"                             \
+        : /* no output */                       \
+        : "a" ((unsigned short)(mode))          \
+    )
+
+#define asm_orbyte(offset)                      \
+    asm volatile (                              \
+        "mov %%ds,%%cx\n"                       \
+        "mov $0xa000,%%ax\n"                    \
+        "mov %%ax,%%ds\n"                       \
+        "or %%al,(%%bx)\n"                      \
+        "mov %%cx,%%ds\n"                       \
+        : /* no output */                       \
+        : "b" ((unsigned short)(offset))        \
+        : "a", "c", "d"                         \
+        )
+
+#define asm_getbyte(offset)                     \
+    __extension__ ({                            \
+    unsigned short _v;                          \
+    asm volatile (                              \
+        "mov %%ds,%%cx\n"                       \
+        "mov $0xa000,%%ax\n"                    \
+        "mov %%ax,%%ds\n"                       \
+        "mov (%%bx),%%al\n"                     \
+        "xor %%ah,%%ah\n"                       \
+        "mov %%cx,%%ds\n"                       \
+        : "=a" (_v)                             \
+        : "b" ((unsigned short)(offset))        \
+        : "c", "d"                              \
+        );                                      \
+    _v; })
+
+#endif /* __ia16__ */
+
+#ifdef __WATCOMC__
+
+void set_color(unsigned int color);
+#pragma aux set_color parm [ax] =               \
+    "mov dx,0x03ce",                            \
+    "mov ah,al",                                \
+    "xor al,al",                                \
+    "out dx,ax",                                \
+    modify [ ax dx ];
+
+void set_enable_sr(unsigned int flag);
+#pragma aux set_enable_sr parm [ax] =           \
+    "mov dx,0x03ce",                            \
+    "mov ah,al",                                \
+    "mov al,1",                                 \
+    "out dx,ax",                                \
+    modify [ ax dx ];
+
+void set_op(unsigned int op);
+#pragma aux set_op parm [ax] =                  \
+    "mov dx,0x03ce",                            \
+    "mov ah,al",                                \
+    "mov al,3",                                 \
+    "out dx,ax",                                \
+    modify [ ax dx ];
+
+void set_read_plane(unsigned int plane);
+#pragma aux set_read_plane parm [ax] =          \
+    "mov dx,0x03ce",                            \
+    "mov ah,al",                                \
+    "mov al,4",                                 \
+    "out dx,ax",                                \
+    modify [ ax dx ];
+
+void set_write_mode(unsigned int mode);
+#pragma aux set_write_mode parm [ax] =          \
+    "mov dx,0x03ce",                            \
+    "mov ah,al",                                \
+    "mov al,5",                                 \
+    "out dx,ax",                                \
+    modify [ ax dx ];
+
+void set_mask(unsigned int mask);
+#pragma aux set_mask parm [ax] =                \
+    "mov dx,0x03ce",                            \
+    "mov ah,al",                                \
+    "mov al,8",                                 \
+    "out dx,ax",                                \
+    modify [ ax dx ];
+
+void set_write_planes(unsigned int mask);
+#pragma aux set_write_planes parm [ax] =        \
+    "mov dx,0x03c4",                            \
+    "mov ah,al",                                \
+    "mov al,2",                                 \
+    "out dx,ax",                                \
+    modify [ ax dx ];
+
+void asm_orbyte(unsigned int offset);
+#pragma aux asm_orbyte parm [ax] =              \
+    "mov cx,ds",                                \
+    "mov bx,ax",                                \
+    "mov ax,0xa000",                            \
+    "mov ds,ax",                                \
+    "or [bx],al",                               \
+    "mov ds,cx",                                \
+    modify [ ax bx cx dx ];
+
+int asm_getbyte(unsigned int offset);
+#pragma aux asm_getbyte parm [ax] =             \
+    "mov cx,ds",                                \
+    "mov bx,ax",                                \
+    "mov ax,0xa000",                            \
+    "mov ds,ax",                                \
+    "mov al,[bx]",                              \
+    "xor ah,ah",                                \
+    "mov ds,cx",                                \
+    modify [ ax bx cx dx ];
+
+void set_bios_mode(int mode);
+#pragma aux set_bios_mode parm [ax] =           \
+    "int 10h",                                  \
+    modify [ ax ];
+
+#endif /* __WATCOMC__ */
+
+#ifdef __C86__
+/*
+ * NOTE: the following C86 macros only work with constant arguments!
+ */
+
+#define set_color(color)                        \
+    asm("mov dx,*0x03ce\n"                      \
+        "xor al,al\n"                           \
+        "mov ah,*" #color "\n"                  \
+        "out dx,ax\n"                           \
+    )
+    
+#define set_enable_sr(flag)                     \
+    asm("mov dx,*0x03ce\n"                      \
+        "mov al,*1\n"                           \
+        "mov ah,*" #flag "\n"                   \
+        "out dx,ax\n"                           \
+    )
+    
+#define set_op(op)                              \
+    asm("mov dx,*0x03ce\n"                      \
+        "mov al,*3\n"                           \
+        "mov ah,*" #op "\n"                     \
+        "out dx,ax\n"                           \
+    )
+    
+#define set_read_plane(plane)                   \
+    asm("mov dx,*0x03ce\n"                      \
+        "mov al,*4\n"                           \
+        "mov ah,*" #plane "\n"                  \
+        "out dx,ax\n"                           \
+    )
+    
+#define set_write_mode(mode)                    \
+    asm("mov dx,*0x03ce\n"                      \
+        "mov al,*5\n"                           \
+        "mov ah,*" #mode "\n"                   \
+        "out dx,ax\n"                           \
+    )
+    
+#define set_mask(mask)                          \
+    asm("mov dx,*0x03ce\n"                      \
+        "mov al,*8\n"                           \
+        "mov ah,*" #mask "\n"                   \
+        "out dx,ax\n"                           \
+    )
+    
+#define set_write_planes(mask)                  \
+    asm("mov dx,*0x03c4\n"                      \
+        "mov al,*2\n"                           \
+        "mov ah,*" #mask "\n"                   \
+        "out dx,ax\n"                           \
+    )
+    
+int asm_getbyte(int offset);
+
+#endif /* __C86__ */
+
+#endif


### PR DESCRIPTION
C macros for programming various VGA hardware registers are moved out of graphics.c into a new file vgalib.h, where they can be used to create functionality not already built into graphics.c functions.

Also allows vga_drawscanline() to be compiled with OpenWatcom, and included in build. Working on C86.
Removes most \_\_far pointers in vga_drawscanline for tighter code and C86 compatibility.
Rewrites drawhline for OpenWatcom by replacing far pointer VGA access with macros for speed.

@Vutshi, the C macros in vgalib.h can now be used to experiment with XOR drawing using any of the existing graphics functions, without having to burden each function with a specific XOR capability. This means you can turn on VGA hardware XOR drawing mode, execute a graphics function, and then turn it back off - for drawing a pixel with drawpixel, or a horizontal line with drawhline, etc. It will be up to you to turn back off XOR drawing before returning into the main loop.

To add this functionality to some function in render.c, try something like:
```
#include "vgalib.h"
...
R_DrawDisk(...)
{
...
    set_op(0x18);    // turn on XOR drawing
    ...
    drawhline(...); 
    ...
    set_op(0);       // turn off XOR drawing
}
```

I played around a bit like above, here's a screenshot of R_DrawDisk doing XOR drawing with a large brush (this XOR paint modification is not included in this PR):
<img width="752" alt="paint xor" src="https://github.com/user-attachments/assets/a20c5228-d329-42da-98e7-692e0d32356a" />
