### PR TITLE
[cmds] Fix makeboot -f option to use passed boot sector size

### DIFF
--- a/dosbox.sh
+++ b/dosbox.sh
@@ -7,6 +7,8 @@
 # just-built 1232k image
 exec ./dosbox-x-sdl2 -set machine=pc98 -set "dosbox quit warning=false" -fastlaunch -c "boot image/fd1232.img"
 
+#exec ./dosbox-x-sdl2 -set machine=pc98 -set "dosbox quit warning=false" -fastlaunch -c "imgmount -size 1024,8,2,77 C image/fd1232.img"
+
 # 1440k image
 #exec ./dosbox-x-sdl2 -set machine=pc98 -set "dosbox quit warning=false" -fastlaunch -c "boot image/fd1440-pc98.img"
 


### PR DESCRIPTION
Found by @tyama501 and discussed in #2389.

The `makeboot -f fat.bin` option never worked, it always wrote a 1024 bytes (512 bytes FAT boot followed by 512 zeros) to the destination. Fixed to use the passed boot sector file size, which is still checked against the destination filesystem: 1024 bytes are required for MINIX, and 512 for FAT.

This problem existed for both IBM PC and PC-98 systems.

The dosbox.sh script is updated with an experimental use of the imgmount command to mount a hard drive image before booting ELKS. This won't work on PC-98 as the DosBox-X considers the hard drive to be IDE, rather than SCSI.