### PR TITLE
[kernel] Store syscall table in ROM on ROM platforms

### DIFF
--- a/elks/arch/i86/kernel/mkentry.sh
+++ b/elks/arch/i86/kernel/mkentry.sh
@@ -12,7 +12,11 @@ cat <<'.eof'
 
 	.code16
 
+#ifdef CONFIG_ROMCODE
+	.text
+#else
 	.data
+#endif
 	.p2align 1
 sys_call_table:
 .eof
@@ -103,6 +107,9 @@ syscall:
 	// look up address and jump to function
 	mov  %ax,%bx
         add  %ax,%bx              // multiply by 2
+#ifdef CONFIG_ROMCODE
+	cs
+#endif
         jmp    *sys_call_table(%bx)
 
 //	All unimplemented calls


### PR DESCRIPTION
Since the system call table is already in memory on ROM platforms, and it doesn't appear to be written to at runtime, there's no need to copy it from the text segment to the data segment.

This saves about 416 bytes of RAM on those platforms at the expense of having to process the `cs:` segment modifier as part of a syscall.