### PR TITLE
[make] Fix parallel builds (by only building libc in parallel, for now)

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -12,6 +12,9 @@ jobs:
 
     runs-on: ubuntu-22.04
 
+    env:
+      MAKEFLAGS: "-j $(nproc)"
+
     steps:
       - name: setup-1
         run: 'sudo apt-get update'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,9 @@ jobs:
 
     runs-on: ubuntu-22.04
 
+    env:
+      MAKEFLAGS: "-j $(nproc)"
+
     steps:
       - name: setup
         run: 'sudo apt-get install texinfo libncurses5-dev libelf-dev ncompress'

--- a/Makefile
+++ b/Makefile
@@ -10,38 +10,38 @@ include $(TOPDIR)/Make.defs
 
 all: .config include/autoconf.h
 	$(MAKE) -C libc all
-	$(MAKE) -C libc DESTDIR='$(TOPDIR)/cross' install
-	$(MAKE) -C elks all
-	$(MAKE) -C bootblocks all
-	$(MAKE) -C elkscmd all
-	$(MAKE) -C image all
+	$(MAKE) -C libc -j1 DESTDIR='$(TOPDIR)/cross' install
+	$(MAKE) -C elks -j1 all
+	$(MAKE) -C bootblocks -j1 all
+	$(MAKE) -C elkscmd -j1 all
+	$(MAKE) -C image -j1 all
 ifeq ($(shell uname), Linux)
 	$(MAKE) -C elksemu PREFIX='$(TOPDIR)/cross' elksemu
 endif
 
 image:
-	$(MAKE) -C image
+	$(MAKE) -C image -j1
 
 images:
-	$(MAKE) -C image images
+	$(MAKE) -C image -j1 images
 
 kimage: kernel image
 
 kernel:
-	$(MAKE) -C elks
+	$(MAKE) -C elks -j1
 
 kclean:
-	$(MAKE) -C elks kclean
+	$(MAKE) -C elks -j1 kclean
 
 clean:
-	$(MAKE) -C libc clean
-	$(MAKE) -C libc DESTDIR='$(TOPDIR)/cross' uninstall
-	$(MAKE) -C elks clean
-	$(MAKE) -C bootblocks clean
-	$(MAKE) -C elkscmd clean
-	$(MAKE) -C image clean
+	$(MAKE) -C libc -j1 clean
+	$(MAKE) -C libc -j1 DESTDIR='$(TOPDIR)/cross' uninstall
+	$(MAKE) -C elks -j1 clean
+	$(MAKE) -C bootblocks -j1 clean
+	$(MAKE) -C elkscmd -j1 clean
+	$(MAKE) -C image -j1 clean
 ifeq ($(shell uname), Linux)
-	$(MAKE) -C elksemu clean
+	$(MAKE) -C elksemu -j1 clean
 endif
 	@echo
 	@if [ ! -f .config ]; then \
@@ -51,13 +51,13 @@ endif
 	fi
 
 libc:
-	$(MAKE) -C libc DESTDIR='$(TOPDIR)/cross' uninstall
+	$(MAKE) -C libc -j1 DESTDIR='$(TOPDIR)/cross' uninstall
 	$(MAKE) -C libc all
-	$(MAKE) -C libc DESTDIR='$(TOPDIR)/cross' install
+	$(MAKE) -C libc -j1 DESTDIR='$(TOPDIR)/cross' install
 
 owclean:
-	$(MAKE) -C libc -f watcom.mk clean
-	$(MAKE) -C elkscmd owclean
+	$(MAKE) -C libc -j1 -f watcom.mk clean
+	$(MAKE) -C elkscmd -j1 owclean
 
 owlibc:
 	$(MAKE) -C libc -f watcom.mk MODEL=c
@@ -66,23 +66,23 @@ owlibc:
 	$(MAKE) -C libc -f watcom.mk MODEL=l
 
 owc: owlibc
-	$(MAKE) -C elkscmd owc
+	$(MAKE) -C elkscmd -j1 owc
 
 c86clean:
-	$(MAKE) -C libc -f c86.mk clean
-	$(MAKE) -C elkscmd c86clean
+	$(MAKE) -C libc -f c86.mk -j1 clean
+	$(MAKE) -C elkscmd -j1 c86clean
 
 c86libc:
-	$(MAKE) -C libc -f c86.mk
+	$(MAKE) -C libc -f c86.mk -j1
 
 c86: c86libc
-	$(MAKE) -C elkscmd c86
+	$(MAKE) -C elkscmd -j1 c86
 
 elks/arch/i86/drivers/char/KeyMaps/config.in:
-	$(MAKE) -C elks/arch/i86/drivers/char/KeyMaps config.in
+	$(MAKE) -C elks/arch/i86/drivers/char/KeyMaps -j1 config.in
 
 kconfig:
-	$(MAKE) -C config all
+	$(MAKE) -C config -j1 all
 
 defconfig:
 	$(RM) .config

--- a/build.sh
+++ b/build.sh
@@ -61,14 +61,14 @@ if [ "$1" != "auto" ]; then
 # Forcing single threaded build because of dirty dependencies (see #273)
 
 echo "Building all..."
-make -j1 all || clean_exit 5
+make all || clean_exit 5
 
 # Possibly build all images
 
 if [ "$2" = "allimages" ]; then
 	echo "Building all images..."
 	cd image
-	make -j1 images || clean_exit 6
+	make images || clean_exit 6
 	cd ..
 fi
 
@@ -78,7 +78,7 @@ if [ "$1" = "auto" ]; then
     cp 8018x.config .config
     make kclean || clean_exit 7
     rm elkscmd/basic/*.o
-    make -j1 || clean_exit 8
+    make || clean_exit 8
 fi
 
 # Build NEC V25 kernel and image
@@ -87,7 +87,7 @@ if [ "$1" = "auto" ]; then
     cp necv25.config .config
     make kclean || clean_exit 7
     rm elkscmd/basic/*.o
-    make -j1 || clean_exit 8
+    make || clean_exit 8
 fi
 
 # Build PC-98 kernel, some user land files and image
@@ -101,7 +101,7 @@ if [ "$1" = "auto" ]; then
     rm elkscmd/sys_utils/meminfo.o
     rm elkscmd/sys_utils/beep.o
     rm elkscmd/basic/*.o
-    make -j1 || clean_exit 10
+    make || clean_exit 10
 fi
 
 # Success

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -55,7 +55,7 @@ $(BUILDDIR)/.binutils.build: $(BUILDDIR)/.binutils.src
 	touch $(BUILDDIR)/.binutils.build
 
 $(CROSSDIR)/.binutils.install: $(BUILDDIR)/.binutils.build
-	$(MAKE) -C $(BUILDDIR)/binutils-build install
+	$(MAKE) -C $(BUILDDIR)/binutils-build -j1 install
 	touch $(CROSSDIR)/.binutils.install
 
 all:: $(CROSSDIR)/.binutils.install
@@ -149,7 +149,7 @@ $(BUILDDIR)/.gcc.build: $(BUILDDIR)/.gcc.src $(BUILDDIR)/.binutils.build
 	touch $(BUILDDIR)/.gcc.build
 
 $(CROSSDIR)/.gcc.install: $(BUILDDIR)/.gcc.build
-	$(MAKE) -C $(BUILDDIR)/gcc-build install
+	$(MAKE) -C $(BUILDDIR)/gcc-build -j1 install
 	touch $(CROSSDIR)/.gcc.install
 
 all:: $(CROSSDIR)/.gcc.install


### PR DESCRIPTION
I like using the cores of my laptop's processor. Unfortunately, the kernel Makefiles are not parallel-safe, and I don't trust `elkscmd/Makefile` to parallelize well in all situations.

This patch makes ELKS build correctly with `export MAKEFLAGS="-jN"` for `N > 1`. It also allows building the libcs in parallel, which already speeds up the build a little for multi-core CPU users, and will translate to slight speed ups for GitHub CI, as well.

Future work would include validating `elkscmd/Makefile` for proper parallel operation and patching the kernel Makefiles for the same.