### PR TITLE
[kernel] Implemented xms_fmemset for LOADALL using block clear

### DIFF
--- a/elks/arch/i86/boot/setup.S
+++ b/elks/arch/i86/boot/setup.S
@@ -1061,11 +1061,10 @@ pc98_int1b:
 
 	jnc	1f
 0:	mov	$'F',%al
-	call	putc
 	jmp	2f
 1:	mov	$' ',%al
-	call	putc
-2:	pop	%es
+2:	call	putc
+	pop	%es
 	pop	%ds
 	ret
 

--- a/elks/arch/i86/drivers/block/ssd-xms.c
+++ b/elks/arch/i86/drivers/block/ssd-xms.c
@@ -49,10 +49,10 @@ int ssddev_ioctl(struct inode *inode, struct file *file,
         xms_ram_size = arg;
         ssd_num_sects = arg << 1;
 
-        /* clear XMS only if using unreal mode as xms_fmemset not supported w/INT 15 */
-        if (xms_enabled == XMS_UNREAL) {
+        /* clear XMS not supported w/INT 15 */
+        if (xms_enabled == XMS_UNREAL || xms_enabled == XMS_LOADALL) {
             for (sector_t sector = 0; sector < ssd_num_sects; sector++)
-                xms_fmemset(0, xms_ram_base + (sector << 9), 0, SD_FIXED_SECTOR_SIZE);
+                xms_fmemset(0, xms_ram_base + (sector << 9), SD_FIXED_SECTOR_SIZE);
         }
         ssd_initialized = 1;
         return 0;

--- a/elks/arch/i86/lib/loadall.S
+++ b/elks/arch/i86/lib/loadall.S
@@ -1,11 +1,12 @@
-####################################################################################
-# Use 80286 LOADALL opcode to set segment cache register base then move/clear memory
+#######################################################################################
+# Use 80286 semi-documented LOADALL opcode to set segment cache register base,
+# then perform block move or memory copy operation.
 # For 80286 CPUs only
 #
 # 1 May 2025 Originally written by @drachen6jp
 #
 # void loadall_block_op(struct gdt_table *gdtp, size_t bytes, int op)
-#   Replacement INT 15/1F block ops function using undocumented Intel LOADALL opcode
+#   Replacement INT 15/1F block ops function using semi-documented Intel LOADALL opcode
 #   Performs block copy or clear from passed GDT structure in int15_fmemcpy
 #   This function must only be called using 80286 CPU!!
 #
@@ -180,8 +181,9 @@ loadall_block_op:
 resetCS:
 	retf			#reset CS to 20-bit segment
 
+# SI = 24-bit source address, DI = 24-bit destination, CX = byte count, BX = op
 newip:				#new IP after LOADALL, interrupts disabled by FLAGS = 0
-	test	%bx,%bx		#copy or clear memory?
+	test	%bx,%bx		#0:copy, 1:clear
 	jnz	clear
 copy:	shr	$1,%cx		#convert to words
 	rep	movsw		#word transfer using DS&ES descriptor cache base values

--- a/elks/arch/i86/lib/loadall.S
+++ b/elks/arch/i86/lib/loadall.S
@@ -1,12 +1,12 @@
 ####################################################################################
-# Use 80286 LOADALL instruction to set segment cache register base then block move
+# Use 80286 LOADALL opcode to set segment cache register base then move/clear memory
 # For 80286 CPUs only
 #
 # 1 May 2025 Originally written by @drachen6jp
 #
 # void loadall_block_op(struct gdt_table *gdtp, size_t bytes, int op)
 #   Replacement INT 15/1F block ops function using undocumented Intel LOADALL opcode
-#   Performs block move from passed GDT structure in int15_fmemcpyw
+#   Performs block copy or clear from passed GDT structure in int15_fmemcpy
 #   This function must only be called using 80286 CPU!!
 #
 	.arch	i8086, nojumps
@@ -90,7 +90,7 @@
 # limits are always passed as FFFFh and the access bytes normal in the GDT table
 # passed to this function.
 
-# Use LOADALL to set the segment cache register limits and perform block move.
+# Use LOADALL to set the segment cache register limits and perform block copy/clear op.
 # Requires 80286 CPU to call!
 loadall_block_op:
 	push	%bp
@@ -181,12 +181,21 @@ resetCS:
 	retf			#reset CS to 20-bit segment
 
 newip:				#new IP after LOADALL, interrupts disabled by FLAGS = 0
-	shr	$1,%cx		#convert to words
+	test	%bx,%bx		#copy or clear memory?
+	jnz	clear
+copy:	shr	$1,%cx		#convert to words
 	rep	movsw		#word transfer using DS&ES descriptor cache base values
 	rcl	$1,%cx		#final byte if any
 	rep	movsb
+	jmp	9f
 
-	call	resetCS		#RETF resets CS to 20-bits, uses previous CS from stack
+clear:	xor	%ax,%ax		#clear block
+	shr	$1,%cx		#convert to words
+	rep	stosw		#word store using DS&ES descriptor cache base values
+	rcl	$1,%cx		#final byte if any
+	rep	stosb
+
+9:	call	resetCS		#RETF resets CS to 20-bits, uses previous CS from stack
 	pop	%ss		#reset SS base
 	pop	%es		#reset ES base
 	pop	%ds		#reset DS base

--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -209,12 +209,12 @@ struct gdt_table {
 static struct gdt_table gdt_table[8];   /* static table requires mutex below */
 
 /* move/clear data between XMS and main memory using either BIOS INT 15/1F or LOADALL */
-/* XMS_INT15 can't handle odd bytes or memory clear! */
+/* NOTE: BIOS INT 15/1F can't handle odd bytes or memory clear! */
 static void int15_fmemcpy(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg,
 	size_t bytes, int op)
 {
 	struct gdt_table *gp;
-	if (xms_enabled == XMS_INT15 && ((bytes & 1) || op != COPY)) panic("int15_fmemcpy");
+	//if (xms_enabled == XMS_INT15 && ((bytes & 1) || op != COPY)) panic("int15_fmemcpy");
 
 	src_seg += (word_t)src_off;
 	dst_seg += (word_t)dst_off;

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -639,7 +639,7 @@ void zero_buffer(struct buffer_head *bh, size_t offset, int count)
 #define FORCEMAP 0
 #endif
     /* xms int15 doesn't support a memset function, so map into L1 */
-    if (FORCEMAP || bh->b_data || xmsenabled >= XMS_INT15 ) {   /* INT 15/1F or LOADALL */
+    if (FORCEMAP || bh->b_data || xmsenabled == XMS_INT15 ) {
         map_buffer(bh);
         memset(bh->b_data + offset, 0, count);
         unmap_buffer(bh);

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -647,7 +647,7 @@ void zero_buffer(struct buffer_head *bh, size_t offset, int count)
 #if !FORCEMAP
     else {
         ext_buffer_head *ebh = EBH(bh);
-        xms_fmemset((char *)offset, ebh->b_L2seg, 0, count);
+        xms_fmemset((char *)offset, ebh->b_L2seg, count);
     }
 #endif
 }

--- a/elks/include/linuxmt/memory.h
+++ b/elks/include/linuxmt/memory.h
@@ -58,7 +58,7 @@ void xms_fmemcpyw(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src
 		size_t count);
 void xms_fmemcpyb(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src_seg,
 		size_t count);
-void xms_fmemset(void *dst_off, ramdesc_t dst_seg, byte_t val, size_t count);
+void xms_fmemset(void *dst_off, ramdesc_t dst_seg, size_t count);
 
 /* low level copy - must have 386 CPU and xms_enabled before calling! */
 void linear32_fmemcpyw(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg,


### PR DESCRIPTION
xms_fmemset can now be called from the buffer subsystem, used to clear newly allocated file blocks, when running XMS LOADALL. This allows for faster operation without having to allocate an L1 buffer to perform the clear operation, which is still required for INT 15/1F.

This pretty much completes the new LOADALL implementation. Now, XMS can run in unreal, loadall, and int15/1f modes,
and is automatically selected based on CPU type when xms=on.

Tested on QEMU and PCem 286 with the following regression tests:
- cat file-with-odd-bytes: tests xms_fmemcpyb and LOADALL byte block move operation
- cat file > file2: tests xms_fmemset and LOADALL block clear operation

The cases where INT 15/1F cannot perform the operation are still coded in the kernel as panics; they will be removed after final testing.
