### PR TITLE
[kernel] Fix kernel heap item not freed if first on list

### DIFF
--- a/elks/lib/heap.c
+++ b/elks/lib/heap.c
@@ -89,8 +89,8 @@ void * heap_alloc (word_t size, byte_t tag)
 		h++;						// skip header
 		if (tag & HEAP_TAG_CLEAR)
 			memset(h, 0, size);
-	}
-	if (!h) printk("HEAP: no memory (%u bytes)\n", size);
+	} else
+		printk("HEAP: no memory (%u bytes)\n", size);
 	return h;
 }
 
@@ -118,10 +118,9 @@ void heap_free (void * data)
 			heap_merge (prev, h);
 			i = _heap_free.prev;
 			h = prev;
-		} else {
-			h->tag = HEAP_TAG_FREE;
 		}
 	}
+	h->tag = HEAP_TAG_FREE;
 
 	// Try to merge with next block if free
 

--- a/elkscmd/rootfs_template/bin/net
+++ b/elkscmd/rootfs_template/bin/net
@@ -1,9 +1,9 @@
 # Start/stop ELKS networking
 #
-# Usage: net [start|stop|restart|show] [ne0|slip|cslip] [baud] [device]
+# Usage: net [start|stop|restart|show] [ne0|wd0|3c0|slip|cslip] [baud] [device]
 #
 # Examples:
-#	net start ne0k			start ethernet networking
+#	net start ne0			start ethernet networking
 #	net start slip			start slip networking
 #	net start slip 19200	start slip at 19200 baud
 #	net start cslip 4800 /dev/ttyS1


### PR DESCRIPTION
Kind of amazing that ELKS kernel heap management code is still buggy in certain circumstances. This case was never found because the first heap allocation, the L1 buffers, is never released. Found and fixed by @Mellvik in https://github.com/Mellvik/TLVC/pull/183.

Also updates bin/net usage internal documentation with default network adaptor names.

Thanks @Mellvik!