### PR TITLE
Paint cursors update

### DIFF
--- a/elkscmd/gui/cursor.c
+++ b/elkscmd/gui/cursor.c
@@ -60,71 +60,97 @@ static MWPIXELVALHW cursavbits[MWMAX_CURSOR_SIZE * MWMAX_CURSOR_SIZE];
 #endif
 
 /* Small 8x8 cursor for machines to slow for 16x16 cursors */
-static MWIMAGEBITS smcursormask[8] = {
-    mask(X,X,X,X,X,X,_,_),
-    mask(X,X,X,X,X,_,_,_),
-    mask(X,X,X,X,_,_,_,_),
-    mask(X,X,X,X,X,_,_,_),
-    mask(X,X,X,X,X,X,_,_),
-    mask(X,_,_,X,X,X,X,_),
-    mask(_,_,_,_,X,X,X,X),
-    mask(_,_,_,_,_,X,X,X)
-};
-static MWIMAGEBITS smcursorbits[8] = {
-    mask(_,_,_,_,_,_,_,_),
-    mask(_,X,X,X,X,_,_,_),
-    mask(_,X,X,X,_,_,_,_),
-    mask(_,X,X,X,_,_,_,_),
-    mask(_,X,_,X,X,_,_,_),
-    mask(_,_,_,_,X,X,_,_),
-    mask(_,_,_,_,_,X,X,_),
-    mask(_,_,_,_,_,_,X,X)
-};
-struct cursor cursor_sm = {
-    8, 8, 1, 1, WHITE, BLACK, smcursorbits, smcursormask
-};
+#if USE_XOR_CURSOR
+    static MWIMAGEBITS smcursorbits[8] = {
+        mask(X,_,_,_,_,_,_,_),
+        mask(X,X,_,_,_,_,_,_),
+        mask(X,_,X,_,_,_,_,_),
+        mask(X,_,_,X,_,_,_,_),
+        mask(X,_,_,_,X,_,_,_),
+        mask(X,_,X,X,X,X,_,_),
+        mask(X,X,_,_,_,_,_,_),
+        mask(X,_,_,_,_,_,_,_)
+    };
+    static MWIMAGEBITS smcursormask[8] = {
+        mask(X,_,_,_,_,_,_,_),
+        mask(X,X,_,_,_,_,_,_),
+        mask(X,X,X,_,_,_,_,_),
+        mask(X,X,X,X,_,_,_,_),
+        mask(X,X,X,X,X,_,_,_),
+        mask(X,X,X,X,X,X,_,_),
+        mask(X,X,_,_,_,_,_,_),
+        mask(X,_,_,_,_,_,_,_)
+    };
+    struct cursor cursor_sm = {
+        6, 8, 1, 1, WHITE, BLACK, smcursorbits, smcursormask
+    };
+#else
+    static MWIMAGEBITS smcursormask[8] = {
+        mask(X,_,_,_,_,_,_,_),
+        mask(X,X,_,_,_,_,_,_),
+        mask(X,X,X,_,_,_,_,_),
+        mask(X,X,X,X,_,_,_,_),
+        mask(X,X,X,X,X,_,_,_),
+        mask(X,X,X,X,X,X,_,_),
+        mask(X,X,X,X,X,X,X,_),
+        mask(X,X,X,_,_,_,_,_)
+    };
+    static MWIMAGEBITS smcursorbits[8] = {
+        mask(_,_,_,_,_,_,_,_),
+        mask(_,_,_,_,_,_,_,_),
+        mask(_,X,_,_,_,_,_,_),
+        mask(_,X,X,_,_,_,_,_),
+        mask(_,X,X,X,_,_,_,_),
+        mask(_,X,X,X,X,_,_,_),
+        mask(_,X,X,_,_,_,_,_),
+        mask(_,_,_,_,_,_,_,_)
+    };
+    struct cursor cursor_sm = {
+        7, 8, 1, 1, WHITE, BLACK, smcursorbits, smcursormask
+    };
+#endif
 
 /* Full size 16x16 cursor */
 static MWIMAGEBITS lgcursorbits[16] = {
 //       8 4 2 1 8 4 2 1 8 4 2 1 8 4 2 1
-    MASK(X,X,X,_,_,_,_,_,_,_,_,_,_,_,_,_),  // E000
-    MASK(X,_,_,X,X,_,_,_,_,_,_,_,_,_,_,_),  // 9800
-    MASK(X,_,_,_,_,X,X,_,_,_,_,_,_,_,_,_),  // 8600
-    MASK(_,X,_,_,_,_,_,X,X,_,_,_,_,_,_,_),  // 4180
-    MASK(_,X,_,_,_,_,_,_,_,X,X,_,_,_,_,_),  // 4060
-    MASK(_,_,X,_,_,_,_,_,_,_,_,X,X,_,_,_),  // 2018
-    MASK(_,_,X,_,_,_,_,_,_,_,_,_,_,X,_,_),  // 2004
-    MASK(_,_,_,X,_,_,_,_,_,X,X,X,X,X,_,_),  // 107C
-    MASK(_,_,_,X,_,_,_,_,_,_,X,_,_,_,_,_),  // 1020
-    MASK(_,_,_,_,X,_,_,X,_,_,_,X,_,_,_,_),  // 0910
-    MASK(_,_,_,_,X,_,_,X,_,_,_,_,X,_,_,_),  // 0988
-    MASK(_,_,_,_,_,X,_,X,_,X,_,_,_,X,_,_),  // 0544
-    MASK(_,_,_,_,_,X,_,X,_,_,X,_,_,_,X,_),  // 0522
-    MASK(_,_,_,_,_,_,X,_,_,_,_,X,_,_,_,X),  // 0211
-    MASK(_,_,_,_,_,_,_,_,_,_,_,_,X,_,X,_),  // 000A
-    MASK(_,_,_,_,_,_,_,_,_,_,_,_,_,X,_,_)   // 0004
+    MASK(X,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_),
+    MASK(X,X,_,_,_,_,_,_,_,_,_,_,_,_,_,_),
+    MASK(X,_,X,_,_,_,_,_,_,_,_,_,_,_,_,_),
+    MASK(X,_,_,X,_,_,_,_,_,_,_,_,_,_,_,_),
+    MASK(X,_,_,_,X,_,_,_,_,_,_,_,_,_,_,_),
+    MASK(X,_,_,_,_,X,_,_,_,_,_,_,_,_,_,_),
+    MASK(X,_,_,_,_,_,X,_,_,_,_,_,_,_,_,_),
+    MASK(X,_,_,_,_,_,_,X,_,_,_,_,_,_,_,_),
+    MASK(X,_,_,_,_,_,_,_,X,_,_,_,_,_,_,_),
+    MASK(X,_,_,_,_,_,_,_,_,X,_,_,_,_,_,_),
+    MASK(X,_,_,_,_,_,X,X,X,X,X,_,_,_,_,_),
+    MASK(X,_,_,_,_,_,X,_,_,_,_,_,_,_,_,_),
+    MASK(X,_,_,X,_,_,X,_,_,_,_,_,_,_,_,_),
+    MASK(X,_,X,_,X,_,_,X,_,_,_,_,_,_,_,_),
+    MASK(X,X,_,_,X,_,_,X,_,_,_,_,_,_,_,_),
+    MASK(X,_,_,_,_,X,X,X,_,_,_,_,_,_,_,_)
 };
 static MWIMAGEBITS lgcursormask[16] = {
 //       8 4 2 1 8 4 2 1 8 4 2 1 8 4 2 1
-    MASK(X,X,X,_,_,_,_,_,_,_,_,_,_,_,_,_),  // E000
-    MASK(X,X,X,X,X,_,_,_,_,_,_,_,_,_,_,_),  // F800
-    MASK(X,X,X,X,X,X,X,_,_,_,_,_,_,_,_,_),  // FE00
-    MASK(_,X,X,X,X,X,X,X,X,_,_,_,_,_,_,_),  // 7F80
-    MASK(_,X,X,X,X,X,X,X,X,X,X,_,_,_,_,_),  // 7FE0
-    MASK(_,_,X,X,X,X,X,X,X,X,X,X,X,_,_,_),  // 3FF8
-    MASK(_,_,X,X,X,X,X,X,X,X,X,X,X,X,_,_),  // 3FFC
-    MASK(_,_,_,X,X,X,X,X,X,X,X,X,X,X,_,_),  // 1FFC
-    MASK(_,_,_,X,X,X,X,X,X,X,X,_,_,_,_,_),  // 1FE0
-    MASK(_,_,_,_,X,X,X,X,X,X,X,X,_,_,_,_),  // 0FF0
-    MASK(_,_,_,_,X,X,X,X,X,X,X,X,X,_,_,_),  // 0FF8
-    MASK(_,_,_,_,_,X,X,X,_,X,X,X,X,X,_,_),  // 077C
-    MASK(_,_,_,_,_,X,X,X,_,_,X,X,X,X,X,_),  // 073E
-    MASK(_,_,_,_,_,_,X,_,_,_,_,X,X,X,X,X),  // 021F
-    MASK(_,_,_,_,_,_,_,_,_,_,_,_,X,X,X,_),  // 000E
-    MASK(_,_,_,_,_,_,_,_,_,_,_,_,_,X,_,_)   // 0004
+    MASK(X,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_),
+    MASK(X,X,_,_,_,_,_,_,_,_,_,_,_,_,_,_),
+    MASK(X,X,X,_,_,_,_,_,_,_,_,_,_,_,_,_),
+    MASK(X,X,X,X,_,_,_,_,_,_,_,_,_,_,_,_),
+    MASK(X,X,X,X,X,_,_,_,_,_,_,_,_,_,_,_),
+    MASK(X,X,X,X,X,X,_,_,_,_,_,_,_,_,_,_),
+    MASK(X,X,X,X,X,X,X,_,_,_,_,_,_,_,_,_),
+    MASK(X,X,X,X,X,X,X,X,_,_,_,_,_,_,_,_),
+    MASK(X,X,X,X,X,X,X,X,X,_,_,_,_,_,_,_),
+    MASK(X,X,X,X,X,X,X,X,X,X,_,_,_,_,_,_),
+    MASK(X,X,X,X,X,X,X,X,X,X,X,_,_,_,_,_),
+    MASK(X,X,X,X,X,X,X,_,_,_,_,_,_,_,_,_),
+    MASK(X,X,X,X,X,X,X,_,_,_,_,_,_,_,_,_),
+    MASK(X,X,X,_,X,X,X,X,_,_,_,_,_,_,_,_),
+    MASK(X,X,_,_,X,X,X,X,_,_,_,_,_,_,_,_),
+    MASK(X,_,_,_,_,X,X,X,_,_,_,_,_,_,_,_)
 };
 struct cursor cursor_lg = {
-    16, 16, 0, 0, WHITE, BLACK, lgcursorbits, lgcursormask
+    11, 16, 0, 0, WHITE, BLACK, lgcursorbits, lgcursormask
 };
 
 void initcursor(void)

--- a/elkscmd/gui/render.c
+++ b/elkscmd/gui/render.c
@@ -123,10 +123,10 @@ void R_DrawCurrentColor(void)
 // ----------------------------------------------------
 void R_HighlightActiveButton(void)
 {
-    int x1 = paletteButtons[currentModeButton].box.x;
-    int x2 = x1 + paletteButtons[currentModeButton].box.w - 1;
-    int y1 = paletteButtons[currentModeButton].box.y;
-    int y2 = y1 + paletteButtons[currentModeButton].box.h - 1;
+    int x1 = paletteButtons[currentModeButton].box.x + 1;
+    int x2 = x1 + paletteButtons[currentModeButton].box.w - 3;
+    int y1 = paletteButtons[currentModeButton].box.y + 1;
+    int y2 = y1 + paletteButtons[currentModeButton].box.h - 3;
     set_op(0x18);    // turn on XOR drawing
     fillrect(x1, y1, x2, y2, WHITE);
     set_op(0);       // turn off XOR drawing


### PR DESCRIPTION
- Introduced new cursor designs, with support for both XOR and non-XOR rendering modes.
- Reduced the thickness of the active mode button outline for a cleaner appearance.

<img width="138" alt="Screenshot 2025-04-15 at 23 18 07" src="https://github.com/user-attachments/assets/5794ab46-7ace-44c2-bef9-bd2270121a35" />      <img width="190" alt="Screenshot 2025-04-15 at 23 17 55" src="https://github.com/user-attachments/assets/28745578-981e-4db2-a465-03e2c078724a" />

XOR:
<img width="124" alt="Screenshot 2025-04-15 at 23 19 11" src="https://github.com/user-attachments/assets/92ca7c5b-4500-4fd6-a6c0-701d01b9c251" />      <img width="153" alt="Screenshot 2025-04-15 at 23 19 19" src="https://github.com/user-attachments/assets/79877f23-8533-43dc-90d4-84a843ea8583" />
