### PR TITLE
[paint] Further optimization of ASM graphics routines

### DIFF
--- a/elkscmd/gui/vga-c86.s
+++ b/elkscmd/gui/vga-c86.s
@@ -56,8 +56,6 @@ _vga_drawpixel:
         mov     bx, cx          ; BX := x
         mov     ax, arg1+2[bp]  ; AX := y
 
-        ;mov     dx, #BYTESPERLN ; AX := [y * BYTESPERLN]
-        ;mul     dx
         shl     ax, 1           ; AX := [y * 80] (= y*64 + y*16)
         shl     ax, 1
         shl     ax, 1
@@ -72,8 +70,9 @@ _vga_drawpixel:
         mov     ch, #1          ; CH := 1 << (7 - (x & 7))
         shl     ch, cl          ; CH is mask
 
-        mov     cl, #3          ; BX := x / 8
-        shr     bx, cl
+        shr     bx, 1           ; BX := x / 8
+        shr     bx, 1
+        shr     bx, 1
         add     bx, ax          ; BX := [y * BYTESPERLN] + [x / 8]
 
         mov     dx, #0x03ce     ; graphics controller port address
@@ -141,8 +140,6 @@ _vga_drawhline:
         mov     bx, x1[bp]
 
         ; compute pixel address
-        ;mov     dx, #BYTESPERLN ; AX := [row * BYTESPERLN]
-        ;mul     dx
         shl     ax, 1           ; AX := [row * 80] (= row*64 + y*16)
         shl     ax, 1
         shl     ax, 1
@@ -181,10 +178,12 @@ _vga_drawhline:
         mov     ax, x2[bp]      ; AX := x2
         mov     bx, x1[bp]      ; BX := x1
 
-        mov     cl, #3          ; bits to convert pixels to bytes
-
-        shr     ax, cl          ; AX := byte offset of X2
-        shr     bx, cl          ; BX := byte offset of X1
+        shr     ax, 1           ; AX := byte offset of X2
+        shr     ax, 1
+        shr     ax, 1
+        shr     bx, 1           ; BX := byte offset of X1
+        shr     bx, 1
+        shr     bx, 1
         mov     cx, ax
         sub     cx, bx          ; CX := [number of bytes in line] - 1
 
@@ -278,9 +277,6 @@ L311:   inc     cx              ; CX := number of pixels to draw
         push    cx              ; save register
 
         ; compute pixel address
-        push    dx
-        ;mov     dx, #BYTESPERLN ; AX := [row * BYTESPERLN]
-        ;mul     dx
         shl     ax, 1           ; AX := [row * 80] (= row*64 + row*16)
         shl     ax, 1
         shl     ax, 1
@@ -300,10 +296,10 @@ L311:   inc     cx              ; CX := number of pixels to draw
         mov     ah, #1          ; AH := 1 << [7 - [col & 7]]    [mask]
         mov     dx, #0x0A000    ; DS := EGA buffer segment address
         mov     ds, dx          ; DS:BX -> video buffer
-        pop     dx
                                 ; AH := bit mask
                                 ; CL := number bits to shift left
         ; set up Graphics controller
+        mov     dx, #0x03ce     ; DX := Graphics Controller port address
         shl     ah, cl          ; AH := bit mask in proper position
         mov     al, #8          ; AL := Bit Mask register number 8
         out     dx, ax
@@ -333,8 +329,6 @@ _vga_readpixel:
 
         mov     ax, arg1+2[bp]  ; AX := y
         mov     bx, arg1[bp]    ; BX := x
-        ;mov     dx, #BYTESPERLN ; AX := [y * BYTESPERLN]
-        ;mul     dx
         shl     ax, 1           ; AX := [y * 80] (= y*64 + y*16)
         shl     ax, 1
         shl     ax, 1

--- a/elkscmd/gui/vga-c86.s
+++ b/elkscmd/gui/vga-c86.s
@@ -221,7 +221,6 @@ L43:    mov     ah, #0xff       ; AH := bit mask
         movsb                   ; update all pixels in the line
 
         ; set pixels in the rightmost byte of the line
-
 L44:    mov     ah, bl          ; AH := bit mask for last byte
         out     dx, ax          ; update Graphics Controller
         movsb                   ; update bit planes
@@ -342,7 +341,6 @@ _vga_readpixel:
         shr     bx, 1           ; BX := [x / 8]
         shr     bx, 1
         shr     bx, 1
-
         add     bx, ax          ; BX := [y * BYTESPERLN] + [x / 8]
 
         and     cl, #7          ; CL := [x & 7]

--- a/elkscmd/gui/vga-ia16.S
+++ b/elkscmd/gui/vga-ia16.S
@@ -222,7 +222,6 @@ L43:    mov     $0xff, %ah      // AH := bit mask
         movsb                   // update all pixels in the line
 
         // set pixels in the rightmost byte of the line
-
 L44:    mov     %bl, %ah        // AH := bit mask for last byte
         out     %ax, %dx        // update Graphics Controller
         movsb                   // update bit planes
@@ -343,7 +342,6 @@ vga_readpixel:
         shr     $1, %bx         // BX := [x / 8]
         shr     $1, %bx
         shr     $1, %bx
-
         add     %ax, %bx        // BX := [y * BYTESPERLN] + [x / 8]
 
         and     $7, %cl         // CL := [x & 7]

--- a/elkscmd/gui/vga-ia16.S
+++ b/elkscmd/gui/vga-ia16.S
@@ -57,8 +57,6 @@ vga_drawpixel:
         mov     %cx, %bx        // BX := x
         mov     arg1+2(%bp), %ax// AX := y
 
-        //mov     $BYTESPERLN, %dx // AX := [y * BYTESPERLN]
-        //mul     %dx
         shl     $1, %ax         // AX := [y * 80] (= y*64 + y*16)
         shl     $1, %ax
         shl     $1, %ax
@@ -73,8 +71,9 @@ vga_drawpixel:
         mov     $1, %ch         // CH := 1 << (7 - (x & 7))
         shl     %cl, %ch        // CH is mask
 
-        mov     $3, %cl         // BX := x / 8
-        shr     %cl, %bx
+        shr     $1, %bx         // BX := x / 8
+        shr     $1, %bx
+        shr     $1, %bx
         add     %ax, %bx        // BX := [y * BYTESPERLN] + [x / 8]
 
         mov     $0x03ce, %dx    // graphics controller port address
@@ -142,8 +141,6 @@ vga_drawhline:
         mov     x1(%bp), %bx
 
         // compute pixel address
-        //mov     $BYTESPERLN, %dx // AX := [row * BYTESPERLN]
-        //mul     %dx
         shl     $1, %ax         // AX := [row * 80] (= row*64 + row*16)
         shl     $1, %ax
         shl     $1, %ax
@@ -182,10 +179,12 @@ vga_drawhline:
         mov     x2(%bp), %ax    // AX := x2
         mov     x1(%bp), %bx    // BX := x1
 
-        mov     $3, %cl         // bits to convert pixels to bytes
-
-        shr     %cl, %ax        // AX := byte offset of X2
-        shr     %cl, %bx        // BX := byte offset of X1
+        shr     $1, %ax         // AX := byte offset of X2
+        shr     $1, %ax
+        shr     $1, %ax
+        shr     $1, %bx         // BX: byte offset of X1
+        shr     $1, %bx
+        shr     $1, %bx
         mov     %ax, %cx
         sub     %bx, %cx        // CX := [number of bytes in line] - 1
 
@@ -279,9 +278,6 @@ L311:   inc     %cx             // CX := number of pixels to draw
         push    %cx             // save register
 
         // compute pixel address
-        push    %dx
-        //mov     $BYTESPERLN, %dx // AX := [row * BYTESPERLN]
-        //mul     %dx
         shl     $1, %ax         // AX := [row * 80] (= row*64 + row*16)
         shl     $1, %ax
         shl     $1, %ax
@@ -301,10 +297,10 @@ L311:   inc     %cx             // CX := number of pixels to draw
         mov     $1, %ah         // AH := 1 << [7 - [col & 7]]    [mask]
         mov     $0x0A000, %dx   // DS := EGA buffer segment address
         mov     %dx ,%ds        // DS:BX -> video buffer
-        pop     %dx
                                 // AH := bit mask
                                 // CL := number bits to shift left
         // set up Graphics controller
+        mov     $0x03ce, %dx    // DX := Graphics Controller port address
         shl     %cl, %ah        // AH := bit mask in proper position
         mov     $8, %al         // AL := Bit Mask register number 8
         out     %ax, %dx
@@ -334,8 +330,6 @@ vga_readpixel:
 
         mov     arg1+2(%bp), %ax// AX := y
         mov     arg1(%bp), %bx  // BX := x
-        //mov     $BYTESPERLN, %dx // AX := [y * BYTESPERLN]
-        //mul     %dx
         shl     $1, %ax         // AX := [y * 80] (= y*64 + y*16)
         shl     $1, %ax
         shl     $1, %ax


### PR DESCRIPTION
In particular, replace `mov cl,#3; shr ax,cl` with multiple `shr ax,1`, as its much faster on 8088.

8088 cycle times:
```
        shr reg,1       3

        mov reg,imm     4
        shr reg,cl      8+4*n
```