### PR TITLE
[paint] Increase speed by changing ia16-elf-gcc -Os to -O2+

### DIFF
--- a/elkscmd/gui/Makefile.gcc
+++ b/elkscmd/gui/Makefile.gcc
@@ -9,10 +9,21 @@ CC = ia16-elf-gcc
 LD = ia16-elf-gcc
 CLBASE = -melks-libc -mtune=i8086 -mcmodel=small -mno-segment-relocation-stuff
 CLBASE += -fno-inline -fno-builtin-printf -fno-builtin-fprintf
+OPTFLAGS = -O2
+OPTFLAGS += -fno-align-jumps
+OPTFLAGS += -fno-align-functions
+OPTFLAGS += -fno-align-loops
+OPTFLAGS += -fno-align-labels
+OPTFLAGS += -fira-region=one
+OPTFLAGS += -fira-hoist-pressure
+OPTFLAGS += -freorder-blocks-algorithm=simple
+OPTFLAGS += -fno-reorder-blocks
+OPTFLAGS += -fno-prefetch-loop-arrays
+OPTFLAGS += -fno-tree-ch
 WARNINGS = -Wall -Wextra -Wtype-limits -Wno-unused-parameter -Wno-sign-compare
 INCLUDES = -I$(TOPDIR)/include -I$(TOPDIR)/libc/include -I$(TOPDIR)/elks/include
 DEFINES = -D__ELKS__
-CFLAGS = -Os $(CLBASE) $(WARNINGS) $(INCLUDES) $(DEFINES) $(LOCALFLAGS)
+CFLAGS = $(OPTFLAGS) $(CLBASE) $(WARNINGS) $(INCLUDES) $(DEFINES) $(LOCALFLAGS)
 LDFLAGS = $(CLBASE)
 LDLIBS =
 

--- a/elkscmd/gui/render.c
+++ b/elkscmd/gui/render.c
@@ -263,7 +263,6 @@ void R_LineFloodFill(int x, int y, int color, int ogColor)
             // Fill right
             if(leftestX < CANVAS_WIDTH && readpixel(leftestX, curElement.y) == ogColor)
             {
-                //pixels[leftestX + curElement.y * width] = color;
                 drawpixel(leftestX, curElement.y, color);
 
                 // Check above this pixel


### PR DESCRIPTION
This is an experimental update for paint, changing the optimization flags for the ia16-elf-gcc compiled version.

[Other research](http://git.musl-libc.org/cgit/musl/commit/?id=b90841e2583237a4132bbbd74752e0e9563660cd) has shown that GCC's -Os optimize for size produced some unwanted optimizations, especially those converting left shifts to MUL instructions, which this group of optimization settings overrides, while also apparently producing pretty small binaries.

These new optimizations are meant to increase speed as much as possible for slow 8088 CPUs while keeping the code size increase small.

In paint's case, the size only increased 400 bytes to 15,616 bytes.

I was previously having problems with paint crashing when compiling with raw -O2 or -O3 but for unknown reasons that problem has gone away. For this reason I am calling this change experimental, and upon further evaluation and testing results will consider it permanent and possibly used for the of ELKS applications and possibly the kernel.