### PR TITLE
[kernel] Allow DOS v3.31+ BPB to set floppy CHS in BIOS driver

### DIFF
--- a/elks/arch/i86/drivers/block/bioshd.c
+++ b/elks/arch/i86/drivers/block/bioshd.c
@@ -180,18 +180,18 @@ static void BFPROC probe_floppy(int target, struct hd_struct *hdp)
                 }
             }
 
-            /* second check for valid FAT BIOS parm block */
+            /* Check for valid FAT v3.31+ BPB in boot sector */
             unsigned char __far *boot = _MK_FP(DMASEG, 0);
-            if (
-                //(boot[510] == 0x55 && boot[511] == 0xAA) &&   /* bootable sig*/
-                ((boot[3] == 'M' && boot[4] == 'S') ||          /* OEM 'MSDOS'*/
-                 (boot[3] == 'I' && boot[4] == 'B'))     &&     /* or 'IBM'*/
-                (boot[54] == 'F' && boot[55] == 'A')       ) {  /* v4.0 fil_sys 'FAT'*/
+            if (((boot[3] == 'M' && boot[4] == 'S') ||      /* OEM 'MSDOS' */
+                 (boot[3] == 'I' && boot[4] == 'B'))     && /* or 'IBM' */
+                boot[0x10] && !boot[0x19] && !boot[0x1B] && /* nzfat, hi head/spt 0 */
+                (boot[0x1A] == 1 || boot[0x1A] == 2)     && /* 1 or 2 heads */
+                (boot[0x18] == 8 || boot[0x18] == 9 ||      /* valid # sectors */
+                 boot[0x18] == 15 || boot[0x18] == 18 || boot[0x18] == 36)) {
 
-                /* has valid MSDOS 4.0+ FAT BPB, use it */
-                drivep->sectors = boot[24];             /* bpb_sec_per_trk */
-                drivep->heads = boot[26];               /* bpb_num_heads */
-                unsigned char media = boot[21];         /* bpb_media_byte */
+                drivep->sectors = boot[0x18];           /* bpb_sec_per_trk */
+                drivep->heads = boot[0x1A];             /* bpb_num_heads */
+                unsigned char media = boot[0x15];       /* bpb_media_byte */
                 drivep->cylinders =
                         (media == 0xFD)? 40:
 #ifdef CONFIG_ARCH_PC98


### PR DESCRIPTION
This enhancement allows DOS FAT floppy images (specifically containing a validated v3.31 BPB or later) to set the CHS (cylinder, sector and head) values for the BIOS driver, instead of having to probe the floppy. Previously, a valid v4.0 DOS BPB was required.

This change allows the BIOS driver to be used with v3.3 DOS floppies on the MartyPC emulator, since a bug was confirmed in #2678 where MartyPC always returns success to the BIOS from its FDC emulation when a single sector is read, even if the sector is non-existent. This breaks ELKS' BIOS probe routine which results in accepting an incorrect CHS for the media, which results in data corruption on reading/writing that media.

Checking for a valid v3.31+ BPB includes validating the BPB sectors-per-track, head count and number of FATs fields, as well as requiring either 'MS' or 'IB' as the first two characters in the OEM name field.

All floppy images created by ELKS (both MINIX and FAT) contain an additional valid EPB (ELKS Parameter Block) which if present is used by the BIOS driver prior to validating any FAT BPB. Thus this enhancement usually only affects FAT floppies from "in the wild" created outside ELKS builds.