### PR TITLE
[kernel] Change int15_fmemcpy to accept byte rather than word count

### DIFF
--- a/elks/arch/i86/lib/bios15-ibm.S
+++ b/elks/arch/i86/lib/bios15-ibm.S
@@ -2,7 +2,7 @@
 # BIOS INT 15H Block Move and A20 enable for IBM PC
 # Nov 2021 Greg Haerr
 #
-# int block_move(struct gdt_table *gdtp, size_t words)
+# int bios_block_movew(struct gdt_table *gdtp, size_t words)
 #
 #	Move words to/from anywhere in physical memory using BIOS INT 15h AH=87h.
 #	Normally used to move data to/from extended memory (> 1M) because
@@ -18,17 +18,17 @@
 	.code16
 	.text
 
-	.global	block_move
+	.global	bios_block_movew
 	.global	enable_a20_gate
 
 # IBM PC A20 gate functions shared with setup.S
 #include "a20-ibm.inc"
 
 #
-# int block_move(struct gdt_table *gdtp, size_t words)
+# int bios_block_movew(struct gdt_table *gdtp, size_t words)
 # Uses BIOS INT 15h AH=87h Block Move
 # NOTE: BIOS disables A20 during call, won't work with HMA kernel
-block_move:
+bios_block_movew:
 	push	%es
 	push	%si
 	push	%bp

--- a/elks/arch/i86/lib/bios15-ibm.S
+++ b/elks/arch/i86/lib/bios15-ibm.S
@@ -2,17 +2,16 @@
 # BIOS INT 15H Block Move and A20 enable for IBM PC
 # Nov 2021 Greg Haerr
 #
-# int bios_block_movew(struct gdt_table *gdtp, size_t words)
+# void bios_block_movew(struct gdt_table *gdtp, size_t words)
 #
 #	Move words to/from anywhere in physical memory using BIOS INT 15h AH=87h.
 #	Normally used to move data to/from extended memory (> 1M) because
 #	real mode addressing can only address the first 1M of RAM, unless
 #	using unreal mode. Protected mode is used for the copy, and interrupts
-#	are disabled the whole time. Returns 0 on success.
+#	are disabled the whole time.
 #
 #	This is a substitute function for linear32_fmemcpyw which requires unreal mode,
 #	and uses a int15_fmemcpy wrapper above it to prefill the passed GDT table.
-#
 
 	.arch	i8086, nojumps
 	.code16
@@ -25,7 +24,7 @@
 #include "a20-ibm.inc"
 
 #
-# int bios_block_movew(struct gdt_table *gdtp, size_t words)
+# void bios_block_movew(struct gdt_table *gdtp, size_t words)
 # Uses BIOS INT 15h AH=87h Block Move
 # NOTE: BIOS disables A20 during call, won't work with HMA kernel
 bios_block_movew:
@@ -41,12 +40,8 @@ bios_block_movew:
 
 	mov	$0x87,%ah	# BIOS Block Move
 	int	$0x15
-	sti			# ensure we've got interrupts
-	jnc	1f
-	mov	$-1,%ax		# fail return AX < 0
-	jmp	2f
-1:	xor	%ax,%ax		# success return AX = 0
-2:	pop	%bp
+	sti			# re-enable interrupts from int15_fmemcpy
+	pop	%bp
 	pop	%si
 	pop	%es
 	ret

--- a/elks/arch/i86/lib/bios1F-pc98.S
+++ b/elks/arch/i86/lib/bios1F-pc98.S
@@ -12,7 +12,7 @@
 #include "a20-pc98.inc"
 
 #
-# int bios_block_movew(struct gdt_table *gdtp, size_t words)
+# void bios_block_movew(struct gdt_table *gdtp, size_t words)
 # Uses BIOS INT 1Fh AH=90h Block Move
 # NOTE: BIOS disables A20 during call, won't work with HMA kernel
 # ES:BX gdtp
@@ -38,12 +38,8 @@ bios_block_movew:
 
 	mov	$0x90,%ah	# BIOS Block Move
 	int	$0x1F
-	sti			# ensure we've got interrupts
-	jnc	1f
-	mov	$-1,%ax		# fail return AX < 0
-	jmp	2f
-1:	xor	%ax,%ax		# success return AX = 0
-2:	pop	%bp
+	sti			# re-enable interrupts from int15_fmemcpy
+	pop	%bp
 	pop	%di
 	pop	%si
 	pop	%es

--- a/elks/arch/i86/lib/bios1F-pc98.S
+++ b/elks/arch/i86/lib/bios1F-pc98.S
@@ -5,14 +5,14 @@
 	.code16
 	.text
 
-	.global	block_move
+	.global	bios_block_movew
 	.global	enable_a20_gate
 
 # PC-98 A20 gate functions shared with setup.S
 #include "a20-pc98.inc"
 
 #
-# int block_move(struct gdt_table *gdtp, size_t words)
+# int bios_block_movew(struct gdt_table *gdtp, size_t words)
 # Uses BIOS INT 1Fh AH=90h Block Move
 # NOTE: BIOS disables A20 during call, won't work with HMA kernel
 # ES:BX gdtp
@@ -20,7 +20,7 @@
 # SI    0000h
 # DI    0000h
 #
-block_move:
+bios_block_movew:
 	push	%es
 	push	%si
 	push	%di

--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -29,7 +29,7 @@ struct gdt_table;
 void bios_block_movew(struct gdt_table *gdtp, size_t words);	/* INT 15/1F */
 void int15_fmemcpy(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg,
 		size_t bytes);
-#define MOVE            0       /* block move */
+#define COPY            0       /* block move */
 #define CLEAR           1       /* block clear */
 int loadall_block_op(struct gdt_table *gdtp, size_t bytes, int op);
 
@@ -150,9 +150,9 @@ void xms_fmemcpyb(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src
 		linear32_fmemcpyb(dst_off, dst_seg, src_off, src_seg, count);
 	  else {
 		/* lots of extra work on odd transfers because INT 15 block moves words only */
-		size_t wc = count >> 1;
 		if ((count & 1) && xms_enabled == XMS_INT15) {
 			static char buf[2];
+			size_t wc = count >> 1;
 
 			if (wc)
 				int15_fmemcpy(dst_off, dst_seg, src_off, src_seg, wc << 1);
@@ -237,7 +237,7 @@ void int15_fmemcpy(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg,
 	gp->base_31_24 = dst_seg >> 24;
 	/* interrupts re-enabled in block_move or loadall_block_op routine */
 	if (xms_enabled == XMS_LOADALL)
-		loadall_block_op(gdt_table, bytes, MOVE);   /* block move bytes */
+		loadall_block_op(gdt_table, bytes, COPY);   /* block move bytes */
 	else 
 		bios_block_movew(gdt_table, bytes >> 1);
 }

--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -26,7 +26,7 @@
 
 /* these used when running XMS_INT15 or XMS_LOADALL */
 struct gdt_table;
-int bios_block_movew(struct gdt_table *gdtp, size_t words);	/* INT 15/1F */
+void bios_block_movew(struct gdt_table *gdtp, size_t words);	/* INT 15/1F */
 void int15_fmemcpy(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg,
 		size_t bytes);
 #define MOVE            0       /* block move */

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -7,9 +7,9 @@
 #3c0=11,0x330,,0x80
 #comirq=,,7,10
 #umb=0xC000:0x800,0xD000:0x1000
-hma=kernel
+#hma=kernel
 xms=on
-#xms=int15
+xms=int15
 #xmsbuf=0
 #task=16 buf=64 cache=8 file=64 inode=96 heap=44000 # std
 #task=6 buf=8 cache=4 file=20 inode=24 heap=15000 n # min

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -7,9 +7,9 @@
 #3c0=11,0x330,,0x80
 #comirq=,,7,10
 #umb=0xC000:0x800,0xD000:0x1000
-#hma=kernel
+hma=kernel
 xms=on
-xms=int15
+#xms=int15
 #xmsbuf=0
 #task=16 buf=64 cache=8 file=64 inode=96 heap=44000 # std
 #task=6 buf=8 cache=4 file=20 inode=24 heap=15000 n # min


### PR DESCRIPTION
Next part of evolving previous INT 15/1F word-count routines to work using byte-counts with the LOADALL block move routine. This allows greater efficiency within the kernel and eventual removal of some special hacks required for INT 15.

PC-98 BIOS INT 1F does allow for byte count block moves, but since LOADALL now working, probably not worth updating.

In general, INT 15/1F support is only being kept for backwards compatibility and regression testing when LOADALL can't be used, for instance in some emulators that don't emulate the undocumented opcode.

Changes include:
- int15_fmemcpyw renamed to int15_fmemcpy and takes byte instead of word count.
- block_move renamed to bios_block_movew and made void function.

Tested on PCem for IBM PC platform only.