### PR TITLE
[kernel] Add write error checking to ATA CF driver

### DIFF
--- a/elks/arch/i86/drivers/block/ata.c
+++ b/elks/arch/i86/drivers/block/ata.c
@@ -570,6 +570,7 @@ int ATPROC ata_write(unsigned int drive, sector_t sector, char *buf, ramdesc_t s
 {
     unsigned char __far *buffer;
     int error;
+    unsigned char status;
 
 
     // send command
@@ -597,6 +598,16 @@ int ATPROC ata_write(unsigned int drive, sector_t sector, char *buf, ramdesc_t s
         write_ioport(BASE(ATA_REG_DATA), buffer, ATA_SECTOR_SIZE);
     }
 
+    error = ata_wait(WAIT_10SEC);
+    if (error)
+        return error;
 
-    return ata_wait(WAIT_10SEC);
+    // check for write error
+
+    status = INB(ATA_REG_STATUS);
+
+    if (status & (ATA_STATUS_ERR|ATA_STATUS_DFE))
+        return -EIO;
+
+    return 0;
 }

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -13,9 +13,10 @@ xms=on
 #xmsbuf=0
 #disable=hda,cfa,df0,fd0
 #disable=cfa
-#xtide=3 # 0=ATA, 1=XTIDEv1, 2=XTIDEv2 (high speed), 3=XTCF
 #disable=hda
-#xtide=1
+#xtide=3 # 0=ATA, 1=XTIDEv1, 2=XTIDEv2 (high speed), 3=XTCF
+#xtide=1	# for PCem
+#disable=hda
 #root=cfa1
 #root=hda1 ro
 #root=df0


### PR DESCRIPTION
Tests for ATA write error bit after sector writes. Tested only on QEMU. Not sure how to test this on real hardware, other than perhaps pulling the card mid-write, although that would likely trigger another error.