### PR TITLE
[kernel] Rearchitect fake FAT /dev inode numbers to fix 360k FAT boot failure

### DIFF
--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -57,8 +57,8 @@ include $(TOPDIR)/Make.defs
 
 VERSION     = 0	# (0-255)
 PATCHLEVEL  = 9	# (0-255)
-SUBLEVEL    = 1	# (0-255)
-PRE         =
+SUBLEVEL    = 2	# (0-255)
+PRE         = dev
 
 #########################################################################
 # Specify the architecture we will use.

--- a/elks/fs/msdos/inode.c
+++ b/elks/fs/msdos/inode.c
@@ -17,7 +17,7 @@
 #include <linuxmt/debug.h>
 
 #ifdef CONFIG_FS_DEV
-/* FAT device table, increase DEVDIR_SIZE and DEVINO_BASE to add entries*/
+/* FAT device table, increase DEVDIR_SIZE to add entries*/
 struct msdos_devdir_entry devnods[DEVDIR_SIZE] = {
     { "hda",	S_IFBLK | 0644, DEV_HDA                     },
     { "hda1",	S_IFBLK | 0644, DEV_HDA+1                   },
@@ -281,7 +281,7 @@ void msdos_read_inode(register struct inode *inode)
 	cluster_t this, nr;
 	int fatsz = MSDOS_SB(inode->i_sb)->fat_bits;
 
-	//debug_fat("read_inode %ld\n", (unsigned long)inode->i_ino);
+	debug_fat("read_inode %lu\n", (unsigned long)inode->i_ino);
 	inode->u.msdos_i.i_busy = 0;
 	inode->i_uid = current->uid;
 	inode->i_gid = current->gid;
@@ -315,15 +315,14 @@ void msdos_read_inode(register struct inode *inode)
 		return;
 	}
 #ifdef CONFIG_FS_DEV
-	else if (MSDOS_SB(inode->i_sb)->dev_ino
-                 && inode->i_ino < DEVINO_BASE + DEVDIR_SIZE) {
-		inode->i_mode = devnods[(int)inode->i_ino - DEVINO_BASE].mode;
+	if (MSDOS_SB(inode->i_sb)->dev_ino && inode->i_ino >= DEVINO_BASE) {
+		inode->i_mode = devnods[inode->i_ino - DEVINO_BASE].mode;
+		inode->i_rdev = devnods[inode->i_ino - DEVINO_BASE].rdev;
 		inode->i_uid  = 0;
 		inode->i_size = 0;
-		inode->i_mtime= current_time();
 		inode->i_gid  = 0;
 		inode->i_nlink= 1;
-		inode->i_rdev = devnods[(int)inode->i_ino - DEVINO_BASE].rdev;
+		inode->i_mtime= current_time();
 		if (S_ISCHR(inode->i_mode))
 			inode->i_op = &chrdev_inode_operations;
 		else if (S_ISBLK(inode->i_mode))
@@ -373,7 +372,7 @@ static void msdos_write_inode(register struct inode *inode)
 	inode->i_dirt = 0;
 #ifdef CONFIG_FS_DEV
 	/* FAT /dev inodes don't actually exist, so don't write anything */
-	if (MSDOS_SB(inode->i_sb)->dev_ino && inode->i_ino < DEVINO_BASE + DEVDIR_SIZE)
+	if (MSDOS_SB(inode->i_sb)->dev_ino && inode->i_ino >= DEVINO_BASE)
 		return;
 #endif
 	debug_fat("write_inode %ld %d\n", (unsigned long)inode->i_ino, inode->i_dirt);

--- a/elks/fs/msdos/misc.c
+++ b/elks/fs/msdos/misc.c
@@ -243,7 +243,7 @@ ino_t FATPROC msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head *
 
 #ifdef CONFIG_FS_DEV
 	if (dir->i_ino == MSDOS_SB(dir->i_sb)->dev_ino) {
-		unsigned i = (unsigned)*pos / sizeof(struct msdos_dir_entry);
+		ino_t i = *pos >> MSDOS_DIR_BITS;
 		if (i - 2 <= DEVDIR_SIZE) {
 			static struct msdos_dir_entry deventry;
 			int j;
@@ -257,7 +257,7 @@ ino_t FATPROC msdos_get_entry(struct inode *dir,loff_t *pos,struct buffer_head *
 
 			i += DEVINO_BASE;
 			return i;
-	    }
+		}
 	}
 #endif
 

--- a/elks/include/linuxmt/msdos_fs_sb.h
+++ b/elks/include/linuxmt/msdos_fs_sb.h
@@ -46,7 +46,7 @@ struct msdos_sb_info { /* space in struct super_block is 28 bytes */
 
 #ifdef CONFIG_FS_DEV
 #define DEVDIR_SIZE             51              /* # entries in FAT device table */
-#define DEVINO_BASE             (MSDOS_DPB*2)   /* (DEVDIR_SIZE+MSDOS_DBP-1) & ~(MSDOS_DBP-1) */
+#define DEVINO_BASE             0xFFFFFF00UL    /* faked base of /dev inode numbers */
 
 struct msdos_devdir_entry {
     const char *name;


### PR DESCRIPTION
While debugging #2678 it was found that the ELKS 360k FAT floppy distribution images would not boot, due to the architecture of the fake FAT /dev mechanism in the kernel. Occurring only in certain FAT floppies formatted to DOS with a small FAT table (< 5, but all 360k FAT floppies produced by ELKS builds), the FAT /dev and sometimes /bin directories were corrupted, causing boot failure.

On FAT filesystems, the "inode" number happens to be the block number of the sector containing the directory entry, since FAT doesn't actually implement inodes. When the FAT table is small, then certain directory entries were at block numbers that were small enough to trigger the /dev emulation, in this case, turning both /bin and /dev into character devices from the internal table. The code was rewritten to use a very high inode number (0xFFFFFF00) for faked /dev entries, which will work with both small and very large FAT images.

This problem seems to have occurred prior to the release of both v0.9.0 and was not fixed in v0.9.1, so it is likely that yet another small release (v0.9.2) should come soon, for those users that might want to boot a 360k FAT floppy. The problem is independent of using the BIOS or direct floppy driver in the kernel.

This PR also increments the ELKS version number to v0.9.2-dev.