### PR TITLE
[genhd] Add incrementing drivep in show_drive_info

### DIFF
--- a/elks/arch/i86/drivers/block/genhd.c
+++ b/elks/arch/i86/drivers/block/genhd.c
@@ -412,6 +412,7 @@ void GENPROC show_drive_info(struct drive_infot *drivep, const char *name, int d
                 name, drive + (drivep->fdtype < 0? 'a' : '0'), (size/10), *unit,
                 drivep->cylinders, drivep->heads, drivep->sectors, eol);
         }
+        drivep++;
     }
 }
 #endif


### PR DESCRIPTION
Hello @ghaerr 

Yes, the fix for #2377 worked.
Thank you!

<img width="644" height="478" alt="image" src="https://github.com/user-attachments/assets/4db2b163-85ed-4e5c-b586-d225f4765198" />
