### PR TITLE
[kernel] Fix major speed bug in ATA CF driver

### DIFF
--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -15,6 +15,7 @@ xms=on
 #disable=cfa
 #xtide=3 # 0=ATA, 1=XTIDEv1, 2=XTIDEv2 (high speed), 3=XTCF
 #disable=hda
+#xtide=1
 #root=cfa1
 #root=hda1 ro
 #root=df0

--- a/env.sh
+++ b/env.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
 # Set up the build environment
+# For macOS Catalina without realpath, uncomment 2nd line below
 
 export TOPDIR="$(realpath $(dirname $BASH_SOURCE))"
+#export TOPDIR=`pwd`
+
 echo TOPDIR set to $TOPDIR
 
 export CROSSDIR="$TOPDIR/cross"


### PR DESCRIPTION
Fixes major speed problem in ATA CF driver, first identified by @toncho11 through testing and unrelenting intuition that something was definitely wrong, in https://github.com/ghaerr/elks/pull/2370#issuecomment-3124456438.

The ATA CF driver was running two times slower than the XTIDE Universal BIOS, as discussed at length in #2370. The problem was solved after setting up the [PCem Emulator](https://github.com/sarah-walker-pcem/pcem) and then modifying it to support XTCF 8-bit I/O while emulating XTIDE v1. While this allowed actual emulation of the insb/outsb macros for XTCF without requiring @toncho11's hardware, only after using ELKS' [precision timing routines](https://github.com/ghaerr/elks/pull/1962) within the driver was the speed issue identified.

The speed issue was that, after writing the drive select byte to the ATA controller, a 10ms delay was performed, which replaced the original 400ns delay. The 10ms delay was enhanced to use the kernel timer which ticks at 10ms resolution. This ended up adding 10-20ms delay per I/O request, which ended up adding tons of time to all ATA CF I/O.

After more research into the ATA spec and the [OSDev Wiki](https://wiki.osdev.org/ATA_PIO_Mode#400ns_delays), it was determined that no select delay at all is actually required by any hardware, since the BSY status is checked prior to sending the drive select command. Removing the wait allowed the driver to run approximately twice as fast.

The driver delay was not limited to XTIDE or XTCF operation, it was also seen using QEMU's 16-bit ATA emulation, where the root=cfa1 boot time decreased from 5.39 secs to 0.58 secs, ten times faster.

The PCem emulated XTCF boot time decreased from 6.64 secs to 2.24 secs, and a `dd` copying 5000 sectors decreased from 2:55 minutes to 42 seconds.

The ATA CF driver is now quicker than the BIOS XUB driver. This probably means we don't have to update the insb/outsb macros even though a slight speed improvement might still result.

Fixes included in this PR are:
- eliminate 10-20ms delay before every command
- eliminate any delay after sector reads
- adding EMUL_XTCF test harness to allow quick reconfiguration for testing on PCem
- alternate revert for previous env.sh fixup for systems without `realpath` (macOS Catalina)

Fixes to be included in another PR:
- add error check to sector write routine
- possibly implement multi-sector I/O
- possibly improve ins/outs macros

Thank you @toncho11 for your testing and not giving up, allowing this to be identified and fixed!