### PR TITLE
Paint: small flood fill optimization

### DIFF
--- a/elkscmd/gui/graphics.c
+++ b/elkscmd/gui/graphics.c
@@ -154,12 +154,6 @@ void vga_cmp8_init(int target_color) {
     set_color_dont_care(0x0F);
 }
 
-unsigned short cmp8(int x, int y) {
-    /* Calculate offset in video memory */
-    unsigned int offset = (y<<6) + (y<<4) + (x >> 3);
-    return asm_getbyte(offset);
-}
-
 #ifdef __C86__
 
 /* use BIOS to set video mode */

--- a/elkscmd/gui/graphics.h
+++ b/elkscmd/gui/graphics.h
@@ -27,7 +27,6 @@ int save_bmp(char *pathname);
 #define drawhline(x1,x2,y,c)    vga_drawhline(x1,x2,y,c)
 #define drawvline(x,y1,y2,c)    vga_drawvline(x,y1,y2,c)
 #define readpixel(x,y)          vga_readpixel(x,y)
-unsigned short cmp8(int x, int y);
 void vga_cmp8_init(int target_color);
 #else
 void drawpixel(int x,int y, int color);


### PR DESCRIPTION
Replace cmp8 with a direct byte read optimizing offset calculation.
It saves 3 seconds in the Paint benchmark: `0m18.600s`.