### PR TITLE
[c86, paint] Support C86 __loadreg builtin, get paint back running w/OWC and C86

### DIFF
--- a/elks/include/arch/cdefs.h
+++ b/elks/include/arch/cdefs.h
@@ -53,6 +53,18 @@
 #define __attribute__(n)
 #define __wcfar
 #define __wcnear
+
+/* register specification flags for __loadreg */
+#define __F_DREG    1               /* data register (AX, BX, CX, DX) */
+#define __F_AREG    2               /* address register (SI, DI) */
+#define __AX        (__F_DREG)
+#define __CX        (__F_DREG|1024)
+#define __DX        (__F_DREG|2048)
+#define __BX        (__F_DREG|4096)
+#define __SI        (__F_AREG)
+#define __DI        (__F_AREG|8192)
+void __loadreg(int reg, int value);
+
 #endif
 
 #endif

--- a/elks/include/arch/types.h
+++ b/elks/include/arch/types.h
@@ -55,7 +55,7 @@ struct uregs {
  */
 
 /* <stddef.h> */
-typedef unsigned    size_t;
+typedef unsigned int    size_t;
 #define offsetof(__typ,__id) ((size_t)((char *)&(((__typ*)0)->__id) - (char *)0))
 
 /* <sys/types.h> */

--- a/elks/tools/objtools/ecc
+++ b/elks/tools/objtools/ecc
@@ -47,6 +47,8 @@ CFLAGS="\
     -stackopt=minimum           \
     -peep=all                   \
     -stackcheck=no              \
+    -obsolete=yes               \
+    -trace=no                   \
     "
 
 ASFLAGS="\

--- a/elks/tools/objtools/ecc
+++ b/elks/tools/objtools/ecc
@@ -36,6 +36,7 @@ CPPFLAGS="\
     $DEFINES                    \
     "
 
+# -trace=yes
 CFLAGS="\
     -g                          \
     -O                          \
@@ -48,7 +49,6 @@ CFLAGS="\
     -peep=all                   \
     -stackcheck=no              \
     -obsolete=yes               \
-    -trace=no                   \
     "
 
 ASFLAGS="\

--- a/elkscmd/gui/app.c
+++ b/elkscmd/gui/app.c
@@ -149,8 +149,12 @@ void A_GameLoop(void)
             case mode_Fill:
                 if(mx <= CANVAS_WIDTH){
                     hidecursor();
+#ifdef __C86__
+                    R_LineFloodFill(omx, omy, current_color, readpixel(mx, my));
+#else
                     int maxCap = R_FrontFill(omx, omy, current_color, readpixel(mx, my));
                     __dprintf("Peak stack size: %d\n", maxCap);
+#endif
                     showcursor();
                     current_state = state_Idle;
                 }

--- a/elkscmd/gui/graphics.c
+++ b/elkscmd/gui/graphics.c
@@ -142,18 +142,6 @@ void fillrect(int x1, int y1, int x2, int y2, int c)
         drawhline(x1, x2, y1++, c);
 }
 
-/* initialize VGA to Read Mode 1 & set compare/color mask */
-void vga_cmp8_init(int target_color) {
-    /* Set Graphics Mode Register to read mode 1 (bit 3 = 1) */
-    set_write_mode(8);
-
-    /* Set Color Compare Register to target color (4 bits) */
-    set_color_compare(target_color & 0x0F);
-
-    /* Set Color Don't Care Register to 0x0F (include all planes) */
-    set_color_dont_care(0x0F);
-}
-
 #ifdef __C86__
 
 /* use BIOS to set video mode */

--- a/elkscmd/gui/graphics.h
+++ b/elkscmd/gui/graphics.h
@@ -27,7 +27,6 @@ int save_bmp(char *pathname);
 #define drawhline(x1,x2,y,c)    vga_drawhline(x1,x2,y,c)
 #define drawvline(x,y1,y2,c)    vga_drawvline(x,y1,y2,c)
 #define readpixel(x,y)          vga_readpixel(x,y)
-void vga_cmp8_init(int target_color);
 #else
 void drawpixel(int x,int y, int color);
 void drawhline(int x1, int x2, int y, int c);

--- a/elkscmd/gui/vgalib.h
+++ b/elkscmd/gui/vgalib.h
@@ -168,6 +168,14 @@ void set_enable_sr(unsigned int flag);
     "out dx,ax",                                \
     modify [ ax dx ];
 
+void set_color_compare(unsigned int color);
+#pragma aux set_color_compare parm [ax] =       \
+    "mov dx,0x03ce",                            \
+    "mov ah,al",                                \
+    "mov al,2",                                 \
+    "out dx,ax",                                \
+    modify [ ax dx ];
+
 void set_op(unsigned int op);
 #pragma aux set_op parm [ax] =                  \
     "mov dx,0x03ce",                            \
@@ -189,6 +197,14 @@ void set_write_mode(unsigned int mode);
     "mov dx,0x03ce",                            \
     "mov ah,al",                                \
     "mov al,5",                                 \
+    "out dx,ax",                                \
+    modify [ ax dx ];
+
+void set_color_dont_care(unsigned int color);
+#pragma aux set_color_dont_care parm [ax] =     \
+    "mov dx,0x03ce",                            \
+    "mov ah,al",                                \
+    "mov al,7",                                 \
     "out dx,ax",                                \
     modify [ ax dx ];
 
@@ -255,6 +271,13 @@ void set_bios_mode(int mode);
         "out dx,ax\n"                           \
     )
 
+#define set_color_compare(color)                \
+    asm("mov dx,*0x03ce\n"                      \
+        "mov al,*2\n"                           \
+        "mov ah,*" #color "\n"                  \
+        "out dx,ax\n"                           \
+    )
+
 #define set_op(op)                              \
     asm("mov dx,*0x03ce\n"                      \
         "mov al,*3\n"                           \
@@ -273,6 +296,13 @@ void set_bios_mode(int mode);
     asm("mov dx,*0x03ce\n"                      \
         "mov al,*5\n"                           \
         "mov ah,*" #mode "\n"                   \
+        "out dx,ax\n"                           \
+    )
+
+#define set_color_dont_care(color)              \
+    asm("mov dx,*0x03ce\n"                      \
+        "mov al,*7\n"                           \
+        "mov ah,*" #color "\n"                  \
         "out dx,ax\n"                           \
     )
 

--- a/libc/include/alloca.h
+++ b/libc/include/alloca.h
@@ -3,6 +3,7 @@
 /*
  * Stack-checking alloca for GCC, OWC and C86
  */
+#include <sys/types.h>
 
 int __stackavail(unsigned int size);    /* return 1 if size bytes stack available */
 extern unsigned int __stacklow;         /* lowest protected SP value */


### PR DESCRIPTION
Adds register definitions for the new builtin function \_\_loadreg enhancement to C86 in https://github.com/ghaerr/8086-toolchain/pull/69.

This will allow supporting non-constant parameters to VGA vgalib.h ASM graphics macros for high speed VGA operation when using the C86 compiler. Both IA16 and OWC already support such a mechanism.

The recently added high speed bucket fill algorithm in ELKS Paint only supported the IA16 compiler. The vgalib.h graphics macros are updated here to support OWC and C86. The C86 macros have not yet been updated to allow for non-constant arguments, required by the new fill algorithm in vga_cmp8_init().

Unfortunately, the C86 compiler doesn't seem to support functions returning structs, so the high speed fill routine is replaced with the original slower fill routine for the C86 compiled version only, at least for now.

Paint's render.c code that uses a GCC non-standard extension to initialize structures doesn't work in OWC or C86; the code was changed to initialize the two (xl, xr) Segment structure members individually so that Paint will compile with all three compilers. I wanted to keep Paint operational with all our supported compilers as it's a useful way to learn about compiler portability issues. (BTW, initializing non-static constant structures or arrays within functions is extremely slow: the compiler will store the constant data in the data segment, then emit memcpy code to copy to the stack frame - way slower than initializing individually unless the structure is large).

Finally, the C86 -obsolete=yes feature showed that the C library alloca.h header file wasn't including the definition of size_t, which is now fixed.

