### PR TITLE
[cmds] Add ELKS Digger game to buildext.sh

### DIFF
--- a/buildext.sh
+++ b/buildext.sh
@@ -15,6 +15,7 @@
 #       dcc             ia6-elf-gcc     DCC self-compiling C compiler for ELKS
 #       dflat           ia16-elf-gcc    D-Flat TUI memopad/library
 #       elkirc          ia16-elf-gcc    IRC for ELKS
+#       elksdigger      ia16-elf-gcc    Digger for ELKS
 #       owc_libc        OpenWatcom      ELKS C Library compiled by OWC
 #       owc_elkscmd     OpenWatcom      Some elkscmd/ programs compiled by OWC
 #       c86_toolchain   OpenWatcom/C86  C86 Toolchain, header files and examples
@@ -234,6 +235,20 @@ elkirc()
     echo "elkirc build complete"
 }
 
+elksdigger()
+{
+    echo "Building elksdigger..."
+    cd $TOPDIR/extapps
+    if [ ! -d ELKS-Digger ] ; then
+        git clone https://github.com/Vutshi/ELKS-Digger
+    fi
+    cd ELKS-Digger/elks
+    git pull
+    make clean
+    make
+    echo "elksdigger build complete"
+}
+
 elks_viewer()
 {
     echo "Building elks-viewer..."
@@ -326,6 +341,7 @@ make_all()
     dcc
     dflat
     elkirc
+    elksdigger
     if [ -n "$WATCOM" ] ; then
         owc_libc
         owc_elkscmd

--- a/elkscmd/ExtApplications
+++ b/elkscmd/ExtApplications
@@ -53,7 +53,7 @@ dflat/memopad                                       :dflat              :2880k
 elkirc/elkirc                                       :elkirc             :2880k
 elkirc/man/elkirc.1     ::lib/man1/elkirc.1         :elkirc             :2880k
 ELKS-Digger/elks/digger                             :elksdigger         :2880k
-ELKS-Digger/elks/digtitle.bmp                       :elksdigger         :2880k
+ELKS-Digger/elks/digtitle.bmp ::lib/digtitle.bmp    :elksdigger         :2880k
 elksdoom/elksdoom       ::bin/doom                  :elksdoom
 elksdoom/elksdoom.wad   ::lib/elksdoom.wad          :elksdoom
 ngircd-elks/ngircd.os2  ::bin/ngircd                :ngircd

--- a/elkscmd/ExtApplications
+++ b/elkscmd/ExtApplications
@@ -52,6 +52,8 @@ dflat/memopad                                       :dflat              :2880k
 # external OWC builds
 elkirc/elkirc                                       :elkirc             :2880k
 elkirc/man/elkirc.1     ::lib/man1/elkirc.1         :elkirc             :2880k
+ELKS-Digger/elks/digger                             :elksdigger         :2880k
+ELKS-Digger/elks/digtitle.bmp                       :elksdigger         :2880k
 elksdoom/elksdoom       ::bin/doom                  :elksdoom
 elksdoom/elksdoom.wad   ::lib/elksdoom.wad          :elksdoom
 ngircd-elks/ngircd.os2  ::bin/ngircd                :ngircd


### PR DESCRIPTION
Adds ELKS Digger game recently ported by @Vutshi in #2664 to distribution images, starting with 2880k floppy and larger images.

@Vutshi, I followed your repo instructions and added digtitle.bmp to /bin (next to /bin/digger) but I'm only seeing the score screen on startup. Is this correct?

It would be nice to have Digger search /lib for digtitle.bmp rather than (or in addition to) /bin, which keeps images out of /bin. If you make that change in your repo, all we have to do is modify ExtApplications of the new location using an added `::lib/digtitle.bmp` after the source filename.