### PR TITLE
[basic] fix 16 color mode setting for pc-98

### DIFF
--- a/elkscmd/basic/host-pc98.c
+++ b/elkscmd/basic/host-pc98.c
@@ -245,11 +245,13 @@ void host_mode(int mode) {
         lio_m[9] = 0xFF;
         int_A2(lio_m_seg);
 
-        lio_m[0] = 0xFF;
         lio_m[1] = 0xFF;
         lio_m[2] = 0xFF;
-        lio_m[3] = 0x02; // 16 Color mode
+        lio_m[3] = 0xFF;
+        lio_m[4] = 0x02; // 16 Color mode
         int_A3(lio_m_seg);
+
+        outb(0x01,0x6A); // 16 Color mode
     }
 }
 


### PR DESCRIPTION
Hello @ghaerr 

This is the similar PR that has been made in scr_pc98 of nano-X.
Wrong parameter is fixed.

Thank you.