### PR TITLE
[kernel] Fix variety of PC-98 issues when using XMS

### DIFF
--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -1247,7 +1247,7 @@ checkhma:
 	mov	%ax,%ds
 	mov	xms_kbytes,%ax		//. must have xms size >= 64k
 	cmp	$64,%ax
-	jl	1f
+	jc	1f
 	mov	hma_kernel,%al		// and hma=kernel in /bootopts
 	test	%al,%al
 	jz	1f
@@ -1312,7 +1312,7 @@ arch_get_mem:
 	push %bx
 	xor %ax,%ax
 	mov %ax,%es
-	mov $0x501,%bx
+	mov $0x501,%bx                  // 3 bit size - 1 in 128k of 0-1M mem range
 	mov %es:(%bx),%cl
 	and $7,%cl
 	inc %cl
@@ -1346,12 +1346,16 @@ arch_set_initseg:
 
    xor %ax,%ax                  // get xms size in CX
    mov %ax,%ds
-   mov $0x401,%bx               // xms_kbytes = *(byte 0x401) * 128
+   mov $0x401,%bx               // byte size in 128k of 1M-16M mem range
    mov (%bx),%al
    mov $128,%cl
    mul %cl
    mov %ax,%cx
-   mov $0x594,%bx               // xms_kbytes += *(word 0x594) * 1024
+// Check for possible hole between end of 1M-16M range and 16M+ range
+// When 0401h = 78h (=15MiB), hole does not exist
+   cmp $15360,%ax               // 15M, no hole
+   jnz 2f
+   mov $0x594,%bx               // word size in 1024k of 16M-4G range
    mov (%bx),%ax
    cmp $49,%ax                  // don't allow overflow when > 64MB
    jl 1f

--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -972,8 +972,9 @@ putc:	push %ax
 	pop %ax
 	ret
 
-// include code to determine early CPU types
+// include code to determine CPU type
 // needed for guessing system capabilities (sys_caps) for XT vs AT BIOS
+// needed for XMS access using unreal vs INT 15
 // TODO: remove and use alternate mechanism for XT vs AT BIOS capabilities
 #include "cputype.S"
 
@@ -1344,6 +1345,8 @@ arch_set_initseg:
    stosw
    pop %es
 
+   call	getcpu                  // implemented in cputype.S
+
    xor %ax,%ax                  // get xms size in CX
    mov %ax,%ds
    mov $0x401,%bx               // byte size in 128k of 1M-16M mem range
@@ -1425,6 +1428,10 @@ putesc_n:
    jmp put_end
 tvram_x:
    .word 160
+
+// include code to determine 286 vs 386 CPU type
+// needed for XMS access using unreal vs INT 1F
+#include "cputype.S"
 
 // include code to enable/verify A20 address gate
 #include "../lib/a20-pc98.inc"

--- a/elks/arch/i86/lib/unreal.S
+++ b/elks/arch/i86/lib/unreal.S
@@ -176,7 +176,6 @@ in_vm86mode:
 #
 	.global	linear32_peekw
 linear32_peekw:
-	call   setgpf
 	mov    %si,%dx
 	//cli                 // uncomment if 32-bit registers used in interrupt routines
 

--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -16,12 +16,12 @@
 
 /*
  * Set the below =1 to automatically disable using XMS INT 15 instead of
- * hanging the system during boot, when hma=kernel and INT 15 disables A20
- * in some Compaq and other BIOSes (QEMU and PC-98 do not).
+ * hanging the system during boot, when hma=kernel and INT 15/1F disables A20
+ * in Compaq and most other BIOSes (QEMU does not).
  * Otherwise, when =0, hma=kernel must be commented out in /bootopts
  * to boot when configured for xms=int15 on those same systems.
  */
-#define AUTODISABLE		0		/* =1 to disable XMS if BIOS INT 15 disables A20 */
+#define AUTODISABLE		1		/* =1 to disable XMS if BIOS INT 15 disables A20 */
 
 /* these used when running XMS_INT15 */
 struct gdt_table;
@@ -71,8 +71,8 @@ int INITPROC xms_init(void)
 	if (xms_bootopts == XMS_INT15 || (arch_cpu <= 6 && xms_bootopts == XMS_UNREAL)) {
 #if AUTODISABLE
 		if (kernel_cs == 0xffff) {
-			/* BIOS INT 15 block_move disables A20 on some systems! */
-			printk("disabled w/kernel HMA and int 15\n");
+			/* BIOS INT 15/1F block_move disables A20 on most systems! */
+			printk("disabled w/kernel HMA and int 15/1F\n");
 			return XMS_DISABLED;
 		}
 #endif

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -55,7 +55,7 @@
 #define MAX_SERIAL              1       /* max number of serial tty devices*/
 #define SETUP_VID_COLS          80      /* video # columns */
 #define SETUP_VID_LINES         25      /* video # lines */
-#define SETUP_CPU_TYPE          1       /* processor type = 8086 */
+#define SETUP_CPU_TYPE          setupb(0x20)    /* processor type */
 #define SETUP_MEM_KBYTES        setupw(0x2a)    /* base memory in 1K bytes */
 #define SETUP_XMS_KBYTES        setupw(0x1ea)   /* xms memory in 1K bytes */
 #define SETUP_ROOT_DEV          setupw(0x1fc)   /* root device, kdev_t or BIOS dev */

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -220,7 +220,7 @@ static void INITPROC kernel_banner(seg_t init, seg_t extra)
 #endif
 
 #ifdef CONFIG_ARCH_PC98
-    printk("PC-9801 machine, ");
+    printk("PC-9801 cpu %d, ", arch_cpu);
 #endif
 
 #ifdef CONFIG_ARCH_8018X


### PR DESCRIPTION
This PR fixes or provides PC-98 system enhancements for the following issues found and described by @tyama501 and @drachen6jp in #2293:

- Fix boot crashes seen on various hardware with extended memory (XMS) sizes
- Handle possible XMS memory hole issue between 15MiB and 16MiB on some systems. If a hardware memory hole exists, by BIOS byte 401h indicating < 15MiB XMS memory present below 16MiB, any upper XMS memory >= 16MiB indicated by BIOS word 594h will be ignored. This effectively means that only the XMS memory below any memory hole will be used
- Automatically detect CPU type of 286 vs 386, and selecting either INT 1F or unreal mode for XMS, respectively
- Automatically disable XMS when on 286 CPU and HMA kernel loaded. This is required until the INT 1F block move function is moved to lower memory and the A20 gate is reenabled, coming in next PR. XMS can be enabled in this situation by removing hma=kernel in /bootopts
- Shows CPU type in boot screen: 6=80286, 7=80386+

PC-98 BIOS memory locations used for XMS calculations:
    0:501h, 3bit size - 1 in 128k of memory in 1-1M range
    0:401h, byte size of memory in 128k of memory in 1M-16M range
    0:594h, word size of memory in 1024k of memory in 16M-4GB range

Tested only on DosBox-X. It seems that DosBox-X always keeps A20 gate enabled after INT 1F, unlike real hardware; this will make moving block-move out of HMA kernel hard to test. 

Testing all XMS modes (xms=on, xms=int15) is needed on 286 and 386 real hardware, as well as on Neko 21/W. This PR enables the first use of unreal mode on any PC-98 system.

@tyama501: I now understand what you are saying in your last issue with portions of the filesystem disappearing when the system is booted on XMS on 286. Unfortunately, I cannot duplicate this problem on DosBox-X. It is possible this has something to do with INT 1F call on 286, versus 386 or emulator? Can you duplicate this on another emulator? Perhaps @drachen6jp can test this problem on his 286 or 386 hardware?

Also, is Neko 21/W or another emulator available for macOS that I might be able to setup and use? @drachen6jp I see you are using a private build of QEMU for PC-98, very cool. Could that be compiled for macOS, that would be very nice for testing!