### PR TITLE
[kernel] Use optional ASM inb/out for fast I/O in ATA CF driver

### DIFF
--- a/elks/arch/i86/drivers/block/idequery.c
+++ b/elks/arch/i86/drivers/block/idequery.c
@@ -31,13 +31,6 @@
 
 static int io_ports[2] = { HD1_PORT, HD2_PORT };	/* physical port addresses */
 
-static void INITPROC insw(word_t port, word_t *buffer, int count) {
-
-    do {
-   	*buffer++ = inw(port);
-    } while (--count);
-}
-
 static void INITPROC out_hd(int drive, word_t cmd)
 {
     word_t port = io_ports[drive >> 1];
@@ -92,7 +85,7 @@ int INITPROC get_ide_data(int drive, struct drive_infot *drivep) {
 		ide_debug("hd%c: drive at port 0x%x not found\n", 'a'+drive, port);
 		break;
 	    }
-	    insw(port, ide_buffer, 512/2);	/* read - word size */
+	    insw(port, kernel_ds, ide_buffer, 512/2);	/* read - word size */
 	    /*
 	     * Sanity check: Head, cyl and sector values must be other than
 	     * 0 and buffer has to contain valid data (first entry in buffer

--- a/elks/include/arch/io.h
+++ b/elks/include/arch/io.h
@@ -57,6 +57,79 @@
                         :"d" (port));     \
         _v; })
 
+#define insb(port,seg,offset,cnt)   \
+    __extension__ ({                \
+        unsigned ax, cx, di;        \
+        asm volatile (              \
+            "push %%es\n"           \
+            "mov %%ax,%%es\n"       \
+            "cld\n"                 \
+            "1:\n"                  \
+            "in (%%dx),%%al\n"      \
+            "stosb\n"               \
+            "dec %%cx\n"            \
+            "jnz 1b\n"              \
+            "pop %%es\n"            \
+            : "=a" (ax), "=c" (cx), "=D" (di)                   \
+            : "d" (port), "a" (seg), "D" (offset), "c" (cnt)    \
+            : "memory" );           \
+    })
+
+#define insw(port,seg,offset,cnt)   \
+    __extension__ ({                \
+        unsigned ax, cx, di;        \
+        asm volatile (              \
+            "push %%es\n"           \
+            "mov %%ax,%%es\n"       \
+            "cld\n"                 \
+            "1:\n"                  \
+            "in (%%dx),%%ax\n"      \
+            "stosw\n"               \
+            "dec %%cx\n"            \
+            "jnz 1b\n"              \
+            "pop %%es\n"            \
+            : "=a" (ax), "=c" (cx), "=D" (di)                   \
+            : "d" (port), "a" (seg), "D" (offset), "c" (cnt)    \
+            : "memory" );           \
+    })
+
+
+#define outsb(port,seg,offset,cnt)  \
+    __extension__ ({                \
+        unsigned ax, cx, si;        \
+        asm volatile (              \
+            "push %%ds\n"           \
+            "mov %%ax,%%ds\n"       \
+            "cld\n"                 \
+            "1:\n"                  \
+            "lodsb\n"               \
+            "out %%al,(%%dx)\n"     \
+            "dec %%cx\n"            \
+            "jnz 1b\n"              \
+            "pop %%ds\n"            \
+            : "=a" (ax), "=c" (cx), "=S" (si)                   \
+            : "d" (port), "a" (seg), "S" (offset), "c" (cnt)    \
+            : "memory" );           \
+    })
+
+#define outsw(port,seg,offset,cnt)  \
+    __extension__ ({                \
+        unsigned ax, cx, si;        \
+        asm volatile (              \
+            "push %%ds\n"           \
+            "mov %%ax,%%ds\n"       \
+            "cld\n"                 \
+            "1:\n"                  \
+            "lodsw\n"               \
+            "out %%ax,(%%dx)\n"     \
+            "dec %%cx\n"            \
+            "jnz 1b\n"              \
+            "pop %%ds\n"            \
+            : "=a" (ax), "=c" (cx), "=S" (si)                   \
+            : "d" (port), "a" (seg), "S" (offset), "c" (cnt)    \
+            : "memory" );           \
+    })
+
 #endif /* __ia16__ */
 
 #endif /* !__ARCH_8086_IO_H*/


### PR DESCRIPTION
Uses GCC ASM extension for fast I/O in ATA CF driver.

Currently turned on using FASTIO=1 in ata.c. Tested on QEMU but not real hardware. ATA CF I/O should be as fast as possible now. IDE query code also updated to use insw() macro.

Getting the GCC ASM constraints correct took a little doing on this one, given ia16-elf-gcc doesn't seem to exactly match GCC documentation.