### PR TITLE
[kernel] XMS enhancements and fixes around new LOADALL block move

### DIFF
--- a/elks/arch/i86/lib/bios15-ibm.S
+++ b/elks/arch/i86/lib/bios15-ibm.S
@@ -41,8 +41,8 @@ block_move:
 
 	mov	$0x87,%ah	# BIOS Block Move
 	int	$0x15
-	jnc	1f
 	sti			# ensure we've got interrupts
+	jnc	1f
 	mov	$-1,%ax		# fail return AX < 0
 	jmp	2f
 1:	xor	%ax,%ax		# success return AX = 0

--- a/elks/arch/i86/lib/bios1F-pc98.S
+++ b/elks/arch/i86/lib/bios1F-pc98.S
@@ -38,8 +38,8 @@ block_move:
 
 	mov	$0x90,%ah	# BIOS Block Move
 	int	$0x1F
-	jnc	1f
 	sti			# ensure we've got interrupts
+	jnc	1f
 	mov	$-1,%ax		# fail return AX < 0
 	jmp	2f
 1:	xor	%ax,%ax		# success return AX = 0

--- a/elks/arch/i86/lib/fmemory.S
+++ b/elks/arch/i86/lib/fmemory.S
@@ -313,11 +313,11 @@ loadall_block_move:
 	mov	%es,%es:(0x24)
 	mov	%bp,%es:(0x2a)  #preserve normal registers
 	mov	%sp,%es:(0x2c)
-	//mov	%di,%es:(0x26)	#set SI, DI zero for REP MOVS below
+	//mov	%di,%es:(0x26)	#set SI, DI zero for REP MOVS
 	//mov	%si,%es:(0x28)
+	mov	%cx,%es:(0x32)  #CX is word count for REP MOVS
 	//mov	%bx,%es:(0x2e)	#the following not required to be preserved
 	//mov	%dx,%es:(0x30)
-	//mov	%cx,%es:(0x32)
 	//mov	%ax,%es:(0x34)
 	.byte   0x0F,0x05       #loadall opcode - execution continues at new IP
 	# not reached

--- a/elks/arch/i86/lib/fmemory.S
+++ b/elks/arch/i86/lib/fmemory.S
@@ -240,11 +240,12 @@ fmemcmpw_exit:
 // passed to this function.
 //
 loadall_block_move:
-	push	%es		#FIXME rewrite prologue to avoid saving DS/ES twice
-	push	%si
-	push	%di
 	push	%bp
 	mov	%sp,%bp
+	push	%si
+	push	%di
+	push	%ds
+	push	%es
 
 	mov	$0x80,%cx	#clear 33h words at 800-866h
 	mov	%cx,%es
@@ -255,7 +256,7 @@ loadall_block_move:
 	cld
 	rep	stosw
 
-	mov	10(%bp),%bx	#BX=GDT
+	mov	4(%bp),%bx	#BX=GDT
 
 #src DS
 	mov	16(%bx),%ax	#src limit
@@ -301,7 +302,7 @@ loadall_block_move:
 	shl	%cl,%ax
 	mov	%ax,%es:(0x42)	#SS low16
 
-	mov	12(%bp),%cx	#word count
+	mov	6(%bp),%cx	#word count
 
 	push	%ss		#save SS for later SS reset
 	push	%cs		#CS used in later call to resetCS
@@ -329,16 +330,11 @@ newip:				#new IP after LOADALL, interrupts disabled by FLAGS = 0
 	rep	movsw		#word transfer using DS&ES descriptor cache base values
 
 	call	resetCS		#RETF resets CS to 20-bits, uses previous CS from stack
-	pop	%ax
-	mov	%ax,%ss		#reset SS base FIXME use POP %ss after testing
-	push	%ds
-	pop	%ds		#reset DS base FIXME pop from rewritten prologue
-	push	%es
-	pop	%es		#reset ES base FIXME pop from rewritten prologue
+	pop	%ss		#reset SS base
+	pop	%es		#reset ES base
+	pop	%ds		#reset DS base
 	sti
-
-	pop	%bp
 	pop	%di
 	pop	%si
-	pop	%es
+	pop	%bp
 	ret

--- a/elks/arch/i86/lib/unreal.S
+++ b/elks/arch/i86/lib/unreal.S
@@ -293,7 +293,7 @@ linear32_peekw:
 # E specifies Executable. 0 for data, 1 for code segments.
 #
 # The D/C bit specifies Direction bit for data segments, 0=Expand Up else Down,
-# For code segments, 0 is nonconfirming, 1 Confirming.
+# For code segments, 0 is nonconforming, 1 Conforming.
 #
 # The W/R bit specifies Writable for data segments, Readable for code.
 #

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -639,7 +639,7 @@ void zero_buffer(struct buffer_head *bh, size_t offset, int count)
 #define FORCEMAP 0
 #endif
     /* xms int15 doesn't support a memset function, so map into L1 */
-    if (FORCEMAP || bh->b_data || xmsenabled == XMS_INT15 ) {
+    if (FORCEMAP || bh->b_data || xmsenabled >= XMS_INT15 ) {   /* INT 15/1F or LOADALL */
         map_buffer(bh);
         memset(bh->b_data + offset, 0, count);
         unmap_buffer(bh);

--- a/elks/include/linuxmt/memory.h
+++ b/elks/include/linuxmt/memory.h
@@ -40,6 +40,7 @@ int enable_a20_gate(void);      /* returns 0 on fail */
 #define XMS_DISABLED    0
 #define XMS_UNREAL      1   /* using unreal mode and linear32_fmemcpy for block moves */
 #define XMS_INT15       2   /* using BIOS INT 15 block move (or INT 1F on PC-98) */
+#define XMS_LOADALL     3   /* using LOADALL 286 opcode and loadall_block_move */
 extern int xms_bootopts;    /* xms=on or xms=int15 /bootopts setting, default off */
 
 #ifdef CONFIG_FS_XMS


### PR DESCRIPTION
Fixes LOADALL CX not saved in last PR https://github.com/ghaerr/elks/pull/2326#issuecomment-2849126837.

Adds several new enhancements / bug fixes as a result of our new LOADALL implementation:
- Disables interrupts at start of int15_fmemcpyw since xms_fmemcpyw, which calls it, is called at interrupt time by the direct floppy driver. Looking into getting rid of static GDT data structure, but too large to place on kernel stack as an array[8].
- Always reenables interrupts on return from BIOS 15/1F calls; previously only did on error return for some reason?
- Allow xms=int15 to force INT 15/1F even on 80286 systems. Otherwise, xms=on will use LOADALL for 286, and unreal mode for 386 CPUs.
- Rewrote loadall_block_move function prologue for speed, remove multiple push/pop of segment registers.
- Fixed auto-disabling XMS when INT 15/1F specified w/kernel HMA, since INT 15/1F disables A20 gate.
- Changed GDT access bytes to standard 0x92 for data segments for consistency throughout kernel and LOADALL code.
- Added internal XMS_LOADALL xms_enabled state when running LOADALL block move.

Tested on pcEM for IBM PC only. PC-98 should work fine but needs testing. Hopefully @drachen6jp and @tyama501 can test PC-98 on real hardware.