### PR TITLE
Add experimental PC speaker sequencer

### DIFF
--- a/elks/arch/i86/drivers/char/Makefile
+++ b/elks/arch/i86/drivers/char/Makefile
@@ -129,7 +129,7 @@ ifdef CONFIG_CHAR_DEV_RS
 endif
 
 ifdef CONFIG_ARCH_IBMPC
-  OBJS += mouse-ps2.o
+  OBJS += mouse-ps2.o pcspkseq.o
 endif
 
 ifdef CONFIG_CHAR_DEV_CGATEXT

--- a/elks/arch/i86/drivers/char/bell-8254.c
+++ b/elks/arch/i86/drivers/char/bell-8254.c
@@ -8,6 +8,7 @@
  */
 
 #include <linuxmt/config.h>
+#include <linuxmt/pcspk.h>
 #include <arch/ports.h>
 #include <arch/io.h>
 #include <arch/irq.h>
@@ -20,6 +21,9 @@
  */
 void soundp(unsigned period)
 {
+#ifdef CONFIG_ARCH_IBMPC
+    pcspk_seq_stop();
+#endif
     clr_irq();
     outb(inb(SPEAKER_PORT) | 0x03, SPEAKER_PORT);
     outb(0xB6, TIMER_CMDS_PORT);
@@ -33,6 +37,9 @@ void soundp(unsigned period)
  */
 void nosound(void)
 {
+#ifdef CONFIG_ARCH_IBMPC
+    pcspk_seq_stop();
+#endif
     clr_irq();
     outb(inb(SPEAKER_PORT) & ~0x03, SPEAKER_PORT);
     set_irq();

--- a/elks/arch/i86/drivers/char/console.c
+++ b/elks/arch/i86/drivers/char/console.c
@@ -1,4 +1,5 @@
 /* shared console routines for Direct and BIOS consoles - #include in console drivers*/
+#include <linuxmt/pcspk.h>
 
 static void WriteChar(Console * C, int c)
 {
@@ -357,6 +358,10 @@ static int Console_ioctl(struct tty *tty, int cmd, char *arg)
                 nosound();
         }
         return 0;
+#ifdef CONFIG_ARCH_IBMPC
+    case KIOCSNDSEQ:
+        return pcspk_seq_ioctl(arg);
+#endif
     case TCSETS:
     case TCSETSW:
     case TCSETSF:

--- a/elks/arch/i86/drivers/char/pcspkseq.c
+++ b/elks/arch/i86/drivers/char/pcspkseq.c
@@ -1,0 +1,286 @@
+/*
+ * ELKS IBM PC speaker low-rate event sequencer.
+ *
+ * This deliberately keeps PIT timer 0 kernel-owned.  PIT channel 2 is used
+ * only as a square-wave carrier.  The sequencer uses the normal kernel
+ * timer_list path, but schedules only note/rest boundary callbacks rather
+ * than running a 100 Hz countdown while active.
+ */
+
+#include <linuxmt/config.h>
+#include <linuxmt/errno.h>
+#include <linuxmt/kd.h>
+#include <linuxmt/mm.h>
+#include <linuxmt/pcspk.h>
+#include <linuxmt/sched.h>
+#include <linuxmt/timer.h>
+#include <arch/io.h>
+#include <arch/irq.h>
+#include <arch/param.h>
+#include <arch/ports.h>
+
+#ifdef CONFIG_ARCH_IBMPC
+
+#define PCSPK_QSIZE        32
+#define PCSPK_GATE_BITS    0x03
+#define PCSPK_TIMER2_MODE3 0xB6
+#define PCSPK_MAX_TICKS    (HZ * 10)    /* per-event stuck-tone guard */
+
+static unsigned int pcspk_q_div[PCSPK_QSIZE];
+static unsigned int pcspk_q_ticks[PCSPK_QSIZE];
+static unsigned char pcspk_q_flags[PCSPK_QSIZE];
+static unsigned char pcspk_head;
+static unsigned char pcspk_tail;
+static unsigned char pcspk_count;
+
+static void pcspk_timer_fn(int unused);
+
+static struct timer_list pcspk_timer = { NULL, 0, 0, pcspk_timer_fn };
+static unsigned char pcspk_timer_on;
+static unsigned char pcspk_active;
+static unsigned char pcspk_gate_on;
+static unsigned int pcspk_hw_divisor;
+static pid_t pcspk_owner;
+
+static void pcspk_hw_gate(unsigned char on)
+{
+    unsigned char v;
+
+    if (on == pcspk_gate_on)
+        return;
+
+    v = inb(SPEAKER_PORT);
+    if (on)
+        v |= PCSPK_GATE_BITS;
+    else
+        v &= ~PCSPK_GATE_BITS;
+    outb(v, SPEAKER_PORT);
+    pcspk_gate_on = on;
+}
+
+static void pcspk_pit2_load(unsigned int divisor)
+{
+    outb(PCSPK_TIMER2_MODE3, TIMER_CMDS_PORT);
+
+#ifdef __ia16__
+    /*
+     * Avoid compiler-generated ``shr ax,cl`` for divisor >> 8 on 8086.
+     * AL already holds the low byte and AH the high byte; swap them between
+     * the two PIT data writes.
+     */
+    asm volatile ("outb %%al,%%dx\n\t"
+                  "xchg %%al,%%ah\n\t"
+                  "outb %%al,%%dx"
+        : "+a" (divisor)
+        : "d" (TIMER2_PORT));
+#else
+    outb((unsigned char)divisor, TIMER2_PORT);
+    outb((unsigned char)(divisor >> 8), TIMER2_PORT);
+#endif
+}
+
+static void pcspk_hw_tone(unsigned int divisor)
+{
+    if (divisor != pcspk_hw_divisor) {
+        pcspk_pit2_load(divisor);
+        pcspk_hw_divisor = divisor;
+    }
+    pcspk_hw_gate(1);
+}
+
+static void pcspk_cancel_timer(void)
+{
+    if (pcspk_timer_on) {
+        del_timer(&pcspk_timer);
+        pcspk_timer_on = 0;
+    }
+}
+
+static void pcspk_arm_timer(unsigned int ticks)
+{
+    if (!ticks)
+        ticks = 1;
+    if (ticks > PCSPK_MAX_TICKS)
+        ticks = PCSPK_MAX_TICKS;
+
+    if (!pcspk_timer_on) {
+        pcspk_timer.tl_expires = jiffies + ticks;
+        add_timer(&pcspk_timer);
+        pcspk_timer_on = 1;
+    }
+}
+
+static void pcspk_stop_locked(void)
+{
+    pcspk_cancel_timer();
+    pcspk_head = pcspk_tail = pcspk_count = 0;
+    pcspk_active = 0;
+    pcspk_owner = 0;
+    pcspk_hw_gate(0);
+    pcspk_hw_divisor = 0;
+}
+
+void pcspk_seq_stop(void)
+{
+    flag_t flags;
+
+    save_flags(flags);
+    clr_irq();
+    pcspk_stop_locked();
+    restore_flags(flags);
+}
+
+void pcspk_seq_exit(pid_t pid)
+{
+    flag_t flags;
+
+    save_flags(flags);
+    clr_irq();
+    if (pcspk_owner == pid)
+        pcspk_stop_locked();
+    restore_flags(flags);
+}
+
+static int pcspk_queue_event(struct pcspk_event *ev)
+{
+    unsigned char head;
+    unsigned int ticks;
+
+    if (pcspk_count >= PCSPK_QSIZE)
+        return -EAGAIN;
+
+    ticks = ev->ticks;
+    if (!ticks)
+        ticks = 1;
+    else if (ticks > PCSPK_MAX_TICKS)
+        ticks = PCSPK_MAX_TICKS;
+
+    head = pcspk_head;
+    pcspk_q_div[head] = ev->divisor;
+    pcspk_q_ticks[head] = ticks;
+    pcspk_q_flags[head] = ev->flags;
+    pcspk_head = (head + 1) & (PCSPK_QSIZE - 1);
+    pcspk_count++;
+    return 0;
+}
+
+static void pcspk_load_next_locked(void)
+{
+    unsigned char tail;
+    unsigned char flags;
+    unsigned int divisor;
+    unsigned int ticks;
+
+    if (!pcspk_count) {
+        pcspk_stop_locked();
+        return;
+    }
+
+    tail = pcspk_tail;
+    divisor = pcspk_q_div[tail];
+    ticks = pcspk_q_ticks[tail];
+    flags = pcspk_q_flags[tail];
+    pcspk_tail = (tail + 1) & (PCSPK_QSIZE - 1);
+    pcspk_count--;
+
+    if (flags & PCSPK_F_STOP) {
+        pcspk_stop_locked();
+        return;
+    }
+
+    if ((flags & PCSPK_F_TONE) && divisor)
+        pcspk_hw_tone(divisor);
+    else
+        pcspk_hw_gate(0);
+
+    pcspk_arm_timer(ticks);
+}
+
+static void pcspk_start_locked(void)
+{
+    if (!pcspk_active) {
+        pcspk_active = 1;
+        pcspk_owner = current->pid;
+        pcspk_load_next_locked();
+    }
+}
+
+static void pcspk_timer_fn(int unused)
+{
+    flag_t flags;
+
+    unused = unused;
+
+    save_flags(flags);
+    clr_irq();
+    pcspk_timer_on = 0;
+
+    if (pcspk_active)
+        pcspk_load_next_locked();
+
+    restore_flags(flags);
+}
+
+int pcspk_seq_ioctl(char *arg)
+{
+    struct pcspk_seq req;
+    struct pcspk_event ev;
+    struct pcspk_event *up;
+    unsigned int n;
+    unsigned int queued = 0;
+    int err;
+    flag_t flags;
+
+    err = verified_memcpy_fromfs(&req, arg, sizeof(req));
+    if (err)
+        return err;
+
+    if (req.rate_hz && req.rate_hz != HZ)
+        return -EINVAL;
+
+    save_flags(flags);
+    clr_irq();
+
+    if (req.flags & (PCSPK_SEQ_F_FLUSH | PCSPK_SEQ_F_STOP))
+        pcspk_stop_locked();
+
+    if (req.flags & PCSPK_SEQ_F_STOP) {
+        restore_flags(flags);
+        return 0;
+    }
+
+    if (pcspk_active && pcspk_owner != current->pid) {
+        restore_flags(flags);
+        return -EBUSY;
+    }
+
+    restore_flags(flags);
+
+    up = req.events;
+    for (n = 0; n < req.count; n++) {
+        err = verified_memcpy_fromfs(&ev, up + n, sizeof(ev));
+        if (err)
+            return queued ? (int)queued : err;
+
+        save_flags(flags);
+        clr_irq();
+        if (pcspk_queue_event(&ev)) {
+            if (queued)
+                pcspk_start_locked();
+            restore_flags(flags);
+            return queued ? (int)queued : -EAGAIN;
+        }
+        queued++;
+        restore_flags(flags);
+    }
+
+    save_flags(flags);
+    clr_irq();
+    if (queued)
+        pcspk_start_locked();
+    restore_flags(flags);
+
+    return (int)queued;
+}
+
+#endif /* CONFIG_ARCH_IBMPC */

--- a/elks/include/linuxmt/kd.h
+++ b/elks/include/linuxmt/kd.h
@@ -9,4 +9,31 @@
 
 #define KIOCSOUND	(__KD_MAJ + 0x2f)
 
+/* PC speaker low-rate event sequencer.  Divisor is PIT channel-2 reload. */
+#define KIOCSNDSEQ	(__KD_MAJ + 0x30)
+
+#define PCSPK_F_REST	0x00
+#define PCSPK_F_TONE	0x01
+#define PCSPK_F_STOP	0x02
+#define PCSPK_F_FLUSH	0x04
+
+#define PCSPK_SEQ_F_FLUSH	0x0001
+#define PCSPK_SEQ_F_STOP	0x0002
+
+#ifndef __ASSEMBLER__
+struct pcspk_event {
+    unsigned short divisor;	/* PIT channel 2 divisor, 0 = silence */
+    unsigned short ticks;	/* duration in kernel sequencer ticks */
+    unsigned char flags;	/* PCSPK_F_* */
+    unsigned char priority;	/* reserved for simple priority policy */
+};
+
+struct pcspk_seq {
+    struct pcspk_event *events;	/* near user pointer in process DS */
+    unsigned short count;		/* number of events pointed to by events */
+    unsigned short rate_hz;	/* 0 or HZ for this first implementation */
+    unsigned short flags;		/* PCSPK_SEQ_F_* */
+};
+#endif
+
 #endif

--- a/elks/include/linuxmt/pcspk.h
+++ b/elks/include/linuxmt/pcspk.h
@@ -1,0 +1,12 @@
+#ifndef __LINUXMT_PCSPK_H
+#define __LINUXMT_PCSPK_H
+
+#include <linuxmt/types.h>
+
+#ifdef __KERNEL__
+int pcspk_seq_ioctl(char *arg);
+void pcspk_seq_stop(void);
+void pcspk_seq_exit(pid_t pid);
+#endif
+
+#endif

--- a/elks/kernel/exit.c
+++ b/elks/kernel/exit.c
@@ -10,6 +10,7 @@
 #include <linuxmt/mm.h>
 #include <linuxmt/init.h>
 #include <linuxmt/debug.h>
+#include <linuxmt/pcspk.h>
 
 static void FARPROC reparent_children(void)
 {
@@ -127,6 +128,9 @@ void do_exit(int status)
     struct task_struct *parent;
 
     debug_wait("EXIT(%P) status %d\n", status);
+#ifdef CONFIG_ARCH_IBMPC
+    pcspk_seq_exit(current->pid);
+#endif
     _close_allfiles();
 
     /* release process group and TTY*/

--- a/elkscmd/Applications
+++ b/elkscmd/Applications
@@ -78,7 +78,7 @@ file_utils/md5sum               :fileutil                               :1440c
 file_utils/mkdir                :fileutil       :360k
 file_utils/mknod                :fileutil       :360k
 #file_utils/mkfifo              :fileutil               :1200k
-file_utils/more                 :fileutil       :360k           
+file_utils/more                 :fileutil       :360k
 file_utils/mv                   :fileutil       :360k
 file_utils/ln                   :fileutil           :720k
 file_utils/ls                   :fileutil       :360k           :128k       :nocomp
@@ -96,6 +96,7 @@ sys_utils/man                   :sysutil                                :1440k
 sys_utils/meminfo       :sash   :sysutil        :360k           :128k
 sys_utils/mouse                 :sysutil                 :1200c     :1440k
 sys_utils/passwd                :sysutil                :1200k
+sys_utils/pcspkpop                :sysutil                :1200k
 #sys_utils/shutdown :::reboot    :sysutil            :720k       :128k
 #sys_utils/shutdown :::poweroff  :sysutil            :720k
 sys_utils/sercat                :sysutil                            :1440c

--- a/elkscmd/sys_utils/Makefile
+++ b/elkscmd/sys_utils/Makefile
@@ -30,6 +30,7 @@ PRGS = \
 	chmem \
 	test_unreal \
 	beep \
+	pcspkpop \
 	mouse \
 	sercat \
 	console \
@@ -120,6 +121,9 @@ unreal.o: $(ELKS_LIB)/unreal.S
 
 beep: beep.o
 	$(LD) $(LDFLAGS) -o beep beep.o $(LDLIBS)
+
+pcspkpop: pcspkpop.o
+	$(LD) $(LDFLAGS) -o pcspkpop pcspkpop.o $(LDLIBS)
 
 sysctl: sysctl.o
 	$(LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)

--- a/elkscmd/sys_utils/pcspkpop.c
+++ b/elkscmd/sys_utils/pcspkpop.c
@@ -1,0 +1,246 @@
+/* pcspkpop - ELKS PC speaker sequencer test: Popcorn opening loop */
+
+#include <sys/ioctl.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#ifndef __KD_MAJ
+#define __KD_MAJ        ('K'<<8)
+#endif
+#ifndef KIOCSOUND
+#define KIOCSOUND       (__KD_MAJ + 0x2f)
+#endif
+#ifndef KIOCSNDSEQ
+#define KIOCSNDSEQ      (__KD_MAJ + 0x30)
+#define PCSPK_F_REST    0x00
+#define PCSPK_F_TONE    0x01
+#define PCSPK_F_STOP    0x02
+#define PCSPK_F_FLUSH   0x04
+#define PCSPK_SEQ_F_FLUSH 0x0001
+#define PCSPK_SEQ_F_STOP  0x0002
+struct pcspk_event {
+    unsigned short divisor;
+    unsigned short ticks;
+    unsigned char flags;
+    unsigned char priority;
+};
+struct pcspk_seq {
+    struct pcspk_event *events;
+    unsigned short count;
+    unsigned short rate_hz;
+    unsigned short flags;
+};
+#endif
+
+#define REST 0
+#define C4   4560
+#define D4   4063
+#define E4   3620
+#define F4   3417
+#define A4   2712
+#define BB4  2560
+#define C5   2280
+#define D5   2031
+#define E5   1810
+#define F5   1708
+#define A5   1356
+
+struct note {
+    unsigned short div;
+    unsigned char dur;
+};
+
+static int seqfd = -1;
+static volatile int stop_requested;
+
+static void stop_sound(void)
+{
+    struct pcspk_seq s;
+
+    if (seqfd < 0)
+        return;
+    s.events = 0;
+    s.count = 0;
+    s.rate_hz = 0;
+    s.flags = PCSPK_SEQ_F_STOP | PCSPK_SEQ_F_FLUSH;
+    ioctl(seqfd, KIOCSNDSEQ, &s);
+    ioctl(seqfd, KIOCSOUND, 0);
+}
+
+static void on_signal(int sig)
+{
+    stop_requested = sig ? sig : 1;
+}
+
+static int send_events(struct pcspk_event *ev, int count, int flush)
+{
+    struct pcspk_seq s;
+    int off = 0;
+    int n;
+
+    while (off < count && !stop_requested) {
+        s.events = ev + off;
+        s.count = count - off;
+        s.rate_hz = 0;
+        s.flags = flush ? PCSPK_SEQ_F_FLUSH : 0;
+        flush = 0;
+
+        n = ioctl(seqfd, KIOCSNDSEQ, &s);
+        if (n > 0) {
+            off += n;
+            continue;
+        }
+        if (n < 0 && errno != EAGAIN && errno != EBUSY)
+            return -1;
+        usleep(50000L);
+    }
+
+    if (stop_requested) {
+        errno = EINTR;
+        return -1;
+    }
+    return 0;
+}
+
+static unsigned short tempo_ticks(unsigned char dur, int tempo)
+{
+    unsigned long v;
+
+    /* dur is in eighth-note units.  ticks = 100Hz * 60s / tempo / 2. */
+    v = (unsigned long)dur * 3000UL;
+    v = (v + (unsigned)tempo / 2) / (unsigned)tempo;
+    if (v < 1)
+        v = 1;
+    if (v > 1000)
+        v = 1000;
+    return (unsigned short)v;
+}
+
+static int build_events(struct pcspk_event *out, struct note *in, int nnotes,
+                        int tempo, int add_stop)
+{
+    int i;
+    int n = 0;
+    unsigned short t;
+    unsigned short gap;
+
+    for (i = 0; i < nnotes; i++) {
+        t = tempo_ticks(in[i].dur, tempo);
+        /* gap = (t > 3) ? 1 : 0; */
+        gap = (t > 8) ? (t >> 3) : 1;
+        if (in[i].div) {
+            out[n].divisor = in[i].div;
+            out[n].ticks = t - gap;
+            out[n].flags = PCSPK_F_TONE;
+            out[n].priority = 0;
+            n++;
+        }
+        if (gap || !in[i].div) {
+            out[n].divisor = 0;
+            out[n].ticks = gap ? gap : t;
+            out[n].flags = PCSPK_F_REST;
+            out[n].priority = 0;
+            n++;
+        }
+    }
+
+    if (add_stop) {
+        out[n].divisor = 0;
+        out[n].ticks = 1;
+        out[n].flags = PCSPK_F_STOP;
+        out[n].priority = 0;
+        n++;
+    }
+    return n;
+}
+
+static void play_fallback(struct note *song, int nnotes, int tempo)
+{
+    int i;
+    unsigned short t;
+
+    while (!stop_requested) {
+        for (i = 0; i < nnotes && !stop_requested; i++) {
+            t = tempo_ticks(song[i].dur, tempo);
+            if (song[i].div)
+                ioctl(seqfd, KIOCSOUND, song[i].div);
+            else
+                ioctl(seqfd, KIOCSOUND, 0);
+            usleep((unsigned long)t * 10000UL);
+            ioctl(seqfd, KIOCSOUND, 0);
+        }
+    }
+}
+
+static void usage(void)
+{
+    fputs("usage: pcspkpop [-s] [-t tempo]\n", stderr);
+}
+
+int main(int argc, char **argv)
+{
+    static struct note popcorn[] = {
+        {D5,1},{C5,1},{D5,1},{A4,1},{F4,1},{A4,1},{D4,2},
+        {REST,1},
+        {D5,1},{C5,1},{D5,1},{A4,1},{F4,1},{A4,1},{D4,2},
+        {REST,1},
+        {D5,1}, {E5,1}, {F5,1}, {E5,1}, {F5,1}, {D5,1},
+        {E5,1}, {D5,1}, {E5,1}, {C5,1},
+        {D5,1}, {C5,1}, {D5,1}, {BB4,1}, {D5,2}
+    };
+    static struct note scale[] = {
+        {C4,1},{D4,1},{E4,1},{F4,1},{A4,1},{C5,1},{D5,1},{E5,1},{F5,1},{A5,2}
+    };
+    static struct pcspk_event events[96];
+    struct note *song = popcorn;
+    int nnotes = sizeof(popcorn) / sizeof(popcorn[0]);
+    int tempo = 120;
+    int i;
+    int nevents;
+    int flush = 1;
+
+    for (i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "-s")) {
+            song = scale;
+            nnotes = sizeof(scale) / sizeof(scale[0]);
+        } else if (!strcmp(argv[i], "-t") && i + 1 < argc) {
+            tempo = atoi(argv[++i]);
+            if (tempo < 30)
+                tempo = 30;
+            if (tempo > 240)
+                tempo = 240;
+        } else {
+            usage();
+            return 1;
+        }
+    }
+
+    signal(SIGINT, on_signal);
+    signal(SIGTERM, on_signal);
+
+    seqfd = open("/dev/tty", 0);
+    if (seqfd < 0)
+        seqfd = 0;
+
+    nevents = build_events(events, song, nnotes, tempo, 0);
+
+    while (!stop_requested) {
+        if (send_events(events, nevents, flush) < 0) {
+            if (stop_requested)
+                break;
+            fputs("pcspkpop: KIOCSNDSEQ unavailable, using KIOCSOUND fallback\n",
+                  stderr);
+            play_fallback(song, nnotes, tempo);
+            break;
+        }
+        flush = 0;
+    }
+
+    stop_sound();
+    return 0;
+}


### PR DESCRIPTION
This PR adds a small experimental PC speaker sequencer for ELKS. See discussion in #2664.

The existing `KIOCSOUND` interface can set a single PIT channel-2 tone, but music playback from user space requires repeated timing-sensitive calls. This patch adds a compact event sequencer: user programs queue `{ divisor, ticks, flags }` events, and the kernel advances them using the existing timer infrastructure.

Design goals:

- keep PIT timer 0 kernel-owned
- use PIT channel 2 for square-wave tone generation
- avoid PCM, PWM, mixing, or high-rate interrupt work
- use event-boundary scheduling rather than a 100 Hz playback loop
- keep the kernel state small and static
- preserve existing bell / `KIOCSOUND` behavior
- stop speaker output on stop/flush and process exit where practical

The sequencer is intended for simple monophonic music/SFX streams on 8086/186 systems. It is not a general audio subsystem.

A small test program, `pcspkpop`, is included. It queues a compact Popcorn melody through the new ioctl and can also be used as a basic regression test for the sequencer.

## Short usage instructions

```c
#include <fcntl.h>
#include <sys/ioctl.h>
#include <linuxmt/pcspk.h>

int fd;
struct pcspk_event evs[2];
struct pcspk_seq seq;

fd = open("/dev/console", O_WRONLY);

/* A4 for 50 ticks, then rest for 10 ticks */
evs[0].divisor = 2712;
evs[0].ticks = 50;
evs[0].flags = PCSPK_F_TONE;
evs[0].priority = 0;

evs[1].divisor = 0;
evs[1].ticks = 10;
evs[1].flags = PCSPK_F_REST;
evs[1].priority = 0;

seq.events = evs;
seq.count = 2;
seq.rate_hz = 0;
seq.flags = PCSPK_F_FLUSH;

ioctl(fd, KIOCSNDSEQ, &seq);
```

To stop playback:

```c
struct pcspk_seq seq;

seq.events = 0;
seq.count = 0;
seq.rate_hz = 0;
seq.flags = PCSPK_F_STOP | PCSPK_F_FLUSH;

ioctl(fd, KIOCSNDSEQ, &seq);
```