### PR TITLE
[libc, paint] Add fmemcpy and fdstmemcpy, port drawscanline to C86

### DIFF
--- a/elkscmd/gui/Makefile.c86
+++ b/elkscmd/gui/Makefile.c86
@@ -50,7 +50,8 @@ LOCALFLAGS =
 
 BINDIR = .
 PROG = $(BINDIR)/cpaint
-SRCS = app.c gui.c input.c render.c event.c mouse.c graphics.c drawbmp.c cursor.c
+SRCS = app.c gui.c input.c render.c event.c mouse.c graphics.c drawbmp.c cursor.c \
+    drawscanline.c
 OBJS += vga-c86.o8j
 
 all: $(PROG)

--- a/elkscmd/gui/Makefile.gcc
+++ b/elkscmd/gui/Makefile.gcc
@@ -25,8 +25,8 @@ OBJS = $(SRCS:.c=.oaj)
 BINDIR = .
 LOCALFLAGS =
 PROG = $(BINDIR)/paint
-SRCS = app.c gui.c input.c render.c event.c mouse.c graphics.c drawbmp.c cursor.c
-SRCS += drawscanline.c
+SRCS = app.c gui.c input.c render.c event.c mouse.c graphics.c drawbmp.c cursor.c \
+    drawscanline.c
 OBJS += vga-ia16.oaj
 
 all: $(PROG)

--- a/elkscmd/gui/drawbmp.c
+++ b/elkscmd/gui/drawbmp.c
@@ -12,6 +12,8 @@
 #include "graphics.h"
 #include "app.h"
 
+#define USE_DRAWSCANLINE    1       /* =1 to use vga_drawscanline instead of drawpixel */
+
 #define MWPACKED
 #define abs(x)  ((x < 0)? -x : x)
 
@@ -301,13 +303,13 @@ draw_bmp(char *path, int x, int y)
                     c = find_nearest_color(pal->r, pal->g, pal->b);
                     cache[image[w]] = c;
                 }
-#if defined(__ia16__) || defined(__WATCOMC__)
+#if USE_DRAWSCANLINE
                 image[w] = c;
 #else
                 drawpixel(x+w, y+h, c);
 #endif
             }
-#if defined(__ia16__) || defined(__WATCOMC__)
+#if USE_DRAWSCANLINE
             vga_drawscanline(image, x, y+h, width);
 #endif
             break;

--- a/elkscmd/gui/drawscanline.c
+++ b/elkscmd/gui/drawscanline.c
@@ -62,7 +62,7 @@ static unsigned char plane1[80];
 static unsigned char plane2[80];
 static unsigned char plane3[80];
 
-#if     defined(__ia16__)
+#if     defined(__ia16__) || defined(__C86__)
 #define MEMCPY(dstoff, src, n)  fdstmemcpy(dstoff, EGA_BASE, src, n)
 #elif   defined(__WATCOMC__)
 #define MEMCPY(dstoff, src, n)  fmemcpy(MK_FP(EGA_BASE, dstoff), src, n);

--- a/elkscmd/gui/drawscanline.c
+++ b/elkscmd/gui/drawscanline.c
@@ -13,6 +13,7 @@
 /* 21 January 1995 - added vga_readscanline(), added support for   */
 /* non 8-pixel aligned scanlines in 16 color mode. billr@rastergr.com */
 
+#include <string.h>
 #include "graphics.h"
 #include "vgalib.h"
 
@@ -61,6 +62,11 @@ static unsigned char plane1[80];
 static unsigned char plane2[80];
 static unsigned char plane3[80];
 
+#if     defined(__ia16__)
+#define MEMCPY(dstoff, src, n)  fdstmemcpy(dstoff, EGA_BASE, src, n)
+#elif   defined(__WATCOMC__)
+#define MEMCPY(dstoff, src, n)  fmemcpy(MK_FP(EGA_BASE, dstoff), src, n);
+#else
 static void MEMCPY(unsigned int dstoff, unsigned char *src, int n)
 {
     unsigned char __far *dst =
@@ -68,6 +74,7 @@ static void MEMCPY(unsigned int dstoff, unsigned char *src, int n)
     while (n--)
         *dst++ = *src++;
 }
+#endif
 
 void vga_drawscanline(unsigned char *colors, int x, int y, int length)
 {

--- a/elkscmd/gui/graphics.c
+++ b/elkscmd/gui/graphics.c
@@ -134,9 +134,9 @@ int asm_getbyte(int offset)
     asm(
         "mov cx,ds\n"
         "mov bx,[bp+4]\n"
-        "mov ax,0xa000\n"
+        "mov ax,#0xa000\n"
         "mov ds,ax\n"
-        "mov al,[bx]\n"
+        "mov al,[bx]\n"         /* offset */
         "xor ah,ah\n"
         "mov ds,cx\n"
     );

--- a/elkscmd/gui/graphics.h
+++ b/elkscmd/gui/graphics.h
@@ -51,7 +51,7 @@ void pal_drawhline(int x1, int x2, int y, int c);
 void pal_drawvline(int x, int y1, int y2, int c);
 int  pal_readpixel(int x, int y);
 
-void fdstmemcpy(int dst_off, int dst_seg, void *src_off, int count);
+void fdstmemcpy(unsigned dst_off, unsigned dst_seg, void *src_off, unsigned count);
 
 unsigned int strtoi(const char *s, int base);
 

--- a/elkscmd/gui/graphics.h
+++ b/elkscmd/gui/graphics.h
@@ -51,6 +51,8 @@ void pal_drawhline(int x1, int x2, int y, int c);
 void pal_drawvline(int x, int y1, int y2, int c);
 int  pal_readpixel(int x, int y);
 
+void fdstmemcpy(int dst_off, int dst_seg, void *src_off, int count);
+
 unsigned int strtoi(const char *s, int base);
 
 /* hardware pixel values (VGA 4bpp) */

--- a/elkscmd/gui/render.c
+++ b/elkscmd/gui/render.c
@@ -153,7 +153,7 @@ void R_Paint(int x1, int y1, int x2, int y2) {
 void R_DrawDisk(int x0, int y0, int r, int color, int X_lim)
 // Based on Algorithm http://members.chello.at/easyfilter/bresenham.html
 {
-    if (bushSize <= 1){
+    if (r <= 1) {
         drawpixel(x0, y0, color);
         return;
     }

--- a/elkscmd/gui/vga-c86.s
+++ b/elkscmd/gui/vga-c86.s
@@ -417,3 +417,33 @@ L112:   out     dx, ax          ; select bit plane
         pop     si
         pop     bp      
         ret
+
+; void fdstmemcpy (int dst_off, seg_t dst_seg, char *src_off, size_t count)
+; Copy near source to far destination
+; segment parameter after offset to allow LES from the stack
+
+ARG0    = 2
+ARG1    = 4
+ARG2    = 6
+ARG3    = 8
+
+        .global _fdstmemcpy
+_fdstmemcpy:
+        mov    ax,si
+        mov    dx,di
+        mov    si,sp
+        mov    bx,es
+        mov    cx,ARG3[si]      ; byte count
+        les    di,ARG0[si]      ; far destination pointer
+        mov    si,ARG2[si]      ; far source pointer
+        cld
+        shr    cx,1             ; copy words
+        rep
+        movsw
+        rcl    cx,1             ; then possibly final byte
+        rep
+        movsb
+        mov    es,bx
+        mov    si,ax
+        mov    di,dx
+        ret

--- a/elkscmd/gui/vga-c86.s
+++ b/elkscmd/gui/vga-c86.s
@@ -418,9 +418,10 @@ L112:   out     dx, ax          ; select bit plane
         pop     bp      
         ret
 
-; void fdstmemcpy (int dst_off, seg_t dst_seg, char *src_off, size_t count)
+; void fdstmemcpy (word_t dst_off, seg_t dst_seg, char *src_off, word_t count)
 ; Copy near source to far destination
 ; segment parameter after offset to allow LES from the stack
+; NOTE: currently saves SI, DI and ES - may not be required
 
 ARG0    = 2
 ARG1    = 4

--- a/elkscmd/gui/vga-ia16.S
+++ b/elkscmd/gui/vga-ia16.S
@@ -419,7 +419,7 @@ L112:   out     %ax, %dx        // select bit plane
         pop     %bp      
         ret
 
-// void fdstmemcpy (int dst_off, seg_t dst_seg, char *src_off, size_t count)
+// void fdstmemcpy (word_t dst_off, seg_t dst_seg, char *src_off, word_t count)
 // Copy near source to far destination
 // segment parameter after offset to allow LES from the stack
 

--- a/elkscmd/gui/vga-ia16.S
+++ b/elkscmd/gui/vga-ia16.S
@@ -421,8 +421,7 @@ L112:   out     %ax, %dx        // select bit plane
 
 // void fdstmemcpy (int dst_off, seg_t dst_seg, char *src_off, size_t count)
 // Copy near source to far destination
-// segment parameter after offset to allow LDS/LES from the stack
-// assume DS=SS, save ES, for GCC-IA16
+// segment parameter after offset to allow LES from the stack
 
 #define ARG0    2
 #define ARG1    4
@@ -437,7 +436,7 @@ fdstmemcpy:
         mov    %es,%bx
         mov    ARG3(%si),%cx    // byte count
         les    ARG0(%si),%di    // far destination pointer
-        mov    ARG2(%si),%si    // far source pointer
+        mov    ARG2(%si),%si    // near far source pointer
         cld
         shr    $1,%cx           // copy words
         rep
@@ -448,6 +447,4 @@ fdstmemcpy:
         mov    %bx,%es
         mov    %ax,%si
         mov    %dx,%di
-        mov    %ss,%ax
-        mov    %ax,%ds
         ret

--- a/elkscmd/gui/vga-ia16.S
+++ b/elkscmd/gui/vga-ia16.S
@@ -418,3 +418,36 @@ L112:   out     %ax, %dx        // select bit plane
         pop     %si
         pop     %bp      
         ret
+
+// void fdstmemcpy (int dst_off, seg_t dst_seg, char *src_off, size_t count)
+// Copy near source to far destination
+// segment parameter after offset to allow LDS/LES from the stack
+// assume DS=SS, save ES, for GCC-IA16
+
+#define ARG0    2
+#define ARG1    4
+#define ARG2    6
+#define ARG3    8
+
+        .global fdstmemcpy
+fdstmemcpy:
+        mov    %si,%ax
+        mov    %di,%dx
+        mov    %sp,%si
+        mov    %es,%bx
+        mov    ARG3(%si),%cx    // byte count
+        les    ARG0(%si),%di    // far destination pointer
+        mov    ARG2(%si),%si    // far source pointer
+        cld
+        shr    $1,%cx           // copy words
+        rep
+        movsw
+        rcl    $1,%cx           // then possibly final byte
+        rep
+        movsb
+        mov    %bx,%es
+        mov    %ax,%si
+        mov    %dx,%di
+        mov    %ss,%ax
+        mov    %ax,%ds
+        ret

--- a/elkscmd/gui/vgalib.h
+++ b/elkscmd/gui/vgalib.h
@@ -35,6 +35,8 @@
  */
 
 #define EGA_BASE 0xA000         /* segment address of EGA/VGA video memory */
+#define MK_FP(seg,off)          \
+        ((void __far *)((((unsigned long)(seg)) << 16) | ((unsigned int)(off))))
 
 #ifdef __ia16__
 

--- a/libc/debug/syms.c
+++ b/libc/debug/syms.c
@@ -20,7 +20,7 @@ struct minix_exec_hdr sym_hdr;
 
 #define MAGIC       0x0301  /* magic number for executable progs */
 
-static void noinstrument fmemcpy(unsigned char __far *dst, unsigned char *src, int n)
+static void noinstrument cfmemcpy(unsigned char __far *dst, unsigned char *src, int n)
 {
     do {
         *dst++ = *src++;
@@ -43,7 +43,7 @@ static unsigned char __far * noinstrument alloc_read(int fd, size_t size)
         n = size > sizeof(buf)? sizeof(buf): size;
         if (read(fd, buf, n) != n)
             return NULL;            // FIXME no fmemfree
-        fmemcpy(s+t, buf, n);
+        cfmemcpy(s+t, buf, n);
         t += n;
         size -= n;
     } while (size);

--- a/libc/include/string.h
+++ b/libc/include/string.h
@@ -31,6 +31,7 @@ void * memmove(void*, const void*, size_t);
 #ifndef __STRICT_ANSI__
 void __far *fmemset(void __far *buf, int c, size_t l);
 int fmemcmp(void __far *s1, void __far *s2, size_t n);  /* Watcom C only, in ASM */
+int fmemcpy(void __far *s1, void __far *s2, size_t n);  /* Watcom C only, in ASM */
 #endif
 
 /* Error messages */

--- a/libc/watcom/asm/fmemcpy.asm
+++ b/libc/watcom/asm/fmemcpy.asm
@@ -1,0 +1,40 @@
+;  void fmemcpy(void __far *s1, void __far *s2, size_t n)
+;
+; 7 Apr 2025 Greg Haerr
+
+include mdef.inc
+include struct.inc
+
+        modstart    fmemcpy
+
+        xdefp   "C",fmemcpy
+        defpe    fmemcpy
+
+; s1 in DX:AX, s2 in CX:BX, n on stack
+        push    bp
+        mov     bp,sp
+        push    si
+        push    di
+
+        mov     ds,cx
+        mov     si,bx
+        mov     es,dx
+        mov     di,ax
+if _MODEL and _BIG_CODE
+        mov     cx,6[bp]    ; n
+else
+        mov     cx,4[bp]    ; n
+endif
+        cld
+        shr     cx,1        ; copy words
+        rep movsw
+        rcl     cx,1        ; then possibly final byte
+        rep movsb
+        pop     di
+        pop     si
+        pop     bp
+        ret     2
+
+fmemcpy endp
+        endmod
+        end


### PR DESCRIPTION
Adds libc fmemcpy for OWC only.
Adds fdstmemcpy for GCC and C86 to paint.

Ports vga_scanline to C86.

@Vutshi: I just noticed, are you aware that the single pixel brush "button" is now showing two horizontal pixels (instead of a single pixel) after your last commit or so? Drawing is still down with a single pixel. This PR doesn't change any render.c code.