### PR TITLE
[kernel] Don't rely on BDA/INT 11 equipment config byte bit 0 for floppies present

### DIFF
--- a/elks/arch/i86/drivers/block/bios.c
+++ b/elks/arch/i86/drivers/block/bios.c
@@ -329,10 +329,10 @@ int INITPROC bios_getfdinfo(struct drive_infot *drivep)
     /*
      * The INT 13h AH=8 floppy query will fail on IBM XT v1 BIOS and earlier,
      * so default to # drives from the BIOS data area at 0x040:0x0010 (INT 11h).
-     * Note: Bit 0 may sometimes be zero even though floppies are present.
+     * Note: Ignore bit 0 as it is sometimes zero even though floppies are present.
      */
     unsigned char equip_flags = peekb(0x10, 0x40);
-    if (equip_flags & 0x01)           /* bit 0 may be zero on some systems, see #2070 */
+    //if (equip_flags & 0x01)           /* bit 0 may be zero on some systems, see #2070 */
         ndrives = (equip_flags >> 6) + 1;
 #endif
 

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -724,7 +724,7 @@ next_block:
 
         /* make sure it's a disk that we are dealing with. */
         if (drive > (DRIVE_FD0 + FD_DRIVES - 1) || drivep->heads == 0) {
-            printk("bioshd: non-existent drive\n");
+            printk("bioshd: non-existent drive: %D\n", req->rq_dev);
             end_request(0);
             continue;
         }


### PR DESCRIPTION
Fixes kernel divide-by-zero panic described in #2070. 

Thank you @640-KB for your help debugging this and describing the history of the PC/XT BIOS equipment configuration byte. Bit 0 (FD drives present) should not be used to indicate whether the drive count is valid - always use the drive count in bits 7-6 regardless. Bit 0 may indicate the position of a switch on the motherboard instead.

Many XT-era system BIOSes, including GLaBIOS and Compaq BIOS behave this way regarding bit 0. Previously, when bit 0 was not set, the drive count was set to 0. If additionally the INT 13 AH=8 function Get Drive Parms was not implemented, the drive_info[].sector_size was not initialized, and a divide by zero occurred in the do_readtrack() function.


