### PR TITLE
[directfd] Fix data corruption on odd sector-per-track disc I/O

### DIFF
--- a/elks/arch/i86/drivers/block/directfd.c
+++ b/elks/arch/i86/drivers/block/directfd.c
@@ -66,6 +66,12 @@
  *
  * 22 May 2025 - Greg Haerr
  * Program 8237 DMA controller external page register instead of using XMS bounce buffer
+ *
+ * 18 May 2026 - Greg Haerr
+ * Fix incorrect cache-hit and possible numsectors < 2 data corruption when
+ * TRACK_CACHE=y, CACHE_CYLINDER=0 and TRACK_SPLIT_BLK=0. This driver requires
+ * the FDC (or emulator) to implement auto-head increment when MT bit set.
+ * Currently MartyPC does not, so odd sector-per-track discs will produce I/O errors.
  */
 
 #include <linuxmt/config.h>
@@ -1219,9 +1225,17 @@ static void DFPROC redo_fd_request(void)
          */
         numsectors = floppy->sect + (floppy->sect & 1 && !head) - startsector;
 #else
-        /* partial track caching */
+        /* Partial track caching. NOTE: this will set numsectors to 1
+         * on odd sector-per-track floppies (i.e. 360k, 720k, 1200k).
+         */
         numsectors = floppy->sect - startsector;
 #endif
+        /* NOTE: TRACK_SPLIT_BLK #else option above requires this, should
+         * probably be combined into TRACK_SPLIT_BLK and option removed.
+         */
+        if (numsectors < req->rq_nr_sectors)
+            numsectors = req->rq_nr_sectors;
+
         if (numsectors > CACHE_SIZE)
             numsectors = CACHE_SIZE;
     }
@@ -1233,8 +1247,8 @@ static void DFPROC redo_fd_request(void)
 
     DEBUG("prep %u|%d,%d|%d-", start, seek_track, cache_drive, current_drive);
 
-    if (cache_drive == current_drive &&
-        start >= cache_start && start < cache_start + cache_numsectors) {
+    if (cache_drive == current_drive && start >= cache_start &&
+            start + req->rq_nr_sectors <= cache_start + cache_numsectors) {
         DEBUG("cache CHS %d/%d/%d\n", seek_track, head, sector);
         debug_cache2("CH %d ", start >> 1);
         cache_offset = (char *)(((start - cache_start) << 9) + CACHE_OFF);


### PR DESCRIPTION
Fixes data corruption and system crash at boot found when using the DF driver on floppies with an odd number of sectors per track (i.e. 360k, 720k and 1200k). The driver would misidentify a cache hit when CACHE_CYLINDER=0 and TRACK_SPLIT_BLK=0 with CONFIG_TRACK_CACHE turned on. This occurred because the driver only checked that the first sector was within the cache, but not the entire request within the cache.

In addition, when both the above internal options were set OFF (=0), the numsectors I/O value would get set to less than the I/O request size (=1 instead of 2), leaving garbage in the cache for the 2nd sector. This would typically result in a STACK UNDERFLOW error when booting under QEMU, both version 5.2.0 and 11.

Discussed heavily in #2678.

During the debugging, it was realized that the DF driver cannot easily be made to work if the FDC doesn't implement multi-track auto-head incrementing when the "MT" bit is set in a read/write command. That is, the way the driver is coded, each DMA complete interrupt must entirely finish the requested I/O, there is no facility to add remaining sectors when an I/O request w/MT set falls short. 

While all known FDC hardware implements the MT bit, the MartyPC emulator does not, and thus there is no workaround when using the DF driver with 360k, 720k or 1200k floppies. 1.44M and 2.88M floppies will work, as they have an even number of sectors per track and a 1K block never straddles across the same track on double sided media.

@Vutshi, this should fix all the outstanding issues discussed in #2678, except for a possible option to force a CMOS drive setting in /bootopts when no CMOS is present. Another option would be to change the default to 1440k instead of 360k when no CMOS is present, as is the case with MartyPC.