### PR TITLE
[paint] Implement XOR cursor for testing

### DIFF
--- a/elkscmd/gui/app.c
+++ b/elkscmd/gui/app.c
@@ -152,6 +152,7 @@ void A_GameLoop(void)
             break;
 
             case mode_Circle:
+                hidecursor();
                 // Erase the old preview circle
                 if (lastRadius > 0) {
                     set_op(0x18);    // turn on XOR drawing
@@ -163,6 +164,7 @@ void A_GameLoop(void)
                     R_DrawDisk(startX, startY, radius, current_color, CANVAS_WIDTH);
                 else
                     R_DrawCircle(startX, startY, radius, current_color); // Final draw
+                showcursor();
                 lastRadius = 0;
                 current_state = state_Idle;
             break;

--- a/elkscmd/gui/app.c
+++ b/elkscmd/gui/app.c
@@ -167,6 +167,7 @@ void A_GameLoop(void)
                 current_state = state_Idle;
             break;
             case mode_Rectangle:
+                hidecursor();
                 // Erase the old preview
                 set_op(0x18);    // turn on XOR drawing
                 R_DrawRectangle(startX, startY, omx, omy); // erase using XOR
@@ -176,6 +177,7 @@ void A_GameLoop(void)
                     R_DrawFilledRectangle(startX, startY, mx, my); // Final draw
                 else
                     R_DrawRectangle(startX, startY, mx, my);
+                showcursor();
                 current_state = state_Idle;
             break;
         }


### PR DESCRIPTION
@Vutshi, this implements quick-and-dirty XOR cursor drawing, for your evaluation and speed testing. It appears quite fast, and I have not yet changed the cursor bitmasks, just using them as-is for early evaluation.

This routine was written quickly and only the cursor mask bits are used when XOR drawing, unmodified. If you like this, we'll probably want to slightly adjust the bits drawn as the size is a bit big for the large cursor, and a little small for the small cursor. There is more space available in 16x16 and 8x8 cursors, since we don't have to "outline" the cursor with a mask and separate cursor bits; instead just one set of bits (mask bits for now) are used to flip the color state when set.

To turn XOR cursor drawing on, edit cursor.c and set USE_XOR_CURSOR to 1 and recompile. You will see how the cursor changes color as it goes over the colors in the control panel, and is a bit different than what you might think/want.

Everything works well, except there was a slight display problem whenever the mouse cursor intersected the rectangle or circle just after mouse up using XOR cursor. I think I fixed this with some hidecursor/showcursor wrappers. (All draw code needs to be wrapped like this, but I tried to have that normally handled automatically the way the input loop was written).

On the issue of mouse release, I am thinking that after circle drawing, the mouse might want to be moved back to the center of the circle using movecursor(startx, starty) rather than have it "appear" outside the circle as it does now. 

To make this easier for you to evaluate, I'm going to commit this now. Feel free to add better XOR cursors (guarded with USE_XOR_CURSOR) for 16x16 or 8x8, depending on how fast an 8088 can handle. If you like XOR cursor, and I can clean up just cursor.c afterwards. If you think XOR is not worth having, we can remove it. It could also be possible to make this a runtime option, cycling through both cursors and XOR/NOP drawing of cursors with 'm' keystrokes, but that's probably overkill.

