### PR TITLE
[kernel] Revert moving block_move and enable_a20_gate to FARPROC

### DIFF
--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -1252,7 +1252,6 @@ checkhma:
 	mov	hma_kernel,%al		// and hma=kernel in /bootopts
 	test	%al,%al
 	jz	1f
-	push    %cs			// enable_a20_gate is FARPROC
 	call	enable_a20_gate		// and A20 enabled
 	test	%ax,%ax
 	jz	1f

--- a/elks/arch/i86/lib/a20-ibm.inc
+++ b/elks/arch/i86/lib/a20-ibm.inc
@@ -3,14 +3,13 @@
 # derived from UNREAL.ASM and A20.ASM code by Chris Giese
 # 8 Nov 2021 Greg Haerr
 #
-# int __far enable_a20_gate(void) - Enable A20 gate, return 0 on fail
-# int verify_a20(void)            - Verify A20 gate status, return 0 if disabled
-# void set_a20                    - ASM routine: enable (AH=1) or disable (AH=0) A20 gate
+# int enable_a20_gate(void) - Enable A20 gate, return verify_a20()
+# int verify_a20(void)      - Verify A20 gate status, return 0 if disabled
 #
 # This file is #included into unreal.S and setup.S
 
 # configurable options for A20 gate
-#   USE_BIOS		- use BIOS AX=2401h INT 15h method (always tried first)
+#   USE_BIOS		- use BIOS AX=2401h INT 15h method (tried first if set)
 #   USE_A20ASM		- use Chris Giese A20.ASM method (send D0, read, OR 2, D1, write)
 #   USE_HIMEM_AT	- use himem.sys PC AT method (send D1,DF,FF)
 #define USE_BIOS
@@ -29,9 +28,10 @@ enable_a20_gate:
 	mov	$1,%ah		# enable A20
 	call	set_a20		# call configurable A20 handler
 	call	verify_a20	# returns 1 if enabled, 0 if disabled
-1:	lret
+1:	ret
 
 # verify if A20 gate is enabled, return 0 if disabled
+# NOTE: only checks A20 wrap, doesn't actually read/write memory at 1M
 verify_a20:
 	push	%ds
 	push	%es
@@ -65,7 +65,7 @@ verify_a20:
 
 #ifdef USE_BIOS
 #
-# enable/disable A20 gate using keyboard port/controller, entry AH=0 disable
+# enable/disable A20 gate using BIOS, entry AH=0 disable
 bios_set_a20:
 	or	%ah,%ah
 	jz	bios_reset_a20
@@ -79,6 +79,7 @@ bios_reset_a20:
 #endif
 
 #ifdef USE_A20ASM
+# enable/disable A20 gate using keyboard port/controller, entry AH=0 disable
 set_a20:
 	pushf			# save interrupt status
 	cli			# interrupts off

--- a/elks/arch/i86/lib/a20-pc98.inc
+++ b/elks/arch/i86/lib/a20-pc98.inc
@@ -1,9 +1,8 @@
 ####################################################################################
 # A20 line enable for PC-98
 #
-# int __far enable_a20_gate(void) - Enable A20 gate, return 0 on fail
-# int verify_a20(void)            - Verify A20 gate status, return 0 if disabled
-# void set_a20                    - ASM routine: enable (AH=1) or disable (AH=0) A20 gate
+# int enable_a20_gate(void) - Enable A20 gate, return verify_a20()
+# int verify_a20(void)      - Verify A20 gate status, return 0 if disabled
 #
 # This file is #included into bios-xms-pc98.S and setup.S
 #
@@ -14,9 +13,10 @@ enable_a20_gate:
 	mov	$2,%al
 	out	%al,$0xF6
 	call	verify_a20	# returns 1 if enabled, 0 if disabled
-	lret
+	ret
 
 # verify if A20 gate is enabled, return 0 if disabled
+# NOTE: only checks A20 wrap, doesn't actually read/write memory at 1M
 verify_a20:
 	push	%ds
 	push	%es

--- a/elks/arch/i86/lib/bios15-ibm.S
+++ b/elks/arch/i86/lib/bios15-ibm.S
@@ -16,7 +16,7 @@
 
 	.arch	i8086, nojumps
 	.code16
-	.section .fartext.far
+	.text
 
 	.global	block_move
 	.global	enable_a20_gate
@@ -25,18 +25,17 @@
 #include "a20-ibm.inc"
 
 #
-# int FARPROC block_move(struct gdt_table *gdtp, size_t words)
+# int block_move(struct gdt_table *gdtp, size_t words)
 # Uses BIOS INT 15h AH=87h Block Move
-# Enables A20 gate on return in case kernel in HMA
-#
+# NOTE: BIOS disables A20 during call, won't work with HMA kernel
 block_move:
 	push	%es
 	push	%si
 	push	%bp
 	mov	%sp,%bp
 
-	mov	12(%bp),%cx	# word count -> CX
-	mov	10(%bp),%si	# gdtp -> ES:SI
+	mov	10(%bp),%cx	# word count -> CX
+	mov	8(%bp),%si	# gdtp -> ES:SI
 	push	%ds
 	pop	%es
 
@@ -50,9 +49,7 @@ block_move:
 2:	pop	%bp
 	pop	%si
 	pop	%es
-	push    %cs
-	call    enable_a20_gate
-	lret
+	ret
 
 #if UNUSED
 #

--- a/elks/arch/i86/lib/bios1F-pc98.S
+++ b/elks/arch/i86/lib/bios1F-pc98.S
@@ -3,7 +3,7 @@
 #
 	.arch	i8086, nojumps
 	.code16
-	.section .fartext.far
+	.text
 
 	.global	block_move
 	.global	enable_a20_gate
@@ -12,9 +12,9 @@
 #include "a20-pc98.inc"
 
 #
-# int FARPROC block_move(struct gdt_table *gdtp, size_t words)
+# int block_move(struct gdt_table *gdtp, size_t words)
 # Uses BIOS INT 1Fh AH=90h Block Move
-# Enables A20 gate on return in case kernel in HMA
+# NOTE: BIOS disables A20 during call, won't work with HMA kernel
 # ES:BX gdtp
 # CX    byte count
 # SI    0000h
@@ -30,9 +30,9 @@ block_move:
 	xor	%si,%si
 	xor	%di,%di
 
-	mov	14(%bp),%cx	# word count
+	mov	12(%bp),%cx	# word count
 	shl	%cx		# byte count -> CX
-	mov	12(%bp),%bx	# gdtp -> ES:BX
+	mov	10(%bp),%bx	# gdtp -> ES:BX
 	push	%ds
 	pop	%es
 
@@ -47,6 +47,4 @@ block_move:
 	pop	%di
 	pop	%si
 	pop	%es
-	push    %cs
-	call    enable_a20_gate
-	lret
+	ret

--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -15,15 +15,17 @@
 #ifdef CONFIG_FS_XMS
 
 /*
- * Set the below =1 to automatically disable using XMS INT 15 instead of
+ * Set the below =1 to automatically disable using XMS INT 15 w/HMA instead of
  * hanging the system during boot, when hma=kernel and INT 15/1F disables A20
- * in Compaq and most other BIOSes (QEMU does not).
+ * in Compaq and most other BIOSes (QEMU and DosBox-X do not).
  * Otherwise, when =0, hma=kernel must be commented out in /bootopts
  * to boot when configured for xms=int15 on those same systems.
  */
-#define AUTODISABLE		0		/* =1 to disable XMS if BIOS INT 15 disables A20 */
+#define AUTODISABLE		1		/* =1 to disable XMS w/HMA if BIOS INT 15 disables A20 */
 
-/* used when running XMS_INT15 */
+/* these used only when running XMS_INT15 */
+struct gdt_table;
+int block_move(struct gdt_table *gdtp, size_t words);
 void int15_fmemcpyw(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg,
 		size_t count);
 

--- a/elks/include/linuxmt/memory.h
+++ b/elks/include/linuxmt/memory.h
@@ -4,7 +4,6 @@
 /* memory primitives */
 
 #include <linuxmt/types.h>
-#include <linuxmt/init.h>
 
 byte_t peekb (word_t off, seg_t seg);
 word_t peekw (word_t off, seg_t seg);
@@ -34,10 +33,7 @@ word_t fmemcmpw (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg, s
 /* unreal mode, A20 gate management */
 int check_unreal_mode(void);	/* check if unreal mode capable, returns > 0 on success */
 void enable_unreal_mode(void);	/* requires 386+ CPU to call */
-/* enable_a20_gate/block_move must be FARPROC INT since 15/1F disables A20 w/HMA kernel */
-int FARPROC enable_a20_gate(void); /* returns 0 on fail */
-struct gdt_table;
-int FARPROC block_move(struct gdt_table *gdtp, size_t words); /* use INT 15/1F */
+int enable_a20_gate(void);      /* returns 0 on fail */
 
 /* XMS memory management */
 


### PR DESCRIPTION
Reverts most of #2320. See https://github.com/ghaerr/elks/pull/2320#issuecomment-2828191980 for complete discussion as to why moving INT 15/1F block_move and enable_a20_gate to the low memory .fartext section is not enough to allow the kernel to reliably function after the BIOS INT 15/1F function disables the A20 gate: any hardware interrupt will still immediately crash the system.

This decision ultimately only affects 80286 users when wanting XMS and HMA kernel: they must pick one or the other, but all systems will at least boot out of the box.

This PR also adds back the automatic disabling of XMS when hma=kernel for 80286 systems. XMS can still be used using INT 15/1F on 286 systems by removing hma=kernel from /bootopts.

Tested for IBM PC and PC-98 using QEMU and DosBox-X.

Thank you @drachen6jp and @tyama501 for your testing on real PC-98 hardware!