### PR TITLE
[kernel] Only use CMOS register 0x10 in DF driver for floppy count

### DIFF
--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -1308,6 +1308,8 @@ static unsigned char * INITPROC find_base(int drive, int type)
 {
     unsigned char *base;
 
+    if (type == 15)
+        type = CMOS_360k;               /* use 360k if no CMOS */
     if (type > 0 && type <= CMOS_MAX) {
         base = probe_list[type - 1];
         printk("df%d is %s (%d)", drive, minor_types[*base].name, type);
@@ -1319,12 +1321,13 @@ static unsigned char * INITPROC find_base(int drive, int type)
 
 static void INITPROC config_types(void)
 {
+    unsigned int type_byte = CMOS_READ(0x10);
+
     printk("df: CMOS ");
-    if (!(base_type[0] = find_base(0, (CMOS_READ(0x10) >> 4) & 0xF)))
-        base_type[0] = find_base(0, CMOS_360k);   /* use 360k if no CMOS */
-    if (((CMOS_READ(0x14) >> 6) & 1) != 0) {
+    base_type[0] = find_base(0, (type_byte >> 4) & 0x0F);
+    if (type_byte & 0x0F) {
         printk(", ");
-        base_type[1] = find_base(1, CMOS_READ(0x10) & 0xF);
+        base_type[1] = find_base(1, type_byte & 0xF);
     }
 #ifdef CONFIG_FS_XMS_BUFFER
     if (xms_enabled) {


### PR DESCRIPTION
Correct some issues found using MartyPC and QEMU v11 in #2678, as well as allow the DF driver to function on IBM XT systems, where no CMOS is present.

These issues are:
- Don't use CMOS register 0x14 (equipment config byte) to determine number of floppies present. It appears that QEMU v11 doesn't maintain this legacy register anymore.
- When CMOS register 0x10 (floppy type byte) returns 15 for floppy type, default to 360k floppy. By spec, value 0 indicates no floppy, and values 1-5 specify valid drive types. Allowing for 15 to specify 360k drive(s) allows MartyPC to work when emulating non-existentCMOS by returning all 1 bits in this register.