### PR TITLE
[libc] Add DEBUG_PORT= environ var for __dprintf output

### DIFF
--- a/elkscmd/inet/telnet/build_telnetc.sh
+++ b/elkscmd/inet/telnet/build_telnetc.sh
@@ -5,5 +5,5 @@
 CFLAGS="-O2 -pipe -Wall"
 
 gcc $CFLAGS -c -o ttn_conf.o ttn_conf.c
-gcc $CFLAGS -c -o ttn.o ttn.c
-gcc $CFLAGS ttn_conf.o ttn.o -o telnetc
+gcc $CFLAGS -c -o telnet.o telnet.c
+gcc $CFLAGS ttn_conf.o telnet.o -o telnetc

--- a/libc/include/malloc.h
+++ b/libc/include/malloc.h
@@ -38,6 +38,5 @@ void   *calloc(size_t elm, size_t sz);
 
 /* debug output */
 int __dprintf(const char *fmt, ...);
-int __open_readable_terminal(void);
 
 #endif


### PR DESCRIPTION
Adds DEBUG_PORT= to specify output device for \_\_dprintf output or DEBUG_PORT=none to discard debug output. By default, /dev/ttyS0 is used for debug output to the serial port.

Discussed in https://github.com/ghaerr/elks/discussions/1810#discussioncomment-14341802 which prohibited running `miniterm` under Nano-X since the debug output was going to /dev/ttyS0 and `miniterm` opens the serial port exclusive use.

The Nano-X mouse port is now also opened exclusive use in PR https://github.com/ghaerr/microwindows/pull/131 and an additional error message displayed if the port is already in use.

Also fixes earlier incorrect compilation of `telnet` for a host using `build_telnetc.sh` in elkscmd/inet/telnet/.