### PR TITLE
ATA driver: improved performance

### DIFF
--- a/elks/arch/i86/drivers/block/ata.c
+++ b/elks/arch/i86/drivers/block/ata.c
@@ -263,7 +263,7 @@ static int ata_identify(unsigned int drive, char *buf)
     {
         for (i = 0; i < ATA_SECTOR_SIZE; i++)
         {
-            buf[i] = inb(ATA_PORT_DATA);
+            *buf++ = inb(ATA_PORT_DATA);
         }
     }
     else
@@ -272,8 +272,8 @@ static int ata_identify(unsigned int drive, char *buf)
         {
             word = inw(ATA_PORT_DATA);
 
-            buf[i+0] = (unsigned char) (word & 0xFF);
-            buf[i+1] = (unsigned char) (word >> 8);
+            *buf++ = (unsigned char) (word & 0xFF);
+            *buf++ = (unsigned char) (word >> 8);
         }
     }
 
@@ -429,7 +429,7 @@ int ata_read(unsigned int drive, sector_t sector, char *buf, ramdesc_t seg)
     {
         for (i = 0; i < ATA_SECTOR_SIZE; i++)
         {
-            buffer[i] = inb(ATA_PORT_DATA);
+            *buffer++ = inb(ATA_PORT_DATA);
         }
     }
     else
@@ -438,8 +438,8 @@ int ata_read(unsigned int drive, sector_t sector, char *buf, ramdesc_t seg)
         {
             word = inw(ATA_PORT_DATA);
 
-            buffer[i+0] = (unsigned char) (word & 0xFF);
-            buffer[i+1] = (unsigned char) (word >> 8);
+            *buffer++ = (unsigned char) (word & 0xFF);
+            *buffer++ = (unsigned char) (word >> 8);
         }
     }
 
@@ -486,14 +486,14 @@ int ata_write(unsigned int drive, sector_t sector, char *buf, ramdesc_t seg)
     {
         for (i = 0; i < ATA_SECTOR_SIZE; i++)
         {
-            outb(buffer[i], ATA_PORT_DATA);
+            outb(*buffer++, ATA_PORT_DATA);
         }
     }
     else
     {
         for (i = 0; i < ATA_SECTOR_SIZE; i+=2)
         {
-            word = buffer[i+0] | buffer[i+1] << 8;
+            word = *buffer++ | *buffer++ << 8;
             outw(word, ATA_PORT_DATA);
         }
     }


### PR DESCRIPTION
Hi @ghaerr 

I disassembled the code in the ATA driver and found that for the 16-bit code, GCC was doing a lookup for each buffer[i] mention (hence, 2 in the 16-bit code).

So, I've switched to using an incremental pointer. The old code was 10 instructions, while this improved version is 5 instructions. The performance improvements are as follows:

## 8-bit original
106s (format FAT32; 4GB)
24s   (write 2Mb file)
11s    (read 2Mb file)

## 8-bit improved
102s
23s
10s

## 16-bit original
106s
24s
11s

## 16-bit improved
92s (thats 14 seconds saved)
22s
10s

I suspect the changes would be even more obvious if I had tested even larger files. 
