### PR TITLE
[ow libc] Save DS within OpenWatcom functions

### DIFF
--- a/libc/watcom/asm/fmemcmp.asm
+++ b/libc/watcom/asm/fmemcmp.asm
@@ -17,6 +17,8 @@ include struct.inc
         mov     bp,sp
         push    si
         push    di
+        push    ds          ; DS must be saved
+        push    es          ; save ES just in case
 
         mov     ds,dx
         mov     si,ax
@@ -33,7 +35,9 @@ endif
         jz      L1          ; equal
         sbb     ax,ax       ; not equal, AX now 0 or -1
         or      ax,1        ; AX now 1 or -1
-L1:     pop     di
+L1:     pop     es
+        pop     ds
+        pop     di
         pop     si
         pop     bp
         ret     2

--- a/libc/watcom/asm/fmemcpy.asm
+++ b/libc/watcom/asm/fmemcpy.asm
@@ -16,10 +16,11 @@ include struct.inc
         push    si
         push    di
         push    ds          ; DS must be saved
+        push    es          ; save ES just in case
 
         mov     ds,cx
         mov     si,bx
-        mov     es,dx       ; ES need not be saved
+        mov     es,dx
         mov     di,ax
 if _MODEL and _BIG_CODE
         mov     cx,6[bp]    ; n
@@ -31,6 +32,7 @@ endif
         rep movsw
         rcl     cx,1        ; then possibly final byte
         rep movsb
+        pop     es
         pop     ds
         pop     di
         pop     si

--- a/libc/watcom/asm/fmemcpy.asm
+++ b/libc/watcom/asm/fmemcpy.asm
@@ -15,10 +15,11 @@ include struct.inc
         mov     bp,sp
         push    si
         push    di
+        push    ds          ; DS must be saved
 
         mov     ds,cx
         mov     si,bx
-        mov     es,dx
+        mov     es,dx       ; ES need not be saved
         mov     di,ax
 if _MODEL and _BIG_CODE
         mov     cx,6[bp]    ; n
@@ -30,6 +31,7 @@ endif
         rep movsw
         rcl     cx,1        ; then possibly final byte
         rep movsb
+        pop     ds
         pop     di
         pop     si
         pop     bp


### PR DESCRIPTION
Fixes issue in #2313 found by @FrenkelS which broke Elksdoom.

`fmemcpy` now saves DS (and ES for good measure). The same fix is applied to `fmemcmp`.

Within Watcom ASM functions, it seems DS needs to be saved if altered, not sure whether ES needs saving or not. I haven't been able to generate any C code that depends on DS (or ES) being saved across a function call. Nonetheless, without saving DS in fmemcpy, Elksdoom crashes.

There seems to be some confusion in whether the segment registers should or must be saved across function calls; not sure whether this is a singular issue with Doom and ASM code, something required for all ASM functions mixed with C, or only required when mixing ASM functions with unknown ASM functions. The Open Watcom C  User's Guide states that saving and restoring segment registers is *not* normally emitted by the C compiler unless the -Wc,-r option is set, and caution should be exercised, although the warning seems related to protected mode selectors only:

![OWC -r option](https://github.com/user-attachments/assets/5b9732d9-cf22-4163-8385-bf3e8e8ba316)
