### PR TITLE
[build] Build ELKS using parallel make automatically (using up to max CPU cores)

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -12,7 +12,7 @@ jobs:
 
     runs-on: ubuntu-22.04
 
-   env:
+    env:
       MAKEFLAGS: "-j$(sysctl -n hw.perflevel0.logicalcpu 2>/dev/null || nproc 2>/dev/null || echo 2)"
 
     steps:

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -12,6 +12,9 @@ jobs:
 
     runs-on: ubuntu-22.04
 
+   env:
+      MAKEFLAGS: "-j$(sysctl -n hw.perflevel0.logicalcpu 2>/dev/null || nproc 2>/dev/null || echo 2)"
+
     steps:
       - name: setup-1
         run: 'sudo apt-get update'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
 
     runs-on: ubuntu-22.04
 
-   env:
+    env:
       MAKEFLAGS: "-j$(sysctl -n hw.perflevel0.logicalcpu 2>/dev/null || nproc 2>/dev/null || echo 2)"
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,9 @@ jobs:
 
     runs-on: ubuntu-22.04
 
+   env:
+      MAKEFLAGS: "-j$(sysctl -n hw.perflevel0.logicalcpu 2>/dev/null || nproc 2>/dev/null || echo 2)"
+
     steps:
       - name: setup
         run: 'sudo apt-get install texinfo libncurses5-dev libelf-dev ncompress nasm'

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,12 @@ endif
 include $(TOPDIR)/Make.defs
 
 .PHONY: all clean libc kconfig defconfig config menuconfig image images \
-    kimage kernel kclean owc c86
+    kimage kernel bootblocks elkscmd kclean owc c86
 
 all: .config include/autoconf.h
 	$(MAKE) -C libc all
 	$(MAKE) -C libc DESTDIR='$(TOPDIR)/cross' install
-	$(MAKE) -C elks all
-	$(MAKE) -C bootblocks all
-	$(MAKE) -C elkscmd all
+	$(MAKE) kernel bootblocks elkscmd
 	$(MAKE) -C image all
 ifeq ($(shell uname), Linux)
 	$(MAKE) -C elksemu PREFIX='$(TOPDIR)/cross' elksemu
@@ -28,7 +26,13 @@ images:
 kimage: kernel image
 
 kernel:
-	$(MAKE) -C elks
+	$(MAKE) -C elks all
+
+bootblocks:
+	$(MAKE) -C bootblocks all
+
+elkscmd: libc kernel
+	$(MAKE) -C elkscmd all
 
 kclean:
 	$(MAKE) -C elks kclean
@@ -60,10 +64,10 @@ owclean:
 	$(MAKE) -C elkscmd owclean
 
 owlibc:
-	#$(MAKE) -C libc -f watcom.mk MODEL=c
-	$(MAKE) -C libc -f watcom.mk MODEL=s
-	$(MAKE) -C libc -f watcom.mk MODEL=m
-	$(MAKE) -C libc -f watcom.mk MODEL=l
+	#$(MAKE) -C libc -j1 -f watcom.mk MODEL=c
+	$(MAKE) -C libc -j1 -f watcom.mk MODEL=s
+	$(MAKE) -C libc -j1 -f watcom.mk MODEL=m
+	$(MAKE) -C libc -j1 -f watcom.mk MODEL=l
 
 owc: owlibc
 	$(MAKE) -C elkscmd owc

--- a/elks/Makefile
+++ b/elks/Makefile
@@ -81,7 +81,7 @@ endif
 #########################################################################
 # Define commands.
 
-Image: $(TOPDIR)/include/autoconf.h tools
+Image: $(TOPDIR)/include/autoconf.h reset tools
 	$(MAKE) $(ARCHIVES)
 	$(MAKE) -C init main.o
 	$(MAKE) -C $(ARCH_DIR) Image
@@ -93,7 +93,7 @@ setup: $(ARCH_DIR)/boot/setup
 # library rules (all these are built even if they aren't used).
 
 .PHONY: fs/fs.a fs/msdos/msdos.a fs/minix/minixfs.a fs/romfs/romfs.a \
-        kernel/kernel.a lib/lib.a net/net.a tools
+        kernel/kernel.a lib/lib.a net/net.a tools reset
 
 fs/fs.a:
 	${MAKE} -C fs fs.a
@@ -119,6 +119,8 @@ net/net.a:
 
 tools:
 	${MAKE} -C tools all
+
+reset:
 	-rm -f include/linuxmt/compiler-generated.h
 	-rm -f kernel/version.o
 
@@ -148,8 +150,9 @@ elks.spec: Makefile
 
 kclean: dokclean
 
-.NOTPARALLEL: clean
-clean:	nodep doclean
+#.NOTPARALLEL: clean
+#clean:	nodep doclean
+clean:	doclean
 
 dep:	$(TOPDIR)/include/autoconf.h
 	@$(MAKE) dodep

--- a/elkscmd/Makefile
+++ b/elkscmd/Makefile
@@ -12,10 +12,9 @@ include $(BASEDIR)/Makefile-rules
 #
 # Subdirectories for clean / build / install
 
-# All subdirectories to build & clean
+# All subdirectories to build & clean (elkscmd/lib handled specially)
 
 IA16DIRS =       \
-	lib         \
 	advent      \
 	ash         \
 	basic       \
@@ -62,7 +61,10 @@ ALL = ia16
 
 all: $(ALL)
 
-ia16:
+lib:
+	$(MAKE) -C lib all
+
+ia16: lib
 	@if [ ! -e $(TOPDIR)/include/autoconf.h ]; \
 	then echo -e "\n*** ERROR: You must configure ELKS first ***\n" >&2; exit 1; fi
 	for DIR in $(IA16DIRS); do $(MAKE) -C $$DIR all || exit 1; done
@@ -74,6 +76,7 @@ c86:
 	for DIR in $(C86DIRS); do $(MAKE) -C $$DIR -f Makefile.c86 all || exit 1; done
 
 clean: owclean c86clean
+	$(MAKE) -C lib clean
 	for DIR in $(IA16DIRS); do $(MAKE) -C $$DIR clean || exit 1; done
 
 owclean:

--- a/env.sh
+++ b/env.sh
@@ -21,6 +21,7 @@ add_path "$CROSSDIR/bin"
 add_path "$TOPDIR/elks/tools/bin"
 echo PATH set to $PATH
 
-# for example MAKEFLAGS="-j$(nproc)" . env.sh
-export MAKEFLAGS="$MAKEFLAGS"
+# Use P-cores only (hw.perflevel0) on macOS — E-cores are much slower for compilation.
+# On Linux falls back to nproc (all cores).
+export MAKEFLAGS="-j$(sysctl -n hw.perflevel0.logicalcpu 2>/dev/null || nproc 2>/dev/null || echo 2)"
 echo MAKEFLAGS set to $MAKEFLAGS

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -62,7 +62,7 @@ $(BUILDDIR)/.binutils.build: $(BUILDDIR)/.binutils.src
 	touch $(BUILDDIR)/.binutils.build
 
 $(CROSSDIR)/.binutils.install: $(BUILDDIR)/.binutils.build
-	$(MAKE) -C $(BUILDDIR)/binutils-build install
+	$(MAKE) -C $(BUILDDIR)/binutils-build -j1 install
 	touch $(CROSSDIR)/.binutils.install
 
 all:: $(CROSSDIR)/.binutils.install
@@ -174,7 +174,7 @@ $(BUILDDIR)/.gcc.build: $(BUILDDIR)/.gcc.src $(BUILDDIR)/.binutils.build
 	touch $(BUILDDIR)/.gcc.build
 
 $(CROSSDIR)/.gcc.install: $(BUILDDIR)/.gcc.build
-	$(MAKE) -C $(BUILDDIR)/gcc-build install
+	$(MAKE) -C $(BUILDDIR)/gcc-build -j1 install
 	touch $(CROSSDIR)/.gcc.install
 
 all:: $(CROSSDIR)/.gcc.install
@@ -211,6 +211,7 @@ $(BUILDDIR)/.emu86.build: $(BUILDDIR)/.emu86.src
 	touch $(BUILDDIR)/.emu86.build
 
 $(CROSSDIR)/.emu86.install: $(BUILDDIR)/.emu86.build
+	mkdir -p $(CROSSDIR)/bin
 	install $(BUILDDIR)/emu86/emu86 $(CROSSDIR)/bin/
 	install $(BUILDDIR)/emu86/pcat $(CROSSDIR)/bin/
 	touch $(CROSSDIR)/.emu86.install
@@ -255,6 +256,7 @@ $(BUILDDIR)/.wf-mednafen.build: $(BUILDDIR)/.wf-mednafen.src
 	touch $(BUILDDIR)/.wf-mednafen.build
 
 $(CROSSDIR)/.wf-mednafen.install: $(BUILDDIR)/.wf-mednafen.build
+	mkdir -p $(CROSSDIR)/bin
 	install $(BUILDDIR)/wf-mednafen-build/src/mednafen $(CROSSDIR)/bin/wf-mednafen
 	touch $(CROSSDIR)/.wf-mednafen.install
 


### PR DESCRIPTION
This PR enhances the ELKS build system to take advantage of make's parallel build capability, which drastically reduces the time required to build the cross-compiler, C library, kernel, and applications. This capability is also added to the GitHub CI system, which is run on every PR/commit.

Time to build ia16-elf-gcc cross-compiler from scratch: **30+ minutes -> 11 minutes**.
Time to build full ELKS C library, kernel and applications: **3-4 minutes -> 45 seconds** (16-core MacBook Pro).

A number of ideas and code for this PR were previously submitted by @asiekierka in #2480 and @djohanse in #2695. Thank you both very much for your submissions, sorry it's taken so long. Also, thanks to @hexadec1mal for providing information and a possible fix for the sometimes-seen compiler-generated.h problem during the kernel build.

When running `. env.sh` to setup the ELKS environment, either `sysctl` (for macOS) or `nproc` (for Linux/CI) is used to obtain the number of cores available, which is then passed as an argument to make using `make -j` using the MAKEFLAGS environment variable. If parallel make building is not desired, edit env.sh and set `MAKEFLAGS=`.

There may be further speedups possible in the kernel build by optimizing the elf2elks/elftoolchain and elks-compress builds, as well as possibly speeding up buildext.sh, build.sh, buildimages.sh and image creation, which are still built sequentially.

This enhancement has been tested on macOS and on GitHub CI. While I believe all the bases are now covered with regards to potential problems in building the C library, kernel and applications, there may still be race conditions that come up. Now that I understand how parallel make actually works, hopefully any problems can be quickly fixed.

Now that I see the huge benefits in building ELKS using all cores, I realize this should have been done a long time ago. Thanks again to @asiekierka and @djohanse for pushing for this as well as providing code.



