### PR TITLE
[kernel] Cleanup BIOSHD and ATA CF driver code; add /dev/cf entries to bin/sys

### DIFF
--- a/elks/arch/i86/drivers/block/ata-cf.c
+++ b/elks/arch/i86/drivers/block/ata-cf.c
@@ -204,7 +204,7 @@ static void do_ata_cf_request(void)
                 ret = ata_read(drive, start, buf, req->rq_seg);
             }
             if (ret != 0) {         /* I/O error */
-                printk("cf%c: I/O error %d cmd %d\n", drive+'a', ret, req->rq_cmd);
+                debug_blk("cf%c: I/O error %d cmd %d\n", drive+'a', ret, req->rq_cmd);
                 end_request(0);
                 return;
             }

--- a/elks/arch/i86/drivers/block/ata.c
+++ b/elks/arch/i86/drivers/block/ata.c
@@ -483,7 +483,7 @@ int ATPROC ata_init(int drive, struct drive_infot *drivep)
         drivep->sectors = buffer[ATA_INFO_SPT];
         drivep->heads = buffer[ATA_INFO_HEADS];
         drivep->sector_size = ATA_SECTOR_SIZE;
-        drivep->fdtype = -1;
+        drivep->fdtype = HARDDISK;
         show_drive_info(drivep, "cf", drive, 1, " ");
 
         // now display extra info: ATA LBA sector total, version and sector size

--- a/elks/arch/i86/drivers/block/bios.c
+++ b/elks/arch/i86/drivers/block/bios.c
@@ -236,25 +236,30 @@ int INITPROC bios_gethdinfo(struct drive_infot *drivep) {
     return ndrives;
 }
 
-void BFPROC bios_disk_park_all(void)
+static BFPROC void bios_disk_park(struct gendisk *hd)
 {
 #ifdef CONFIG_ARCH_IBMPC
     struct drive_infot *drivep;
     unsigned int cyl;
 
-    for (drivep = drive_info; drivep < &drive_info[NUM_DRIVES]; drivep++) {
+    for (drivep = hd->drive_info; drivep < &hd->drive_info[NUM_DRIVES]; drivep++) {
         if (drivep->fdtype != -1)       /* hard drives only */
             continue;
         cyl = drivep->cylinders - 1;    /* expects zero-based cylinder */
         BD_AX = BIOSHD_SEEK;
         BD_CX = ((cyl & 0xFF) << 8) | ((cyl & 0x300) >> 2) | 1; /* 1 = sector */
-        BD_DX = bios_drive_map[drivep - drive_info];
+        BD_DX = bios_drive_map[drivep - hd->drive_info];
         call_bios(&bdt);
     }
 #endif
 }
 
-#endif
+void BFPROC bios_disk_park_all(void)
+{
+    bios_disk_park(&bioshd_gendisk);
+}
+
+#endif /* CONFIG_BLK_DEV_BHD */
 
 #ifdef CONFIG_BLK_DEV_BFD_HARD
 int INITPROC bios_getfdinfo(struct drive_infot *drivep)

--- a/elks/arch/i86/drivers/block/bios.c
+++ b/elks/arch/i86/drivers/block/bios.c
@@ -217,7 +217,7 @@ int INITPROC bios_gethdinfo(struct drive_infot *drivep) {
             /* NOTE: some BIOS may underreport cylinders by 1*/
             drivep->cylinders = (((BD_CX & 0xc0) << 2) | (BD_CX >> 8)) + 1;
 #endif
-            drivep->fdtype = -1;
+            drivep->fdtype = HARDDISK;
             drivep->sector_size = 512;
             debug_bios("hd%c:  BIOS CHS %3d,%d,%d\n", 'a'+drive, drivep->cylinders,
                 drivep->heads, drivep->sectors);
@@ -243,7 +243,7 @@ static BFPROC void bios_disk_park(struct gendisk *hd)
     unsigned int cyl;
 
     for (drivep = hd->drive_info; drivep < &hd->drive_info[NUM_DRIVES]; drivep++) {
-        if (drivep->fdtype != -1)       /* hard drives only */
+        if (drivep->fdtype != HARDDISK)
             continue;
         cyl = drivep->cylinders - 1;    /* expects zero-based cylinder */
         BD_AX = BIOSHD_SEEK;

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -74,18 +74,17 @@ struct elks_disk_parms {
     __u8 marker[2];             /* should be "eL" */
 } __attribute__((packed));
 
-static int bioshd_initialized = 0;
+static char bioshd_initialized;
+static char mbr_modified;
 static int fd_count;                    /* number of floppy disks */
 static int hd_count;                    /* number of hard disks */
 
 static int access_count[NUM_DRIVES];    /* device open count */
-static struct drive_infot drive_info[NUM_DRIVES];       /* operating drive info */
+static struct drive_infot drive_info[NUM_DRIVES];        /* operating drive info */
+static struct hd_struct part[NUM_DRIVES << MINOR_SHIFT]; /* partitions start, size*/
 static struct drive_infot *cache_drive;
-struct drive_infot *last_drive;         /* set to last drivep-> used in read/write */
+       struct drive_infot *last_drive;  /* set to last drivep-> used in read/write */
 extern struct drive_infot fd_types[];   /* BIOS floppy formats */
-
-static struct hd_struct hd[NUM_DRIVES << MINOR_SHIFT];  /* partitions start, size*/
-static char mbr_modified;
 
 static int bioshd_open(struct inode *, struct file *);
 static void bioshd_release(struct inode *, struct file *);
@@ -97,7 +96,7 @@ struct gendisk bioshd_gendisk = {
     MINOR_SHIFT,                /* Bits to shift to get real from partition */
     1 << MINOR_SHIFT,           /* maximum number of partitions per drive */
     NUM_DRIVES,                 /* maximum number of drives */
-    hd,                         /* partition table */
+    part,                       /* partition table */
     0,                          /* hd drives found */
     drive_info                  /* fd/hd drive CHS and type */
 };
@@ -315,7 +314,7 @@ static void BFPROC probe_floppy(int target, struct hd_struct *hdp)
 static int bioshd_open(struct inode *inode, struct file *filp)
 {
     int minor = MINOR(inode->i_rdev);
-    struct hd_struct *hdp = &hd[minor];
+    struct hd_struct *hdp = &part[minor];
     int target = minor >> MINOR_SHIFT;
 
     if (!bioshd_initialized || target >= NUM_DRIVES || hdp->start_sect == NOPART)
@@ -651,7 +650,7 @@ next_block:
             break;
         CHECK_REQUEST(req);
 
-        if (bioshd_initialized != 1) {
+        if (!bioshd_initialized) {
             end_request(0);
             continue;
         }
@@ -666,18 +665,18 @@ next_block:
         }
 
         /* get request start sector and sector count */
-        count = req->rq_nr_sectors;
+        buf = req->rq_buffer;
         start = req->rq_sector;
+        count = req->rq_nr_sectors;
 
-        if (hd[minor].start_sect == NOPART || start + count > hd[minor].nr_sects) {
+        if (part[minor].start_sect == NOPART || start + count > part[minor].nr_sects) {
             printk("bioshd: sector %ld not in partition (%ld,%ld)\n",
-                start, hd[minor].start_sect, hd[minor].nr_sects);
+                start, part[minor].start_sect, part[minor].nr_sects);
             end_request(0);
             continue;
         }
-        start += hd[minor].start_sect;
+        start += part[minor].start_sect;
 
-        buf = req->rq_buffer;
         while (count > 0) {
             int num_sectors = 0;
 #ifdef CONFIG_TRACK_CACHE
@@ -699,9 +698,9 @@ next_block:
                 goto next_block;
             }
 
-            count -= num_sectors;
-            start += num_sectors;
             buf += num_sectors * drivep->sector_size;
+            start += num_sectors;
+            count -= num_sectors;
         }
         debug_bios("cache: hits %u total %u %lu%%\n", cache_hits, cache_tries,
             (long)cache_hits * 100L / cache_tries);

--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -79,7 +79,7 @@ static int fd_count;                    /* number of floppy disks */
 static int hd_count;                    /* number of hard disks */
 
 static int access_count[NUM_DRIVES];    /* device open count */
-struct drive_infot drive_info[NUM_DRIVES];   /* operating drive info */
+static struct drive_infot drive_info[NUM_DRIVES];       /* operating drive info */
 static struct drive_infot *cache_drive;
 struct drive_infot *last_drive;         /* set to last drivep-> used in read/write */
 extern struct drive_infot fd_types[];   /* BIOS floppy formats */
@@ -91,7 +91,7 @@ static int bioshd_open(struct inode *, struct file *);
 static void bioshd_release(struct inode *, struct file *);
 static int bioshd_ioctl(struct inode *, struct file *, unsigned int, unsigned int);
 
-static struct gendisk bioshd_gendisk = {
+struct gendisk bioshd_gendisk = {
     MAJOR_NR,                   /* Major number */
     "hd",                       /* Major name */
     MINOR_SHIFT,                /* Bits to shift to get real from partition */

--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -33,11 +33,6 @@
 
 #define NR_SECTS(p)     p->nr_sects
 #define START_SECT(p)   p->start_sect
-#ifdef CONFIG_ARCH_PC98
-# define NR_SECTS_PC98(p98)     ((sector_t) END_SECT_PC98(p98) - START_SECT_PC98(p98) + 1)
-# define START_SECT_PC98(p98)   ((sector_t) p98->cyl * last_drive->heads * last_drive->sectors + p98->head * last_drive->sectors + p98->sector)
-# define END_SECT_PC98(p98)     ((sector_t) p98->end_cyl * last_drive->heads * last_drive->sectors + p98->end_head * last_drive->sectors + p98->end_sector)
-#endif
 
 int boot_partition;         /* MBR boot partition, if any*/
 static unsigned int current_minor;
@@ -284,6 +279,10 @@ out:
     }
 
 #ifdef CONFIG_ARCH_PC98
+#define NR_SECTS_PC98(p98)     ((sector_t) END_SECT_PC98(p98) - START_SECT_PC98(p98) + 1)
+#define START_SECT_PC98(p98)   ((sector_t) p98->cyl * last_drive->heads * last_drive->sectors + p98->head * last_drive->sectors + p98->sector)
+#define END_SECT_PC98(p98)     ((sector_t) p98->end_cyl * last_drive->heads * last_drive->sectors + p98->end_head * last_drive->sectors + p98->end_sector)
+
     if (*(unsigned short *) (bh->b_data + 0x4) == 0x5049 &&
         *(unsigned short *) (bh->b_data + 0x6) == 0x314C) {
         struct partition_pc98 *p98;
@@ -307,7 +306,7 @@ out:
     return 1;
 }
 
-static void GENPROC check_partition(register struct gendisk *hd, kdev_t dev)
+static void GENPROC check_partition(struct gendisk *hd, kdev_t dev)
 {
     sector_t first_sector = hd->part[MINOR(dev)].start_sect;
 

--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -329,15 +329,15 @@ static void GENPROC check_partition(struct gendisk *hd, kdev_t dev)
     printk(" no partitions\n");
 }
 
-static void GENPROC clear_partition(struct gendisk *dev)
+static void GENPROC clear_partition(struct gendisk *hd)
 {
-    struct drive_infot *drivep = dev->drive_info;
-    struct hd_struct *hdp = dev->part;
+    struct drive_infot *drivep = hd->drive_info;
+    struct hd_struct *hdp = hd->part;
     int i;
 
-    memset(hdp, 0, sizeof(struct hd_struct) * dev->num_drives * dev->max_partitions);
-    for (i = 0; i < dev->num_drives << dev->minor_shift; i++) {
-        if ((i & ((1 << dev->minor_shift) - 1)) == 0) {
+    memset(hdp, 0, sizeof(struct hd_struct) * hd->num_drives * hd->max_partitions);
+    for (i = 0; i < hd->num_drives << hd->minor_shift; i++) {
+        if ((i & ((1 << hd->minor_shift) - 1)) == 0) {
             //hdp->start_sect = 0;
             hdp->nr_sects = (sector_t)drivep->sectors * drivep->heads * drivep->cylinders;
             if (hdp->nr_sects == 0)
@@ -352,14 +352,14 @@ static void GENPROC clear_partition(struct gendisk *dev)
 
 }
 
-void GENPROC init_partitions(struct gendisk *dev)
+void GENPROC init_partitions(struct gendisk *hd)
 {
-    clear_partition(dev);
+    clear_partition(hd);
 
-    for (int i = 0; i < dev->nr_hd; i++) {
-        unsigned int first_minor = i << dev->minor_shift;
+    for (int i = 0; i < hd->nr_hd; i++) {
+        unsigned int first_minor = i << hd->minor_shift;
         current_minor = first_minor + 1;
-        check_partition(dev, MKDEV(dev->major, first_minor));
+        check_partition(hd, MKDEV(hd->major, first_minor));
     }
 }
 #endif /* CONFIG_BLK_DEV_BHD || CONFIG_BLK_DEV_ATA_CF */

--- a/elks/include/linuxmt/genhd.h
+++ b/elks/include/linuxmt/genhd.h
@@ -24,7 +24,7 @@
 #define DOS_EXTENDED_PARTITION   5
 #define LINUX_EXTENDED_PARTITION 0x85
 
-struct partition
+struct partition                /* IBM PC MBR partition entry */
 {
     unsigned char boot_ind;     /* 0x80 - active */
     unsigned char head;         /* starting head */
@@ -38,7 +38,7 @@ struct partition
     sector_t nr_sects;          /* nr of sectors in partition */
 };
 
-struct partition_pc98
+struct partition_pc98           /* PC-98 IPL1 partition entry */
 {
     unsigned char boot_ind;     /* bootable */
     unsigned char active;       /* active or sleep */
@@ -57,7 +57,7 @@ struct partition_pc98
 
 #define NOPART      -1UL        /* no partition at start_sect */
 
-struct hd_struct
+struct hd_struct                /* internal partition table entry */
 {
     sector_t start_sect;        /* start sector of partition or NOPART */
     sector_t nr_sects;          /* # sectors in partition */
@@ -74,7 +74,7 @@ struct drive_infot              /* CHS per drive*/
     int fdtype;                 /* floppy fd_types[] index  or HARDDISK if hd */
 };
 
-struct gendisk
+struct gendisk                  /* general disk information struct */
 {
     int major;                  /* major number of driver */
     const char *major_name;     /* name of major driver */

--- a/elks/include/linuxmt/genhd.h
+++ b/elks/include/linuxmt/genhd.h
@@ -63,13 +63,15 @@ struct hd_struct
     sector_t nr_sects;          /* # sectors in partition */
 };
 
+#define HARDDISK    (-1)        /* fdtype for hard disk */
+
 struct drive_infot              /* CHS per drive*/
 {
     unsigned int cylinders;
     int sectors;
     int heads;
     int sector_size;
-    int fdtype;                 /* floppy fd_types[] index  or -1 if hd */
+    int fdtype;                 /* floppy fd_types[] index  or HARDDISK if hd */
 };
 
 struct gendisk

--- a/elks/include/linuxmt/genhd.h
+++ b/elks/include/linuxmt/genhd.h
@@ -95,9 +95,9 @@ struct hd_geometry              /* structure returned from HDIO_GETGEO */
 /* hd/ide ctl's that pass (arg) ptrs to user space are numbered 0x030n/0x031n */
 #define HDIO_GETGEO     0x0301  /* get device geometry */
 
-extern struct drive_infot *last_drive;  /* set to last drivep-> used in read/write */
+extern struct gendisk bioshd_gendisk;   /* IBM for bios_disk_park_all() */
+extern struct drive_infot *last_drive;  /* PC98 set to last drivep-> used in read/write */
 extern unsigned char bios_drive_map[];  /* map drive to BIOS drivenum */
-extern struct drive_infot drive_info[];
 extern int boot_partition;              /* MBR boot partition, if any */
 
 void GENPROC init_partitions(struct gendisk *dev);

--- a/elkscmd/rootfs_template/bin/sys
+++ b/elkscmd/rootfs_template/bin/sys
@@ -24,6 +24,11 @@ create_dev_dir()
 	mknod -p $MNT/dev/fd1	b 3 40
 	mknod -p $MNT/dev/df0	b 4 0
 	mknod -p $MNT/dev/df1	b 4 1
+	mknod -p $MNT/dev/cfa	b 5 0
+	mknod -p $MNT/dev/cfa1	b 5 1
+	mknod -p $MNT/dev/cfa2	b 5 2
+	mknod -p $MNT/dev/cfa3	b 5 3
+	mknod -p $MNT/dev/cfa4	b 5 4
 	mknod -p $MNT/dev/kmem	c 1 2
 	mknod -p $MNT/dev/null	c 1 3
 	mknod -p $MNT/dev/zero	c 1 5
@@ -49,6 +54,11 @@ create_dev_dir()
 	mknod -p $MNT/dev/hdc	b 3 16
 	mknod -p $MNT/dev/hdc1	b 3 17
 	mknod -p $MNT/dev/hdd	b 3 24
+	mknod -p $MNT/dev/cfb	b 5 8
+	mknod -p $MNT/dev/cfb1	b 5 9
+	mknod -p $MNT/dev/cfb2	b 5 10
+	mknod -p $MNT/dev/cfb3	b 5 11
+	mknod -p $MNT/dev/cfb4	b 5 12
 	mknod -p $MNT/dev/rd0	b 1 0
 	mknod -p $MNT/dev/rd1	b 1 1
 	mknod -p $MNT/dev/tty2	c 4 1


### PR DESCRIPTION
Mostly source code cleanup in BIOSHD and ATA CF drivers for easier understanding of partition table management.

Adds /dev/cf\* entries to `sys` command, identified by @toncho11 in https://github.com/ghaerr/elks/pull/2370#issuecomment-3123423268.

