### PR TITLE
[cmds] Add XMS total, used and free memory to meminfo display

### DIFF
--- a/elks/arch/i86/drivers/char/mem.c
+++ b/elks/arch/i86/drivers/char/mem.c
@@ -111,7 +111,7 @@ static int kmem_ioctl(struct inode *inode, struct file *file, int cmd, char *arg
         retword = (unsigned)((long)buffer_init >> 16);
         break;
     case MEM_GETUSAGE:
-        mm_get_usage (&(mu.free_memory), &(mu.used_memory));
+        mm_get_usage(&mu);
         memcpy_tofs(arg, &mu, sizeof(struct mem_usage));
         return 0;
     case MEM_GETHEAP:

--- a/elks/arch/i86/mm/malloc.c
+++ b/elks/arch/i86/mm/malloc.c
@@ -5,6 +5,8 @@
 #include <linuxmt/config.h>
 #include <linuxmt/sched.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/mem.h>
+#include <linuxmt/memory.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/debug.h>
 #include <linuxmt/heap.h>
@@ -199,7 +201,7 @@ segment_s * seg_dup (segment_s * src)
 
 // Get memory information (free and used) in KB
 
-void mm_get_usage (unsigned int * pfree, unsigned int * pused)
+void mm_get_usage (struct mem_usage *mu)
 {
     unsigned int free = 0;
     unsigned int used = 0;
@@ -223,8 +225,15 @@ void mm_get_usage (unsigned int * pfree, unsigned int * pused)
     // Convert paragraphs to kilobytes
     // Floor, not ceiling, so average return
 
-    *pfree = ((free + 31) >> 6);
-    *pused = ((used + 31) >> 6);
+    mu->main_free = ((free + 31) >> 6);
+    mu->main_used = ((used + 31) >> 6);
+#ifdef CONFIG_FS_XMS
+    mu->xms_used = xms_alloc_ptr - KBYTES(XMS_START_ADDR);
+    mu->xms_free = SETUP_XMS_KBYTES - mu->xms_used;
+#else
+    mu->xms_free = 0;
+    mu->xms_used = 0;
+#endif
 }
 
 

--- a/elks/include/linuxmt/mem.h
+++ b/elks/include/linuxmt/mem.h
@@ -13,9 +13,13 @@
 #define MEM_GETJIFFADDR 11
 #define MEM_GETSEGALL   12
 
-struct mem_usage {
-    unsigned int free_memory;
-    unsigned int used_memory;
+struct mem_usage {              /* all in Kbytes */
+    unsigned int main_free;
+    unsigned int main_used;
+    unsigned int xms_free;
+    unsigned int xms_used;
 };
+
+void mm_get_usage(struct mem_usage *mu);
 
 #endif

--- a/elks/include/linuxmt/mm.h
+++ b/elks/include/linuxmt/mm.h
@@ -64,8 +64,6 @@ void seg_free_pid(pid_t pid);
 
 extern list_s _seg_all;
 
-void mm_get_usage (unsigned int * free, unsigned int * used);
-
 #endif /* __KERNEL__ */
 
 #endif

--- a/elkscmd/sys_utils/meminfo.c
+++ b/elkscmd/sys_utils/meminfo.c
@@ -255,8 +255,10 @@ int main(int argc, char **argv)
 
     if (!ioctl(fd, MEM_GETUSAGE, &mu)) {
         /* note MEM_GETUSAGE amounts are floors, so total may display less by 1k than actual*/
-        printf("  Memory usage %4dKB total, %4dKB used, %4dKB free\n",
-            mu.used_memory + mu.free_memory, mu.used_memory, mu.free_memory);
+        printf("  Main %d/%dK used, %dK free, ",
+            mu.main_used, mu.main_used + mu.main_free, mu.main_free);
+        printf("XMS %d/%dK used, %dK free\n",
+            mu.xms_used, mu.xms_used + mu.xms_free, mu.xms_free);
     }
 
     return 0;


### PR DESCRIPTION
XMS memory usage is now displayed in meminfo:
<img width="832" alt="meminfo" src="https://github.com/user-attachments/assets/7ed32c82-831d-4ad4-84fc-edc918aabd4f" />
