### PR TITLE
[kernel] Fix config.h typo with CONFIG_BLK_DEV_FD option for DF driver track cache

### DIFF
--- a/elks/include/linuxmt/config.h
+++ b/elks/include/linuxmt/config.h
@@ -187,11 +187,11 @@
 #define DMASEGSZ        0           /* no external XMS/DMA buffer */
 #endif
 
-#if defined(CONFIG_BLK_DEV_BFD) || defined(CONFIG_BLK_DEV_BHD) || defined(CONFIG_BLK_FD)
+#if defined(CONFIG_BLK_DEV_BFD) || defined(CONFIG_BLK_DEV_BHD) || defined(CONFIG_BLK_DEV_FD)
 #ifdef CONFIG_TRACK_CACHE           /* floppy track buffer in low mem */
 #   define TRACKSEGSZ   0x2400      /* SECTOR_SIZE * 18 (9216) */
 #else
-#  ifdef CONFIG_BLK_FD
+#  ifdef CONFIG_BLK_DEV_FD
 #  define TRACKSEGSZ    0x0400      /* DF driver requires DMASEG internal to TRACKSEG */
 #  else
 #  define TRACKSEGSZ    0           /* no TRACKSEG buffer */


### PR DESCRIPTION
Another fix found by @Vutshi in #2678.

When the BIOS driver was unset and the DF driver set along with CONFIG_TRACK_CACHE unset, the kernel compiled but then crashed on boot, since a typo disallowed the required allocation of the track cache used the DF driver. (CONFIG_TRACK_CACHE is only applicable to the BIOS driver, whereas DF driver settings are currently within its own source file directfd.c).

Thanks @Vutshi!