### PR TITLE
[cmds] Fix makeboot to use proper minor number mask to get raw device using sys -M

### DIFF
--- a/elkscmd/sys_utils/makeboot.c
+++ b/elkscmd/sys_utils/makeboot.c
@@ -31,6 +31,7 @@
 #include <linuxmt/minix_fs.h>
 #include <linuxmt/kdev_t.h>
 #include "../../bootblocks/mbr_autogen.c"
+#include "../../elks/arch/i86/drivers/block/bioshd.h"
 
 #define BUF_SIZE	1024 
 
@@ -40,10 +41,10 @@
 #define SYSFILE2	"/bootopts"		/* copied for MINIX and FAT */
 #define DEVDIR		"/dev"			/* created for FAT only */
 
-/* BIOS driver numbers must match bioshd.c*/
-#define BIOS_NUM_MINOR	32		/* max minor devices per drive*/
+/* BIOS driver numbers must match elks/arch/i86/drivers/block/bioshd.h */
+#define BIOS_NUM_MINOR	NUM_MINOR       /* max minor devices per drive */
 #define BIOS_MINOR_MASK	(BIOS_NUM_MINOR - 1)
-#define BIOS_FD0_MINOR	128		/* minor # of first floppy, must match bioshd.c*/
+#define BIOS_FD0_MINOR	(DRIVE_FD0 * (1<<MINOR_SHIFT)) /* minor # of first floppy */
 
 /* See bootblocks/minix.map for the offsets, these used for MINIX and FAT */
 #define ELKS_BPB_NumTracks	0x1F7		/* offset of number of tracks (word)*/


### PR DESCRIPTION
Fixes `sys -M` writing MBR to wrong hard drive, identified in #2385 with "Writing MBR to ..." an incorrect device.

This bug cropped up some time ago when the BIOS hard and floppy drive numbers were renumbered, but `makeboot` was hard-coded to use the older numbering scheme, and the error never found until now. The `makeboot` source code now uses the minor drive numbers directly from the BIOS driver, so this won't happen again.

On a two-hard drive system, using `sys -M /dev/hdb1`:
BEFORE (Writing MBR to /dev/hda)
<img width="832" height="540" alt="before" src="https://github.com/user-attachments/assets/0fa11985-557a-40ec-9146-e047c2000602" />
AFTER (Writing MBR to /dev/hdb)
<img width="832" height="540" alt="after" src="https://github.com/user-attachments/assets/25cc7efd-e34a-4a24-96ef-b2502ca7a6d4" />
