### PR TITLE
[paint] Small cleanup of graphics functions for multiple compilers

### DIFF
--- a/elkscmd/gui/drawbmp.c
+++ b/elkscmd/gui/drawbmp.c
@@ -215,6 +215,9 @@ draw_bmp(char *path, int x, int y)
     /*__dprintf("'%s' bpp %d comp %d pal %d %dx%d\n",
         path, bpp, compression, palsize, width, height);*/
 
+    if (width > 640)        /* bounds check for later array overflow */
+        goto out;
+
     /* compute pitch: bytes per line*/
     switch(bpp) {
 #if UNUSED

--- a/elkscmd/gui/drawscanline.c
+++ b/elkscmd/gui/drawscanline.c
@@ -75,6 +75,8 @@ void vga_drawscanline(unsigned char *colors, int x, int y, int length)
     unsigned int offset, eoffs, soffs, ioffs;
     union bits bytes;
     
+    if (length > 640)
+        length = 640;
     k = 0;
     soffs = ioffs = (x & 0x7);  /* starting offset into first byte */
     eoffs = (x + length) & 0x7;     /* ending offset into last byte */

--- a/elkscmd/gui/vgalib.h
+++ b/elkscmd/gui/vgalib.h
@@ -293,6 +293,7 @@ void set_bios_mode(int mode);
     )
     
 int asm_getbyte(int offset);
+void set_bios_mode(int mode);
 
 #endif /* __C86__ */
 


### PR DESCRIPTION
Adds max 640 width check to drawbmp and drawscanline routines to avoid buffer overflows.
Makes readpixel slightly faster for OWC.
Other small code cleanups.