### PR TITLE
[boot] Create distribution /bootopts file larger than 512 bytes

### DIFF
--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -11,7 +11,7 @@ hma=kernel
 xms=on
 #xms=int15
 #xmsbuf=0
-#xtide=2 # 0=ATA, 1=XTIDEv1, 2=XTIDEv2 (high speed), 3=XTCF
+#xtide=3 # 0=ATA, 1=XTIDEv1, 2=XTIDEv2 (high speed), 3=XTCF
 #task=16 buf=64 cache=8 file=64 inode=96 heap=44000 # std
 #task=6 buf=8 cache=4 file=20 inode=24 heap=15000 n # min
 #sync=30

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -1,4 +1,4 @@
-## 1023 max
+## /bootopts 1023 max
 #TZ=MDT6
 #LOCALIP=10.0.2.16
 #HOSTNAME=elks16
@@ -11,7 +11,7 @@ hma=kernel
 xms=on
 #xms=int15
 #xmsbuf=0
-#xtide=2
+#xtide=2 # 0=ATA, 1=XTIDEv1, 2=XTIDEv2 (high speed), 3=XTCF
 #task=16 buf=64 cache=8 file=64 inode=96 heap=44000 # std
 #task=6 buf=8 cache=4 file=20 inode=24 heap=15000 n # min
 #sync=30


### PR DESCRIPTION
Extends the distribution /bootopts file to larger than 512 bytes (max size still 1023 bytes). This was done for two reasons:
- The /bootopts loader for FAT always reads two sectors, but if only one is present, a garbage sector (the next consecutive sector) will also be read. If the /bootopts file is exactly 512 bytes long, then it won't be zero terminated and the garbage sector will be interpreted at startup.
- If the /bootopts file is edited on a FAT filesystem, the new /bootopts will only work if the file was already two sectors in size, thus guaranteeing the file sectors remain contiguous. When editing /bootopts on FAT, the file size should not be reduced below 513 bytes, as doing so may cause the file contents to become non-contiguous when next edited.

Comments were added to the  xtide= line for informational purposes:
```
#xtide=3 # 0=ATA, 1=XTIDEv1, 2=XTIDEv2 (high speed), 3=XTCF
```