### PR TITLE
[kernel] Implement XMS floppy I/O without bounce buffers

### DIFF
--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -68,16 +68,6 @@
  * Program 8237 DMA controller external page register instead of using XMS bounce buffer
  */
 
-/*
- * TODO (HS 2023):
- * - When XMS buffers are active, the BIOS hd driver will use DMASEG as a bounce buffer
- *   thus colliding with the usage here. This is a problem only in the odd case 
- *   that we're using BIOS HD + DIRECT FD + XMS buffers + TRACK cache, 
- *   which really should not happen. IOW - use either BIOS block IO or DIRECT block IO,
- *   don't mix!!
- * - Test density detection logic & floppy change detection
- */
-
 #include <linuxmt/config.h>
 #include <linuxmt/sched.h>
 #include <linuxmt/fs.h>
@@ -1216,7 +1206,7 @@ static void DFPROC redo_fd_request(void)
     numsectors = req->rq_nr_sectors;
 #ifdef CONFIG_TRACK_CACHE
     use_cache = (command == FD_READ) && (req->rq_errors < 4)
-        && (arch_cpu != 7 || running_qemu);     /* disable cache on 32-bit systems */
+        ; //&& (arch_cpu != 7 || running_qemu);     /* disable cache on 32-bit systems */
     if (use_cache) {
         /* full track caching only if cache large enough */
         if (CACHE_FULL_TRACK && floppy->sect < CACHE_SIZE)

--- a/elks/arch/i86/drivers/block/ll_rw_blk.c
+++ b/elks/arch/i86/drivers/block/ll_rw_blk.c
@@ -355,17 +355,17 @@ void INITPROC blk_dev_init(void)
     rd_init();          /* RAMDISK block device*/
 #endif
 
-#if defined(CONFIG_BLK_DEV_SSD_TEST) || defined(CONFIG_BLK_DEV_SSD_SD8018X) || \
-    defined(CONFIG_FS_XMS_RAMDISK)
-    ssd_init();         /* SSD block device*/
-#endif
-
 #ifdef CONFIG_BLK_DEV_HD
     directhd_init();
 #endif
 
 #ifdef CONFIG_BLK_DEV_FD
-    floppy_init();
+    floppy_init();      /* direct floppy, init before SSD for possible XMS track cache */
+#endif
+
+#if defined(CONFIG_BLK_DEV_SSD_TEST) || defined(CONFIG_BLK_DEV_SSD_SD8018X) || \
+    defined(CONFIG_FS_XMS_RAMDISK)
+    ssd_init();         /* SSD block device*/
 #endif
 
 #if defined(CONFIG_BLK_DEV_BFD) || defined(CONFIG_BLK_DEV_BHD)

--- a/elks/arch/i86/mm/xms.c
+++ b/elks/arch/i86/mm/xms.c
@@ -125,11 +125,15 @@ void xms_fmemcpyw(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src
 		if (!need_xms_src) src_seg <<= 4;
 		if (!need_xms_dst) dst_seg <<= 4;
 
-	  if (xms_enabled == XMS_UNREAL)
-		linear32_fmemcpyw(dst_off, dst_seg, src_off, src_seg, count);
-	  else
-		int15_fmemcpy(dst_off, dst_seg, src_off, src_seg, count << 1, COPY);
-	  return;
+		if (need_xms_src && need_xms_dst)
+			debug("xms to xms fmemcpy %08lx -> %08lx %u\n",
+				src_seg + (unsigned)src_off, dst_seg + (unsigned)dst_off, count);
+
+		if (xms_enabled == XMS_UNREAL)
+			linear32_fmemcpyw(dst_off, dst_seg, src_off, src_seg, count);
+		else
+			int15_fmemcpy(dst_off, dst_seg, src_off, src_seg, count << 1, COPY);
+		return;
 	}
 	fmemcpyw(dst_off, (seg_t)dst_seg, src_off, (seg_t)src_seg, count);
 }

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -208,8 +208,8 @@ int INITPROC buffer_init(void)
     if (bufs_to_alloc > 256) bufs_to_alloc = 256; /* protect against high XMS value*/
 #endif
 
-    printk("%d %s buffers (%dK ram), %dK cache, %d req hdrs\n", bufs_to_alloc,
-        xmsenabled? "xms": "ext", bufs_to_alloc, nr_map_bufs, NR_REQUEST);
+    printk("%dK %s buffers, %dK cache, %d req hdrs\n", bufs_to_alloc,
+        xmsenabled? "xms": "ext", nr_map_bufs, NR_REQUEST);
 #else
     int bufs_to_alloc = nr_map_bufs;
 #endif

--- a/elks/fs/buffer.c
+++ b/elks/fs/buffer.c
@@ -194,8 +194,13 @@ int INITPROC buffer_init(void)
 #ifdef CONFIG_FS_XMS_BUFFER
     if (nr_xms_bufs)
         xmsenabled = xms_init();        /* try to enable unreal mode and A20 gate*/
-    if (xmsenabled)
+    if (xmsenabled) {
         bufs_to_alloc = nr_xms_bufs;
+#ifdef CONFIG_BLK_DEV_FD
+        /* must allocate direct floppy track cache before buffers to avoid any 64k wrap */
+        df_cache_seg = xms_alloc(TRACKSEGSZ >> 10); /* in K, must match CACHE_SIZE */
+#endif
+    }
 #endif
 #ifdef CONFIG_FAR_BUFHEADS
     if (bufs_to_alloc > 2975) bufs_to_alloc = 2975; /* max 64K far bufheads @22 bytes*/

--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -136,7 +136,8 @@
  * old 8237 DMA controller which wraps addresses wider than 16-bits on PC/XT systems.
  * If floppy track caching is enabled, the track buffer is also configured in
  * low memory for direct DMA access usig multisector I/O.
- * The DF driver uses the first sector of its track cache for the XMS/DMA buffer.
+ * The DF driver uses the first sector of its track cache for the DMA buffer,
+ * and doesn't require an XMS buffer, instead programming the 8237 external page register.
  * In contrast, the BIOS FD/HD driver is configured to use an XMS/DMA buffer
  * outside its track cache; thus the complicated defines below.
  */

--- a/elks/include/linuxmt/memory.h
+++ b/elks/include/linuxmt/memory.h
@@ -47,6 +47,7 @@ extern int xms_bootopts;    /* xms=on or xms=int15 /bootopts setting, default of
 extern int xms_enabled;
 
 typedef __u32 ramdesc_t;	/* special physical ram descriptor */
+extern ramdesc_t df_cache_seg;  /* track cache segment or linear address if XMS */
 
 /* allocate from XMS memory */
 ramdesc_t xms_alloc(unsigned int kbytes);

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -17,7 +17,7 @@ xms=on
 #3	# multiuser serial
 #n	# no rc.sys
 #init=/bin/sash
-root=df0
+#root=df0
 #root=hda1 ro
 #kstack
 #strace

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -17,7 +17,7 @@ xms=on
 #3	# multiuser serial
 #n	# no rc.sys
 #init=/bin/sash
-#root=df0
+root=df0
 #root=hda1 ro
 #kstack
 #strace


### PR DESCRIPTION
Proof of concept hopefully making the impossible possible... discussed in https://github.com/Mellvik/TLVC/pull/164#issuecomment-2848713015.

Implements DMA-driven floppy I/O using direct floppy driver directly to and from XMS buffers in memory > 1MB. The top 8 bits of the XMS address (A16-A23) are written to the external page register at port 81h for DMA channel 2. In the current direct floppy driver, this was always the case, except that when XMS buffers were in use, a bounce buffer was forced. That's now turned off, and the full 24-bit source or destination XMS address (max 16MB) is used for the transfer.

This version has track caching turned off for simplicity; track caching is always turned off due to it having been tested as inefficient with faster CPUs (386+). A later version will likely dynamically allocate a track cache buffer in either XMS or low main memory, depending on whether XMS buffers are enabled. 

Ultimately, more discussion is needed as to when or whether a track cache is needed at all on XMS systems, since XMS memory isn't available on PC or PC/XTs, leaving only PC/ATs and possibly some other hardware before 386+ CPUs were in use, where track caching isn't helpful. More discussion on this in https://github.com/Mellvik/TLVC/pull/164.

Tested on QEMU. Not yet tested on real hardware.

