### PR TITLE
[kernel] Place temporary stacks in BSS over data

### DIFF
--- a/elks/arch/i86/kernel/irqtab.S
+++ b/elks/arch/i86/kernel/irqtab.S
@@ -441,6 +441,7 @@ pmsg:   .ascii "Running unknown code\0"
 #endif
 dmsg:   .ascii  "DIVIDE FAULT\0"
 
+	.bss
         .p2align 1
 endistack:
         .skip ISTACK_BYTES,0    // interrupt stack


### PR DESCRIPTION
This reduces the kernel near data size by 640 bytes, which reduces the Image size a little on both disk and ROM platforms.