### PR TITLE
[NECV25] Add ISA wait state handling and a minor change to tools/mfs

### DIFF
--- a/elks/include/arch/necv25.h
+++ b/elks/include/arch/necv25.h
@@ -71,12 +71,12 @@
  * Port.Pin  Name   Function Direction Used in
  * P1.0             special  in        do not change
  * P1.1      INTP0  special  in        do not change
- * P1.2             special  in        do not change
- * P1.3             special  in        NE200 NIC
+ * P1.2      INTP1  special  in        do not change
+ * P1.3      INTP2  special  in        NE200 NIC
  * P1.4             I/O      in
  * P1.5             I/O      in
  * P1.6      /SCK0  special  out       spi-hw-necv25.S
- * P1.7             I/O      in
+ * P1.7      READY  I/O      in        connected to ISA IOCHRDY
  *
  * Port.Pin  Name   Function Direction Used in
  * P2.0      SDA    I/O      in/out    i2c-ll.S
@@ -91,7 +91,7 @@
 // PM1 PMC1, PM2 and PMC2 have to get initialized in BIOS
 // or startup code with these values before ELKS starts:
 #define NEC_PM1_DEF  0xbf
-#define NEC_PMC1_DEF 0x40
+#define NEC_PMC1_DEF 0xc0
 #define NEC_PM2_DEF  0x80
 #define NEC_PMC2_DEF 0x00
  

--- a/elks/tools/mfs/main.c
+++ b/elks/tools/mfs/main.c
@@ -81,7 +81,7 @@ void usage(const char *name) {
 	"	genfs [-1|2] [-i<#inodes>] [-n<#direntlen>] [-s<#blocks>] [-k] [-a] <directory>\n"
 	"	addfs <file_of_relative_paths> <directory>\n"
 	"	[stat]\n"
-	"	ls [-ld] [filelist...]"
+	"	ls [-ld] [filelist...]\n"
 	"	cp source_file dest_dir_or_file\n"
 	"	rm file_list ...\n"
 	"	mkdir directory_list ...\n"


### PR DESCRIPTION
1. To use NECV25 on the ISA bus handling of ISA-Signal IOCHRDY has been added.

2. Minor change to mfs: A line feed was added to the usage message