### PR TITLE
[kernel] Automatic re-read partition table after MBR modified

### DIFF
--- a/elks/arch/i86/drivers/block/ata-cf.c
+++ b/elks/arch/i86/drivers/block/ata-cf.c
@@ -12,9 +12,9 @@
 #include <linuxmt/kernel.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/genhd.h>
+#include <linuxmt/ata.h>
 #include <linuxmt/devnum.h>
 #include <linuxmt/debug.h>
-#include <arch/ata.h>
 
 #define MAJOR_NR        ATHD_MAJOR
 #include "blk.h"
@@ -41,7 +41,8 @@ static struct gendisk ata_gendisk = {
     ata_drive_info              /* fd/hd drive CHS and type */
 };
 
-static int ata_cf_ioctl(struct inode *inode, struct file *file, unsigned int cmd, unsigned int arg);
+static int ata_cf_ioctl(struct inode *inode, struct file *file, unsigned int cmd,
+    unsigned int arg);
 static int ata_cf_open(struct inode *, struct file *);
 static void ata_cf_release(struct inode *, struct file *);
 
@@ -55,7 +56,6 @@ static struct file_operations ata_cf_fops = {
     ata_cf_open,                /* open */
     ata_cf_release              /* release */
 };
-
 
 /**********************************************************************
  * ATA-CF functions

--- a/elks/arch/i86/drivers/block/ata.c
+++ b/elks/arch/i86/drivers/block/ata.c
@@ -568,7 +568,7 @@ int ATPROC ata_write(unsigned int drive, sector_t sector, char *buf, ramdesc_t s
     if (use_xms)
     {
         xms_fmemcpyw(0, DMASEG, buf, seg, ATA_SECTOR_SIZE / 2);
-        buffer = _MK_FP(seg, buf);
+        buffer = _MK_FP(DMASEG, 0);
         write_ioport(BASE(ATA_REG_DATA), buffer, ATA_SECTOR_SIZE);
     }
     else

--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -42,7 +42,7 @@
 int boot_partition;         /* MBR boot partition, if any*/
 static unsigned int current_minor;
 
-static void INITPROC print_minor_name(register struct gendisk *hd, unsigned int minor)
+static void GENPROC print_minor_name(register struct gendisk *hd, unsigned int minor)
 {
     unsigned int part;
     struct hd_struct *hdp = &hd->part[minor];
@@ -54,7 +54,7 @@ static void INITPROC print_minor_name(register struct gendisk *hd, unsigned int 
     printk(":(%lu,%lu) ", hdp->start_sect, hdp->nr_sects);
 }
 
-static void INITPROC add_partition(struct gendisk *hd, unsigned int minor,
+static void GENPROC add_partition(struct gendisk *hd, unsigned int minor,
                           sector_t start, sector_t size)
 {
     struct hd_struct *hdp = &hd->part[minor];
@@ -107,7 +107,7 @@ static void INITPROC add_partition(struct gendisk *hd, unsigned int minor,
 #endif
 }
 
-static int INITPROC is_extended_partition(register struct partition *p)
+static int GENPROC is_extended_partition(register struct partition *p)
 {
     return (p->sys_ind == DOS_EXTENDED_PARTITION ||
             p->sys_ind == LINUX_EXTENDED_PARTITION);
@@ -124,7 +124,7 @@ static int INITPROC is_extended_partition(register struct partition *p)
  * only for the actual data partitions.
  */
 
-static void INITPROC extended_partition(register struct gendisk *hd, kdev_t dev)
+static void GENPROC extended_partition(register struct gendisk *hd, kdev_t dev)
 {
     struct buffer_head *bh;
     register struct partition *p;
@@ -212,7 +212,7 @@ static void INITPROC extended_partition(register struct gendisk *hd, kdev_t dev)
     unmap_brelse(bh);
 }
 
-static int INITPROC mbr_partition(struct gendisk *hd, kdev_t dev, sector_t first_sector)
+static int GENPROC mbr_partition(struct gendisk *hd, kdev_t dev, sector_t first_sector)
 {
     register struct partition *p;
     register struct hd_struct *hdp;
@@ -307,7 +307,7 @@ out:
     return 1;
 }
 
-static void INITPROC check_partition(register struct gendisk *hd, kdev_t dev)
+static void GENPROC check_partition(register struct gendisk *hd, kdev_t dev)
 {
     sector_t first_sector = hd->part[MINOR(dev)].start_sect;
 
@@ -330,7 +330,7 @@ static void INITPROC check_partition(register struct gendisk *hd, kdev_t dev)
     printk(" no partitions\n");
 }
 
-static void INITPROC clear_partition(struct gendisk *dev)
+static void GENPROC clear_partition(struct gendisk *dev)
 {
     struct drive_infot *drivep = dev->drive_info;
     struct hd_struct *hdp = dev->part;
@@ -353,7 +353,7 @@ static void INITPROC clear_partition(struct gendisk *dev)
 
 }
 
-void INITPROC init_partitions(struct gendisk *dev)
+void GENPROC init_partitions(struct gendisk *dev)
 {
     clear_partition(dev);
 
@@ -386,8 +386,8 @@ int ioctl_hdio_geometry(struct gendisk *hd, kdev_t dev, struct hd_geometry *loc)
     return err;
 }
 
-void show_drive_info(struct drive_infot *drivep, const char *name, int drive, int count,
-   const char *eol)
+void GENPROC show_drive_info(struct drive_infot *drivep, const char *name, int drive,
+    int count, const char *eol)
 {
     unsigned long size;
     char *unit;

--- a/elks/include/linuxmt/ata.h
+++ b/elks/include/linuxmt/ata.h
@@ -3,6 +3,13 @@
 
 #include <linuxmt/memory.h>
 
+/* place most of this driver in the far text section if possible */
+#if defined(CONFIG_FARTEXT_KERNEL) && !defined(__STRICT_ANSI__)
+#define ATPROC __far __attribute__ ((far_section, noinline, section (".fartext.at")))
+#else
+#define ATPROC
+#endif
+
 /*
  * Command block register offsets from base I/O address,
  * for standard ATA and XTIDE v1.
@@ -70,10 +77,10 @@
 
 extern int ata_mode;        /* ATA CF driver operating mode, /bootopts xtide= */
 
-int ata_reset(void);
+int ATPROC ata_reset(void);
 struct drive_infot;
-int ata_init(int drive, struct drive_infot *drivep);
-int ata_read(unsigned int drive, sector_t sector, char *buf, ramdesc_t seg);
-int ata_write(unsigned int drive, sector_t sector, char *buf, ramdesc_t seg);
+int ATPROC ata_init(int drive, struct drive_infot *drivep);
+int ATPROC ata_read(unsigned int drive, sector_t sector, char *buf, ramdesc_t seg);
+int ATPROC ata_write(unsigned int drive, sector_t sector, char *buf, ramdesc_t seg);
 
 #endif /* !__ARCH_8086_ATA_H*/

--- a/elks/include/linuxmt/genhd.h
+++ b/elks/include/linuxmt/genhd.h
@@ -12,10 +12,16 @@
  *              <drew@colorado.edu>
  */
 
+/* the genhd partition code can be INITPROC if called only at kernel init time */
+#if defined(CONFIG_FARTEXT_KERNEL) && !defined(__STRICT_ANSI__)
+#define GENPROC __far __attribute__ ((far_section, noinline, section (".fartext.gen")))
+#else
+#define GENPROC
+#endif
+
 /* These two have identical behaviour; use the second one if DOS fdisk gets
    confused about extended/logical partitions starting past cylinder 1023. */
-
-#define DOS_EXTENDED_PARTITION 5
+#define DOS_EXTENDED_PARTITION   5
 #define LINUX_EXTENDED_PARTITION 0x85
 
 struct partition
@@ -94,8 +100,10 @@ extern unsigned char bios_drive_map[];  /* map drive to BIOS drivenum */
 extern struct drive_infot drive_info[];
 extern int boot_partition;              /* MBR boot partition, if any */
 
+void GENPROC init_partitions(struct gendisk *dev);
+void GENPROC show_drive_info(struct drive_infot *drivep, const char *name, int drive,
+    int count, const char *eol);
+
 int ioctl_hdio_geometry(struct gendisk *hd, kdev_t dev, struct hd_geometry *loc);
-void show_drive_info(struct drive_infot *drivep, const char *name, int drive, int count,
-    const char *eol);
 
 #endif

--- a/elks/include/linuxmt/init.h
+++ b/elks/include/linuxmt/init.h
@@ -37,7 +37,6 @@ extern void INITPROC tty_init(void);
 extern int  INITPROC xms_init(void);
 
 extern void INITPROC device_init(void);
-extern void INITPROC init_partitions(struct gendisk *dev);
 
 extern void INITPROC tz_init(const char *tzstr);
 

--- a/elkscmd/disk_utils/fdisk.c
+++ b/elkscmd/disk_utils/fdisk.c
@@ -329,7 +329,9 @@ void write_out()
     else {
         MBR[510] = 0x55;
         MBR[511] = 0xAA;
-        if ((i=write(pFd,MBR,512))!=512) {
+        i = write(pFd,MBR,512);
+        sync();
+        if (i != 512) {
             printf("Error writing partition table to %s (%d)\n", errno);
         } else
             printf("Partition table written to %s\n",dev);


### PR DESCRIPTION
Fixes the fdisk reboot and sys problems described in https://github.com/ghaerr/elks/pull/2364#issuecomment-3098087627.

Now, after running `fdisk` the system automatically rereads the partition table when using either the BIOSHD or ATA CF drivers. No reboot necessary.

The partition table will be re-read the next time any process opens the device with the modified MBR. The revised partition table will at that point be (re)displayed on the console in the same format as the partition table boot screen display. For example, running fdisk again after writing the MBR will provoke this behavior, or accessing the newly created partition using `mkfs` or `mkfat`.

Also fixes a major problem writing garbage data when using the ATA CF driver (to either hard disk or CF). This was bad code added approximately a week ago when I added XMS support. This is now fixed, and is likely the cause of @toncho11's second problem described in the link above where `sys` after fdisk/reboot didn't work: the MBR was being written incorrectly, as well as any other data written to a CF card or hard disk by the ATA CF driver.

The partition reading code was moved out of INITPROC into far text to allow for re-reading the partition table; this added 2K to the kernel resident memory usage. The ATA CF driver was also added to the far text segment to make room in the normal text segment.

Also added was an automatic `sync` after `fdisk` writes the MBR; it was previously possible that the MBR would not actually have been synced to disk if the system were rebooted immediately after fdisk without syncing. Neither sync nor reboot are necessary anymore.