### PR TITLE
[kernel] Rewrite ATA CF driver timeouts to use accurate kernel timer

### DIFF
--- a/elks/arch/i86/drivers/block/ata.c
+++ b/elks/arch/i86/drivers/block/ata.c
@@ -270,7 +270,7 @@ static int ata_select(unsigned int drive, unsigned int cmd, unsigned long sector
 
     // wait for drive to be non-busy
 
-    error = ata_wait(WAIT_50Ms);
+    error = ata_wait(WAIT_50MS);
     if (error)
         return error;
 
@@ -282,7 +282,7 @@ static int ata_select(unsigned int drive, unsigned int cmd, unsigned long sector
 
     // wait for drive to be non-busy
 
-    return ata_wait(WAIT_50Ms);
+    return ata_wait(WAIT_50MS);
 }
 
 /**
@@ -311,7 +311,7 @@ static int ata_cmd(unsigned int drive, unsigned int cmd, unsigned long sector,
 
     // wait for drive to be not-busy
 
-    error = ata_wait(cmd == ATA_CMD_READ? WAIT_10SEC: WAIT_50Ms);
+    error = ata_wait(cmd == ATA_CMD_READ? WAIT_10SEC: WAIT_50MS);
     if (error)
         return error;
 

--- a/elks/arch/i86/drivers/block/init.c
+++ b/elks/arch/i86/drivers/block/init.c
@@ -36,7 +36,10 @@ int boot_rootdev;       /* set by /bootopts options if configured*/
 void INITPROC device_init(void)
 {
     chr_dev_init();
-    blk_dev_init();     /* interrupts enabled here prior to partition table reading */
+
+    set_irq();          /* interrupts enabled for possible disk I/O or timers */
+
+    blk_dev_init();
 
 #if defined(CONFIG_BLK_DEV_BFD) || defined(CONFIG_BLK_DEV_BHD) || \
     defined(CONFIG_BLK_DEV_FD) || defined(CONFIG_BLK_DEV_ATA_CF)

--- a/elks/arch/i86/drivers/block/ll_rw_blk.c
+++ b/elks/arch/i86/drivers/block/ll_rw_blk.c
@@ -380,8 +380,6 @@ void INITPROC blk_dev_init(void)
     struct gendisk *atadisk = ata_cf_init();
 #endif
 
-    set_irq();          /* interrupts enabled for possible disk I/O */
-
 #ifdef CONFIG_BLK_DEV_BHD
     if (biosdisk)
         init_partitions(biosdisk);


### PR DESCRIPTION
Replaces timer loops with 10ms kernel jiffies variable for accurate timing in ATA CF driver.

All busy waits are replaced with 50ms timeouts except for read/write commands, which can require up to 10 secs, including some flash devices.

It was found that previously moving the first kernel startup interrupt enable to after BIOSHD and ATA CF initialization would not work, since both drivers use kernel jiffies-based timers, which require the clock interrupt to be operational. Now, interrupts are first enabled before calling any block device init routine, allowing for possible disk I/O or timers within their startup code.