### PR TITLE
fix net stop

### DIFF
--- a/elkscmd/rootfs_template/bin/net
+++ b/elkscmd/rootfs_template/bin/net
@@ -69,7 +69,15 @@ start_network()
 stop_network()
 {
 	echo "Stopping network"
-	kill $(ps | grep "ktcp|telnet|httpd|ftpd" | cut -c 1-5) > /dev/null 2>&1
+	ps > /tmp/psout
+	while read pid cmd
+	do
+		case $cmd in
+		*ktcp*|*telnet*|*httpd*|*ftpd*)
+			kill $pid > /dev/null 2>&1
+			;;
+		esac
+	done < /tmp/psout
 	custom_stop_network
 }
 
@@ -89,7 +97,16 @@ restart)
 	start_network ;;
 show)
 	echo -n ip $localip gateway $gateway mask $netmask $link
-	if test "$link" = "slip"; then echo "" $baud $device; else echo; fi ;;
+	if test "$link" = "slip"; then echo "" $baud $device; else echo; fi
+	running="[stopped]"
+	ps > /tmp/psout
+	while read pid cmd
+	do
+		case $cmd in
+		*ktcp*) running="[running]" ;;
+		esac
+	done < /tmp/psout
+	echo "ktcp $running" ;;
 *) usage ;;
 esac
 

--- a/elkscmd/rootfs_template/etc/inittab
+++ b/elkscmd/rootfs_template/etc/inittab
@@ -1,4 +1,4 @@
-id:1:initdefault:
+id:3:initdefault:
 
 si::sysinit:/etc/rc.sys
 

--- a/qemu.sh
+++ b/qemu.sh
@@ -74,10 +74,8 @@ KEYBOARD=
 # Uncomment the following line to emulate two serial devices, required for Nano-X:
 SERIAL="-chardev msmouse,id=c1 -device isa-serial,chardev=c1,id=s1 -chardev msmouse,id=c2 -device isa-serial,chardev=c2,id=s2"
 
-# Uncomment this to route ELKS /dev/ttyS0 to host terminal
+# Route ELKS /dev/ttyS0 to host terminal in addition to VGA window
 CONSOLE="-serial stdio"
-# Hides qemu window also
-#CONSOLE="-serial stdio -nographic"
 
 # Host forwarding for networking
 # No forwarding: only outgoing from ELKS to host
@@ -92,7 +90,7 @@ FWD="\
 hostfwd=tcp:127.0.0.1:8080-10.0.2.15:80,\
 hostfwd=tcp:127.0.0.1:2323-10.0.2.15:23,\
 hostfwd=tcp::8020-:20,\
-hostfwd=tcp::8021-:21,\
+hostfwd=tcp::2121-:21,\
 hostfwd=tcp::8041-:49821,\
 hostfwd=tcp::8042-:49822,\
 hostfwd=tcp::8043-:49823,\
@@ -143,5 +141,5 @@ fi
 
 echo "Using QEMU: $QEMU $ACCEL"
 exec $QEMU $ACCEL $DEBUG $AUDIO $CONSOLE -nodefaults -name ELKS -machine isapc -cpu 486,tsc -m 8M \
-$KEYBOARD $QDISPLAY -vga std -rtc base=utc $SERIAL \
+$KEYBOARD $QDISPLAY -vga std -boot order=a -rtc base=utc $SERIAL \
 $NET $NETDUMP $IMAGE $DISK2 $@


### PR DESCRIPTION
1. Fix grep error on net stop which was causing net stop to not actually stop the network (this is fixed)

<img width="672" height="154" alt="Screenshot 2026-06-11 at 10 56 54 PM" src="https://github.com/user-attachments/assets/2e1f6511-814c-4cbe-8d22-6005cec06105" />

2. modify qemu.sh to use port 2121 instead of 8021.  8021 conflicts with an ftp proxy server in macOS 26.5

3. Net show shows status of net processes:

<img width="646" height="198" alt="Screenshot 2026-06-11 at 10 59 54 PM" src="https://github.com/user-attachments/assets/973e2d36-61b4-4470-82c7-cb0ad71cc00e" />

4. Mods so serial console works better (easier for copy and paste)

<img width="905" height="414" alt="Screenshot 2026-06-11 at 11 03 05 PM" src="https://github.com/user-attachments/assets/842a6a3d-2fe1-46df-a709-1d1eaaa88d62" />
