### PR TITLE
286 Loadall block_move

### DIFF
--- a/elks/arch/i86/lib/fmemory.S
+++ b/elks/arch/i86/lib/fmemory.S
@@ -242,10 +242,6 @@ rep	stosw			#800h-866h clear
 	mov	-6(%bp),%ax
 	add	$2,%ax
 	mov	%ax,%es:(0x1a)	#new IP
-	mov	%ax,%bx
-	sub	$7,%bx
-	mov	$0x050f,%ax		#loadall
-	mov	%ax,%cs:(%bx)
 
 	mov	%ds,%es:(0x1e)	#not realaddress
 	mov	%ss,%es:(0x20)	#
@@ -259,10 +255,8 @@ rep	stosw			#800h-866h clear
 	mov	%dx,%es:(0x30)
 	mov	%cx,%es:(0x32)
 	mov	%ax,%es:(0x34)
-#db 0xf,db 0x5			#ia16-elf-as "no such instruction" error!!
-#syscall(0xf,0x5)			#ia16-elf-as "not supported on i8086" error
-	nop			#loadall
-	nop
+.word 0x050f				#loadall for direct binary
+
 modechange2:
 	call	retaddr	#3byte
 #this address is stacked [bp-6]
@@ -273,9 +267,11 @@ retaddr:
 rep	movsw				#word transfer
 	call	modechange2		#retf "cs back to 20bit segment" this is for 32bit CPU noneed?
 	pop	%ax
-	mov	%ax,%ss
+	mov	%ax,%ss		#SS 20bit segment
 	push	%ds
 	pop	%ds			#used 24bit DS back to 20bit segment
+	push	%es
+	pop	%es			#used 24bit ES back to 20bit segment
 	sti
 
 	pop	%bp

--- a/elks/arch/i86/lib/fmemory.S
+++ b/elks/arch/i86/lib/fmemory.S
@@ -20,6 +20,8 @@
 	.global fmemcmpb
 	.global fmemcmpw
 
+	.global loadall_block_move
+
 // void fmemcpyb (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg,
 //		size_t count)
 
@@ -158,4 +160,127 @@ fmemcmpw_exit:
 	mov    %ss,%dx
 	mov    %dx,%ds
 	mov    %bx,%es
+	ret
+
+loadall_block_move:
+# DS:BX gdtp
+# CX    word count
+# SI    0000h
+# DI    0000h
+	push	%es
+	push	%si
+	push	%di
+	push	%bp
+	mov	%sp,%bp
+
+	xor	%si,%si
+	xor	%di,%di
+
+	mov	$0x80,%cx
+	mov	%cx,%es	#ES=0080h segment
+	mov	$0x33,%cx	#loadall 800-866h
+	xor	%ax,%ax
+	cli
+rep	stosw			#800h-866h clear
+
+	xor	%di,%di
+	mov	10(%bp),%bx	# gdtp -> DS:BX
+
+#src DS
+	mov	16(%bx),%ax	#src limit
+	mov	%ax,%es:(0x4c)	#new DS limit
+	mov	18(%bx),%ax	#src addr low16
+	mov	%ax,%es:(0x48)	#new DS low16
+	mov	20(%bx),%ax	#src addr high8 & access byte
+	mov	%ax,%es:(0x4a)	#new DS high8 & access byte
+	
+#dst ES
+	mov	24(%bx),%ax	#dst limit
+	mov	%ax,%es:(0x3a)	#new ES limit
+	mov	26(%bx),%ax	#dst addr low16
+	mov	%ax,%es:(0x36)	#new ES low16
+	mov	28(%bx),%ax	#dst addr high8 & access byte
+	mov	%ax,%es:(0x38)	#new ES high8 & access byte
+
+#cs
+	mov	%cs,%ax
+	mov	$12,%cl
+	shr	%cl,%ax
+	mov	%al,%es:(0x3e)	#CS high8
+	mov	%cs,%ax
+	mov	$4,%cl
+	shl	%cl,%ax
+	mov	%ax,%es:(0x3c)	#CS low16
+	mov	$-1,%ax
+	mov	%ax,%es:(0x40)	#cs limit
+	mov	%ax,%es:(0x46)	#ss limit
+	mov	%al,%es:(0x5f)	#IDT limit(FF00h but 3FFh?) very important
+
+
+	mov	$0x9a93,%ax
+	mov	%ah,%es:(0x3f)	#cs access byte
+	mov	%al,%es:(0x45)	#ss access byte
+
+#ss
+	mov	%ss,%ax
+	mov	$12,%cl
+	shr	%cl,%ax
+	mov	%al,%es:(0x44)	#SS high8
+	mov	%ss,%ax
+	mov	$4,%cl
+	shl	%cl,%ax
+	mov	%ax,%es:(0x42)	#SS low16
+
+	mov	12(%bp),%cx	# word count
+
+	push	%ss
+	push	%cs
+
+	push	%cs
+	call	modechange2
+	mov	%sp,%bp
+	mov	-6(%bp),%ax
+	add	$2,%ax
+	mov	%ax,%es:(0x1a)	#new IP
+	mov	%ax,%bx
+	sub	$7,%bx
+	mov	$0x050f,%ax		#loadall
+	mov	%ax,%cs:(%bx)
+
+	mov	%ds,%es:(0x1e)	#not realaddress
+	mov	%ss,%es:(0x20)	#
+	mov	%cs,%es:(0x22)	#
+	mov	%es,%es:(0x24)	#set 20bit segment
+	mov	%di,%es:(0x26)
+	mov	%si,%es:(0x28)
+	mov	%bp,%es:(0x2a)
+	mov	%sp,%es:(0x2c)
+	mov	%bx,%es:(0x2e)
+	mov	%dx,%es:(0x30)
+	mov	%cx,%es:(0x32)
+	mov	%ax,%es:(0x34)
+#db 0xf,db 0x5			#ia16-elf-as "no such instruction" error!!
+#syscall(0xf,0x5)			#ia16-elf-as "not supported on i8086" error
+	nop			#loadall
+	nop
+modechange2:
+	call	retaddr	#3byte
+#this address is stacked [bp-6]
+	retf			#1byte
+retaddr:
+	ret			#1byte
+#new IP
+rep	movsw				#word transfer
+	call	modechange2		#retf "cs back to 20bit segment" this is for 32bit CPU noneed?
+	pop	%ax
+	mov	%ax,%ss
+	push	%ds
+	pop	%ds			#used 24bit DS back to 20bit segment
+	sti
+
+	pop	%bp
+	pop	%di
+	pop	%si
+	pop	%es
+	xor	%ax,%ax		#all success
 	ret

--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -66,10 +66,10 @@ int INITPROC xms_init(void)
 	}
 	/* 80286 machines and Compaq BIOSes can't use unreal mode and must use INT 15/1F */
 	if (xms_bootopts == XMS_INT15 || (arch_cpu <= 6 && xms_bootopts == XMS_UNREAL)) {
+		enabled = XMS_INT15
 #if AUTODISABLE
 		if(arch_cpu == 6){
 			printk("LOADALL, ");
-			enabled = XMS_INT15;
 		}else if (kernel_cs == 0xffff) {
 			/* BIOS INT 15/1F block_move disables A20 on most systems! */
 			printk("disabled w/kernel HMA and int 15/1F\n");
@@ -78,10 +78,9 @@ int INITPROC xms_init(void)
 #else
 		if(arch_cpu == 6)
 			printk("LOADALL, ");
+#endif
 		else
 			printk("int 15/1F, ");
-		enabled = XMS_INT15;
-#endif
 	} else {
 		if (xms_bootopts != XMS_UNREAL) {
 			printk("off. ");

--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -230,11 +230,10 @@ void int15_fmemcpyw(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg
 	//gp->flags_limit_19_16 = 0;	/* byte-granular, 16-bit, limit=64K */
 	//gp->flags_limit_19_16 = 0xCF;	/* page-granular, 32-bit, limit=4GB */
 	gp->base_31_24 = dst_seg >> 24;
-	if(arch_cpu == 6){
+	if(arch_cpu == 6)
 	 loadall_block_move(gdt_table,count);
-	} else {
+	else 
 	 block_move(gdt_table, count);
-	}
 }
 
 #endif /* CONFIG_FS_XMS */

--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -66,7 +66,7 @@ int INITPROC xms_init(void)
 	}
 	/* 80286 machines and Compaq BIOSes can't use unreal mode and must use INT 15/1F */
 	if (xms_bootopts == XMS_INT15 || (arch_cpu <= 6 && xms_bootopts == XMS_UNREAL)) {
-		enabled = XMS_INT15
+		enabled = XMS_INT15;
 #if AUTODISABLE
 		if(arch_cpu == 6){
 			printk("LOADALL, ");

--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -75,12 +75,13 @@ int INITPROC xms_init(void)
 			printk("disabled w/kernel HMA and int 15/1F\n");
 			return XMS_DISABLED;
 		}
-#endif
+#else
 		if(arch_cpu == 6)
 			printk("LOADALL, ");
 		else
 			printk("int 15/1F, ");
 		enabled = XMS_INT15;
+#endif
 	} else {
 		if (xms_bootopts != XMS_UNREAL) {
 			printk("off. ");
@@ -229,10 +230,11 @@ void int15_fmemcpyw(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg
 	//gp->flags_limit_19_16 = 0;	/* byte-granular, 16-bit, limit=64K */
 	//gp->flags_limit_19_16 = 0xCF;	/* page-granular, 32-bit, limit=4GB */
 	gp->base_31_24 = dst_seg >> 24;
-	if(arch_cpu == 6)
+	if(arch_cpu == 6){
 	 loadall_block_move(gdt_table,count);
-	else
+	} else {
 	 block_move(gdt_table, count);
+	}
 }
 
 #endif /* CONFIG_FS_XMS */

--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -67,13 +67,19 @@ int INITPROC xms_init(void)
 	/* 80286 machines and Compaq BIOSes can't use unreal mode and must use INT 15/1F */
 	if (xms_bootopts == XMS_INT15 || (arch_cpu <= 6 && xms_bootopts == XMS_UNREAL)) {
 #if AUTODISABLE
-		if (kernel_cs == 0xffff) {
+		if(arch_cpu == 6){
+			printk("LOADALL, ");
+			enabled = XMS_INT15;
+		}else if (kernel_cs == 0xffff) {
 			/* BIOS INT 15/1F block_move disables A20 on most systems! */
 			printk("disabled w/kernel HMA and int 15/1F\n");
 			return XMS_DISABLED;
 		}
 #endif
-		printk("int 15/1F, ");
+		if(arch_cpu == 6)
+			printk("LOADALL, ");
+		else
+			printk("int 15/1F, ");
 		enabled = XMS_INT15;
 	} else {
 		if (xms_bootopts != XMS_UNREAL) {
@@ -223,7 +229,10 @@ void int15_fmemcpyw(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg
 	//gp->flags_limit_19_16 = 0;	/* byte-granular, 16-bit, limit=64K */
 	//gp->flags_limit_19_16 = 0xCF;	/* page-granular, 32-bit, limit=4GB */
 	gp->base_31_24 = dst_seg >> 24;
-	block_move(gdt_table, count);
+	if(arch_cpu == 6)
+	 loadall_block_move(gdt_table,count);
+	else
+	 block_move(gdt_table, count);
 }
 
 #endif /* CONFIG_FS_XMS */

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -174,18 +174,20 @@
 
 #ifdef CONFIG_ARCH_IBMPC
 #define OPTSEGSZ        0x400       /* max size of /bootopts file (1024 bytes max) */
-#define DEF_OPTSEG      0x50        /* 0x400 bytes boot options at lowest usable ram */
-#define REL_INITSEG     0x90        /* 0x200 bytes setup data */
-#define DMASEG          0xB0        /* start of floppy sector buffer */
+#define REL_INITSEG     0x50        /* 0x200 bytes setup data */
+//700-8ff 512byte for 800-866h LOADALL
+#define DEF_OPTSEG      0x90        /* 0x400 bytes boot options at lowest usable ram */
+#define DMASEG          0xD0        /* start of floppy sector buffer */
 #define REL_SYSSEG      DMASEGEND   /* kernel code segment */
 #define SETUP_DATA      REL_INITSEG
 #endif
 
 #ifdef CONFIG_ARCH_PC98
 #define OPTSEGSZ        0x400       /* max size of /bootopts file (1024 bytes max) */
-#define DEF_OPTSEG      0x60        /* 0x400 bytes boot options at lowest usable ram */
-#define REL_INITSEG     0xA0        /* 0x200 bytes setup data */
-#define DMASEG          0xC0        /* start of floppy sector buffer */
+#define REL_INITSEG     0x60        /* 0x200 bytes setup data */
+//800-8FF 256byte for 800-866h LOADALL
+#define DEF_OPTSEG      0x90        /* 0x400 bytes boot options at lowest usable ram */
+#define DMASEG          0xD0        /* start of floppy sector buffer */
 #define REL_SYSSEG      DMASEGEND   /* kernel code segment */
 #define SETUP_DATA      REL_INITSEG
 #endif

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -174,20 +174,18 @@
 
 #ifdef CONFIG_ARCH_IBMPC
 #define OPTSEGSZ        0x400       /* max size of /bootopts file (1024 bytes max) */
-#define REL_INITSEG     0x50        /* 0x200 bytes setup data */
-//700-8ff 512byte for 800-866h LOADALL
-#define DEF_OPTSEG      0x90        /* 0x400 bytes boot options at lowest usable ram */
-#define DMASEG          0xD0        /* start of floppy sector buffer */
+#define DEF_OPTSEG      0x50        /* 0x400 bytes boot options at lowest usable ram */
+#define REL_INITSEG     0x90        /* 0x200 bytes setup data */
+#define DMASEG          0xB0        /* start of floppy sector buffer */
 #define REL_SYSSEG      DMASEGEND   /* kernel code segment */
 #define SETUP_DATA      REL_INITSEG
 #endif
 
 #ifdef CONFIG_ARCH_PC98
 #define OPTSEGSZ        0x400       /* max size of /bootopts file (1024 bytes max) */
-#define REL_INITSEG     0x60        /* 0x200 bytes setup data */
-//800-8FF 256byte for 800-866h LOADALL
-#define DEF_OPTSEG      0x90        /* 0x400 bytes boot options at lowest usable ram */
-#define DMASEG          0xD0        /* start of floppy sector buffer */
+#define DEF_OPTSEG      0x60        /* 0x400 bytes boot options at lowest usable ram */
+#define REL_INITSEG     0xA0        /* 0x200 bytes setup data */
+#define DMASEG          0xC0        /* start of floppy sector buffer */
 #define REL_SYSSEG      DMASEGEND   /* kernel code segment */
 #define SETUP_DATA      REL_INITSEG
 #endif


### PR DESCRIPTION
thanks @ghaerr 
I've checked this code.with my machine and 286 emulators.

your question
1.
why did't I use "db0xf 0xb"? 
ia16-elf-as refuse this pattern.

2. why call set_a20_enable?
my mistake. Loadall set new DS. but I reset old DS. so after movsw push ds and pop ds.

3.
mov dx,37
mov al,6
out dx,al

this is PC-98 beep code. I 've not deleted this debug code.

4.meminfo doesn't run.
menuconfig  Memory character devices was not set.sorry.

thank you!