### PR TITLE
[kernel] Fix application errors when running XMS LOADALL

### DIFF
--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -175,6 +175,7 @@
 #ifdef CONFIG_ARCH_IBMPC
 #define OPTSEGSZ        0x400       /* max size of /bootopts file (1024 bytes max) */
 #define DEF_OPTSEG      0x50        /* 0x400 bytes boot options at lowest usable ram */
+#define LOADALL_SEG     0x80        /* LOADALL buffer from 0x800-0x865 on 80286 CPU */
 #define REL_INITSEG     0x90        /* 0x200 bytes setup data */
 #define DMASEG          0xB0        /* start of floppy sector buffer */
 #define REL_SYSSEG      DMASEGEND   /* kernel code segment */
@@ -184,6 +185,7 @@
 #ifdef CONFIG_ARCH_PC98
 #define OPTSEGSZ        0x400       /* max size of /bootopts file (1024 bytes max) */
 #define DEF_OPTSEG      0x60        /* 0x400 bytes boot options at lowest usable ram */
+#define LOADALL_SEG     0x80        /* LOADALL buffer from 0x800-0x865 on 80286 CPU */
 #define REL_INITSEG     0xA0        /* 0x200 bytes setup data */
 #define DMASEG          0xC0        /* start of floppy sector buffer */
 #define REL_SYSSEG      DMASEGEND   /* kernel code segment */

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -279,6 +279,12 @@ static void INITPROC do_init_task(void)
 #ifdef CONFIG_BOOTOPTS
     /* Release options parsing buffers and setup data seg */
     heap_add(&opts, sizeof(opts));
+#ifdef CONFIG_FS_XMS
+    if (xms_enabled == XMS_LOADALL) {
+        seg_add(DEF_OPTSEG, 0x80);  /* carve out LOADALL buf 0x800-0x865 from release! */
+        seg_add(0x87, DMASEG);
+    } else  /* fall through */
+#endif
     seg_add(DEF_OPTSEG, DMASEG);    /* DEF_OPTSEG through REL_INITSEG */
 
     /* pass argc/argv/env array to init_command */


### PR DESCRIPTION
Fixes system stability and application problems seen when running certain programs when XMS LOADALL is enabled. In particular, this fixes the `cat` problem mentioned in https://github.com/ghaerr/elks/pull/2329#issuecomment-2850070989, and should also fix the `ramdisk` problem reported by @drachen6jp in https://github.com/ghaerr/elks/pull/2329#issuecomment-2850206403 and by @tyama501 previously.

It took a while to track this down, but what was happening is that even though the LOADALL buffer at physical address 0800-0865 is within DEF_OPTSEG (the 1K /bootopts buffer loaded at boot time), after kernel initialization the entire DEF_OPTSEG and REL_INITSEG (512 byte setup.S data area) were being released back to the kernel main memory manager. That memory was then allocated to program loading and execution on demand.

The freed memory usually totaled 1536 bytes. Then, when small programs such as cat (928 bytes) or ramdisk (1392 bytes) ran, they were sometimes placed in this 1536 byte segment. If/when the kernel did any XMS I/O during the period when the application was running, the LOADALL loadall_block_op routine would write to its fixed buffer, which is right in the middle of the running application! We were sometimes seeing crashes, but other times just strange results, like not exiting, since the exit() code just happened to be linked into the scribbled location(s). I'm very glad to have finally found this.

The `ramdisk` problem has not been tested since I can't yet emulate > 512K XMS on 80286 PCem, but given the reported result of not issuing an error or the size created, I think this is the same problem.

The fix is to "carve out" the LOADALL buffer's 66h bytes (70h when rounded to paragraph) from the released memory. Here's a screenshot showing two segments, 768 and 656 bytes at 0050 and 0087, just 112 bytes short of the originally released amount. So LOADALL is only costing 112 bytes of application RAM, and it's only carved out when the system is running XMS LOADALL:

<img width="788" alt="Screen Shot 2025-05-05 at 9 52 25 PM" src="https://github.com/user-attachments/assets/1e550061-8170-4d6e-a666-8ec712f415b1" />

@Mellvik: I'm not sure whether your fork releases this memory like ELKS based on your comment https://github.com/Mellvik/TLVC/pull/165#issuecomment-2848688954, if so you may the same problem!