### PR TITLE
[kernel] Add disable= /bootopts option to disable ATA CF, BIOS FD/HD or DF drivers

### DIFF
--- a/elks/arch/i86/drivers/block/ata-cf.c
+++ b/elks/arch/i86/drivers/block/ata-cf.c
@@ -12,6 +12,7 @@
 #include <linuxmt/kernel.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/genhd.h>
+#include <linuxmt/devnum.h>
 #include <linuxmt/debug.h>
 #include <arch/ata.h>
 
@@ -66,6 +67,10 @@ struct gendisk * INITPROC ata_cf_init(void)
 
     // register device
 
+    if (dev_disabled(DEV_CFA)) {
+        printk("cfa: disabled\n");
+        return NULL;
+    }
     if (register_blkdev(MAJOR_NR, DEVICE_NAME, &ata_cf_fops))
         return NULL;
     blk_dev[MAJOR_NR].request_fn = DEVICE_REQUEST;

--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -81,6 +81,7 @@
 #include <linuxmt/string.h>
 #include <linuxmt/heap.h>
 #include <linuxmt/genhd.h>
+#include <linuxmt/devnum.h>
 #include <linuxmt/debug.h>
 
 #include <arch/dma.h>
@@ -1505,6 +1506,10 @@ static int DFPROC floppy_register(void)
 
 void INITPROC floppy_init(void)
 {
+    if (dev_disabled(DEV_DF0)) {
+        printk("df0: disabled\n");
+        return;
+    }
     if (register_blkdev(MAJOR_NR, DEVICE_NAME, &floppy_fops))
         return;
     blk_dev[MAJOR_NR].request_fn = DEVICE_REQUEST;

--- a/elks/include/linuxmt/init.h
+++ b/elks/include/linuxmt/init.h
@@ -45,6 +45,7 @@ extern void INITPROC tz_init(const char *tzstr);
 struct file_operations;
 extern int INITPROC register_blkdev(unsigned int,const char *,struct file_operations *);
 extern void INITPROC blk_dev_init(void);
+extern int INITPROC dev_disabled(int dev);
 extern struct gendisk * INITPROC bioshd_init(void);
 extern int INITPROC bios_gethdinfo(struct drive_infot *);
 extern int INITPROC bios_getfdinfo(struct drive_infot *);

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -12,6 +12,7 @@ xms=on
 #xms=int15
 #xmsbuf=0
 #xtide=3 # 0=ATA, 1=XTIDEv1, 2=XTIDEv2 (high speed), 3=XTCF
+#disable=hda,cfa,df0,fd0
 #task=16 buf=64 cache=8 file=64 inode=96 heap=44000 # std
 #task=6 buf=8 cache=4 file=20 inode=24 heap=15000 n # min
 #sync=30


### PR DESCRIPTION
Allows disabling compiled-in drivers for testing, or for when drivers may try to talk to the same hardware. Discussed in https://github.com/ghaerr/elks/pull/2357#issuecomment-3092540943.

/bootopts now parses a comma separated list of block device names to disable them at boot. The complete list of allowable drivers is:
```
disable=hda,cfa,df0,fd0
```
Note that there are two options for the BIOS driver: hda turns off the hard disk, and fd0 the floppy. df0 is the direct DF driver and cfa is the ATA CF driver.

This line should be edited to only include only drivers that might be causing problems. Leaving in the entire list will end up disabling all bootable block devices, and the boot will fail when trying to mount the root device.

The most common use of this option will likely be to either turn off the BIOS hard disk driver when booting from CF card. To do this, one would use:
```
disable=hda
root=cfa
```

Since the ATA CF driver will likely be compiled in, one might want to turn it off when not desired, and just use the BIOS HD driver instead:
```
disable=cfa
```