### PR TITLE
[paint] Fix cursor wrap and last line not displayed, fix keyboard ignored until mouse event

### DIFF
--- a/elkscmd/gui/event.c
+++ b/elkscmd/gui/event.c
@@ -41,12 +41,13 @@ int event_wait_timeout(struct event *e, int timeout)
         timeint.tv_usec = (timeout & 0x3FF) << 10;
         tv = &timeint;
     }
-    FD_ZERO(&fdset);
-    FD_SET(mouse_fd, &fdset);
-    FD_SET(0, &fdset);
 
     for (;;)
     {
+        FD_ZERO(&fdset);
+        FD_SET(mouse_fd, &fdset);
+        FD_SET(0, &fdset);
+
         ret = select(mouse_fd + 1, &fdset, NULL, NULL, tv);
         if (ret == 0)
         {
@@ -125,6 +126,7 @@ out:
                     lasty = y;
                     return 1;
                 }
+                /* here when duplicate mouse event - ignore */
             }
         }
     }

--- a/elkscmd/gui/graphics.c
+++ b/elkscmd/gui/graphics.c
@@ -105,14 +105,14 @@ void drawvline(int x, int y1, int y2, int c)
 #endif /* __WATCOMC__ */
 
 #if defined(__WATCOMC__) || defined(__ia16__)
-/* draw 8 bits horizontally using XOR amd one or two memory writes */
+/* draw 8 bits horizontally using XOR and one or two memory writes w/clipping */
 static void drawbits(int x, int y, unsigned char bits)
 {
     set_op(0x18);
     set_color(15);
     unsigned int dst = (y<<6) + (y<<4) + (x>>3);  /* y * 80 + x / 8 */
     if (x < SCREENWIDTH) {
-        set_mask(bits >> ((x & 7)));
+        set_mask(bits >> (x & 7));
         asm_orbyte(dst);
     }
     if (x < SCREENWIDTH-8) {

--- a/elkscmd/gui/graphics.c
+++ b/elkscmd/gui/graphics.c
@@ -111,15 +111,13 @@ static void drawbits(int x, int y, unsigned char bits)
     set_op(0x18);
     set_color(15);
     unsigned int dst = (y<<6) + (y<<4) + (x>>3);  /* y * 80 + x / 8 */
-    if ((x & 7) == 0) {
-        set_mask(bits);
-        asm_orbyte(dst);
-    } else {
+    if (x < SCREENWIDTH) {
         set_mask(bits >> ((x & 7)));
-        asm_orbyte(dst); dst++;
-
-        set_mask(bits << (8 - (x & 7)));
         asm_orbyte(dst);
+    }
+    if (x < SCREENWIDTH-8) {
+        set_mask(bits << (8 - (x & 7)));
+        asm_orbyte(dst+1);
     }
     set_op(0);
 }
@@ -127,9 +125,8 @@ static void drawbits(int x, int y, unsigned char bits)
 /* fast cursor draw for EGA/VGA hardware */
 void vga_drawcursor(int x, int y, int height, unsigned short *mask)
 {
-    unsigned int bits;
     for (int i=0; i<height; i++) {
-        bits = *mask++;
+        unsigned int bits = *mask++;
         if (bits >> 8)
             drawbits(x, y, bits >> 8);
         if (bits & 0xff)

--- a/elkscmd/gui/mouse.c
+++ b/elkscmd/gui/mouse.c
@@ -24,6 +24,7 @@
 #define MOUSE_PC            0       /* pc/logitech mouse*/
 #define MOUSE_PS2           0       /* PS/2 mouse */
 
+#define USE_MOUSE_ACCEL     0       /* =1 to use mouse acceleration */
 #define SCALE       2               /* default scaling factor for acceleration */
 #define THRESH      5               /* default threshhold for acceleration */
 
@@ -168,6 +169,7 @@ void close_mouse(void)
     mouse_fd = -1;
 }
 
+#if USE_MOUSE_ACCEL
 static void
 filter_relative(int *xpos, int *ypos, int x, int y)
 {
@@ -196,6 +198,7 @@ filter_relative(int *xpos, int *ypos, int x, int y)
     *xpos = x;
     *ypos = y;
 }
+#endif
 
 #if MOUSE_PS2
 /* IntelliMouse PS/2 protocol uses four byte reports
@@ -290,7 +293,7 @@ int read_mouse(int *dx, int *dy, int *dz, int *bptr)
      */
     while (nbytes-- > 0) {
         if ((*parse)((int) *bp++)) {
-#if MOUSE_MICROSOFT
+#if USE_MOUSE_ACCEL && MOUSE_MICROSOFT
             filter_relative(&xd, &yd, xd, yd);
 #endif
             *dx = xd;

--- a/elkscmd/gui/vgalib.h
+++ b/elkscmd/gui/vgalib.h
@@ -42,79 +42,58 @@
 
 #define set_color(color)                        \
     asm volatile (                              \
-        "mov $0x03ce,%%dx\n"                    \
-        "mov %%al,%%ah\n"                       \
-        "xor %%al,%%al\n"                       \
         "out %%ax,%%dx\n"                       \
         : /* no output */                       \
-        : "a" ((unsigned short)(color))         \
-        : "d"                                   \
+        : "a" ((unsigned short)(((color)<<8)|0))\
+        , "d" (0x03ce)                          \
         )
 
 #define set_enable_sr(flag)                     \
     asm volatile (                              \
-        "mov $0x03ce,%%dx\n"                    \
-        "mov %%al,%%ah\n"                       \
-        "mov $1,%%al\n"                         \
         "out %%ax,%%dx\n"                       \
         : /* no output */                       \
-        : "a" ((unsigned short)(flag))          \
-        : "d"                                   \
+        : "a" ((unsigned short)(((flag)<<8)|1)) \
+        , "d" (0x03ce)                          \
         )
 
 #define set_op(op)                              \
     asm volatile (                              \
-        "mov $0x03ce,%%dx\n"                    \
-        "mov %%al,%%ah\n"                       \
-        "mov $3,%%al\n"                         \
         "out %%ax,%%dx\n"                       \
         : /* no output */                       \
-        : "a" ((unsigned short)(op))            \
-        : "d"                                   \
+        : "a" ((unsigned short)(((op)<<8)|3))   \
+        , "d" (0x03ce)                          \
         )
 
 #define set_read_plane(plane)                   \
     asm volatile (                              \
-        "mov $0x03ce,%%dx\n"                    \
-        "mov %%al,%%ah\n"                       \
-        "mov $4,%%al\n"                         \
         "out %%ax,%%dx\n"                       \
         : /* no output */                       \
-        : "a" ((unsigned short)(plane))         \
-        : "d"                                   \
+        : "a" ((unsigned short)(((plane)<<8)|4))\
+        , "d" (0x03ce)                          \
         )
 
 #define set_write_mode(mode)                    \
     asm volatile (                              \
-        "mov $0x03ce,%%dx\n"                    \
-        "mov %%al,%%ah\n"                       \
-        "mov $5,%%al\n"                         \
         "out %%ax,%%dx\n"                       \
         : /* no output */                       \
-        : "a" ((unsigned short)(mode))          \
-        : "d"                                   \
+        : "a" ((unsigned short)(((mode)<<8)|5)) \
+        , "d" (0x03ce)                          \
         )
 
 #define set_mask(mask)                          \
     asm volatile (                              \
-        "mov $0x03ce,%%dx\n"                    \
-        "mov %%al,%%ah\n"                       \
-        "mov $8,%%al\n"                         \
         "out %%ax,%%dx\n"                       \
         : /* no output */                       \
-        : "a" ((unsigned short)(mask))          \
-        : "d"                                   \
+        : "a" ((unsigned short)(((mask)<<8)|8)) \
+        , "d" (0x03ce)                          \
         )
 
 #define set_write_planes(mask)                  \
     asm volatile (                              \
-        "mov $0x03c4,%%dx\n"                    \
-        "mov %%al,%%ah\n"                       \
-        "mov $2,%%al\n"                         \
         "out %%ax,%%dx\n"                       \
         : /* no output */                       \
-        : "a" ((unsigned short)(mask))          \
-        : "d"                                   \
+        : "a" ((unsigned short)(((mask)<<8)|2)) \
+        , "d" (0x03c4)                          \
         )
 
 #define set_bios_mode(mode)                     \
@@ -127,13 +106,13 @@
 #define asm_orbyte(offset)                      \
     asm volatile (                              \
         "mov %%ds,%%dx\n"                       \
-        "mov $0xa000,%%ax\n"                    \
         "mov %%ax,%%ds\n"                       \
         "or %%al,(%%bx)\n"                      \
         "mov %%dx,%%ds\n"                       \
         : /* no output */                       \
-        : "b" ((unsigned short)(offset))        \
-        : "a", "d"                              \
+        : "a" (0xa000)                          \
+        , "b" ((unsigned short)(offset))        \
+        : "d","dl","dh"                         \
         )
 
 #define asm_getbyte(offset)                     \
@@ -141,14 +120,14 @@
     unsigned short _v;                          \
     asm volatile (                              \
         "mov %%ds,%%dx\n"                       \
-        "mov $0xa000,%%ax\n"                    \
         "mov %%ax,%%ds\n"                       \
         "mov (%%bx),%%al\n"                     \
         "xor %%ah,%%ah\n"                       \
         "mov %%dx,%%ds\n"                       \
         : "=a" (_v)                             \
-        : "b" ((unsigned short)(offset))        \
-        : "d"                                   \
+        : "a" (0xa000)                          \
+        , "b" ((unsigned short)(offset))        \
+        : "d","dl","dh"                         \
         );                                      \
     _v; })
 


### PR DESCRIPTION
Several enhancements and fixes included in this PR:
- Fix XOR cursor wrap when using fast VGA drawcursor
- Fix ignored keyboard events until mouse moved from https://github.com/ghaerr/elks/pull/2303#issuecomment-2812046071
- Draws last line of XOR cursor previously not displayed
- Rewrite ia16-gcc graphics macros for improved speed and code generation
- Mouse acceleration now optional and default OFF, better with no acceleration when using faster XOR cursor display
- Fixed ia16-gcc code generation bug when using ASM "d" constraint and char variable as function parameter
- Rewrote drawbits function for higher speed

Very long story short, the ignored keypress bug turned out not to be a kernel problem, although I ended up fully tracing through all the select() codepaths before finding that the issue was in the Paint event code. The fd_set file descriptor array being passed to select() was not being reset in the inner event wait loop. When the kernel happened to send a mouse event with the same X,Y location as just previous, which apparently happens on occasion, then the select() loop was reentered with just the mouse file descriptor set and wasn't in fact selecting for keyboard events - so none were delivered until the next (mouse) event.

Learned more about ia16-gcc magic asm macro constraints: when specifying "d" as modified for DX, the compiler still thinks that DH or DL are available and was generating code loading DH which corrupted the function, but only when the function used a char parameter (or likely a char variable as well). Just goes to show that using char parameters for functions ends up using lesser-used compiler code paths, and this one was buggy. Also found that the 
cross/build/gcc-src/gcc/config.ia16/constraints.md file which lists the asm constraints doesn't actually match the compiler constraints accepted. There seems to be no documentation for this anywhere, so its trial and error.

After fiddling lots with the asm constraints, it was seen that far better code is generated if AX and DX were loaded via parameters to the asm macro, rather than internally and specifying modifiers. This ended up making the VGA hardware set_op and other functions faster, since the compiler knew what was in each register and could optimize its own code generation around that.

