### PR TITLE
[kernel] Revise kernel device name/number messages for clarity

### DIFF
--- a/elks/arch/i86/drivers/block/ata.c
+++ b/elks/arch/i86/drivers/block/ata.c
@@ -252,11 +252,11 @@ static int ATPROC ata_set8bitmode(void)
 
     if (status & ATA_STATUS_ERR)
     {
-        printk("cfa: can't set 8-bit transfer mode (error %02xh)\n", INB(ATA_REG_ERR));
+        printk("cfa: can't set 8-bit xfer\n");
         return -EINVAL;
     }
 
-    printk("cfa: setting 8-bit transfer mode\n");
+    printk("cfa: 8-bit xfer on\n");
     return 0;
 }
 
@@ -417,9 +417,8 @@ int ATPROC ata_reset(void)
     delay_10ms();
     if (INB(ATA_REG_SELECT) != 0xA0)    // FIXME try probe w/message only for now
     {
-        printk("cf: probe failed at %x/%x (%x) xtide=%d\n",
+        printk("cf: probe fail at %x/%x (%x) xtide=%d\n",
             ata_base_port, ata_ctrl_port, byte, ata_mode);
-        printk("cf: probe failed %x\n", byte);
         OUTB(byte, ATA_REG_SELECT);
         //return -ENODEV;
     }

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -661,7 +661,7 @@ next_block:
 
         /* make sure it's a disk that we are dealing with. */
         if (drive > (DRIVE_FD0 + FD_DRIVES - 1) || drivep->heads == 0) {
-            printk("bioshd: non-existent drive: %D %E\n", req->rq_dev, req->rq_dev);
+            printk("bioshd: invalid device %E (%D)\n", req->rq_dev, req->rq_dev);
             end_request(0);
             continue;
         }

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -661,8 +661,7 @@ next_block:
 
         /* make sure it's a disk that we are dealing with. */
         if (drive > (DRIVE_FD0 + FD_DRIVES - 1) || drivep->heads == 0) {
-            printk("bioshd: invalid device %E (%D)\n", req->rq_dev, req->rq_dev);
-            end_request(0);
+            end_request(0);     /* will display I/O error */
             continue;
         }
 

--- a/elks/arch/i86/drivers/block/blk.h
+++ b/elks/arch/i86/drivers/block/blk.h
@@ -118,7 +118,7 @@ static void end_request(int uptodate)
 
     if (!uptodate) {
         /*if (req->rq_errors >= 0)*/
-        printk(DEVICE_NAME ": I/O %s error dev %D %E lba sector %lu\n",
+        printk(DEVICE_NAME ": I/O %s error %E (%D) LBA %lu\n",
             (req->rq_cmd == WRITE)? "write": "read",
             req->rq_dev, req->rq_dev, req->rq_sector);
     }

--- a/elks/arch/i86/drivers/block/config.in
+++ b/elks/arch/i86/drivers/block/config.in
@@ -5,7 +5,7 @@ mainmenu_option next_comment
     comment 'Block device drivers'
 
 	bool '  BIOS floppy drive support'	CONFIG_BLK_DEV_BFD	y
-	bool '  Direct to hw floppy support'    CONFIG_BLK_DEV_FD       n
+	bool '  Direct hw floppy support'	CONFIG_BLK_DEV_FD	n
 	bool '  Floppy drive track caching'	CONFIG_TRACK_CACHE	y
 	bool '  BIOS preset floppy types'	CONFIG_BLK_DEV_BFD_HARD n
 	bool '  BIOS hard drive support'	CONFIG_BLK_DEV_BHD	y
@@ -26,7 +26,7 @@ mainmenu_option next_comment
 		ssd_test CONFIG_BLK_DEV_SSD_TEST \
 		ssd_sd_8018x CONFIG_BLK_DEV_SSD_SD8018X " None
 
-	bool 'ATA-CF disk drive support'	CONFIG_BLK_DEV_ATA_CF	n
+	bool 'ATA-CF drive support'	        CONFIG_BLK_DEV_ATA_CF	n
 
     comment 'Block device options'
     bool 'Character access to block devices'	CONFIG_BLK_DEV_CHAR	y

--- a/elks/arch/i86/drivers/block/init.c
+++ b/elks/arch/i86/drivers/block/init.c
@@ -67,7 +67,7 @@ void INITPROC device_init(void)
         if (!rootdev)
             rootdev = bios_conv_bios_drive(ROOT_DEV);
 #endif
-        printk("boot: BIOS drive %x, root device %D %E\n", ROOT_DEV, rootdev, rootdev);
+        printk("boot: BIOS drive %x, root device %E (%D)\n", ROOT_DEV, rootdev, rootdev);
         ROOT_DEV = (kdev_t)rootdev;
     }
 #endif

--- a/elks/fs/minix/inode.c
+++ b/elks/fs/minix/inode.c
@@ -143,7 +143,7 @@ struct super_block *minix_read_super(register struct super_block *s, char *data,
 	ms = (struct minix_super_block *) bh->b_data;
 	if (ms->s_magic != MINIX_SUPER_MAGIC) {
 	    if (!silent)
-		printk("VFS: device %D %E is not minixfs\n", dev, dev);
+		printk("VFS: %E (%D) is not minixfs\n", dev, dev);
 	    msgerr = err0;
 	    goto err_read_super_1;
 	}

--- a/elks/fs/super.c
+++ b/elks/fs/super.c
@@ -173,7 +173,7 @@ static struct super_block *read_super(kdev_t dev, int t, int flags,
     if (s) return s;
 
     if (!(type = get_fs_type(t))) {
-        printk("VFS: device %D %E unknown fs type %d\n", dev, dev, t);
+        printk("VFS: %E (%D) unknown fs type %d\n", dev, dev, t);
         return NULL;
     }
 
@@ -444,7 +444,7 @@ void mount_root(void)
         retval = open_filp(0, d_inode, &filp);
     }
     if (retval) {
-        printk("VFS: Unable to open root device %D %E (%d)\n",
+        printk("VFS: Unable to open root device %E (%D) %d\n",
             ROOT_DEV, ROOT_DEV, retval);
         halt();
     }
@@ -461,9 +461,9 @@ void mount_root(void)
             memcpy(sb->s_mntonname, "/", 2);
 /*          sb->s_flags = (unsigned short int) root_mountflags;*/
             current->fs.pwd = current->fs.root = sb->s_mounted;
-            printk("VFS: Mounted root device %04x %E (%s filesystem)%s.\n",
+            printk("VFS: Mounted root device %E (%04x) %s %sfilesystem.\n",
                 ROOT_DEV, ROOT_DEV, fsname[fp->type],
-               (sb->s_flags & MS_RDONLY) ? " readonly" : "");
+               (sb->s_flags & MS_RDONLY) ? "readonly " : "");
             iput(d_inode);
             filp->f_count = 0;
             return;
@@ -479,6 +479,6 @@ void mount_root(void)
     }
 #endif
 
-    printk("VFS: Unable to mount root fs on %D %E\n", ROOT_DEV, ROOT_DEV);
+    printk("VFS: Unable to mount root fs on %E (%D)\n", ROOT_DEV, ROOT_DEV);
     halt();
 }

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -11,17 +11,19 @@ hma=kernel
 xms=on
 #xms=int15
 #xmsbuf=0
-#xtide=3 # 0=ATA, 1=XTIDEv1, 2=XTIDEv2 (high speed), 3=XTCF
 #disable=hda,cfa,df0,fd0
+#disable=cfa
+#xtide=3 # 0=ATA, 1=XTIDEv1, 2=XTIDEv2 (high speed), 3=XTCF
+#disable=hda
+#root=cfa1
+#root=hda1 ro
+#root=df0
 #task=16 buf=64 cache=8 file=64 inode=96 heap=44000 # std
 #task=6 buf=8 cache=4 file=20 inode=24 heap=15000 n # min
 #sync=30
 #3	# multiuser serial
 #n	# no rc.sys
 #init=/bin/sash
-#root=df0
-#root=cfa1
-#root=hda1 ro
 #kstack
 #strace
 #FTRACE=1

--- a/image/Make.devices
+++ b/image/Make.devices
@@ -159,7 +159,9 @@ endif
 ##############################################################################
 # ROM / Flash memory card
 
-#	$(MKDEV) /dev/rom b 6 0
+ifdef CONFIG_ROMCODE
+	$(MKDEV) /dev/rom b 6 0
+endif
 
 ##############################################################################
 # Direct PATA / IDE disks. (Not working)


### PR DESCRIPTION
Also adds some commented-out lines in /bootopts useful for more easily configuring booting ELKS from CF card, or disabling ATA CF driver when overlapping with existing ATA hard disk.