### PR TITLE
Paint: hardware-accelerated flood fill

### DIFF
--- a/elkscmd/gui/app.c
+++ b/elkscmd/gui/app.c
@@ -274,15 +274,15 @@ int main(int argc, char* argv[])
             R_DrawCircle(x, y, 12, WHITE);
             currentMainColor = i;
             currentAltColor = j;
-            R_LineFloodFill(x, y, currentMainColor, readpixel(x, y));
-            // R_FrontFill(x, y, currentMainColor, readpixel(x, y));
+            // R_LineFloodFill(x, y, currentMainColor, readpixel(x, y));
+            R_FrontFill(x, y, currentMainColor, readpixel(x, y));
         }
     }
     int x = 300;
     int y = 101;
-    R_LineFloodFill(x, y, 5, readpixel(x, y));
-    // int maxCap = R_FrontFill(x, y, 5, readpixel(x, y));
-    // __dprintf("Peak stack size: %d\n", maxCap);
+    // R_LineFloodFill(x, y, 5, readpixel(x, y));
+    int maxCap = R_FrontFill(x, y, 5, readpixel(x, y));
+    __dprintf("Peak stack size: %d\n", maxCap);
 
     graphics_close();
     return 0;

--- a/elkscmd/gui/graphics.c
+++ b/elkscmd/gui/graphics.c
@@ -154,7 +154,7 @@ void vga_cmp8_init(int target_color) {
     set_color_dont_care(0x0F);
 }
 
-unsigned short cmp8(int x, int y, int target_color) {
+unsigned short cmp8(int x, int y) {
     /* Calculate offset in video memory */
     unsigned int offset = (y<<6) + (y<<4) + (x >> 3);
     return asm_getbyte(offset);

--- a/elkscmd/gui/graphics.c
+++ b/elkscmd/gui/graphics.c
@@ -143,7 +143,7 @@ void fillrect(int x1, int y1, int x2, int y2, int c)
 }
 
 /* initialize VGA to Read Mode 1 & set compare/color mask */
-static void vga_cmp8_init(int target_color) {
+void vga_cmp8_init(int target_color) {
     /* Set Graphics Mode Register to read mode 1 (bit 3 = 1) */
     set_write_mode(8);
 
@@ -155,7 +155,6 @@ static void vga_cmp8_init(int target_color) {
 }
 
 unsigned short cmp8(int x, int y, int target_color) {
-    vga_cmp8_init(target_color);
     /* Calculate offset in video memory */
     unsigned int offset = (y<<6) + (y<<4) + (x >> 3);
     return asm_getbyte(offset);

--- a/elkscmd/gui/graphics.c
+++ b/elkscmd/gui/graphics.c
@@ -142,6 +142,25 @@ void fillrect(int x1, int y1, int x2, int y2, int c)
         drawhline(x1, x2, y1++, c);
 }
 
+/* initialize VGA to Read Mode 1 & set compare/color mask */
+static void vga_cmp8_init(int target_color) {
+    /* Set Graphics Mode Register to read mode 1 (bit 3 = 1) */
+    set_write_mode(8);
+
+    /* Set Color Compare Register to target color (4 bits) */
+    set_color_compare(target_color & 0x0F);
+
+    /* Set Color Don't Care Register to 0x0F (include all planes) */
+    set_color_dont_care(0x0F);
+}
+
+unsigned short cmp8(int x, int y, int target_color) {
+    vga_cmp8_init(target_color);
+    /* Calculate offset in video memory */
+    unsigned int offset = (y<<6) + (y<<4) + (x >> 3);
+    return asm_getbyte(offset);
+}
+
 #ifdef __C86__
 
 /* use BIOS to set video mode */

--- a/elkscmd/gui/graphics.h
+++ b/elkscmd/gui/graphics.h
@@ -27,7 +27,7 @@ int save_bmp(char *pathname);
 #define drawhline(x1,x2,y,c)    vga_drawhline(x1,x2,y,c)
 #define drawvline(x,y1,y2,c)    vga_drawvline(x,y1,y2,c)
 #define readpixel(x,y)          vga_readpixel(x,y)
-unsigned short cmp8(int x, int y, int target_color);
+unsigned short cmp8(int x, int y);
 void vga_cmp8_init(int target_color);
 #else
 void drawpixel(int x,int y, int color);

--- a/elkscmd/gui/graphics.h
+++ b/elkscmd/gui/graphics.h
@@ -28,6 +28,7 @@ int save_bmp(char *pathname);
 #define drawvline(x,y1,y2,c)    vga_drawvline(x,y1,y2,c)
 #define readpixel(x,y)          vga_readpixel(x,y)
 unsigned short cmp8(int x, int y, int target_color);
+void vga_cmp8_init(int target_color);
 #else
 void drawpixel(int x,int y, int color);
 void drawhline(int x1, int x2, int y, int c);

--- a/elkscmd/gui/graphics.h
+++ b/elkscmd/gui/graphics.h
@@ -27,6 +27,7 @@ int save_bmp(char *pathname);
 #define drawhline(x1,x2,y,c)    vga_drawhline(x1,x2,y,c)
 #define drawvline(x,y1,y2,c)    vga_drawvline(x,y1,y2,c)
 #define readpixel(x,y)          vga_readpixel(x,y)
+unsigned short cmp8(int x, int y, int target_color);
 #else
 void drawpixel(int x,int y, int color);
 void drawhline(int x1, int x2, int y, int c);

--- a/elkscmd/gui/render.c
+++ b/elkscmd/gui/render.c
@@ -540,7 +540,7 @@ static SegList LINK(const SegList *E, int target) {
     int i =  0;
     int x =  E->s[0].xl;
     /* Initialize Color Compare Mode to target color */
-    // vga_cmp8_init(target);
+    vga_cmp8_init(target);
     while (1) {
         /* skip past any parent that ends before x */
         while (i < E->n && x > E->s[i].xr) i++;
@@ -755,7 +755,9 @@ int R_FrontFill(int x0, int y0, int newColor, int targetColor) {
     /* seed span on row y0 */
     Segment s0 = {x0, x0};
     // EXPAND(s0, x0, y0, targetColor);
+    vga_cmp8_init(targetColor);
     s0 = expand_cmp8(x0, y0, targetColor);
+    set_write_mode(0);
 
     E.y = y0;
     E.dir = +1;

--- a/elkscmd/gui/render.c
+++ b/elkscmd/gui/render.c
@@ -472,7 +472,7 @@ static inline Segment expand_cmp8(int x, int y, int target) {
     Segment seg = { 0, -1 };
 
     /* seed must match */
-    unsigned short m = cmp8(x, y, target);
+    unsigned short m = cmp8(x, y);
     int bit = x & 7;
 
     seg.xl = seg.xr = x;
@@ -486,7 +486,7 @@ static inline Segment expand_cmp8(int x, int y, int target) {
     if (b == 0) {
         int bx = (x >> 3) - 1;
         while (bx >= 0) {
-            unsigned short m2 = cmp8(bx<<3, y, target);
+            unsigned short m2 = cmp8(bx<<3, y);
             if (m2 == 0xFF) {
                 seg.xl = (bx<<3);
                 bx--;
@@ -509,7 +509,7 @@ static inline Segment expand_cmp8(int x, int y, int target) {
         int bx = (x >> 3) + 1;
         int maxBX = (CANVAS_WIDTH>>3);
         while (bx <= maxBX) {
-            unsigned short m2 = cmp8(bx<<3, y, target);
+            unsigned short m2 = cmp8(bx<<3, y);
             if (m2 == 0xFF) {
                 seg.xr = (bx<<3) + 7;
                 bx++;
@@ -549,7 +549,7 @@ static SegList LINK(const SegList *E, int target) {
         if (x < E->s[i].xl) x = E->s[i].xl;
 
         /* if we hit the target, expand and record */
-        if (cmp8(x, out.y, target) & (1 << (7 - (x & 7)))) {
+        if (cmp8(x, out.y) & (1 << (7 - (x & 7)))) {
         // if (readpixel(x, out.y) == target) {
             Segment seg_new = {x, x};
             seg_new = expand_cmp8(x, out.y, target);

--- a/elkscmd/gui/render.c
+++ b/elkscmd/gui/render.c
@@ -403,13 +403,6 @@ typedef struct {
 //     while (seg.xr < CANVAS_WIDTH-1 && readpixel(seg.xr + 1, y) == target) seg.xr++;
 //     return seg;
 // }
-// /* EXPAND_RIGHT: only to the right from x (already target) */
-// static Segment expand_right(int x, int y, int target) {
-//     Segment seg = {x, x};
-//     while (seg.xr < CANVAS_WIDTH-1 && readpixel(seg.xr + 1, y) == target)
-//         seg.xr++;
-//     return seg;
-// }
 
 #define EXPAND(result, x, y, target)                      \
     do {                                                         \
@@ -421,15 +414,118 @@ typedef struct {
         (result).xl = _xl; (result).xr = _xr;                \
     } while (0)
 
-#define EXPAND_RIGHT(result, x, y, target)                 \
-    do {                                                          \
-        int _xr = (x);                                            \
-        while (_xr < CANVAS_WIDTH-1 && readpixel(_xr + 1, (y)) == target) \
-            _xr++;                                                \
-        (result).xl = (x);                                        \
-        (result).xr = _xr;                                        \
-    } while (0)
 
+/* lookup table for number of leading 1s in a 4‑bit nibble
+   index = nibble value (0x0–0xF), value = count of 1‑bits
+   starting at the nibble’s MSB */
+static const unsigned short L1[16] = {
+    /*0x0*/ 0, /*0x1*/ 0, /*0x2*/ 0, /*0x3*/ 0,
+    /*0x4*/ 0, /*0x5*/ 0, /*0x6*/ 0, /*0x7*/ 0,
+    /*0x8*/ 1, /*0x9*/ 1, /*0xA*/ 1, /*0xB*/ 1,
+    /*0xC*/ 2, /*0xD*/ 2, /*0xE*/ 3, /*0xF*/ 4
+};
+
+/*
+ * Count the run of 1‑bits from bit 7 downward.
+ * – Extract the high nibble, look up its leading‑1 count.
+ * – If it was all ones (0xF), continue into the low nibble.
+ */
+static int count_leading_ones(unsigned short x) {
+    unsigned short hi = x >> 4;
+    int cnt = L1[hi];
+    if (hi == 0x0F) {
+        /* high nibble was 1111, so add low‑nibble’s leading‑1 count */
+        cnt += L1[x & 0x0F];
+    }
+    return cnt-1;
+}
+
+/* lookup table for number of trailing 1s in a 4‑bit nibble */
+static const unsigned short T1[16] = {
+    /* 0x0 */ 0,     /* 0x1 */ 1,    /* 0x2 */ 0,     /* 0x3 */ 2,
+    /* 0x4 */ 0,     /* 0x5 */ 1,    /* 0x6 */ 0,     /* 0x7 */ 3,
+    /* 0x8 */ 0,     /* 0x9 */ 1,    /* 0xA */ 0,     /* 0xB */ 2,
+    /* 0xC */ 0,     /* 0xD */ 1,    /* 0xE */ 0,     /* 0xF */ 4
+};
+
+/*
+ * Count the run of 1‐bits from bit 0 upward.
+ * For low nibble ≠ 0xF this is just one table lookup.
+ * If low nibble == 0xF, we get 4 + table[high_nibble].
+ */
+static int count_trailing_ones(unsigned short x) {
+    unsigned short lo = x & 0x0F;
+    int cnt = T1[lo];
+    if (lo == 0x0F) {
+        /* still all 1s in low nibble, so add count from high nibble */
+        cnt += T1[x >> 4];
+    }
+    return cnt-1;
+}
+
+
+/*
+    * expand_cmp8:
+    *   full two‑sided expansion around seed (x,y) for 'target' color.
+    */
+static inline Segment expand_cmp8(int x, int y, int target) {
+    Segment seg = { 0, -1 };
+
+    /* seed must match */
+    unsigned short m = cmp8(x, y, target);
+    int bit = x & 7;
+
+    seg.xl = seg.xr = x;
+
+    /* —— grow left within this byte —— */
+    int b = bit;
+    while (b > 0 && (m & (1 << (7 - (b - 1))))) {
+        b--; seg.xl--;
+    }
+    /* —— only if we reached the leftmost bit of this byte, go byte‑wise —— */
+    if (b == 0) {
+        int bx = (x >> 3) - 1;
+        while (bx >= 0) {
+            unsigned short m2 = cmp8(bx<<3, y, target);
+            if (m2 == 0xFF) {
+                seg.xl = (bx<<3);
+                bx--;
+            } else {
+                int hb = count_trailing_ones(m2);
+                if (hb >= 0)
+                    seg.xl = (bx<<3) + (7 - hb);
+                break;
+            }
+        }
+    }
+
+    /* —— grow right within this byte —— */
+    b = bit;
+    while (b < 7 && (m & (1 << (7 - (b + 1))))) {
+        b++; seg.xr++;
+    }
+    /* —— only if we reached the rightmost bit of this byte, go byte‑wise —— */
+    if (b == 7) {
+        int bx = (x >> 3) + 1;
+        int maxBX = (CANVAS_WIDTH>>3);
+        while (bx <= maxBX) {
+            unsigned short m2 = cmp8(bx<<3, y, target);
+            if (m2 == 0xFF) {
+                seg.xr = (bx<<3) + 7;
+                bx++;
+            } else {
+                int lb = count_leading_ones(m2);
+                if (lb >= 0)
+                    seg.xr = (bx<<3) + lb;
+                break;
+            }
+        }
+    }
+
+    if (seg.xr >= CANVAS_WIDTH)
+            seg.xr = CANVAS_WIDTH - 1;
+    return seg;
+}
 
 /* LINK: scan one row above/below E for 4-connected runs under E.s */
 static SegList LINK(const SegList *E, int target) {
@@ -443,6 +539,8 @@ static SegList LINK(const SegList *E, int target) {
     /* scan across the union of parent spans */
     int i =  0;
     int x =  E->s[0].xl;
+    /* Initialize Color Compare Mode to target color */
+    // vga_cmp8_init(target);
     while (1) {
         /* skip past any parent that ends before x */
         while (i < E->n && x > E->s[i].xr) i++;
@@ -451,12 +549,11 @@ static SegList LINK(const SegList *E, int target) {
         if (x < E->s[i].xl) x = E->s[i].xl;
 
         /* if we hit the target, expand and record */
-        if (readpixel(x, out.y) == target) {
+        if (cmp8(x, out.y, target) & (1 << (7 - (x & 7)))) {
+        // if (readpixel(x, out.y) == target) {
             Segment seg_new = {x, x};
-            if (x == E->s[i].xl)
-                EXPAND(seg_new, x, out.y, target);
-            else
-                EXPAND_RIGHT(seg_new, x, out.y, target);
+            seg_new = expand_cmp8(x, out.y, target);
+            // EXPAND(seg_new, x, out.y, target);
 
             if (seg_new.xl <= seg_new.xr && out.n < MAX_SEGS) {
                 out.s[out.n++] = seg_new;
@@ -466,6 +563,8 @@ static SegList LINK(const SegList *E, int target) {
         }
         x++;
     }
+    /* Restore default write mode */
+    set_write_mode(0);
     return out;
 }
 
@@ -655,7 +754,8 @@ int R_FrontFill(int x0, int y0, int newColor, int targetColor) {
 
     /* seed span on row y0 */
     Segment s0 = {x0, x0};
-    EXPAND(s0, x0, y0, targetColor);
+    // EXPAND(s0, x0, y0, targetColor);
+    s0 = expand_cmp8(x0, y0, targetColor);
 
     E.y = y0;
     E.dir = +1;

--- a/elkscmd/gui/vgalib.h
+++ b/elkscmd/gui/vgalib.h
@@ -12,15 +12,17 @@
  * Functions/Macros:
  *  set_color(color)            // 03ce REG 0 Set/Reset Register (color for write mode 0)
  *  set_enable_sr(flag)         // 03ce REG 1 Enable Set/Reset Register (forces REG 0)
+ *  set_color_compare(color)    // 03ce REG 2 Color Compare Register
  *  set_op(op)                  // 03ce REG 3 Data Rotate Register (nop, xor)
  *  set_read_plane(plane)       // 03ce REG 4 Read Map Select Register
  *  set_write_mode(mode)        // 03ce REG 5 Graphics Mode Register (write mode 0)
+ *  set_color_dont_care(color)  // 03ce REG 7 Color Don't Care Register
  *  set_mask(mask)              // 03ce REG 8 Bit Mask Register
  *  set_write_planes(mask)      // 03c4 REG 2 Memory Plane Write Enable Register
  *
  *  void set_bios_mode(mode)    // set BIOS graphics/text mode
  *  void asm_orbyte(int offset) // OR byte at A000:offset
- *  int  asm_getbyte(int offset)// read byte at A000:offset
+ *  unsigned short  asm_getbyte(int offset)// read byte at A000:offset
  *
  * Some defaults:
  *  set_color(0)                // REG 0
@@ -56,6 +58,14 @@
         , "d" (0x03ce)                          \
         )
 
+#define set_color_compare(color)                \
+    asm volatile (                              \
+        "out %%ax,%%dx\n"                       \
+        : /* no output */                       \
+        : "a" ((unsigned short)(((color)<<8)|2))\
+        , "d" (0x03ce)                          \
+        )
+
 #define set_op(op)                              \
     asm volatile (                              \
         "out %%ax,%%dx\n"                       \
@@ -85,6 +95,13 @@
         "out %%ax,%%dx\n"                       \
         : /* no output */                       \
         : "a" ((unsigned short)(((mask)<<8)|8)) \
+        , "d" (0x03ce)                          \
+        )
+#define set_color_dont_care(color)              \
+    asm volatile (                              \
+        "out %%ax,%%dx\n"                       \
+        : /* no output */                       \
+        : "a" ((unsigned short)(((color)<<8)|7))\
         , "d" (0x03ce)                          \
         )
 
@@ -230,49 +247,49 @@ void set_bios_mode(int mode);
         "mov ah,*" #color "\n"                  \
         "out dx,ax\n"                           \
     )
-    
+
 #define set_enable_sr(flag)                     \
     asm("mov dx,*0x03ce\n"                      \
         "mov al,*1\n"                           \
         "mov ah,*" #flag "\n"                   \
         "out dx,ax\n"                           \
     )
-    
+
 #define set_op(op)                              \
     asm("mov dx,*0x03ce\n"                      \
         "mov al,*3\n"                           \
         "mov ah,*" #op "\n"                     \
         "out dx,ax\n"                           \
     )
-    
+
 #define set_read_plane(plane)                   \
     asm("mov dx,*0x03ce\n"                      \
         "mov al,*4\n"                           \
         "mov ah,*" #plane "\n"                  \
         "out dx,ax\n"                           \
     )
-    
+
 #define set_write_mode(mode)                    \
     asm("mov dx,*0x03ce\n"                      \
         "mov al,*5\n"                           \
         "mov ah,*" #mode "\n"                   \
         "out dx,ax\n"                           \
     )
-    
+
 #define set_mask(mask)                          \
     asm("mov dx,*0x03ce\n"                      \
         "mov al,*8\n"                           \
         "mov ah,*" #mask "\n"                   \
         "out dx,ax\n"                           \
     )
-    
+
 #define set_write_planes(mask)                  \
     asm("mov dx,*0x03c4\n"                      \
         "mov al,*2\n"                           \
         "mov ah,*" #mask "\n"                   \
         "out dx,ax\n"                           \
     )
-    
+
 int asm_getbyte(int offset);
 void set_bios_mode(int mode);
 


### PR DESCRIPTION
Use VGA Read Mode 1 for hardware-accelerated color comparison to optimize flood fill operations. Add segment expansion functions that leverage VGA color compare features for improved performance with bit-level optimizations.