### PR TITLE
Documentation/index.html: fix dead link to text/shell.txt

### DIFF
--- a/Documentation/index.html
+++ b/Documentation/index.html
@@ -45,7 +45,7 @@
 	<li><p style="margin-bottom: 0cm"><a href="html/user/ELKS_OPM.html">ELKS
 	One Page Manual</a> 
 	</p>
-	<li><p style="margin-bottom: 0cm"><a href="text/shell.txt">Shell
+	<li><p style="margin-bottom: 0cm"><a href="html/user/shell.html">Shell
 	command line editing and Tab completion</a></p>
 	<li><p style="margin-bottom: 0cm"><a href="html/user/screen.html">The
 	screen window manager</a> 


### PR DESCRIPTION
Currently this links to https://raw.githubusercontent.com/ghaerr/elks/master/Documentation/text/shell.txt which is a 404, the correct address is https://htmlpreview.github.io/?https://raw.githubusercontent.com/ghaerr/elks/master/Documentation/html/user/shell.html

Fixes: commit ea11059c55 ("Update index.html in Documentation directory")