### PR TITLE
[kernel] Fix file writes discarded on FAT filesystems witout /DEV directory

### DIFF
--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -372,8 +372,8 @@ static void msdos_write_inode(register struct inode *inode)
 
 	inode->i_dirt = 0;
 #ifdef CONFIG_FS_DEV
-	/* FAT /dev inodes don't actually exist, so don't write anything*/
-	if (inode->i_ino < DEVINO_BASE + DEVDIR_SIZE)
+	/* FAT /dev inodes don't actually exist, so don't write anything */
+	if (MSDOS_SB(inode->i_sb)->dev_ino && inode->i_ino < DEVINO_BASE + DEVDIR_SIZE)
 		return;
 #endif
 	debug_fat("write_inode %ld %d\n", (unsigned long)inode->i_ino, inode->i_dirt);


### PR DESCRIPTION
Fixes #2676 where writing to files created early in the root directory of a FAT filesystem without a /DEV directory were discarded. 

This occurred because the /dev entry is emulated by ELKS on FAT filesystems with a directory named DEV in the root directory, and apparently writing to files created early (i.e. first 64 entries) in the root directory of FAT images not produced by ELKS (which don't have /dev present), was never well tested.