### PR TITLE
[kernel] Move INT 15/1F block move to FARPROC, enable A20 gate afterwards

### DIFF
--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -1252,6 +1252,7 @@ checkhma:
 	mov	hma_kernel,%al		// and hma=kernel in /bootopts
 	test	%al,%al
 	jz	1f
+	push    %cs			// enable_a20_gate is FARPROC
 	call	enable_a20_gate		// and A20 enabled
 	test	%ax,%ax
 	jz	1f

--- a/elks/arch/i86/lib/Makefile
+++ b/elks/arch/i86/lib/Makefile
@@ -82,9 +82,9 @@ $(OBJS1): $(TMPS1)
 $(OBJS2): $(SRCS2)
 $(OBJS3): $(SRCS3)
 
-unreal.o: a20-ibm.inc
+bios15-ibm.o: a20-ibm.inc
 
-bios-xms-pc98.o: a20-pc98.inc
+bios1F-pc98.o: a20-pc98.inc
 
 #########################################################################
 # Standard commands.

--- a/elks/arch/i86/lib/a20-ibm.inc
+++ b/elks/arch/i86/lib/a20-ibm.inc
@@ -3,9 +3,9 @@
 # derived from UNREAL.ASM and A20.ASM code by Chris Giese
 # 8 Nov 2021 Greg Haerr
 #
-# int enable_a20_gate(void)	- Enable A20 gate, return 0 on fail
-# int verify_a20		- Verify A20 gate status, return 0 if disabled
-# void set_a20			- ASM routine: enable (AH=1) or disable (AH=0) A20 gate
+# int __far enable_a20_gate(void) - Enable A20 gate, return 0 on fail
+# int verify_a20(void)            - Verify A20 gate status, return 0 if disabled
+# void set_a20                    - ASM routine: enable (AH=1) or disable (AH=0) A20 gate
 #
 # This file is #included into unreal.S and setup.S
 
@@ -16,10 +16,6 @@
 #define USE_BIOS
 #define USE_A20ASM
 //#define USE_HIMEM_AT
-
-	.global	enable_a20_gate
-	.global	verify_a20
-	.global	set_a20
 
 # Attempt to enable A20 address gate, return 0 on fail
 enable_a20_gate:
@@ -33,7 +29,7 @@ enable_a20_gate:
 	mov	$1,%ah		# enable A20
 	call	set_a20		# call configurable A20 handler
 	call	verify_a20	# returns 1 if enabled, 0 if disabled
-1:	ret
+1:	lret
 
 # verify if A20 gate is enabled, return 0 if disabled
 verify_a20:

--- a/elks/arch/i86/lib/a20-pc98.inc
+++ b/elks/arch/i86/lib/a20-pc98.inc
@@ -1,15 +1,12 @@
 ####################################################################################
 # A20 line enable for PC-98
 #
-# int enable_a20_gate(void)	- Enable A20 gate, return 0 on fail
-# int verify_a20		- Verify A20 gate status, return 0 if disabled
-# void set_a20			- ASM routine: enable (AH=1) or disable (AH=0) A20 gate
+# int __far enable_a20_gate(void) - Enable A20 gate, return 0 on fail
+# int verify_a20(void)            - Verify A20 gate status, return 0 if disabled
+# void set_a20                    - ASM routine: enable (AH=1) or disable (AH=0) A20 gate
 #
 # This file is #included into bios-xms-pc98.S and setup.S
 #
-	.global	enable_a20_gate
-	.global	verify_a20
-
 # Attempt to enable A20 address gate, return 0 on fail
 enable_a20_gate:
 	mov	$0,%al
@@ -17,7 +14,7 @@ enable_a20_gate:
 	mov	$2,%al
 	out	%al,$0xF6
 	call	verify_a20	# returns 1 if enabled, 0 if disabled
-	ret
+	lret
 
 # verify if A20 gate is enabled, return 0 if disabled
 verify_a20:

--- a/elks/arch/i86/lib/bios15-ibm.S
+++ b/elks/arch/i86/lib/bios15-ibm.S
@@ -16,16 +16,18 @@
 
 	.arch	i8086, nojumps
 	.code16
-	.text
+	.section .fartext.far
 
 	.global	block_move
+	.global	enable_a20_gate
 
 # IBM PC A20 gate functions shared with setup.S
 #include "a20-ibm.inc"
 
 #
-# int block_move(struct gdt_table *gdtp, size_t words)
+# int FARPROC block_move(struct gdt_table *gdtp, size_t words)
 # Uses BIOS INT 15h AH=87h Block Move
+# Enables A20 gate on return in case kernel in HMA
 #
 block_move:
 	push	%es
@@ -33,8 +35,8 @@ block_move:
 	push	%bp
 	mov	%sp,%bp
 
-	mov	10(%bp),%cx	# word count -> CX
-	mov	8(%bp),%si	# gdtp -> ES:SI
+	mov	12(%bp),%cx	# word count -> CX
+	mov	10(%bp),%si	# gdtp -> ES:SI
 	push	%ds
 	pop	%es
 
@@ -48,7 +50,9 @@ block_move:
 2:	pop	%bp
 	pop	%si
 	pop	%es
-	ret
+	push    %cs
+	call    enable_a20_gate
+	lret
 
 #if UNUSED
 #

--- a/elks/arch/i86/lib/bios1F-pc98.S
+++ b/elks/arch/i86/lib/bios1F-pc98.S
@@ -3,18 +3,18 @@
 #
 	.arch	i8086, nojumps
 	.code16
-	.text
+	.section .fartext.far
 
 	.global	block_move
 	.global	enable_a20_gate
-	.global	verify_a20
 
 # PC-98 A20 gate functions shared with setup.S
 #include "a20-pc98.inc"
 
 #
-# int block_move(struct gdt_table *gdtp, size_t words)
+# int FARPROC block_move(struct gdt_table *gdtp, size_t words)
 # Uses BIOS INT 1Fh AH=90h Block Move
+# Enables A20 gate on return in case kernel in HMA
 # ES:BX gdtp
 # CX    byte count
 # SI    0000h
@@ -30,9 +30,9 @@ block_move:
 	xor	%si,%si
 	xor	%di,%di
 
-	mov	12(%bp),%cx	# word count
+	mov	14(%bp),%cx	# word count
 	shl	%cx		# byte count -> CX
-	mov	10(%bp),%bx	# gdtp -> ES:BX
+	mov	12(%bp),%bx	# gdtp -> ES:BX
 	push	%ds
 	pop	%es
 
@@ -47,4 +47,6 @@ block_move:
 	pop	%di
 	pop	%si
 	pop	%es
-	ret
+	push    %cs
+	call    enable_a20_gate
+	lret

--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -21,11 +21,9 @@
  * Otherwise, when =0, hma=kernel must be commented out in /bootopts
  * to boot when configured for xms=int15 on those same systems.
  */
-#define AUTODISABLE		1		/* =1 to disable XMS if BIOS INT 15 disables A20 */
+#define AUTODISABLE		0		/* =1 to disable XMS if BIOS INT 15 disables A20 */
 
-/* these used when running XMS_INT15 */
-struct gdt_table;
-extern int block_move(struct gdt_table *gdtp, size_t words);
+/* used when running XMS_INT15 */
 void int15_fmemcpyw(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg,
 		size_t count);
 
@@ -60,8 +58,7 @@ int INITPROC xms_init(void)
 	if (!size)                      /* 8086 systems won't have XMS */
 		return XMS_DISABLED;
 	debug("A20 was %s", verify_a20()? "on" : "off");
-	enable_a20_gate();
-	enabled = verify_a20();
+	enabled = enable_a20_gate();    /* returns verify_a20() */
 	debug(" now %s, ", enabled? "on" : "off");
 	if (!enabled) {
 		printk("disabled, A20 error. ");

--- a/elks/include/linuxmt/memory.h
+++ b/elks/include/linuxmt/memory.h
@@ -4,6 +4,7 @@
 /* memory primitives */
 
 #include <linuxmt/types.h>
+#include <linuxmt/init.h>
 
 byte_t peekb (word_t off, seg_t seg);
 word_t peekw (word_t off, seg_t seg);
@@ -33,8 +34,10 @@ word_t fmemcmpw (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg, s
 /* unreal mode, A20 gate management */
 int check_unreal_mode(void);	/* check if unreal mode capable, returns > 0 on success */
 void enable_unreal_mode(void);	/* requires 386+ CPU to call */
-int enable_a20_gate(void);	/* returns 0 on fail */
-int verify_a20(void);		/* returns 0 if a20 disabled */
+/* enable_a20_gate/block_move must be FARPROC INT since 15/1F disables A20 w/HMA kernel */
+int FARPROC enable_a20_gate(void); /* returns 0 on fail */
+struct gdt_table;
+int FARPROC block_move(struct gdt_table *gdtp, size_t words); /* use INT 15/1F */
 
 /* XMS memory management */
 


### PR DESCRIPTION
This PR adds the capability of running XMS using INT 15 (IBM PC) or INT 1F (PC-98) block moves while also having the kernel resident in HMA.

Discussed in #2318, https://github.com/ghaerr/elks/issues/2293#issuecomment-2818319219 and https://github.com/Mellvik/TLVC/pull/163.

Almost all BIOSes (except QEMU and DosBox-X) will reset (disable) the A20 address line gate after executing the protected mode BIOS INT 15/1F block move XMS function. This change moves the block_move and enable_a20_gate functions to the .fartext section so the BIOS can return to a non-affected A20 address (i.e. low memory, not HMA) and re-enable the A20 gate before possibly continuing execution in HMA.

Note: This is tested for both IBM PC and PC-98 however both my only emulators don't actually disable A20 on return from INT 15/!F; so this definitely needs testing on real hardware or a more accurate emulator. In addition, the XMS auto-disable feature is now turned off when hma=kernel since INT 15/1F and HMA kernel can now co-exist. If the system doesn't boot, remove the hma=kernel line from /bootopts.

@tyama501 and @drachen6jp, please test this on PC-98 real hardware or Neko 21/W if possible, thank you!

@Mellvik, you should be able to use this code in TLVC to solve the same HMA/A20 issue we've been discussing.

After successful testing, more cleanup will follow: the AUTODISABLE code and comment will be removed, and the lengthy verify_a20 routine called after every enable_a20_gate can be removed when called just after block_move. This is potentially problematic for IBM PC since there are currently two methods for enabling A20, and the first working one needs to be recorded so that both don't have to when A20 is re-enabled.

It turned out to be a bit tricky to get the a20*.inc files working when called from both setup.S, where the setup code needs to be fully relocatable, but also from kernel code. Adding a .global symbol causes the assembler to generate a relocatable reference (which affected setup.S), and the C compiler can't call a near function within .fartext using the auto-generated thunking code. The latter necessitated the need to remove verify_a20() as a C callable function, since that function needed to stay as a near proc to be called from within enable_a20_gate. This works because the assembler can generate the relocatable form of the call instruction rather than have to use LCALL which requires an immediate form that won't also work in setup.S without special macros.... The good news is the final result is pretty clean, with the exception of calling the slow verify_a20 function after every block_move (for now).