### PR TITLE
[kernel] Display device name as well as number in important kernel messages

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -655,7 +655,7 @@ next_block:
 
         /* make sure it's a disk that we are dealing with. */
         if (drive > (DRIVE_FD0 + FD_DRIVES - 1) || drivep->heads == 0) {
-            printk("bioshd: non-existent drive: %D\n", req->rq_dev);
+            printk("bioshd: non-existent drive: %D %E\n", req->rq_dev, req->rq_dev);
             end_request(0);
             continue;
         }

--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -118,9 +118,9 @@ static void end_request(int uptodate)
 
     if (!uptodate) {
         /*if (req->rq_errors >= 0)*/
-        printk(DEVICE_NAME ": I/O %s error dev %D lba sector %lu\n",
+        printk(DEVICE_NAME ": I/O %s error dev %D %E lba sector %lu\n",
             (req->rq_cmd == WRITE)? "write": "read",
-            req->rq_dev, req->rq_sector);
+            req->rq_dev, req->rq_dev, req->rq_sector);
     }
 
 #ifdef MULTI_BH

--- a/elks/arch/i86/drivers/block/init.c
+++ b/elks/arch/i86/drivers/block/init.c
@@ -67,7 +67,7 @@ void INITPROC device_init(void)
         if (!rootdev)
             rootdev = bios_conv_bios_drive(ROOT_DEV);
 #endif
-        printk("boot: BIOS drive %x, root device %04x\n", ROOT_DEV, rootdev);
+        printk("boot: BIOS drive %x, root device %D %E\n", ROOT_DEV, rootdev, rootdev);
         ROOT_DEV = (kdev_t)rootdev;
     }
 #endif

--- a/elks/fs/minix/inode.c
+++ b/elks/fs/minix/inode.c
@@ -91,9 +91,9 @@ static struct super_operations minix_sops = {
 static void minix_mount_warning(register struct super_block *sb, const char *prefix)
 {
 	if ((sb->u.minix_sb.s_mount_state & (MINIX_VALID_FS|MINIX_ERROR_FS)) != MINIX_VALID_FS)
-		printk("MINIX-fs: %smounting %s %D %E, running fsck is recommended\n", prefix,
+		printk("MINIX-fs: %smounting %s %E, running fsck recommended\n", prefix,
 	     !(sb->u.minix_sb.s_mount_state & MINIX_VALID_FS) ?
-		 "unchecked filesystem" : "filesystem with errors", sb->s_dev, sb->s_dev);
+		 "unchecked filesystem" : "filesystem with errors", sb->s_dev);
 }
 
 

--- a/elks/fs/minix/inode.c
+++ b/elks/fs/minix/inode.c
@@ -91,9 +91,9 @@ static struct super_operations minix_sops = {
 static void minix_mount_warning(register struct super_block *sb, const char *prefix)
 {
 	if ((sb->u.minix_sb.s_mount_state & (MINIX_VALID_FS|MINIX_ERROR_FS)) != MINIX_VALID_FS)
-		printk("MINIX-fs: %smounting %s %D, running fsck is recommended\n", prefix,
+		printk("MINIX-fs: %smounting %s %D %E, running fsck is recommended\n", prefix,
 	     !(sb->u.minix_sb.s_mount_state & MINIX_VALID_FS) ?
-		 "unchecked filesystem" : "filesystem with errors", sb->s_dev);
+		 "unchecked filesystem" : "filesystem with errors", sb->s_dev, sb->s_dev);
 }
 
 
@@ -143,7 +143,7 @@ struct super_block *minix_read_super(register struct super_block *s, char *data,
 	ms = (struct minix_super_block *) bh->b_data;
 	if (ms->s_magic != MINIX_SUPER_MAGIC) {
 	    if (!silent)
-		printk("VFS: device %D is not minixfs\n", dev);
+		printk("VFS: device %D %E is not minixfs\n", dev, dev);
 	    msgerr = err0;
 	    goto err_read_super_1;
 	}

--- a/elks/fs/super.c
+++ b/elks/fs/super.c
@@ -173,7 +173,7 @@ static struct super_block *read_super(kdev_t dev, int t, int flags,
     if (s) return s;
 
     if (!(type = get_fs_type(t))) {
-        printk("VFS: device %D unknown fs type %d\n", dev, t);
+        printk("VFS: device %D %E unknown fs type %d\n", dev, dev, t);
         return NULL;
     }
 
@@ -444,7 +444,8 @@ void mount_root(void)
         retval = open_filp(0, d_inode, &filp);
     }
     if (retval) {
-        printk("VFS: Unable to open root device %D (%d)\n", ROOT_DEV, retval);
+        printk("VFS: Unable to open root device %D %E (%d)\n",
+            ROOT_DEV, ROOT_DEV, retval);
         halt();
     }
 
@@ -460,8 +461,9 @@ void mount_root(void)
             memcpy(sb->s_mntonname, "/", 2);
 /*          sb->s_flags = (unsigned short int) root_mountflags;*/
             current->fs.pwd = current->fs.root = sb->s_mounted;
-            printk("VFS: Mounted root device %04x (%s filesystem)%s.\n", ROOT_DEV,
-                   fsname[fp->type], (sb->s_flags & MS_RDONLY) ? " readonly" : "");
+            printk("VFS: Mounted root device %04x %E (%s filesystem)%s.\n",
+                ROOT_DEV, ROOT_DEV, fsname[fp->type],
+               (sb->s_flags & MS_RDONLY) ? " readonly" : "");
             iput(d_inode);
             filp->f_count = 0;
             return;
@@ -477,6 +479,6 @@ void mount_root(void)
     }
 #endif
 
-    printk("VFS: Unable to mount root fs on %D\n", ROOT_DEV);
+    printk("VFS: Unable to mount root fs on %D %E\n", ROOT_DEV, ROOT_DEV);
     halt();
 }

--- a/elks/include/linuxmt/fs.h
+++ b/elks/include/linuxmt/fs.h
@@ -428,6 +428,7 @@ extern int do_umount(kdev_t);
 extern kdev_t ROOT_DEV;
 
 extern void mount_root(void);
+extern char *root_dev_name(kdev_t dev);     /* actually returns ROOTDEV=/dev/name */
 
 extern int fd_check(unsigned int,char *,size_t,int,struct file **);
 

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -325,17 +325,18 @@ static struct dev_name_struct {
     int num;
 } devices[] = {
 	/* the 6 partitionable drives must be first */
-	{ "hda",     DEV_HDA },
+	{ "hda",     DEV_HDA },         /* 0 */
 	{ "hdb",     DEV_HDB },
 	{ "hdc",     DEV_HDC },
 	{ "hdd",     DEV_HDD },
 	{ "cfa",     DEV_CFA },
 	{ "cfb",     DEV_CFB },
-	{ "fd0",     DEV_FD0 },
+	{ "fd0",     DEV_FD0 },         /* 6 */
 	{ "fd1",     DEV_FD1 },
-	{ "df0",     DEV_DF0 },
+	{ "df0",     DEV_DF0 },         /* 8 */
 	{ "df1",     DEV_DF1 },
-	{ "ttyS0",   DEV_TTYS0 },
+	{ "rom",     DEV_ROM },
+	{ "ttyS0",   DEV_TTYS0 },       /* 11 */
 	{ "ttyS1",   DEV_TTYS1 },
 	{ "tty1",    DEV_TTY1 },
 	{ "tty2",    DEV_TTY2 },
@@ -351,11 +352,14 @@ static struct dev_name_struct {
 char *root_dev_name(kdev_t dev)
 {
     int i;
+    unsigned int mask;
 #define NAMEOFF 13
     static char name[18] = "ROOTDEV=/dev/";
 
-    for (i=0; i<7; i++) {
-        if (devices[i].num == (dev & 0xfff0)) {
+    name[8] = '/';
+    for (i=0; i<11; i++) {
+        mask = (i < 6)? 0xfff8: 0xffff;
+        if (devices[i].num == (dev & mask)) {
             strcpy(&name[NAMEOFF], devices[i].name);
             if (i < 6) {
                 if (dev & 0x07) {
@@ -366,7 +370,8 @@ char *root_dev_name(kdev_t dev)
             return name;
         }
     }
-    return NULL;
+    name[8] = '\0';     /* just return "ROOTDEV=" on not found */
+    return name;
 }
 
 #ifdef CONFIG_BOOTOPTS

--- a/elks/init/main.c
+++ b/elks/init/main.c
@@ -95,7 +95,6 @@ static struct {
 } opts;
 
 extern int boot_rootdev;
-static char * INITPROC root_dev_name(int dev);
 static int INITPROC parse_options(void);
 static void INITPROC finalize_options(void);
 static char * INITPROC option(char *s);
@@ -321,7 +320,6 @@ static void init_task(void)
     do_init_task();
 }
 
-#ifdef CONFIG_BOOTOPTS
 static struct dev_name_struct {
     const char *name;
     int num;
@@ -350,7 +348,7 @@ static struct dev_name_struct {
  * Convert a root device number to name.
  * Device number could be bios device, not kdev_t.
  */
-static char * INITPROC root_dev_name(int dev)
+char *root_dev_name(kdev_t dev)
 {
     int i;
 #define NAMEOFF 13
@@ -371,6 +369,7 @@ static char * INITPROC root_dev_name(int dev)
     return NULL;
 }
 
+#ifdef CONFIG_BOOTOPTS
 /*
  * Convert a /dev/ name to device number.
  */

--- a/elks/kernel/printk.c
+++ b/elks/kernel/printk.c
@@ -18,6 +18,7 @@
  *              %#x/%#X hexadecimal using 0x alt prefix
  *              %p      pointer - same as %04x
  *              %D      device name as %04x
+ *              %E      device name as /dev/...
  *              %P      process ID
  *              %k      pticks (0.838usec intervals auto displayed as us, ms or s)
  *              %#k     pticks truncated at decimal point
@@ -260,6 +261,9 @@ static void vprintk(const char *fmt, va_list p)
             case 't':
                 n = current->t_regs.ds;
                 goto str;
+            case 'E':
+                kputs(root_dev_name(va_arg(p, unsigned int))+8); /* skip ROOTDEV= */
+                break;
             case 's':
                 n = kernel_ds;
             str:

--- a/libc/misc/devname.c
+++ b/libc/misc/devname.c
@@ -33,6 +33,7 @@ static struct dev_name_struct {
     { "fd1",     S_IFBLK,   DEV_FD1             },
     { "df0",     S_IFBLK,   DEV_DF0             },
     { "df1",     S_IFBLK,   DEV_DF1             },
+    { "rom",     S_IFBLK,   DEV_ROM             },
     { "ssd",     S_IFBLK,   MKDEV(SSD_MAJOR, 0) },
     { "rd0",     S_IFBLK,   MKDEV(RAM_MAJOR, 0) },
     { "ttyS0",   S_IFCHR,   DEV_TTYS0           },


### PR DESCRIPTION
Discussed in https://github.com/ghaerr/elks/pull/2364#issuecomment-3098152489.

Shows device /dev name as well as number in kernel boot and error messages, for easier understanding by users.

Adds %E as printk format specifier to display device name as /dev/{name}.

For example, here's the latest boot screen booting from the first partition of the first hard drive:
<img width="832" height="540" alt="Screenshot 2025-07-21 at 5 41 16 PM" src="https://github.com/user-attachments/assets/30ebfe9b-7059-4ab5-81d1-98f091483cfb" />
