### PR TITLE
[kernel] Allow unimplemented FDC version command for MartyPC in direct FD driver

### DIFF
--- a/elks/Makefile-rules
+++ b/elks/Makefile-rules
@@ -58,7 +58,7 @@ include $(TOPDIR)/Make.defs
 VERSION     = 0	# (0-255)
 PATCHLEVEL  = 9	# (0-255)
 SUBLEVEL    = 2	# (0-255)
-PRE         = dev
+PRE         = -dev
 
 #########################################################################
 # Specify the architecture we will use.

--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -1447,18 +1447,17 @@ static void DFPROC floppy_deregister(void)
     set_irq();
 }
 
-/* Try to determine the floppy controller type */
-static int DFPROC get_fdc_version(void)
+/* Try to determine the floppy controller type; sets fdc_version global */
+static void DFPROC get_fdc_version(void)
 {
     int type = FDC_TYPE_8272A;
     const char *name;
 
     do_floppy = ignore_interrupt;
     output_byte(FD_VERSION);    /* get FDC version code */
-    if (result() != 1) {
-        printk("df: can't get FDC version\n");
-        return 0;
-    }
+    if (result() != 1)
+        reply_buffer[0] = 0;    /* NOTE: fixes unimplemented command in MartyPC */
+
     switch (reply_buffer[0]) {
     case 0x80:
         if (arch_cpu >= CPU_80286) {     /* PC/AT or better */
@@ -1473,10 +1472,11 @@ static int DFPROC get_fdc_version(void)
         name = "82077";
         break;
     default:
-        name = "Unknown";
+        name = "8272A assumed";
     }
     printk("df: direct floppy FDC %s (0x%x), irq %d, dma %d\n",
         name, reply_buffer[0], FLOPPY_IRQ, FLOPPY_DMA);
+    fdc_version = type;         /* must set version before reset_floppy called */
 
     /* Not all FDCs seem to be able to handle the version command
      * properly, so force a reset for the standard FDC clones,
@@ -1484,8 +1484,6 @@ static int DFPROC get_fdc_version(void)
      */
     initial_reset_flag = 1;
     reset_floppy();
-
-    return type;
 }
 
 static int DFPROC floppy_register(void)
@@ -1502,7 +1500,7 @@ static int DFPROC floppy_register(void)
         return err;
     }
 
-    fdc_version = get_fdc_version();
+    get_fdc_version();
     if (!fdc_version) return -EIO;
     return 0;
 }

--- a/elkscmd/rootfs_template/bootopts
+++ b/elkscmd/rootfs_template/bootopts
@@ -20,6 +20,8 @@ hma=kernel
 #root=cfa1
 #root=hda1 ro
 #root=df0
+#enable=df0
+#disable=fd0
 #task=16 buf=64 cache=8 file=64 inode=96 heap=44000 # std
 #task=6 buf=8 cache=4 file=20 inode=24 heap=15000 n # min
 #sync=30


### PR DESCRIPTION
This is the first of two PRs being made to overcome emulation issues running ELKS on MartyPC. Discussed in detail in #2678.

This PR works around new information that the VERSION command is in fact not implemented in uDP765 FDC chips. While real hardware returns an invalid command code of 0x80 which is handled by the ELKS DF driver, MartyPC does not (yet) do so. This workaround now reports "8272A assumed" and allows continuation of the boot, rather than disallowing further DF driver use as was done previously.

During testing it was found that when a 2.88M floppy image is booted using the DF driver, an incorrect and unnecessary message "df: need 82077 FDC for disc" was displayed and the driver possibly not initialized correctly. This is also fixed in this PR.