### PR TITLE
[kernel] Add XTIDE v2 support to ATA CF driver

### DIFF
--- a/elks/arch/i86/drivers/block/ata.c
+++ b/elks/arch/i86/drivers/block/ata.c
@@ -21,7 +21,7 @@
  * DEVCTL                      0x307
  *
  * This code assumes only supports one ATA controller, and sets XTCF operation
- * on 8088/8086 CPUs, unless reconfigured below.
+ * on 8088/8086 CPUs, unless overriden using xtide= in /bootopts.
  *
  * This code uses LBA addressing for the disks. Any disks without
  * LBA support (they'd need to be pretty old) are simply ignored.
@@ -36,8 +36,8 @@
  * - read/write data
  * - wait till drive is not busy
  *
- * Caveat emptor: This code is based on the ATA specifications and
- * some common sense.
+ * Caveat emptor: This code is based on the ATA specifications,
+ * XTIDE Universal BIOS source, and some common sense.
  *
  * Ferry Hendrikx, June 2025
  * Greg Haerr, July 2025 Added XTCF and XTIDE support

--- a/elks/include/arch/ata.h
+++ b/elks/include/arch/ata.h
@@ -3,18 +3,36 @@
 
 #include <linuxmt/memory.h>
 
-/* ATA register offsets from base I/O address */
+/*
+ * Command block register offsets from base I/O address,
+ * for standard ATA and XTIDE v1.
+ * These offsets are shifted left 1 for XTCF operation,
+ * and the offsets have bits 0 and 3 swapped for XTIDE v2.
+ */
 
-#define ATA_REG_DATA       0
-#define ATA_REG_ERR        1
-#define ATA_REG_FEAT       1
-#define ATA_REG_CNT        2
-#define ATA_REG_LBA_LO     3
-#define ATA_REG_LBA_MD     4
-#define ATA_REG_LBA_HI     5
-#define ATA_REG_DRVH       6
-#define ATA_REG_CMD        7
-#define ATA_REG_STATUS     7
+#define ATA_REG_DATA        0       /* r/w */
+#define ATA_REG_ERR         1       /* r   */
+#define ATA_REG_FEAT        1       /*   w */
+#define ATA_REG_CNT         2       /* r/w */
+#define ATA_REG_LBA_LO      3       /* r/w */
+#define ATA_REG_LBA_MD      4       /* r/w */
+#define ATA_REG_LBA_HI      5       /* r/w */
+#define ATA_REG_DRVH        6       /* r/w */
+#define ATA_REG_STATUS      7       /* r   */
+#define ATA_REG_CMD         7       /*   w */
+#define ATA_REG_DATA_HI     8       /* r/w XTIDE only */
+
+/* XTIDE v2 block register offsets (a3/a0 swapped from ATA/XTIDE v1) */
+#define XTIDEV2_DATA        0       /* r/w */
+#define XTIDEV2_DATA_HI     1       /* r/w */
+#define XTIDEV2_CNT         2       /* r/w */
+#define XTIDEV2_LBA_MD      4       /* r/w */
+#define XTIDEV2_DRVH        6       /* r/w */
+#define XTIDEV2_ERR         8       /* r   */
+#define XTIDEV2_LBA_LO      10      /* r/w */
+#define XTIDEV2_LBA_HI      12      /* r/w */
+#define XTIDEV2_STATUS      14      /* r   */
+#define XTIDEV2_CMD         14      /*   w */
 
 /* ATA commands */
 

--- a/elks/include/arch/ata.h
+++ b/elks/include/arch/ata.h
@@ -68,6 +68,8 @@
 
 #define ATA_SECTOR_SIZE     512
 
+extern int ata_mode;        /* ATA CF driver operating mode, /bootopts xtide= */
+
 void ata_reset(void);
 struct drive_infot;
 int ata_init(int drive, struct drive_infot *drivep);

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -45,6 +45,7 @@ int root_mountflags;
 int tracing;
 int nr_ext_bufs, nr_xms_bufs, nr_map_bufs;
 int xms_bootopts;
+int ata_mode = -1;              /* =AUTO default set ATA CF driver mode automatically */
 char running_qemu;
 static int boot_console;
 static segext_t umbtotal;
@@ -557,6 +558,10 @@ static int INITPROC parse_options(void)
         }
         if (!strncmp(line,"xmsbuf=",7)) {
             nr_xms_bufs = (int)simple_strtol(line+7, 10);
+            continue;
+        }
+        if (!strncmp(line,"xtide=",6)) {
+            ata_mode = (int)simple_strtol(line+6, 10);
             continue;
         }
         if (!strncmp(line,"cache=",6)) {

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,4 +1,4 @@
-## /bootopts 1023 max
+## 1023 max
 #TZ=MDT6
 #LOCALIP=10.0.2.16
 #HOSTNAME=elks16
@@ -11,6 +11,7 @@ hma=kernel
 xms=on
 #xms=int15
 #xmsbuf=0
+#xtide=2
 #task=16 buf=64 cache=8 file=64 inode=96 heap=44000 # std
 #task=6 buf=8 cache=4 file=20 inode=24 heap=15000 n # min
 #sync=30


### PR DESCRIPTION
Adds full support for XTIDE v1 and v2 to ATA CF driver. Discussed in https://github.com/86Box/86Box/discussions/5797#discussioncomment-13812478 and https://github.com/ghaerr/elks/pull/2359#issuecomment-3090843045.

Since the ATA CF driver now supports four different controller types, this PR also adds a /bootopts option to specify the controller type (by number specified in ata.c). Here are the values:
```
xtide=0    standard ATA (default for PC/AT (80286+) systems)
xtide=1    XTIDE rev 1 (pre 2012)
xtide=2    XTIDE rev 2 (now standard for XTIDE)
xtide=3    XTCF (automatically set for 8088/8086 systems
```
The default port for XTIDE and XTCF is 0x300; a configurable setting in the driver file ata.c will need to be changed and the kernel recompiled for other base port addresses. Everything else is pretty much automatic.

Kind of a complicated mess, but I think it's all figured out now.